### PR TITLE
Fix South Walk bug

### DIFF
--- a/Source/engine/actor_position.cpp
+++ b/Source/engine/actor_position.cpp
@@ -92,14 +92,14 @@ struct WalkParameter {
 constexpr std::array<const WalkParameter, 8> WalkParameters { {
 	// clang-format off
 	// Direction      startingOffset,                   VelocityX,                      VelocityY
-	{ /* South     */ {    0, -512 },         VelocityToUse::None,            VelocityToUse::Half },
-	{ /* SouthWest */ {  512, -256 }, VelocityToUse::NegativeHalf,         VelocityToUse::Quarter },
+	{ /* South     */ {    0,    0 },         VelocityToUse::None,            VelocityToUse::Half },
+	{ /* SouthWest */ {    0,    0 }, VelocityToUse::NegativeHalf,         VelocityToUse::Quarter },
 	{ /* West      */ {  512, -256 }, VelocityToUse::NegativeFull,            VelocityToUse::None },
 	{ /* NorthWest */ {    0,    0 }, VelocityToUse::NegativeHalf, VelocityToUse::NegativeQuarter },
 	{ /* North     */ {    0,    0 },         VelocityToUse::None,    VelocityToUse::NegativeHalf },
 	{ /* NorthEast */ {    0,    0 },         VelocityToUse::Half, VelocityToUse::NegativeQuarter },
 	{ /* East      */ { -512, -256 },         VelocityToUse::Full,            VelocityToUse::None },
-	{ /* SouthEast */ { -512, -256 },         VelocityToUse::Half,         VelocityToUse::Quarter }
+	{ /* SouthEast */ {    0,    0 },         VelocityToUse::Half,         VelocityToUse::Quarter }
 	// clang-format on
 } };
 

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1334,7 +1334,7 @@ Displacement GetOffsetForWalking(const AnimationInfo &animationInfo, const Direc
 {
 	// clang-format off
 	//                                           South,        SouthWest,    West,         NorthWest,    North,        NorthEast,     East,         SouthEast,
-	constexpr Displacement StartOffset[8]    = { {   0, -32 }, {  32, -16 }, {  64,   0 }, {   0,   0 }, {   0,   0 }, {  0,    0 },  { -64,   0 }, { -32, -16 } };
+	constexpr Displacement StartOffset[8]    = { {   0,   0 }, {  0,    0 }, {  64,   0 }, {   0,   0 }, {   0,   0 }, {  0,    0 },  { -64,   0 }, {   0,   0 } };
 	constexpr Displacement MovingOffset[8]   = { {   0,  32 }, { -32,  16 }, { -64,   0 }, { -32, -16 }, {   0, -32 }, {  32, -16 },  {  64,   0 }, {  32,  16 } };
 	// clang-format on
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -75,21 +75,10 @@ void UpdatePlayerLightOffset(Player &player)
 	ChangeLightOffset(player.lightId, offset.screenToLight());
 }
 
-void WalkNorthwards(Player &player, const DirectionSettings &walkParams)
+void WalkNonSideways(Player &player, const DirectionSettings &walkParams)
 {
 	player.occupyTile(player.position.future, true);
 	player.position.temp = player.position.tile + walkParams.tileAdd;
-}
-
-void WalkSouthwards(Player &player, const DirectionSettings & /*walkParams*/)
-{
-	player.position.temp = player.position.tile;
-	player.position.tile = player.position.future; // Move player to the next tile to maintain correct render order
-	player.occupyTile(player.position.temp, true);
-	player.occupyTile(player.position.tile, false);
-	// BUGFIX: missing `if (leveltype != DTYPE_TOWN) {` for call to ChangeLightXY and PM_ChangeLightOff.
-	ChangeLightXY(player.lightId, player.position.tile);
-	UpdatePlayerLightOffset(player);
 }
 
 void WalkSideways(Player &player, const DirectionSettings &walkParams)
@@ -109,14 +98,14 @@ void WalkSideways(Player &player, const DirectionSettings &walkParams)
 
 constexpr std::array<const DirectionSettings, 8> WalkSettings { {
 	// clang-format off
-	{ Direction::South,     {  1,  1 }, { 0, 0 }, PM_WALK_SOUTHWARDS, WalkSouthwards },
-	{ Direction::SouthWest, {  0,  1 }, { 0, 0 }, PM_WALK_SOUTHWARDS, WalkSouthwards },
+	{ Direction::South,     {  1,  1 }, { 0, 0 }, PM_WALK_SOUTHWARDS, WalkNonSideways },
+	{ Direction::SouthWest, {  0,  1 }, { 0, 0 }, PM_WALK_SOUTHWARDS, WalkNonSideways },
 	{ Direction::West,      { -1,  1 }, { 0, 1 }, PM_WALK_SIDEWAYS,   WalkSideways   },
-	{ Direction::NorthWest, { -1,  0 }, { 0, 0 }, PM_WALK_NORTHWARDS, WalkNorthwards },
-	{ Direction::North,     { -1, -1 }, { 0, 0 }, PM_WALK_NORTHWARDS, WalkNorthwards },
-	{ Direction::NorthEast, {  0, -1 }, { 0, 0 }, PM_WALK_NORTHWARDS, WalkNorthwards },
+	{ Direction::NorthWest, { -1,  0 }, { 0, 0 }, PM_WALK_NORTHWARDS, WalkNonSideways },
+	{ Direction::North,     { -1, -1 }, { 0, 0 }, PM_WALK_NORTHWARDS, WalkNonSideways },
+	{ Direction::NorthEast, {  0, -1 }, { 0, 0 }, PM_WALK_NORTHWARDS, WalkNonSideways },
 	{ Direction::East,      {  1, -1 }, { 1, 0 }, PM_WALK_SIDEWAYS,   WalkSideways   },
-	{ Direction::SouthEast, {  1,  0 }, { 0, 0 }, PM_WALK_SOUTHWARDS, WalkSouthwards }
+	{ Direction::SouthEast, {  1,  0 }, { 0, 0 }, PM_WALK_SOUTHWARDS, WalkNonSideways }
 	// clang-format on
 } };
 
@@ -449,12 +438,10 @@ bool DoWalk(Player &player, int variant)
 	// We reached the new tile -> update the player's tile position
 	switch (variant) {
 	case PM_WALK_NORTHWARDS:
+	case PM_WALK_SOUTHWARDS:
 		dPlayer[player.position.tile.x][player.position.tile.y] = 0;
 		player.position.tile = player.position.temp;
 		player.occupyTile(player.position.tile, false);
-		break;
-	case PM_WALK_SOUTHWARDS:
-		dPlayer[player.position.temp.x][player.position.temp.y] = 0;
 		break;
 	case PM_WALK_SIDEWAYS:
 		dPlayer[player.position.tile.x][player.position.tile.y] = 0;


### PR DESCRIPTION
Fixes the notorious "South Walk" bug. Due to difficulties in Diablo's development with floor tiles being drawn over the player, Blizzard North's solution was to change the player's tile occupation to the tile the player was moving into in the south direction, and drawing the player using an offset from above the tile, with the player walking from the top down into the newly occupied tile.

This resulted in two prominent problems noticeable by players:
- Monsters attempting to attack a player moving southwards were completely unable to hit the player
- Players entering hit recovery while moving southwards would "snap" into the tile they were moving into

DevilutionX has a fix for render order, rendering all the floor tiles separately before other things are rendered, therefore we're able to unify the behavior of northwards movement and southwards movement without any rendering issues.

https://github.com/diasurgical/devilution/issues/64