### PR TITLE
Clear Panel so lines don't repeat

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1033,6 +1033,7 @@ void CycleAutomapType()
 void CheckPanelInfo()
 {
 	panelflag = false;
+	InfoString = StringOrView {};
 	const Point mainPanelPosition = GetMainPanel().position;
 	for (int i = 0; i < PanelButtonIndex; i++) {
 		int xend = PanBtnPos[i].x + mainPanelPosition.x + PanBtnPos[i].w;


### PR DESCRIPTION
This fixes #7054
I tested to make sure the other buttons and things on the panel still show up properly, but someone might want to double check that this is the correct way to clear the panel.