### PR TITLE
Randomize Unique Item Generation (Forwards compatible)

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1478,6 +1478,7 @@ _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
 	else
 		uidx = static_cast<int>(uids.size() - 1); // last uid in list (reverse compatibility)
 
+	// Single Player item creation: Check if there are any available uids
 	if (!recreate && !gbIsMultiplayer) {
 		bool hasAvailUids = std::any_of(uids.begin(), uids.end(), [](const std::pair<int, bool> &element) {
 			return !element.second;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1479,12 +1479,12 @@ _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
 		uidx = static_cast<int>(uids.size() - 1); // last uid in list (reverse compatibility)
 
 	if (!recreate && !gbIsMultiplayer) {
-		bool hasAvailableSpUid = std::any_of(uids.begin(), uids.end(), [](const std::pair<int, bool> &element) {
+		bool hasAvailUids = std::any_of(uids.begin(), uids.end(), [](const std::pair<int, bool> &element) {
 			return !element.second;
 		});
 
 		// No uniques are available, abort mission.
-		if (!hasAvailableSpUid) {
+		if (!hasAvailUids) {
 			// Remove uniqueX flag, item isn't unique.
 			item.dwBuff = (item.dwBuff & ~CF_UNIQUEX);
 			return UITEM_INVALID;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1476,9 +1476,7 @@ _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
 	DiscardRandomValues(1);
 	if ((item.dwBuff & CF_UNIQUEX) != 0) {
 		idx = GenerateRnd(static_cast<int32_t>(validUids.size()));
-		SDL_Log("right");
 	} else {
-		SDL_Log("wrong");
 		idx = static_cast<int>(validUids.size() - 1);
 	}
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1485,6 +1485,8 @@ _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
 
 		// No uniques are available, abort mission.
 		if (!hasAvailableSpUid) {
+			// Remove uniqueX flag, item isn't unique.
+			item.dwBuff = (item.dwBuff & ~CF_UNIQUEX);
 			return UITEM_INVALID;
 		}
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1467,18 +1467,16 @@ _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
 		return UITEM_INVALID;
 
 	// For newly created items, use logic that selects a random uid instead of last uid
-	if (!recreate) {
+	if (!recreate)
 		item.dwBuff |= CF_UNIQUEX;
-	}
 
 	int idx = static_cast<int>(UITEM_INVALID);
 
 	DiscardRandomValues(1);
-	if ((item.dwBuff & CF_UNIQUEX) != 0) {
+	if ((item.dwBuff & CF_UNIQUEX) != 0)
 		idx = GenerateRnd(static_cast<int32_t>(validUids.size()));
-	} else {
+	else
 		idx = static_cast<int>(validUids.size() - 1);
-	}
 
 	return static_cast<_unique_items>(validUids[idx]);
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1476,15 +1476,15 @@ _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
 	if ((item.dwBuff & CF_UNIQUEX) != 0)
 		uidx = GenerateRnd(static_cast<int32_t>(uids.size())); // random uid in list
 	else
-		uidx = static_cast<int>(uids.size() - 1); // last uid in list
+		uidx = static_cast<int>(uids.size() - 1); // last uid in list (reverse compatibility)
 
 	if (!recreate && !gbIsMultiplayer) {
-		bool hasAvailableSPUid = std::any_of(uids.begin(), uids.end(), [](const std::pair<int, bool> &element) {
+		bool hasAvailableSpUid = std::any_of(uids.begin(), uids.end(), [](const std::pair<int, bool> &element) {
 			return !element.second;
 		});
 
 		// No uniques are available, abort mission.
-		if (!hasAvailableSPUid) {
+		if (!hasAvailableSpUid) {
 			return UITEM_INVALID;
 		}
 	}
@@ -1582,7 +1582,7 @@ void SetupAllItems(const Player &player, Item &item, _item_indexes idx, uint32_t
 				return;
 			}
 
-			GetUniqueItem(player, item, (_unique_items)iseed); // uid is stored in iseed for uniques
+			GetUniqueItem(player, item, (_unique_items)iseed, recreate); // uid is stored in iseed for uniques
 		}
 	}
 	SetupItem(item);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3251,7 +3251,7 @@ Item *SpawnUnique(_unique_items uid, Point position, std::optional<int> level /*
 
 	if (sgGameInitInfo.nDifficulty == DIFF_NORMAL) {
 		GetItemAttrs(item, static_cast<_item_indexes>(idx), curlv);
-		GetUniqueItem(*MyPlayer, item, uid);
+		GetUniqueItem(*MyPlayer, item, uid, false);
 		SetupItem(item);
 	} else {
 		if (level)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1458,9 +1458,8 @@ _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
 		bool meetsLevelRequirement = lvl >= uniqueItem.UIMinLvl;
 		bool isAvailableForGeneration = recreate || !UniqueItemFlags[i] || gbIsMultiplayer;
 
-		if (IsUniqueAvailable(i) && isMatchingItemId && meetsLevelRequirement && isAvailableForGeneration) {
+		if (IsUniqueAvailable(i) && isMatchingItemId && meetsLevelRequirement && isAvailableForGeneration)
 			validUids.push_back(i);
-		}
 	}
 
 	if (validUids.empty())

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1465,7 +1465,7 @@ _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
 	if (validUids.empty())
 		return UITEM_INVALID;
 
-	// For newly created items, use logic that selects a random uid instead of last uid
+	// For newly created items, use logic that selects a random uid instead of last uid.
 	if (!recreate)
 		item.dwBuff |= CF_UNIQUEX;
 
@@ -1473,9 +1473,9 @@ _unique_items CheckUnique(Item &item, int lvl, int uper, bool recreate)
 
 	DiscardRandomValues(1);
 	if ((item.dwBuff & CF_UNIQUEX) != 0)
-		idx = GenerateRnd(static_cast<int32_t>(validUids.size()));
+		idx = GenerateRnd(static_cast<int32_t>(validUids.size())); // random uid in list
 	else
-		idx = static_cast<int>(validUids.size() - 1);
+		idx = static_cast<int>(validUids.size() - 1); // last uid in list
 
 	return static_cast<_unique_items>(validUids[idx]);
 }

--- a/Source/items.h
+++ b/Source/items.h
@@ -166,6 +166,7 @@ enum icreateinfo_flag {
 enum icreateinfo_flag2 {
 	// clang-format off
 	CF_HELLFIRE = 1,
+	CF_UNIQUEX = 1 << 1,
 	// clang-format on
 };
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2425,6 +2425,7 @@ void PrepareEarForNetwork(const Item &item, TEar &ear)
 void RecreateItem(const Player &player, const TItem &messageItem, Item &item)
 {
 	const uint32_t dwBuff = SDL_SwapLE32(messageItem.dwBuff);
+	item.dwBuff = dwBuff;
 	RecreateItem(player, item,
 	    static_cast<_item_indexes>(SDL_SwapLE16(messageItem.wIndx)), SDL_SwapLE16(messageItem.wCI),
 	    SDL_SwapLE32(messageItem.dwSeed), SDL_SwapLE16(messageItem.wValue), (dwBuff & CF_HELLFIRE) != 0);
@@ -2438,7 +2439,6 @@ void RecreateItem(const Player &player, const TItem &messageItem, Item &item)
 		item._iPLToHit = ClampToHit(item, static_cast<uint8_t>(SDL_SwapLE16(messageItem.wToHit)));
 		item._iMaxDam = ClampMaxDam(item, static_cast<uint8_t>(SDL_SwapLE16(messageItem.wMaxDam)));
 	}
-	item.dwBuff = dwBuff;
 }
 
 void ClearLastSentPlayerCmd()

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -431,6 +431,7 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 		RecreateEar(item, ic, iseed, ivalue & 0xFF, heroName);
 	} else {
 		item = {};
+		item.dwBuff = SDL_SwapLE32(packedItem.dwBuff);
 		RecreateItem(player, item, idx, SDL_SwapLE16(packedItem.iCreateInfo), SDL_SwapLE32(packedItem.iSeed), SDL_SwapLE16(packedItem.wValue), isHellfire);
 		item._iIdentified = (packedItem.bId & 1) != 0;
 		item._iMaxDur = packedItem.bMDur;


### PR DESCRIPTION
Randomizes unique item generation for items created on/after this commit.

`dwBuff` now gets loaded on item recreation; I'm not sure if this is going to have a negative impact or not on things related to `CF_HELLFIRE` or `gbIsHellfire`

---
- Preexisting items will remain the same and will not morph.
- New items will roll with a random uid from available uids based on item type and min level.

Single Player specific:

As before, the game will not drop a unique that has already dropped. If a uid is selected that has already dropped in the game, generation of the unique item will begin again with a new seed, and will ensure the new roll is also a unique item. This can loop several times until a new valid uid is selected. If there are no more possible unique items that can drop, The item will not be unique, and unfortunately, this item will probably morph (returning -1 for uid if there are no options is the same outcome that happens in vanilla).

Choosing to allow the game to select a uid that it can't drop was a deliberate choice, because `UniqueItemFlags` changing between game sessions changes the available uids, which can cause item morphing on item regeneration. A seed should always have a deterministic outcome, and if that outcome isn't desirable, we just get a new seed.

*This PR will need thorough testing. I'm satisified with the state of the code, however I'll need to playtest it quite a bit*
