### PR TITLE
Fix undeterministic Item Generation

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4604,6 +4604,8 @@ void TalktoMonster(Player &player, Monster &monster)
 			Quests[Q_ZHAR]._qactive = QUEST_ACTIVE;
 			Quests[Q_ZHAR]._qlog = true;
 			Quests[Q_ZHAR]._qvar1 = QS_ZHAR_ITEM_SPAWNED;
+			SetRndSeed(monster.rndItemSeed);
+			DiscardRandomValues(10);
 			CreateTypeItem(monster.position.tile + Displacement { 1, 1 }, false, ItemType::Misc, IMISC_BOOK, false, false, true);
 			monster.flags |= MFLAG_QUEST_COMPLETE;
 			NetSendCmdQuest(true, Quests[Q_ZHAR]);
@@ -4617,6 +4619,8 @@ void TalktoMonster(Player &player, Monster &monster)
 			NetSendCmdQuest(true, Quests[Q_GARBUD]);
 		}
 		if (monster.talkMsg == TEXT_GARBUD2 && (monster.flags & MFLAG_QUEST_COMPLETE) == 0) {
+			SetRndSeed(monster.rndItemSeed);
+			DiscardRandomValues(10);
 			SpawnItem(monster, monster.position.tile + Displacement { 1, 1 }, false, true);
 			monster.flags |= MFLAG_QUEST_COMPLETE;
 			Quests[Q_GARBUD]._qvar1 = QS_GHARBAD_FIRST_ITEM_SPAWNED;


### PR DESCRIPTION
Gharbad and Zhar the Mad can keep changing their rolls in Single Player by doing anything that advances the random seed, and then talking to them. Exploitable behavior using save/load game. We set the monster seed, and then roll a new seed to avoid situations where killing the monsters drops a dupe of the item they previously gave you.