### PR TITLE
Fix broken monster walking offset + unify walking behavior

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1320,9 +1320,6 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, cons
 	const uint8_t playerColor = MapColorsPlayer + (8 * player.getId()) % 128;
 
 	Point tile = player.position.tile;
-	if (player._pmode == PM_WALK_SIDEWAYS) {
-		tile = player.position.future;
-	}
 
 	int px = tile.x - 2 * AutomapOffset.deltaX - ViewPosition.x;
 	int py = tile.y - 2 * AutomapOffset.deltaY - ViewPosition.y;

--- a/Source/engine/actor_position.cpp
+++ b/Source/engine/actor_position.cpp
@@ -75,7 +75,6 @@ constexpr RoundedWalkVelocity WalkVelocityForFrames[24] = {
 };
 
 struct WalkParameter {
-	DisplacementOf<int16_t> startingOffset;
 	VelocityToUse VelocityX;
 	VelocityToUse VelocityY;
 	DisplacementOf<int16_t> getVelocity(int8_t numberOfFrames) const
@@ -91,15 +90,15 @@ struct WalkParameter {
 
 constexpr std::array<const WalkParameter, 8> WalkParameters { {
 	// clang-format off
-	// Direction      startingOffset,                   VelocityX,                      VelocityY
-	{ /* South     */ {    0,    0 },         VelocityToUse::None,            VelocityToUse::Half },
-	{ /* SouthWest */ {    0,    0 }, VelocityToUse::NegativeHalf,         VelocityToUse::Quarter },
-	{ /* West      */ {    0,    0 }, VelocityToUse::NegativeFull,            VelocityToUse::None },
-	{ /* NorthWest */ {    0,    0 }, VelocityToUse::NegativeHalf, VelocityToUse::NegativeQuarter },
-	{ /* North     */ {    0,    0 },         VelocityToUse::None,    VelocityToUse::NegativeHalf },
-	{ /* NorthEast */ {    0,    0 },         VelocityToUse::Half, VelocityToUse::NegativeQuarter },
-	{ /* East      */ {    0,    0 },         VelocityToUse::Full,            VelocityToUse::None },
-	{ /* SouthEast */ {    0,    0 },         VelocityToUse::Half,         VelocityToUse::Quarter }
+	// Direction      VelocityX,                   VelocityY
+	{ /* South     */ VelocityToUse::None,         VelocityToUse::Half },
+	{ /* SouthWest */ VelocityToUse::NegativeHalf, VelocityToUse::Quarter },
+	{ /* West      */ VelocityToUse::NegativeFull, VelocityToUse::None },
+	{ /* NorthWest */ VelocityToUse::NegativeHalf, VelocityToUse::NegativeQuarter },
+	{ /* North     */ VelocityToUse::None,         VelocityToUse::NegativeHalf },
+	{ /* NorthEast */ VelocityToUse::Half,         VelocityToUse::NegativeQuarter },
+	{ /* East      */ VelocityToUse::Full,         VelocityToUse::None },
+	{ /* SouthEast */ VelocityToUse::Half,         VelocityToUse::Quarter }
 	// clang-format on
 } };
 
@@ -115,9 +114,8 @@ DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted4(Direction 
 {
 	int16_t velocityProgress = static_cast<int16_t>(animInfo.getAnimationProgress()) * animInfo.numberOfFrames / AnimationInfo::baseValueFraction;
 	const WalkParameter &walkParameter = WalkParameters[static_cast<size_t>(dir)];
-	DisplacementOf<int16_t> offset = walkParameter.startingOffset;
 	DisplacementOf<int16_t> velocity = walkParameter.getVelocity(animInfo.numberOfFrames);
-	offset += (velocity * velocityProgress);
+	DisplacementOf<int16_t> offset = (velocity * velocityProgress);
 	return offset;
 }
 

--- a/Source/engine/actor_position.cpp
+++ b/Source/engine/actor_position.cpp
@@ -94,11 +94,11 @@ constexpr std::array<const WalkParameter, 8> WalkParameters { {
 	// Direction      startingOffset,                   VelocityX,                      VelocityY
 	{ /* South     */ {    0,    0 },         VelocityToUse::None,            VelocityToUse::Half },
 	{ /* SouthWest */ {    0,    0 }, VelocityToUse::NegativeHalf,         VelocityToUse::Quarter },
-	{ /* West      */ {  512, -256 }, VelocityToUse::NegativeFull,            VelocityToUse::None },
+	{ /* West      */ {    0,    0 }, VelocityToUse::NegativeFull,            VelocityToUse::None },
 	{ /* NorthWest */ {    0,    0 }, VelocityToUse::NegativeHalf, VelocityToUse::NegativeQuarter },
 	{ /* North     */ {    0,    0 },         VelocityToUse::None,    VelocityToUse::NegativeHalf },
 	{ /* NorthEast */ {    0,    0 },         VelocityToUse::Half, VelocityToUse::NegativeQuarter },
-	{ /* East      */ { -512, -256 },         VelocityToUse::Full,            VelocityToUse::None },
+	{ /* East      */ {    0,    0 },         VelocityToUse::Full,            VelocityToUse::None },
 	{ /* SouthEast */ {    0,    0 },         VelocityToUse::Half,         VelocityToUse::Quarter }
 	// clang-format on
 } };

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1334,7 +1334,6 @@ Displacement GetOffsetForWalking(const AnimationInfo &animationInfo, const Direc
 {
 	// clang-format off
 	//                                           South,        SouthWest,    West,         NorthWest,    North,        NorthEast,     East,         SouthEast,
-	constexpr Displacement StartOffset[8]    = { {   0,   0 }, {  0,    0 }, {  64,   0 }, {   0,   0 }, {   0,   0 }, {  0,    0 },  { -64,   0 }, {   0,   0 } };
 	constexpr Displacement MovingOffset[8]   = { {   0,  32 }, { -32,  16 }, { -64,   0 }, { -32, -16 }, {   0, -32 }, {  32, -16 },  {  64,   0 }, {  32,  16 } };
 	// clang-format on
 
@@ -1345,8 +1344,6 @@ Displacement GetOffsetForWalking(const AnimationInfo &animationInfo, const Direc
 
 	if (cameraMode) {
 		offset = -offset;
-	} else {
-		offset += StartOffset[static_cast<size_t>(dir)];
 	}
 
 	return offset;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -710,18 +710,21 @@ void StartSpecialStand(Monster &monster, Direction md)
 	monster.position.old = monster.position.tile;
 }
 
-void Walk(Monster &monster, int xadd, int yadd, Direction endDir)
+void WalkInDirection(Monster &monster, Direction endDir)
 {
-	const auto fx = static_cast<WorldTileCoord>(xadd + monster.position.tile.x);
-	const auto fy = static_cast<WorldTileCoord>(yadd + monster.position.tile.y);
+	Point dir = { 0, 0 };
+	dir += endDir;
+
+	const auto fx = static_cast<WorldTileCoord>(monster.position.tile.x + dir.x);
+	const auto fy = static_cast<WorldTileCoord>(monster.position.tile.y + dir.y);
 
 	monster.mode = MonsterMode::MoveNorthwards;
 	monster.position.old = monster.position.tile;
 	monster.position.future = { fx, fy };
 	monster.occupyTile(monster.position.future, true);
-	monster.var1 = xadd;
-	monster.var2 = yadd;
-	monster.var3 = static_cast<int>(endDir);
+	monster.var1 = dir.x;
+	monster.var2 = dir.y;
+	monster.var3 = static_cast<int8_t>(endDir);
 	NewMonsterAnim(monster, MonsterGraphic::Walk, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 }
 
@@ -3930,34 +3933,10 @@ bool Walk(Monster &monster, Direction md)
 		return false;
 	}
 
-	switch (md) {
-	case Direction::North:
-		Walk(monster, -1, -1, Direction::North);
-		break;
-	case Direction::NorthEast:
-		Walk(monster, 0, -1, Direction::NorthEast);
-		break;
-	case Direction::East:
-		Walk(monster, 1, -1, Direction::East);
-		break;
-	case Direction::SouthEast:
-		Walk(monster, 1, 0, Direction::SouthEast);
-		break;
-	case Direction::South:
-		Walk(monster, 1, 1, Direction::South);
-		break;
-	case Direction::SouthWest:
-		Walk(monster, 0, 1, Direction::SouthWest);
-		break;
-	case Direction::West:
-		Walk(monster, -1, 1, Direction::West);
-		break;
-	case Direction::NorthWest:
-		Walk(monster, -1, 0, Direction::NorthWest);
-		break;
-	case Direction::NoDirection:
-		break;
-	}
+	if (md == Direction::NoDirection)
+		return true;
+
+	WalkInDirection(monster, md);
 	return true;
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -710,7 +710,7 @@ void StartSpecialStand(Monster &monster, Direction md)
 	monster.position.old = monster.position.tile;
 }
 
-void WalkNonSideways(Monster &monster, int xadd, int yadd, Direction endDir)
+void Walk(Monster &monster, int xadd, int yadd, Direction endDir)
 {
 	const auto fx = static_cast<WorldTileCoord>(xadd + monster.position.tile.x);
 	const auto fy = static_cast<WorldTileCoord>(yadd + monster.position.tile.y);
@@ -721,28 +721,6 @@ void WalkNonSideways(Monster &monster, int xadd, int yadd, Direction endDir)
 	monster.occupyTile(monster.position.future, true);
 	monster.var1 = xadd;
 	monster.var2 = yadd;
-	monster.var3 = static_cast<int>(endDir);
-	NewMonsterAnim(monster, MonsterGraphic::Walk, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
-}
-
-void WalkSideways(Monster &monster, int xoff, int yoff, int xadd, int yadd, int mapx, int mapy, Direction endDir)
-{
-	const auto fx = static_cast<WorldTileCoord>(xadd + monster.position.tile.x);
-	const auto fy = static_cast<WorldTileCoord>(yadd + monster.position.tile.y);
-	const auto x = static_cast<WorldTileCoord>(mapx + monster.position.tile.x);
-	const auto y = static_cast<WorldTileCoord>(mapy + monster.position.tile.y);
-
-	if (monster.lightId != NO_LIGHT)
-		ChangeLightXY(monster.lightId, { x, y });
-
-	monster.position.temp = { x, y };
-	monster.position.old = monster.position.tile;
-	monster.position.future = { fx, fy };
-	monster.occupyTile(monster.position.tile, true);
-	monster.occupyTile(monster.position.future, false);
-	monster.mode = MonsterMode::MoveSideways;
-	monster.var1 = fx;
-	monster.var2 = fy;
 	monster.var3 = static_cast<int>(endDir);
 	NewMonsterAnim(monster, MonsterGraphic::Walk, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 }
@@ -3954,28 +3932,28 @@ bool Walk(Monster &monster, Direction md)
 
 	switch (md) {
 	case Direction::North:
-		WalkNonSideways(monster, -1, -1, Direction::North);
+		Walk(monster, -1, -1, Direction::North);
 		break;
 	case Direction::NorthEast:
-		WalkNonSideways(monster, 0, -1, Direction::NorthEast);
+		Walk(monster, 0, -1, Direction::NorthEast);
 		break;
 	case Direction::East:
-		WalkSideways(monster, -32, -16, 1, -1, 1, 0, Direction::East);
+		Walk(monster, 1, -1, Direction::East);
 		break;
 	case Direction::SouthEast:
-		WalkNonSideways(monster, 1, 0, Direction::SouthEast);
+		Walk(monster, 1, 0, Direction::SouthEast);
 		break;
 	case Direction::South:
-		WalkNonSideways(monster, 1, 1, Direction::South);
+		Walk(monster, 1, 1, Direction::South);
 		break;
 	case Direction::SouthWest:
-		WalkNonSideways(monster, 0, 1, Direction::SouthWest);
+		Walk(monster, 0, 1, Direction::SouthWest);
 		break;
 	case Direction::West:
-		WalkSideways(monster, 32, -16, -1, 1, 0, 1, Direction::West);
+		Walk(monster, -1, 1, Direction::West);
 		break;
 	case Direction::NorthWest:
-		WalkNonSideways(monster, -1, 0, Direction::NorthWest);
+		Walk(monster, -1, 0, Direction::NorthWest);
 		break;
 	case Direction::NoDirection:
 		break;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -710,7 +710,7 @@ void StartSpecialStand(Monster &monster, Direction md)
 	monster.position.old = monster.position.tile;
 }
 
-void WalkNorthwards(Monster &monster, int xadd, int yadd, Direction endDir)
+void WalkNonSideways(Monster &monster, int xadd, int yadd, Direction endDir)
 {
 	const auto fx = static_cast<WorldTileCoord>(xadd + monster.position.tile.x);
 	const auto fy = static_cast<WorldTileCoord>(yadd + monster.position.tile.y);
@@ -721,25 +721,6 @@ void WalkNorthwards(Monster &monster, int xadd, int yadd, Direction endDir)
 	monster.occupyTile(monster.position.future, true);
 	monster.var1 = xadd;
 	monster.var2 = yadd;
-	monster.var3 = static_cast<int>(endDir);
-	NewMonsterAnim(monster, MonsterGraphic::Walk, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
-}
-
-void WalkSouthwards(Monster &monster, int xoff, int yoff, int xadd, int yadd, Direction endDir)
-{
-	const auto fx = static_cast<WorldTileCoord>(xadd + monster.position.tile.x);
-	const auto fy = static_cast<WorldTileCoord>(yadd + monster.position.tile.y);
-
-	monster.var1 = monster.position.tile.x;
-	monster.var2 = monster.position.tile.y;
-	monster.position.old = monster.position.tile;
-	monster.position.tile = { fx, fy };
-	monster.position.future = { fx, fy };
-	monster.occupyTile(monster.position.old, true);
-	monster.occupyTile(monster.position.tile, false);
-	if (monster.lightId != NO_LIGHT)
-		ChangeLightXY(monster.lightId, monster.position.tile);
-	monster.mode = MonsterMode::MoveSouthwards;
 	monster.var3 = static_cast<int>(endDir);
 	NewMonsterAnim(monster, MonsterGraphic::Walk, endDir, AnimationDistributionFlags::ProcessAnimationPending, -1);
 }
@@ -3973,28 +3954,28 @@ bool Walk(Monster &monster, Direction md)
 
 	switch (md) {
 	case Direction::North:
-		WalkNorthwards(monster, -1, -1, Direction::North);
+		WalkNonSideways(monster, -1, -1, Direction::North);
 		break;
 	case Direction::NorthEast:
-		WalkNorthwards(monster, 0, -1, Direction::NorthEast);
+		WalkNonSideways(monster, 0, -1, Direction::NorthEast);
 		break;
 	case Direction::East:
 		WalkSideways(monster, -32, -16, 1, -1, 1, 0, Direction::East);
 		break;
 	case Direction::SouthEast:
-		WalkSouthwards(monster, -32, -16, 1, 0, Direction::SouthEast);
+		WalkNonSideways(monster, 1, 0, Direction::SouthEast);
 		break;
 	case Direction::South:
-		WalkSouthwards(monster, 0, -32, 1, 1, Direction::South);
+		WalkNonSideways(monster, 1, 1, Direction::South);
 		break;
 	case Direction::SouthWest:
-		WalkSouthwards(monster, 32, -16, 0, 1, Direction::SouthWest);
+		WalkNonSideways(monster, 0, 1, Direction::SouthWest);
 		break;
 	case Direction::West:
 		WalkSideways(monster, 32, -16, -1, 1, 0, 1, Direction::West);
 		break;
 	case Direction::NorthWest:
-		WalkNorthwards(monster, -1, 0, Direction::NorthWest);
+		WalkNonSideways(monster, -1, 0, Direction::NorthWest);
 		break;
 	case Direction::NoDirection:
 		break;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -60,7 +60,6 @@ namespace {
 
 struct DirectionSettings {
 	Direction dir;
-	DisplacementOf<int8_t> tileAdd;
 	PLR_MODE walkMode;
 	void (*walkModeHandler)(Player &, const DirectionSettings &);
 };
@@ -77,19 +76,19 @@ void UpdatePlayerLightOffset(Player &player)
 void Walk(Player &player, const DirectionSettings &walkParams)
 {
 	player.occupyTile(player.position.future, true);
-	player.position.temp = player.position.tile + walkParams.tileAdd;
+	player.position.temp = player.position.tile + walkParams.dir;
 }
 
 constexpr std::array<const DirectionSettings, 8> WalkSettings { {
 	// clang-format off
-	{ Direction::South,     {  1,  1 }, PM_WALK_SOUTHWARDS, Walk },
-	{ Direction::SouthWest, {  0,  1 }, PM_WALK_SOUTHWARDS, Walk },
-	{ Direction::West,      { -1,  1 }, PM_WALK_SIDEWAYS,   Walk },
-	{ Direction::NorthWest, { -1,  0 }, PM_WALK_NORTHWARDS, Walk },
-	{ Direction::North,     { -1, -1 }, PM_WALK_NORTHWARDS, Walk },
-	{ Direction::NorthEast, {  0, -1 }, PM_WALK_NORTHWARDS, Walk },
-	{ Direction::East,      {  1, -1 }, PM_WALK_SIDEWAYS,   Walk },
-	{ Direction::SouthEast, {  1,  0 }, PM_WALK_SOUTHWARDS, Walk }
+	{ Direction::South,     PM_WALK_SOUTHWARDS, Walk },
+	{ Direction::SouthWest, PM_WALK_SOUTHWARDS, Walk },
+	{ Direction::West,      PM_WALK_SIDEWAYS,   Walk },
+	{ Direction::NorthWest, PM_WALK_NORTHWARDS, Walk },
+	{ Direction::North,     PM_WALK_NORTHWARDS, Walk },
+	{ Direction::NorthEast, PM_WALK_NORTHWARDS, Walk },
+	{ Direction::East,      PM_WALK_SIDEWAYS,   Walk },
+	{ Direction::SouthEast, PM_WALK_SOUTHWARDS, Walk }
 	// clang-format on
 } };
 
@@ -123,7 +122,7 @@ void HandleWalkMode(Player &player, Direction dir)
 	player._pdir = dir;
 
 	// The player's tile position after finishing this movement action
-	player.position.future = player.position.tile + dirModeParams.tileAdd;
+	player.position.future = player.position.tile + dirModeParams.dir;
 
 	dirModeParams.walkModeHandler(player, dirModeParams);
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -61,7 +61,6 @@ namespace {
 struct DirectionSettings {
 	Direction dir;
 	PLR_MODE walkMode;
-	void (*walkModeHandler)(Player &, const DirectionSettings &);
 };
 
 void UpdatePlayerLightOffset(Player &player)
@@ -73,7 +72,7 @@ void UpdatePlayerLightOffset(Player &player)
 	ChangeLightOffset(player.lightId, offset.screenToLight());
 }
 
-void Walk(Player &player, const DirectionSettings &walkParams)
+void WalkInDirection(Player &player, const DirectionSettings &walkParams)
 {
 	player.occupyTile(player.position.future, true);
 	player.position.temp = player.position.tile + walkParams.dir;
@@ -81,14 +80,14 @@ void Walk(Player &player, const DirectionSettings &walkParams)
 
 constexpr std::array<const DirectionSettings, 8> WalkSettings { {
 	// clang-format off
-	{ Direction::South,     PM_WALK_SOUTHWARDS, Walk },
-	{ Direction::SouthWest, PM_WALK_SOUTHWARDS, Walk },
-	{ Direction::West,      PM_WALK_SIDEWAYS,   Walk },
-	{ Direction::NorthWest, PM_WALK_NORTHWARDS, Walk },
-	{ Direction::North,     PM_WALK_NORTHWARDS, Walk },
-	{ Direction::NorthEast, PM_WALK_NORTHWARDS, Walk },
-	{ Direction::East,      PM_WALK_SIDEWAYS,   Walk },
-	{ Direction::SouthEast, PM_WALK_SOUTHWARDS, Walk }
+	{ Direction::South,     PM_WALK_SOUTHWARDS },
+	{ Direction::SouthWest, PM_WALK_SOUTHWARDS },
+	{ Direction::West,      PM_WALK_SIDEWAYS   },
+	{ Direction::NorthWest, PM_WALK_NORTHWARDS },
+	{ Direction::North,     PM_WALK_NORTHWARDS },
+	{ Direction::NorthEast, PM_WALK_NORTHWARDS },
+	{ Direction::East,      PM_WALK_SIDEWAYS   },
+	{ Direction::SouthEast, PM_WALK_SOUTHWARDS }
 	// clang-format on
 } };
 
@@ -124,7 +123,7 @@ void HandleWalkMode(Player &player, Direction dir)
 	// The player's tile position after finishing this movement action
 	player.position.future = player.position.tile + dirModeParams.dir;
 
-	dirModeParams.walkModeHandler(player, dirModeParams);
+	WalkInDirection(player, dirModeParams);
 
 	player.tempDirection = dirModeParams.dir;
 	player._pmode = dirModeParams.walkMode;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -61,7 +61,6 @@ namespace {
 struct DirectionSettings {
 	Direction dir;
 	DisplacementOf<int8_t> tileAdd;
-	DisplacementOf<int8_t> map;
 	PLR_MODE walkMode;
 	void (*walkModeHandler)(Player &, const DirectionSettings &);
 };
@@ -75,37 +74,22 @@ void UpdatePlayerLightOffset(Player &player)
 	ChangeLightOffset(player.lightId, offset.screenToLight());
 }
 
-void WalkNonSideways(Player &player, const DirectionSettings &walkParams)
+void Walk(Player &player, const DirectionSettings &walkParams)
 {
 	player.occupyTile(player.position.future, true);
 	player.position.temp = player.position.tile + walkParams.tileAdd;
 }
 
-void WalkSideways(Player &player, const DirectionSettings &walkParams)
-{
-	Point const nextPosition = player.position.tile + walkParams.map;
-
-	player.occupyTile(player.position.tile, true);
-	player.occupyTile(player.position.future, false);
-
-	if (leveltype != DTYPE_TOWN) {
-		ChangeLightXY(player.lightId, nextPosition);
-		UpdatePlayerLightOffset(player);
-	}
-
-	player.position.temp = player.position.future;
-}
-
 constexpr std::array<const DirectionSettings, 8> WalkSettings { {
 	// clang-format off
-	{ Direction::South,     {  1,  1 }, { 0, 0 }, PM_WALK_SOUTHWARDS, WalkNonSideways },
-	{ Direction::SouthWest, {  0,  1 }, { 0, 0 }, PM_WALK_SOUTHWARDS, WalkNonSideways },
-	{ Direction::West,      { -1,  1 }, { 0, 1 }, PM_WALK_SIDEWAYS,   WalkSideways   },
-	{ Direction::NorthWest, { -1,  0 }, { 0, 0 }, PM_WALK_NORTHWARDS, WalkNonSideways },
-	{ Direction::North,     { -1, -1 }, { 0, 0 }, PM_WALK_NORTHWARDS, WalkNonSideways },
-	{ Direction::NorthEast, {  0, -1 }, { 0, 0 }, PM_WALK_NORTHWARDS, WalkNonSideways },
-	{ Direction::East,      {  1, -1 }, { 1, 0 }, PM_WALK_SIDEWAYS,   WalkSideways   },
-	{ Direction::SouthEast, {  1,  0 }, { 0, 0 }, PM_WALK_SOUTHWARDS, WalkNonSideways }
+	{ Direction::South,     {  1,  1 }, PM_WALK_SOUTHWARDS, Walk },
+	{ Direction::SouthWest, {  0,  1 }, PM_WALK_SOUTHWARDS, Walk },
+	{ Direction::West,      { -1,  1 }, PM_WALK_SIDEWAYS,   Walk },
+	{ Direction::NorthWest, { -1,  0 }, PM_WALK_NORTHWARDS, Walk },
+	{ Direction::North,     { -1, -1 }, PM_WALK_NORTHWARDS, Walk },
+	{ Direction::NorthEast, {  0, -1 }, PM_WALK_NORTHWARDS, Walk },
+	{ Direction::East,      {  1, -1 }, PM_WALK_SIDEWAYS,   Walk },
+	{ Direction::SouthEast, {  1,  0 }, PM_WALK_SOUTHWARDS, Walk }
 	// clang-format on
 } };
 


### PR DESCRIPTION
Fixes https://github.com/diasurgical/devilutionX/issues/7047.
With this change along with https://github.com/diasurgical/devilutionX/pull/7043, walking in any direction uses the same function for walking for players and monsters respectively, regardless of direction.