### PR TITLE
Fix draw monster

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -633,8 +633,6 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 {
 	int mi = dMonster[tilePosition.x][tilePosition.y];
 
-	if (mi < 0) // negative monster (moving into tile)
-		return;
 	mi = std::abs(mi) - 1;
 
 	if (leveltype == DTYPE_TOWN) {
@@ -773,9 +771,8 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 		auto monsterId = static_cast<size_t>(monster->getId() + 1);
 		// If sprite is moving southwards or east, we want to draw it offset from the tile it's moving to, so we need negative ID
 		// This respests the order that tiles are drawn. By using the negative id, we ensure that the sprite is drawn with priority
-		if (monster->mode == MonsterMode::MoveSouthwards || (monster->mode == MonsterMode::MoveSideways && monster->direction == Direction::East)) {
+		if (monster->mode == MonsterMode::MoveSouthwards || (monster->mode == MonsterMode::MoveSideways && monster->direction == Direction::East))
 			monsterId = -monsterId;
-		}
 		if (dMonster[tilePosition.x][tilePosition.y] == monsterId) {
 			auto tempTilePosition = tilePosition;
 			auto tempTargetBufferPosition = targetBufferPosition;

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -632,9 +632,10 @@ void DrawItem(const Surface &out, int8_t itemIndex, Point targetBufferPosition)
 void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBufferPosition)
 {
 	int mi = dMonster[tilePosition.x][tilePosition.y];
-	mi = std::abs(mi) - 1;
+
 	if (mi < 0) // negative monster (moving into tile)
 		return;
+	mi = std::abs(mi) - 1;
 
 	if (leveltype == DTYPE_TOWN) {
 		auto &towner = Towners[mi];
@@ -769,11 +770,12 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 
 	Monster *monster = FindMonsterAtPosition(tilePosition);
 	if (monster != nullptr) {
-		auto monsterId = static_cast<int8_t>(monster->getId() + 1);
+		auto monsterId = static_cast<size_t>(monster->getId() + 1);
 		// If sprite is moving southwards or east, we want to draw it offset from the tile it's moving to, so we need negative ID
 		// This respests the order that tiles are drawn. By using the negative id, we ensure that the sprite is drawn with priority
-		if (monster->mode == MonsterMode::MoveSouthwards || (monster->mode == MonsterMode::MoveSideways && monster->direction == Direction::East))
+		if (monster->mode == MonsterMode::MoveSouthwards || (monster->mode == MonsterMode::MoveSideways && monster->direction == Direction::East)) {
 			monsterId = -monsterId;
+		}
 		if (dMonster[tilePosition.x][tilePosition.y] == monsterId) {
 			auto tempTilePosition = tilePosition;
 			auto tempTargetBufferPosition = targetBufferPosition;

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -768,7 +768,7 @@ void DrawDungeon(const Surface &out, Point tilePosition, Point targetBufferPosit
 
 	Monster *monster = FindMonsterAtPosition(tilePosition);
 	if (monster != nullptr) {
-		auto monsterId = static_cast<size_t>(monster->getId() + 1);
+		auto monsterId = static_cast<int16_t>(monster->getId() + 1);
 		// If sprite is moving southwards or east, we want to draw it offset from the tile it's moving to, so we need negative ID
 		// This respests the order that tiles are drawn. By using the negative id, we ensure that the sprite is drawn with priority
 		if (monster->mode == MonsterMode::MoveSouthwards || (monster->mode == MonsterMode::MoveSideways && monster->direction == Direction::East))


### PR DESCRIPTION
Fixed a bug that caused monsters with a `dMonster` value of over 127 to be invisible.

Removed an unnecessary return in `DrawMonsterHelper()`, because `dMonster` at the tile position passed down will never be negative.