### PR TITLE
Safe access to Life and Mana via Player struct

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2779,7 +2779,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	player._pMaxHP = ihp + player._pMaxHPBase;
 	player._pHitPoints = std::min(ihp + player._pHPBase, player._pMaxHP);
 
-	if (&player == MyPlayer && (player._pHitPoints >> 6) <= 0) {
+	if (&player == MyPlayer && player.isDead()) {
 		player.setLife(0);
 	}
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2780,7 +2780,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	player._pHitPoints = std::min(ihp + player._pHPBase, player._pMaxHP);
 
 	if (&player == MyPlayer && (player._pHitPoints >> 6) <= 0) {
-		SetPlayerHitPoints(player, 0);
+		player.setLife(0);
 	}
 
 	player._pMaxMana = imana + player._pMaxManaBase;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2776,8 +2776,9 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	madd = (madd * playerClassAttributes.itmMana) >> 6;
 	imana += (madd << 6);
 
+	player.setCurrentLife(0, ihp);
 	player._pMaxHP = ihp + player._pMaxHPBase;
-	player._pHitPoints = std::min(ihp + player._pHPBase, player._pMaxHP);
+	player._pHitPoints = ihp + player._pHPBase;
 
 	if (&player == MyPlayer && player.isDead()) {
 		player.setLife(0);

--- a/Source/lua/modules/dev/player/stats.cpp
+++ b/Source/lua/modules/dev/player/stats.cpp
@@ -60,9 +60,8 @@ std::string DebugCmdChangeHealth(int change)
 	if (change == 0)
 		return StrCat("Enter a value not equal to 0 to change life!");
 
-	int newHealth = myPlayer._pHitPoints + (change * 64);
-	myPlayer.setLife(newHealth);
-	if (newHealth <= 0)
+	myPlayer.modifyLife(change);
+	if (myPlayer.isDead())
 		SyncPlrKill(myPlayer, DeathReason::MonsterOrTrap);
 
 	return StrCat("Changed life by ", change);
@@ -74,9 +73,7 @@ std::string DebugCmdChangeMana(int change)
 	if (change == 0)
 		return StrCat("Enter a value not equal to 0 to change mana!");
 
-	int newMana = myPlayer._pMana + (change * 64);
-	myPlayer._pMana = newMana;
-	myPlayer._pManaBase = myPlayer._pMana + myPlayer._pMaxManaBase - myPlayer._pMaxMana;
+	myPlayer.modifyMana(change);
 	RedrawComponent(PanelDrawComponent::Mana);
 
 	return StrCat("Changed mana by ", change);

--- a/Source/lua/modules/dev/player/stats.cpp
+++ b/Source/lua/modules/dev/player/stats.cpp
@@ -61,7 +61,7 @@ std::string DebugCmdChangeHealth(int change)
 		return StrCat("Enter a value not equal to 0 to change life!");
 
 	int newHealth = myPlayer._pHitPoints + (change * 64);
-	SetPlayerHitPoints(myPlayer, newHealth);
+	myPlayer.setLife(newHealth);
 	if (newHealth <= 0)
 		SyncPlrKill(myPlayer, DeathReason::MonsterOrTrap);
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1202,7 +1202,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 
 	if ((monster.flags & MFLAG_NOLIFESTEAL) == 0 && monster.type().type == MT_SKING && gbIsMultiplayer)
 		monster.hitPoints += dam;
-	if (player.getLife().whole() <= 0) {
+	if (player.isDead()) {
 		if (gbIsHellfire)
 			M_StartStand(monster, monster.direction);
 		return;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -616,7 +616,7 @@ void UpdateEnemy(Monster &monster)
 		for (size_t pnum = 0; pnum < Players.size(); pnum++) {
 			const Player &player = Players[pnum];
 			if (!player.plractive || !player.isOnActiveLevel() || player._pLvlChanging
-			    || (((player._pHitPoints >> 6) == 0) && gbIsMultiplayer))
+			    || (player.isDead() && gbIsMultiplayer))
 				continue;
 			const bool sameroom = (dTransVal[position.x][position.y] == dTransVal[player.position.tile.x][player.position.tile.y]);
 			const int dist = position.WalkingDistance(player.position.tile);
@@ -1139,7 +1139,7 @@ int GetMinHit()
 
 void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, int maxDam)
 {
-	if (player._pHitPoints >> 6 <= 0 || player._pInvincible || HasAnyOf(player._pSpellFlags, SpellFlag::Etherealize))
+	if (player.isDead() || player._pInvincible || HasAnyOf(player._pSpellFlags, SpellFlag::Etherealize))
 		return;
 	if (monster.position.tile.WalkingDistance(player.position.tile) >= 2)
 		return;
@@ -3946,10 +3946,10 @@ void PrepDoEnding()
 		player._pmode = PM_QUIT;
 		player._pInvincible = true;
 		if (gbIsMultiplayer) {
-			if (player._pHitPoints >> 6 == 0)
-				player._pHitPoints = 64;
-			if (player._pMana >> 6 == 0)
-				player._pMana = 64;
+			if (player.isDead())
+				player.setLife(1);
+			if (player.getMana().whole() == 0)
+				player.setMana(1);
 		}
 	}
 }

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1177,19 +1177,8 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 		}
 		return;
 	}
