### PR TITLE
Fix outdated values for starting items

### DIFF
--- a/assets/txtdata/items/itemdat.tsv
+++ b/assets/txtdata/items/itemdat.tsv
@@ -1,10 +1,10 @@
 id	dropRate	class	equipType	cursorGraphic	itemType	uniqueBaseItem	name	shortName	minMonsterLevel	durability	minDamage	maxDamage	minArmor	maxArmor	minStrength	minMagic	minDexterity	specialEffects	miscId	spell	usable	value
 IDI_GOLD	Regular	Gold	Unequippable	GOLD_SMALL	Gold	NONE	Gold		1	0	0	0	0	0	0	0	0		NONE	Null	true	0
-IDI_WARRIOR	Never	Weapon	One-handed	SHORT_SWORD	Sword	NONE	Short Sword		2	20	2	6	0	0	18	0	0		NONE	Null	false	50
-IDI_WARRSHLD	Never	Armor	One-handed	BUCKLER	Shield	NONE	Buckler		2	10	0	0	3	3	0	0	0		NONE	Null	false	50
+IDI_WARRIOR	Never	Weapon	One-handed	SHORT_SWORD	Sword	NONE	Short Sword		2	24	2	6	0	0	18	0	0		NONE	Null	false	120
+IDI_WARRSHLD	Never	Armor	One-handed	BUCKLER	Shield	NONE	Buckler		2	16	0	0	3	3	0	0	0		NONE	Null	false	30
 IDI_WARRCLUB	Never	Weapon	One-handed	CLUB	Mace	SPIKCLUB	Club		1	20	1	6	0	0	0	0	0		NONE	Null	false	20
 IDI_ROGUE	Never	Weapon	Two-handed	SHORT_BOW	Bow	NONE	Short Bow		1	30	1	4	0	0	0	0	0		NONE	Null	false	100
-IDI_SORCERER	Never	Weapon	Two-handed	SHORT_STAFF	Staff	NONE	Short Staff of Mana		1	25	2	4	0	0	0	20	0		STAFF	Mana	false	520
+IDI_SORCERER	Never	Weapon	Two-handed	SHORT_STAFF	Staff	NONE	Short Staff of Mana		1	25	2	4	0	0	0	17	0		STAFF	Mana	false	210
 IDI_CLEAVER	Never	Weapon	Two-handed	CLEAVER	Axe	CLEAVER	Cleaver		10	10	4	24	0	0	0	0	0		UNIQUE	Null	false	2000
 IDI_SKCROWN	Never	Armor	Helm	THE_UNDEAD_CROWN	Helm	SKCROWN	The Undead Crown		0	50	0	0	15	15	0	0	0	RandomStealLife	UNIQUE	Null	false	10000
 IDI_INFRARING	Never	Misc	Ring	EMPYREAN_BAND	Ring	INFRARING	Empyrean Band		0	0	0	0	0	0	0	0	0		UNIQUE	Null	false	8000
@@ -165,5 +165,5 @@ IDI_SHORT_BATTLE_BOW	Double	Weapon	Two-handed	SHORT_BATTLE_BOW	Bow	NONE	Short Ba
 	Regular	Misc	Unequippable	GREATER_RUNE_OF_FIRE	Misc	NONE	Greater Rune of Fire	Rune	7	0	0	0	0	0	0	42	0		GR_RUNEF	Null	true	400
 	Regular	Misc	Unequippable	GREATER_RUNE_OF_LIGHTNING	Misc	NONE	Greater Rune of Lightning	Rune	7	0	0	0	0	0	0	42	0		GR_RUNEL	Null	true	500
 	Regular	Misc	Unequippable	RUNE_OF_STONE	Misc	NONE	Rune of Stone	Rune	7	0	0	0	0	0	0	25	0		RUNES	Null	true	300
-IDI_SORCERER	Never	Weapon	Two-handed	SHORT_STAFF	Staff	NONE	Short Staff of Charged Bolt		1	25	2	4	0	0	0	20	0		STAFF	ChargedBolt	false	520
+IDI_SORCERER	Never	Weapon	Two-handed	SHORT_STAFF	Staff	NONE	Short Staff of Charged Bolt		1	25	2	4	0	0	0	25	0		STAFF	ChargedBolt	false	470
 IDI_ARENAPOT	Never	Misc	Unequippable	ARENA_POTION	Misc	NONE	Arena Potion		7	0	0	0	0	0	0	0	0		ARENAPOT	Null	true	0


### PR DESCRIPTION
4 of the starting items have outdated values that match the values from in the PR demo, meaning they were never updated to match the retail values. This PR sets the correct values which are found in retail on non-starting items. Here's the evidence:

**Short Sword**

New Char Item - Durability (PR): 20
Normal Item - Durability (PR): 20

New Char Item - Durability (Retail): 20
Normal Item - Durability (Retail): 24


New Char Item - Value (PR): 50
Normal Item - Value (PR): 50

New Char Item - Value (Retail): 50
Normal Item - Value (Retail): 120

**Buckler**

New Char Item - Durability (PR): 10
Normal Item - Durability (PR): 10

New Char Item - Durability (Retail): 10
Normal Item - Durability (Retail): 16


New Char Item - Value (PR): 50
Normal Item - Value (PR): 50

New Char Item - Value (Retail): 50
Normal Item - Value (Retail): 30

**Short Staff of [Spell] (Lightning in PR, Charged Bolt in Retail)**

New Char Item (Lightning) - Required Magic (PR): 20
Normal Item (Lightning) - Required Magic (PR): 20

New Char Item (Charged Bolt) - Required Magic (Retail): 20
Normal Item (Charged Bolt) - Required Magic (Retail): 25
Normal Item (Lightning) - Required Magic (Retail): 20


New Char Item (Lightning, 6 charges) - Value (PR): 520

New Char Item (Charged Bolt, 40 charges) - Value (Retail): 520
Normal Item (Charged Bolt, 40 charges) - Value (Retail): 470

**Short Staff of Mana**

New Char Item (Mana) - Required Magic: 20
Normal Item (Mana) - Required Magic: 17

New Char Item (Mana) - Value: 520
Normal Item (Mana) - Value: 210

