### PR TITLE
Patch up wrong tree tile near Hive entrance (#6869)

### DIFF
--- a/Source/levels/town.cpp
+++ b/Source/levels/town.cpp
@@ -316,17 +316,17 @@ void TownOpenHive()
 	dPiece[83][62] = 0x523;
 	dPiece[82][63] = 0x524;
 	dPiece[83][63] = 0x525;
-	dPiece[84][61] = 0x117; // 0x117
-	dPiece[84][62] = 0x118; // 0x117
-	dPiece[84][63] = 0x117; // 0x117
-	dPiece[84][64] = 10; // 0x117
-	dPiece[85][60] = 11; // 0x117
-	dPiece[85][61] = 12; // 0x117
-	dPiece[85][62] = 13; // 0x117
-	dPiece[85][63] = 14; // 7
-	dPiece[85][64] = 15; // 7
-	dPiece[86][60] = 16; // 0xd8: used to patch up a tree that has been poorly cutoff by the HF devs
-	dPiece[86][61] = 17; // 0x17
+	dPiece[84][61] = 279;
+	dPiece[84][62] = 280;
+	dPiece[84][63] = 279;
+	dPiece[84][64] = 10;
+	dPiece[85][60] = 11;
+	dPiece[85][61] = 12;
+	dPiece[85][62] = 13;
+	dPiece[85][63] = 14;
+	dPiece[85][64] = 15;
+	dPiece[86][60] = 16;
+	dPiece[86][61] = 17;
 }
 
 void TownOpenGrave()

--- a/Source/levels/town.cpp
+++ b/Source/levels/town.cpp
@@ -113,17 +113,17 @@ void TownCloseHive()
 	dPiece[83][62] = 0x505;
 	dPiece[82][63] = 0x506;
 	dPiece[83][63] = 0x507;
-	dPiece[84][61] = 0x117;
-	dPiece[84][62] = 0x117;
-	dPiece[84][63] = 0x117;
-	dPiece[85][60] = 0x117;
-	dPiece[85][61] = 0x117;
-	dPiece[85][63] = 7;
-	dPiece[85][64] = 7;
-	dPiece[86][60] = 0xd8;
-	dPiece[86][61] = 0x17;
-	dPiece[85][62] = 0x12;
-	dPiece[84][64] = 0x117;
+	dPiece[84][61] = 0x117; // 0x117
+	dPiece[84][62] = 0x118; // 0x117
+	dPiece[84][63] = 0x117; // 0x117
+	dPiece[84][64] = 10; // 0x117
+	dPiece[85][60] = 11; // 0x117
+	dPiece[85][61] = 12; // 0x117
+	dPiece[85][62] = 13; // 0x117
+	dPiece[85][63] = 14; // 7
+	dPiece[85][64] = 15; // 7
+	dPiece[86][60] = 16; // 0xd8: used to patch up a tree that has been poorly cutoff by the HF devs
+	dPiece[86][61] = 17; // 0x17
 }
 
 /**
@@ -316,17 +316,17 @@ void TownOpenHive()
 	dPiece[83][62] = 0x523;
 	dPiece[82][63] = 0x524;
 	dPiece[83][63] = 0x525;
-	dPiece[84][61] = 0x117;
-	dPiece[84][62] = 0x117;
-	dPiece[84][63] = 0x117;
-	dPiece[85][60] = 0x117;
-	dPiece[85][61] = 0x117;
-	dPiece[85][63] = 7;
-	dPiece[85][64] = 7;
-	dPiece[86][60] = 0xd8;
-	dPiece[86][61] = 0x17;
-	dPiece[85][62] = 0x12;
-	dPiece[84][64] = 0x117;
+	dPiece[84][61] = 0x117; // 0x117
+	dPiece[84][62] = 0x118; // 0x117
+	dPiece[84][63] = 0x117; // 0x117
+	dPiece[84][64] = 10; // 0x117
+	dPiece[85][60] = 11; // 0x117
+	dPiece[85][61] = 12; // 0x117
+	dPiece[85][62] = 13; // 0x117
+	dPiece[85][63] = 14; // 7
+	dPiece[85][64] = 15; // 7
+	dPiece[86][60] = 16; // 0xd8: used to patch up a tree that has been poorly cutoff by the HF devs
+	dPiece[86][61] = 17; // 0x17
 }
 
 void TownOpenGrave()

--- a/Source/levels/town.cpp
+++ b/Source/levels/town.cpp
@@ -113,17 +113,17 @@ void TownCloseHive()
 	dPiece[83][62] = 0x505;
 	dPiece[82][63] = 0x506;
 	dPiece[83][63] = 0x507;
-	dPiece[84][61] = 0x117; // 0x117
-	dPiece[84][62] = 0x118; // 0x117
-	dPiece[84][63] = 0x117; // 0x117
-	dPiece[84][64] = 10; // 0x117
-	dPiece[85][60] = 11; // 0x117
-	dPiece[85][61] = 12; // 0x117
-	dPiece[85][62] = 13; // 0x117
-	dPiece[85][63] = 14; // 7
-	dPiece[85][64] = 15; // 7
-	dPiece[86][60] = 16; // 0xd8: used to patch up a tree that has been poorly cutoff by the HF devs
-	dPiece[86][61] = 17; // 0x17
+	dPiece[84][61] = 279;
+	dPiece[84][62] = 280;
+	dPiece[84][63] = 279;
+	dPiece[84][64] = 10;
+	dPiece[85][60] = 11;
+	dPiece[85][61] = 12;
+	dPiece[85][62] = 13;
+	dPiece[85][63] = 14;
+	dPiece[85][64] = 15;
+	dPiece[86][60] = 16;
+	dPiece[86][61] = 17;
 }
 
 /**


### PR DESCRIPTION
Hi!

This is my first code commit, fixes #6869.

I patched up the offending tiles in town.cpp. I also tried to fix the neighbouring tiles as the Hellfire team did one ugly job there. I hope it's okay. Let me know if the comments are unnecessary, I wanted to keep the original values there.

![nest-entrance-compared](https://github.com/diasurgical/devilutionX/assets/166401925/9bf652a9-b757-43b8-b06e-a65adb0febfa)

On a related note, there's another faulty tree above the river fork that has its shadow cut-off, but it probably has no correct tiles.

![bad_tree](https://github.com/diasurgical/devilutionX/assets/166401925/c1d26f72-3710-4c29-bdda-c69287ee9ec3)