-	if (monster.type().type == MT_YZOMBIE && &player == MyPlayer) {
-		if (player._pMaxHP > 64) {
-			if (player._pMaxHPBase > 64) {
-				player._pMaxHP -= 64;
-				if (player._pHitPoints > player._pMaxHP) {
-					player._pHitPoints = player._pMaxHP;
-				}
-				player._pMaxHPBase -= 64;
-				if (player._pHPBase > player._pMaxHPBase) {
-					player._pHPBase = player._pMaxHPBase;
-				}
-			}
-		}
+	if (monster.type().type == MT_YZOMBIE && &player == MyPlayer && player.getMaxLife().whole() > 1 && player.getMaxBaseLife().whole() > 1) {
+		player.modifyMaxLife(-1, 0, false);
 	}
 	int dam = (minDam << 6) + GenerateRnd(((maxDam - minDam) << 6) + 1);
 	dam = std::max(dam + (player._pIGetHit << 6), 64);
@@ -1213,7 +1202,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 
 	if ((monster.flags & MFLAG_NOLIFESTEAL) == 0 && monster.type().type == MT_SKING && gbIsMultiplayer)
 		monster.hitPoints += dam;
-	if (player._pHitPoints >> 6 <= 0) {
+	if (player.getLife().whole() <= 0) {
 		if (gbIsHellfire)
 			M_StartStand(monster, monster.direction);
 		return;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1642,7 +1642,7 @@ void UpdateBurningCrossDamage(Object &cross)
 		return;
 
 	ApplyPlrDamage(DamageType::Fire, myPlayer, 0, 0, damage[leveltype - 1]);
-	if (myPlayer._pHitPoints >> 6 > 0) {
+	if (!myPlayer.isDead()) {
 		myPlayer.Say(HeroSpeech::Argh);
 	}
 }
@@ -3210,14 +3210,9 @@ bool OperateFountains(Player &player, Object &fountain)
 		if (&player != MyPlayer)
 			return false;
 
-		if (player._pHitPoints < player._pMaxHP) {
+		if (player.getLife().frac() < player.getMaxLife().frac()) {
 			PlaySfxLoc(SfxID::OperateFountain, fountain.position);
-			player._pHitPoints += 64;
-			player._pHPBase += 64;
-			if (player._pHitPoints > player._pMaxHP) {
-				player._pHitPoints = player._pMaxHP;
-				player._pHPBase = player._pMaxHPBase;
-			}
+			player.modifyLife(1);
 			applied = true;
 		} else
 			PlaySfxLoc(SfxID::OperateFountain, fountain.position);
@@ -3226,16 +3221,9 @@ bool OperateFountains(Player &player, Object &fountain)
 		if (&player != MyPlayer)
 			return false;
 
-		if (player._pMana < player._pMaxMana) {
+		if (player.getMana().frac() < player.getMaxMana().frac()) {
 			PlaySfxLoc(SfxID::OperateFountain, fountain.position);
-
-			player._pMana += 64;
-			player._pManaBase += 64;
-			if (player._pMana > player._pMaxMana) {
-				player._pMana = player._pMaxMana;
-				player._pManaBase = player._pMaxManaBase;
-			}
-
+			player.modifyMana(1);
 			applied = true;
 		} else
 			PlaySfxLoc(SfxID::OperateFountain, fountain.position);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2618,10 +2618,8 @@ void OperateShrineDivine(Player &player, Point spawnPosition)
 		CreateTypeItem(spawnPosition, false, ItemType::Misc, IMISC_FULLREJUV, false, false, true);
 	}
 
-	player._pMana = player._pMaxMana;
-	player._pManaBase = player._pMaxManaBase;
-	player._pHitPoints = player._pMaxHP;
-	player._pHPBase = player._pMaxHPBase;
+	player.setFullLife();
+	player.setFullMana();
 
 	RedrawEverything();
 
@@ -2666,10 +2664,8 @@ void OperateShrineSpooky(const Player &player)
 
 	Player &myPlayer = *MyPlayer;
 
-	myPlayer._pHitPoints = myPlayer._pMaxHP;
-	myPlayer._pHPBase = myPlayer._pMaxHPBase;
-	myPlayer._pMana = myPlayer._pMaxMana;
-	myPlayer._pManaBase = myPlayer._pMaxManaBase;
+	myPlayer.setFullLife();
+	myPlayer.setFullMana();
 
 	RedrawEverything();
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1124,7 +1124,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 	case ACTION_RATTACKPLR:
 	case ACTION_SPELLPLR:
 		target = &Players[targetId];
-		if ((target->getLife().whole()) <= 0) {
+		if (target->isDead()) {
 			player.Stop();
 			return;
 		}
@@ -2153,7 +2153,7 @@ void InitPlayerGFX(Player &player)
 
 	ResetPlayerGFX(player);
 
-	if (player.getLife().whole() == 0) {
+	if (player.isDead()) {
 		player._pgfxnum &= ~0xFU;
 		LoadPlrGFX(player, player_graphic::Death);
 		return;
@@ -2380,7 +2380,7 @@ void NextPlrLevel(Player &player)
 
 void Player::_addExperience(uint32_t experience, int levelDelta)
 {
-	if (this != MyPlayer || getLife().frac() <= 0)
+	if (this != MyPlayer || isDead())
 		return;
 
 	if (isMaxCharacterLevel()) {
@@ -2804,14 +2804,14 @@ void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP /*
 	if (player.getLife().frac() < minHitPoints) {
 		player.setLife(minHitPoints);
 	}
-	if (player.getLife().whole() <= 0) {
+	if (player.isDead()) {
 		SyncPlrKill(player, deathReason);
 	}
 }
 
 void SyncPlrKill(Player &player, DeathReason deathReason)
 {
-	if (player.getLife().frac() <= 0 && leveltype == DTYPE_TOWN) {
+	if (player.isDead() && leveltype == DTYPE_TOWN) {
 		player.setLife(1);
 		return;
 	}
@@ -2967,7 +2967,7 @@ void ProcessPlayers()
 		if (player.plractive && player.isOnActiveLevel() && (&player == MyPlayer || !player._pLvlChanging)) {
 			CheckCheatStats(player);
 
-			if (!PlrDeathModeOK(player) && player.getLife().whole() <= 0) {
+			if (!PlrDeathModeOK(player) && player.isDead()) {
 				SyncPlrKill(player, DeathReason::Unknown);
 			}
 
@@ -3045,7 +3045,7 @@ bool PosOkPlayer(const Player &player, Point position)
 	if (!IsTileWalkable(position))
 		return false;
 	Player *otherPlayer = PlayerAtPosition(position);
-	if (otherPlayer != nullptr && otherPlayer != &player && otherPlayer->getLife().frac() != 0)
+	if (otherPlayer != nullptr && otherPlayer != &player && !otherPlayer->isDead())
 		return false;
 
 	if (dMonster[position.x][position.y] != 0) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2451,7 +2451,7 @@ void InitPlayer(Player &player, bool firstTime)
 
 		ClearStateVariables(player);
 
-		if (player._pHitPoints >> 6 > 0) {
+		if (!player.isDead()) {
 			player._pmode = PM_STAND;
 			NewPlrAnim(player, player_graphic::Stand, Direction::South);
 			player.AnimInfo.currentFrame = GenerateRnd(player._pNFrames - 1);
@@ -2540,7 +2540,7 @@ void FixPlayerLocation(Player &player, Direction bDir)
 
 void StartStand(Player &player, Direction dir)
 {
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer) {
+	if (player._pInvincible && player.isDead() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -2555,7 +2555,7 @@ void StartStand(Player &player, Direction dir)
 
 void StartPlrBlock(Player &player, Direction dir)
 {
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer) {
+	if (player._pInvincible && player.isDead() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -2589,7 +2589,7 @@ void FixPlrWalkTags(const Player &player)
 
 void StartPlrHit(Player &player, int dam, bool forcehit)
 {
-	if (player._pInvincible && player._pHitPoints == 0 && &player == MyPlayer) {
+	if (player._pInvincible && player.isDead() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -2633,7 +2633,7 @@ __attribute__((no_sanitize("shift-base")))
 void
 StartPlayerKill(Player &player, DeathReason deathReason)
 {
-	if (player._pHitPoints <= 0 && player._pmode == PM_DEATH) {
+	if (player.isDead() && player._pmode == PM_DEATH) {
 		return;
 	}
 
@@ -2773,7 +2773,7 @@ void StripTopGold(Player &player)
 void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP /*= 0*/, int frac /*= 0*/, DeathReason deathReason /*= DeathReason::MonsterOrTrap*/)
 {
 	int totalDamage = (dam << 6) + frac;
-	if (&player == MyPlayer && player._pHitPoints > 0) {
+	if (&player == MyPlayer && !player.isDead()) {
 		AddFloatingNumber(damageType, player, totalDamage);
 	}
 	if (totalDamage > 0 && player.pManaShield) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -173,7 +173,7 @@ void StartWalkAnimation(Player &player, Direction dir, bool pmWillBeCalled)
  */
 void StartWalk(Player &player, Direction dir, bool pmWillBeCalled)
 {
-	if (player._pInvincible && player.getLife().frac() == 0 && &player == MyPlayer) {
+	if (player._pInvincible && player.isDead() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -191,7 +191,7 @@ void ClearStateVariables(Player &player)
 
 void StartAttack(Player &player, Direction d, bool includesFirstFrame)
 {
-	if (player._pInvincible && player.getLife().frac() == 0 && &player == MyPlayer) {
+	if (player._pInvincible && player.isDead() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}
@@ -234,7 +234,7 @@ void StartAttack(Player &player, Direction d, bool includesFirstFrame)
 
 void StartRangeAttack(Player &player, Direction d, WorldTileCoord cx, WorldTileCoord cy, bool includesFirstFrame)
 {
-	if (player._pInvincible && player.getLife().frac() == 0 && &player == MyPlayer) {
+	if (player._pInvincible && player.isDead() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -274,7 +274,7 @@ player_graphic GetPlayerGraphicForSpell(SpellID spellId)
 
 void StartSpell(Player &player, Direction d, WorldTileCoord cx, WorldTileCoord cy)
 {
-	if (player._pInvincible && player.getLife().frac() && &player == MyPlayer) {
+	if (player._pInvincible && player.isDead() && &player == MyPlayer) {
 		SyncPlrKill(player, DeathReason::Unknown);
 		return;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3370,6 +3370,21 @@ void Player::modifyMaxLife(int val, int frac /*= 0*/, bool adjCurrentLife /*= tr
 	updateLifeGlobe();
 	CalcPlrInv(*this, true);
 }
+void Player::setCurrentLife(int val, int frac /*= 0*/)
+{
+	int amount = (val << 6) + frac;
+
+	_pHitPoints = amount + _pHPBase;
+	_pMaxHP = amount + _pMaxHPBase;
+}
+
+void Player::modifyCurrentLife(int val, int frac /*= 0*/)
+{
+	int amount = (val << 6) + frac;
+
+	_pHitPoints += amount;
+	_pMaxHP += amount;
+}
 
 void Player::setFullLife()
 {
@@ -3379,12 +3394,12 @@ void Player::setFullLife()
 
 void Player::checkManaShield() const
 {
-		if (this != MyPlayer)
-			return;
-		if (!pManaShield)
-			return;
-		if (_pMana <= 0)
-			NetSendCmd(true, CMD_REMSHIELD);
+	if (this != MyPlayer)
+		return;
+	if (!pManaShield)
+		return;
+	if (_pMana <= 0)
+		NetSendCmd(true, CMD_REMSHIELD);
 }
 
 void Player::updateManaGlobe() const
@@ -3418,7 +3433,7 @@ void Player::modifyMana(int val, int frac)
 		checkManaShield();
 }
 
-void Player::setMaxMana(int val, int frac /*= 0*/, bool adjCurrentMana /*= true*/)
+void Player::setMaxBaseMana(int val, int frac /*= 0*/, bool adjCurrentMana /*= true*/)
 {
 	int amount = (val << 6) + frac;
 
@@ -3432,7 +3447,7 @@ void Player::setMaxMana(int val, int frac /*= 0*/, bool adjCurrentMana /*= true*
 	CalcPlrInv(*this, true);
 }
 
-void Player::modifyMaxMana(int val, int frac /*= 0*/, bool adjCurrentMana /*= true*/)
+void Player::modifyMaxBaseMana(int val, int frac /*= 0*/, bool adjCurrentMana /*= true*/)
 {
 	int amount = (val << 6) + frac;
 
@@ -3440,10 +3455,28 @@ void Player::modifyMaxMana(int val, int frac /*= 0*/, bool adjCurrentMana /*= tr
 		_pManaBase += amount;
 		_pMana += amount;
 	}
-	
+
 	_pMaxManaBase += amount;
 	_pMaxMana += amount;
 	CalcPlrInv(*this, true);
+}
+
+void Player::setMaxCurrentMana(int val, int frac /*= 0*/, bool adjCurrentMana /*= true*/)
+{
+	int amount = (val << 6) + frac;
+
+	if (adjCurrentMana)
+		_pMana = amount;
+	_pMaxMana = amount;
+}
+
+void Player::modifyMaxCurrentMana(int val, int frac /*= 0*/, bool adjCurrentMana /*= true*/)
+{
+	int amount = (val << 6) + frac;
+
+	if (adjCurrentMana)
+		_pMana += amount;
+	_pMaxMana += amount;
 }
 
 void Player::setFullMana()

--- a/Source/player.h
+++ b/Source/player.h
@@ -919,7 +919,7 @@ public:
 	/** @brief Returns a character's max life. */
 	[[nodiscard]] LifeManaValue getMaxLife() const { return LifeManaValue(_pMaxHP); }
 
-
+private:
 	/** @brief Sets life to a valid value. */
 	void clampLife()
 	{
@@ -932,19 +932,40 @@ public:
 	/** @brief Redraws the life globe. */
 	void updateLifeGlobe() const;
 
-	/** @brief Sets a character's life. */
-	void setLife(int val, int frac = 0);
+public:
+	/** @brief Sets a character's CURRENT BASE/CURRENT NOW life.
+	 * Example usage: Taking damage, using healing potions.
+	 */
+	void setCurrentLife(int val, int frac = 0);
 
-	/** @brief Modifies a character's life. */
-	void modifyLife(int val, int frac = 0);
+	/** @brief Modifies a character's CURRENT BASE/CURRENT NOW life.
+	 * Example usage: Taking damage, using healing potions.
+	 */
+	void modifyCurrentLife(int val, int frac = 0);
 
-	/** @brief Sets a character's max life. */
+	/** @brief Sets a character's MAX BASE/MAX NOW life.
+	 * CURRENT BASE/CURRENT NOW values optionally adjusted.
+	 * Example usage: Getting hit by Black Death, gaining Vitality.
+	 */
 	void setMaxLife(int val, int frac = 0, bool adjCurrentLife = true);
 
-	/** @brief Modifies a character's max life. */
+	/** @brief Modifies a character's MAX BASE/MAX NOW life.
+	 * CURRENT BASE/CURRENT NOW values optionally adjusted.
+	 * Example usage: Getting hit by Black Death, gaining Vitality.
+	 */
 	void modifyMaxLife(int val, int frac = 0, bool adjCurrentLife = true);
 
-	/** @brief Sets the characters's current life to the max life. */
+	/** @brief Sets a character's CURRENT NOW/MAX NOW life.
+	 * Example usage: Equipping an item that increases Life.
+	 */
+	void setNowLife(int val, int frac = 0);
+
+	/** @brief Modifies a character's CURRENT NOW/MAX NOW life.
+	 * Example usage: Equipping an item that increases Life.
+	 */
+	void modifyNowLife(int val, int frac = 0);
+
+	/** @brief Sets the characters's CURRENT BASE/CURRENT NOW life to the MAX BASE/MAX NOW life. */
 	void setFullLife();
 
 	/** @brief Check if mana shield should be removed. */
@@ -962,6 +983,7 @@ public:
 	/** @brief Returns a character's max mana. */
 	[[nodiscard]] LifeManaValue getMaxMana() const { return LifeManaValue(_pMaxMana); }
 
+private:
 	/** @brief Sets mana to valid value. */
 	void clampMana()
 	{
@@ -974,17 +996,24 @@ public:
 	/** @brief Redraws the mana globe. */
 	void updateManaGlobe() const;
 
-	/** @brief Sets a character's mana. */
+public:
+	/** @brief Sets a character's base and current mana. */
 	void setMana(int val, int frac = 0);
 
-	/** @brief Modifies a character's mana. */
+	/** @brief Modifies a character's base and current mana. */
 	void modifyMana(int val, int frac = 0);
 
-	/** @brief Sets a character's max mana. */
-	void setMaxMana(int val, int frac = 0, bool adjCurrentMana = true);
+	/** @brief Sets a character's max base mana (permanent). */
+	void setMaxBaseMana(int val, int frac = 0, bool adjCurrentMana = true);
 
-	/** @brief Modifies a character's max mana. */
-	void modifyMaxMana(int val, int frac = 0, bool adjCurrentLife = true);
+	/** @brief Modifies a character's max base mana (permanent). */
+	void modifyMaxBaseMana(int val, int frac = 0, bool adjCurrentMana = true);
+
+	/** @brief Sets a character's max current mana (temporary). */
+	void setMaxCurrentMana(int val, int frac = 0, bool adjCurrentMana = true);
+
+	/** @brief Modifies a character's max current mana (temporary). */
+	void modifyMaxCurrentMana(int val, int frac = 0, bool adjCurrentMana = true);
 
 	/** @brief Sets the characters's current mana to the max mana. */
 	void setFullMana();

--- a/Source/player.h
+++ b/Source/player.h
@@ -883,6 +883,11 @@ public:
 		this->plrIsOnSetLevel = true;
 	}
 
+	bool isDead()
+	{
+		return _pHitPoints >> 6 <= 0;
+	}
+
 	struct LifeManaValue {
 		int32_t value; // Internal representation as a fraction of 64.
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -236,6 +236,8 @@ struct Player {
 	int _pBaseVit;
 	int _pStatPts;
 	int _pDamageMod;
+
+private:
 	int _pHPBase;
 	int _pMaxHPBase;
 	int _pHitPoints;
@@ -246,6 +248,8 @@ struct Player {
 	int _pMana;
 	int _pMaxMana;
 	int _pManaPer;
+
+public:
 	int _pIMinDam;
 	int _pIMaxDam;
 	int _pIAC;

--- a/Source/player.h
+++ b/Source/player.h
@@ -879,11 +879,117 @@ public:
 		this->plrIsOnSetLevel = true;
 	}
 
+	struct LifeManaValue {
+		int32_t value; // Internal representation as a fraction of 64.
+
+		// Constructor
+		explicit LifeManaValue(int32_t val)
+		    : value(val)
+		{
+		}
+
+		// Returns the whole part of the life value.
+		[[nodiscard]] int32_t whole() const { return value >> 6; }
+
+		// Returns the fractional part of the life value.
+		[[nodiscard]] int32_t frac() const { return value; }
+
+		static LifeManaValue fromWhole(int32_t wholeValue)
+		{
+			return LifeManaValue(wholeValue << 6);
+		}
+
+		static LifeManaValue fromFrac(int32_t fracValue)
+		{
+			return LifeManaValue(fracValue << 6);
+		}
+	};
+
 	/** @brief Returns a character's life based on starting life, character level, and base vitality. */
 	int32_t calculateBaseLife() const;
 
 	/** @brief Returns a character's mana based on starting mana, character level, and base magic. */
 	int32_t calculateBaseMana() const;
+
+	/** @brief Returns a character's base life. */
+	[[nodiscard]] LifeManaValue getBaseLife() const { return LifeManaValue(_pHPBase); }
+
+	/** @brief Returns a character's max base life. */
+	[[nodiscard]] LifeManaValue getMaxBaseLife() const { return LifeManaValue(_pMaxHPBase); }
+
+	/** @brief Returns a character's life. */
+	[[nodiscard]] LifeManaValue getLife() const { return LifeManaValue(_pHitPoints); }
+
+	/** @brief Returns a character's max life. */
+	[[nodiscard]] LifeManaValue getMaxLife() const { return LifeManaValue(_pMaxHP); }
+
+
+	/** @brief Sets life to a valid value. */
+	void clampLife()
+	{
+		if (_pHitPoints > _pMaxHP) {
+			_pHitPoints = _pMaxHP;
+			_pHPBase = _pMaxHPBase;
+		}
+	}
+
+	/** @brief Redraws the life globe. */
+	void updateLifeGlobe() const;
+
+	/** @brief Sets a character's life. */
+	void setLife(int val, int frac = 0);
+
+	/** @brief Modifies a character's life. */
+	void modifyLife(int val, int frac = 0);
+
+	/** @brief Sets a character's max life. */
+	void setMaxLife(int val, int frac = 0, bool adjCurrentLife = true);
+
+	/** @brief Modifies a character's max life. */
+	void modifyMaxLife(int val, int frac = 0, bool adjCurrentLife = true);
+
+	void setFullLife();
+
+	/** @brief Check if mana shield should be removed. */
+	void checkManaShield() const;
+
+	/** @brief Returns a character's base mana. */
+	[[nodiscard]] LifeManaValue getBaseMana() const { return LifeManaValue(_pManaBase); }
+
+	/** @brief Returns a character's max base mana. */
+	[[nodiscard]] LifeManaValue getMaxBaseMana() const { return LifeManaValue(_pMaxManaBase); }
+
+	/** @brief Returns a character's mana. */
+	[[nodiscard]] LifeManaValue getMana() const { return LifeManaValue(_pMana); }
+
+	/** @brief Returns a character's max mana. */
+	[[nodiscard]] LifeManaValue getMaxMana() const { return LifeManaValue(_pMaxMana); }
+
+	/** @brief Sets mana to valid value. */
+	void clampMana()
+	{
+		if (_pMana > _pMaxMana) {
+			_pMana = _pMaxMana;
+			_pManaBase = _pMaxManaBase;
+		}
+	}
+
+	/** @brief Redraws the mana globe. */
+	void updateManaGlobe() const;
+
+	/** @brief Sets a character's mana. */
+	void setMana(int val, int frac = 0);
+
+	/** @brief Modifies a character's mana. */
+	void modifyMana(int val, int frac = 0);
+
+	/** @brief Sets a character's max mana. */
+	void setMaxMana(int val, int frac = 0, bool adjCurrentMana = true);
+
+	/** @brief Modifies a character's max mana. */
+	void modifyMaxMana(int val, int frac = 0, bool adjCurrentLife = true);
+
+	void setFullMana();
 
 	/**
 	 * @brief Sets a tile/dPlayer to be occupied by the player
@@ -968,7 +1074,6 @@ void ModifyPlrStr(Player &player, int l);
 void ModifyPlrMag(Player &player, int l);
 void ModifyPlrDex(Player &player, int l);
 void ModifyPlrVit(Player &player, int l);
-void SetPlayerHitPoints(Player &player, int val);
 void SetPlrStr(Player &player, int v);
 void SetPlrMag(Player &player, int v);
 void SetPlrDex(Player &player, int v);

--- a/Source/player.h
+++ b/Source/player.h
@@ -883,7 +883,7 @@ public:
 		this->plrIsOnSetLevel = true;
 	}
 
-	bool isDead()
+	bool isDead() const
 	{
 		return _pHitPoints >> 6 <= 0;
 	}
@@ -891,27 +891,14 @@ public:
 	struct LifeManaValue {
 		int32_t value; // Internal representation as a fraction of 64.
 
-		// Constructor
 		explicit LifeManaValue(int32_t val)
 		    : value(val)
 		{
 		}
 
-		// Returns the whole part of the life value.
 		[[nodiscard]] int32_t whole() const { return value >> 6; }
 
-		// Returns the fractional part of the life value.
 		[[nodiscard]] int32_t frac() const { return value; }
-
-		static LifeManaValue fromWhole(int32_t wholeValue)
-		{
-			return LifeManaValue(wholeValue << 6);
-		}
-
-		static LifeManaValue fromFrac(int32_t fracValue)
-		{
-			return LifeManaValue(fracValue << 6);
-		}
 	};
 
 	/** @brief Returns a character's life based on starting life, character level, and base vitality. */
@@ -957,6 +944,7 @@ public:
 	/** @brief Modifies a character's max life. */
 	void modifyMaxLife(int val, int frac = 0, bool adjCurrentLife = true);
 
+	/** @brief Sets the characters's current life to the max life. */
 	void setFullLife();
 
 	/** @brief Check if mana shield should be removed. */
@@ -998,6 +986,7 @@ public:
 	/** @brief Modifies a character's max mana. */
 	void modifyMaxMana(int val, int frac = 0, bool adjCurrentLife = true);
 
+	/** @brief Sets the characters's current mana to the max mana. */
 	void setFullMana();
 
 	/**

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -237,7 +237,7 @@ void DoResurrect(Player &player, Player &target)
 {
 	AddMissile(target.position.tile, target.position.tile, Direction::South, MissileID::ResurrectBeam, TARGET_MONSTERS, player, 0, 0);
 
-	if (target._pHitPoints != 0)
+	if (!target.isDead())
 		return;
 
 	if (&target == MyPlayer) {
@@ -264,7 +264,7 @@ void DoResurrect(Player &player, Player &target)
 
 void DoHealOther(const Player &caster, Player &target)
 {
-	if ((target._pHitPoints >> 6) <= 0) {
+	if (target.isDead()) {
 		return;
 	}
 
@@ -284,8 +284,7 @@ void DoHealOther(const Player &caster, Player &target)
 		hp *= 3;
 	}
 
-	target._pHitPoints = std::min(target._pHitPoints + hp, target._pMaxHP);
-	target._pHPBase = std::min(target._pHPBase + hp, target._pMaxHPBase);
+	target.modifyLife(0, hp);
 
 	if (&target == MyPlayer) {
 		RedrawComponent(PanelDrawComponent::Health);

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -251,17 +251,8 @@ void DoResurrect(Player &player, Player &target)
 	target.destAction = ACTION_NONE;
 	target._pInvincible = false;
 	SyncInitPlrPos(target);
-
-	int hp = 10 << 6;
-	if (target._pMaxHPBase < (10 << 6)) {
-		hp = target._pMaxHPBase;
-	}
-	SetPlayerHitPoints(target, hp);
-
-	target._pHPBase = target._pHitPoints + (target._pMaxHPBase - target._pMaxHP); // CODEFIX: does the same stuff as SetPlayerHitPoints above, can be removed
-	target._pMana = 0;
-	target._pManaBase = target._pMana + (target._pMaxManaBase - target._pMaxMana);
-
+	target.setLife(10);
+	target.setMana(0);
 	target._pmode = PM_STAND;
 
 	CalcPlrInv(target, true);


### PR DESCRIPTION
Goal:
* Set life and mana member variables in Player struct to private to prevent direct access, which can be easily error prone
* Create a new struct to handle getter methods to more fluently access whole number or fractional numbers
* Reduce potential errors that can occur if life and mana modifications aren't handled properly in tandem
* Reduce many instances of duplicate code