### PR TITLE
Fix draw order problems with south walk

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -632,12 +632,11 @@ void DrawItem(const Surface &out, int8_t itemIndex, Point targetBufferPosition)
 void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBufferPosition)
 {
 	int mi = dMonster[tilePosition.x][tilePosition.y];
-	bool isNegativeMonster = mi < 0;
 	mi = std::abs(mi) - 1;
-
+	if (mi < 0) // negative monster (moving into tile)
+		return;
 	if (leveltype == DTYPE_TOWN) {
-		if (isNegativeMonster)
-			return;
+
 		auto &towner = Towners[mi];
 		const Point position = targetBufferPosition + towner.getRenderingOffset();
 		const ClxSprite sprite = towner.currentSprite();
@@ -662,10 +661,7 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 	}
 
 	const ClxSprite sprite = monster.animInfo.currentSprite();
-
 	Displacement offset = monster.getRenderingOffset(sprite);
-	if (isNegativeMonster)
-		return;
 
 	const Point monsterRenderPosition = targetBufferPosition + offset;
 	if (mi == pcursmonst) {
@@ -741,8 +737,10 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 	Player *player = PlayerAtPosition(tilePosition);
 	if (player != nullptr) {
 		// If sprite is moving southwards, we want to draw it offset from the tile it's moving to, so we need negative ID
-		int8_t playerId = (player->_pmode != PM_WALK_SOUTHWARDS) ? player->getId() + 1 : -player->getId() - 1;
+		int8_t playerId = static_cast<int8_t>(player->getId() + 1);
 
+		if (player->_pmode == PM_WALK_SOUTHWARDS)
+			playerId = -playerId;
 		if (dPlayer[tilePosition.x][tilePosition.y] == playerId) {
 			auto tempTilePosition = tilePosition;
 			auto tempTargetBufferPosition = targetBufferPosition;
@@ -769,8 +767,10 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 	Monster *monster = FindMonsterAtPosition(tilePosition);
 	if (monster != nullptr) {
 		// If sprite is moving southwards, we want to draw it offset from the tile it's moving to, so we need negative ID
-		int8_t monsterId = (monster->mode != MonsterMode::MoveSouthwards) ? monster->getId() + 1 : -monster->getId() - 1;
+		int8_t monsterId = static_cast<int8_t>(monster->getId() + 1);
 
+		if (monster->mode == MonsterMode::MoveSouthwards)
+			monsterId = -monsterId;
 		if (dMonster[tilePosition.x][tilePosition.y] == monsterId) {
 			auto tempTilePosition = tilePosition;
 			auto tempTargetBufferPosition = targetBufferPosition;

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -751,18 +751,16 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 			if (player->_pmode == PM_WALK_SOUTHWARDS) {
 				switch (player->_pdir) {
 				case Direction::SouthWest:
-					tempTilePosition += Direction::NorthEast;
 					tempTargetBufferPosition += { TILE_WIDTH / 2, -TILE_HEIGHT / 2 };
 					break;
 				case Direction::South:
-					tempTilePosition += Direction::North;
 					tempTargetBufferPosition += { 0, -TILE_HEIGHT };
 					break;
 				case Direction::SouthEast:
-					tempTilePosition += Direction::NorthWest;
 					tempTargetBufferPosition += { -TILE_WIDTH / 2, -TILE_HEIGHT / 2 };
 					break;
 				}
+				tempTilePosition += Opposite(player->_pdir);
 			}
 			DrawPlayerHelper(out, *player, tempTilePosition, tempTargetBufferPosition); // BUGFIX: Player sprite gets cut off walking in front of certain corners in caves
 		}
@@ -781,18 +779,16 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 			if (monster->mode == MonsterMode::MoveSouthwards) {
 				switch (monster->direction) {
 				case Direction::SouthWest:
-					tempTilePosition += Direction::NorthEast;
 					tempTargetBufferPosition += { TILE_WIDTH / 2, -TILE_HEIGHT / 2 };
 					break;
 				case Direction::South:
-					tempTilePosition += Direction::North;
 					tempTargetBufferPosition += { 0, -TILE_HEIGHT };
 					break;
 				case Direction::SouthEast:
-					tempTilePosition += Direction::NorthWest;
 					tempTargetBufferPosition += { -TILE_WIDTH / 2, -TILE_HEIGHT / 2 };
 					break;
 				}
+				tempTilePosition += Opposite(monster->direction);
 			}
 			DrawMonsterHelper(out, tempTilePosition, tempTargetBufferPosition); // BUGFIX: Monster sprite gets cut off walking in front of certain corners in caves
 		}

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -740,13 +740,14 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 	}
 	Player *player = PlayerAtPosition(tilePosition);
 	if (player != nullptr) {
+		// If sprite is moving southwards, we want to draw it offset from the tile it's moving to, so we need negative ID
 		int8_t playerId = (player->_pmode != PM_WALK_SOUTHWARDS) ? player->getId() + 1 : -player->getId() - 1;
 
 		if (dPlayer[tilePosition.x][tilePosition.y] == playerId) {
 			auto tempTilePosition = tilePosition;
 			auto tempTargetBufferPosition = targetBufferPosition;
 
-			// Needed to fix draw order issues with doors
+			// Offset the sprite to the tile it's moving from
 			if (player->_pmode == PM_WALK_SOUTHWARDS) {
 				switch (player->_pdir) {
 				case Direction::SouthWest:
@@ -769,13 +770,14 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 
 	Monster *monster = FindMonsterAtPosition(tilePosition);
 	if (monster != nullptr) {
+		// If sprite is moving southwards, we want to draw it offset from the tile it's moving to, so we need negative ID
 		int8_t monsterId = (monster->mode != MonsterMode::MoveSouthwards) ? monster->getId() + 1 : -monster->getId() - 1;
 
 		if (dMonster[tilePosition.x][tilePosition.y] == monsterId) {
 			auto tempTilePosition = tilePosition;
 			auto tempTargetBufferPosition = targetBufferPosition;
 
-			// Needed to fix draw order issues with doors
+			// Offset the sprite to the tile it's moving from
 			if (monster->mode == MonsterMode::MoveSouthwards) {
 				switch (monster->direction) {
 				case Direction::SouthWest:

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -635,8 +635,8 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 	mi = std::abs(mi) - 1;
 	if (mi < 0) // negative monster (moving into tile)
 		return;
-	if (leveltype == DTYPE_TOWN) {
 
+	if (leveltype == DTYPE_TOWN) {
 		auto &towner = Towners[mi];
 		const Point position = targetBufferPosition + towner.getRenderingOffset();
 		const ClxSprite sprite = towner.currentSprite();


### PR DESCRIPTION
This resolves a problem with draw order for players and monsters passing through doorways, caused by https://github.com/diasurgical/devilutionX/pull/7043. It's possible there are other situations where draw order was a problem which this should also resolve.

This PR is step 1; step 2 will be fixing draw order problems with sideways walk.