### PR TITLE
[Bugfix & Enchancement?] Clicking on the sound slider plays the sound at wrong volume

### DIFF
--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -351,7 +351,13 @@ bool gmenu_left_mouse(bool isDown)
 		return true;
 	}
 	sgpCurrItem = pItem;
-	PlaySFX(SfxID::MenuMove);
+	
+	// Do not play a duplicate sound if we are clicking on the sound slider.
+	// CurrentMenuId == 5 is the options menu, i == 1 is the sound slider.
+	if ((sgCurrentMenuIdx != 5) || (i != 1)) {
+		PlaySFX(SfxID::MenuMove);
+	}
+	
 	if (pItem->isSlider()) {
 		isDraggingSlider = GmenuMouseIsOverSlider();
 		gmenu_on_mouse_move();

--- a/Source/utils/soundsample.cpp
+++ b/Source/utils/soundsample.cpp
@@ -36,9 +36,9 @@ constexpr float VolumeScale = 3321.9281F;
 
 /**
  * Min and max volume range, in millibel.
- * -100 dB (muted) to 0 dB (max. loudness).
+ * -60 dB (muted) to 0 dB (max. loudness).
  */
-constexpr float MillibelMin = -10000.F;
+constexpr float MillibelMin = -6000.F;
 constexpr float MillibelMax = 0.F;
 
 /**


### PR DESCRIPTION
This pull request does two things: the first commit is a bug-fix, the second one is a related adjustment.

The sound slider in the game menu plays the move sound at the previous volume level when clicked on, as clicking itself will play the same sound (`gmenu.cpp`) and because of that the duplicate in `gamemenu.cpp/gmenu_left_mouse` will never play again. This fix makes the left click not play a sound when clicked on the sound slider as an exception. If there's a better way to do it, let me know!

The second one changes the minimum volume from -100.0 dB to -60.0 dB. Initially I thought the sound slider was wrong, as moving it to the middle almost made the music go silent, but after checking the code, it seems to be working perfectly, logarithmic conversion et al, just the minimum value seems to be way too low and this caused the slider to seem off. -60.0 dB is arbitrary, but in my opinion, -100.0 dB seems too low in any case.
