### PR TITLE
[Bugfix]: Not being able to equip two-handed items in a certain case (#5076)

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -731,19 +731,21 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 						}
 						break;
 					case ILOC_TWOHAND:
-						// Moving a two-hand item from inventory to InvBody requires emptying both hands
+						// Moving a two-hand item from inventory to InvBody requires emptying both hands.
 						if (!player.InvBody[INVLOC_HAND_RIGHT].isEmpty()) {
 							holdItem = player.InvBody[INVLOC_HAND_RIGHT];
 							if (!AutoPlaceItemInInventory(player, holdItem, true)) {
-								// No space to  move right hand item to inventory, abort.
+								// No space to move right hand item to inventory, abort.
 								break;
 							}
-							holdItem = player.InvBody[INVLOC_HAND_LEFT];
-							if (!AutoPlaceItemInInventory(player, holdItem, false)) {
-								// No space for left item. Move back right item to right hand and abort.
-								player.InvBody[INVLOC_HAND_RIGHT] = player.InvList[player._pNumInv - 1];
-								player.RemoveInvItem(player._pNumInv - 1, false);
-								break;
+							if (!player.InvBody[INVLOC_HAND_LEFT].isEmpty()) {
+								holdItem = player.InvBody[INVLOC_HAND_LEFT];
+								if (!AutoPlaceItemInInventory(player, holdItem, false)) {
+									// No space for left item. Move back right item to right hand and abort.
+									player.InvBody[INVLOC_HAND_RIGHT] = player.InvList[player._pNumInv - 1];
+									player.RemoveInvItem(player._pNumInv - 1, false);
+									break;
+								}
 							}
 							RemoveEquipment(player, INVLOC_HAND_RIGHT, false);
 							invloc = INVLOC_HAND_LEFT;


### PR DESCRIPTION
Fixes #5076.

It seems that if there's an item only in the right hand, the function will also attempt to put something from the left hand into the inventory as well and if there's no space for it, the said issue will occur. I believe it actually tries to place the right hand item twice and if there's no place for two shields, the check will fail. This is not case if the shield is in your left hand, as it's handled separately I think.

This commit makes it so that no extra check performed when the left hand is empty in this case.