### PR TITLE
[Bugfix]: Infravision monsters flickering when manipulating inventory (#6687)

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2791,8 +2791,6 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	player._pILMinDam = lmin;
 	player._pILMaxDam = lmax;
 
-	player._pInfraFlag = false;
-
 	player._pBlockFlag = false;
 	if (player._pClass == HeroClass::Monk) {
 		if (player.InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Staff && player.InvBody[INVLOC_HAND_LEFT]._iStatFlag) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1466,6 +1466,7 @@ void ValidatePlayer()
 	}
 
 	myPlayer._pMemSpells &= msk;
+	myPlayer._pInfraFlag = false;
 }
 
 void CheckCheatStats(Player &player)


### PR DESCRIPTION
Based on #6687.

Clicking on an item called `CalcPlrItemVals`, which reset _pInfraFlag to `false`, which was responsible for allowing unseen monsters to be drawn. As infravision technically is a "missile" that sets this variable to `true` every step (_not_ every frame) that meant that on slower speed there could be a few frames where this variable was `false` before being set to `true` again by this "missile".

As I did not want to change how infravision works, I moved `_pInfraFlag = false` to `ValidatePlayer`, called by `ProcessPlayers`, which is called before `ProcessMissiles`. This solved this issue for me.
