### PR TITLE
Fix rendering monsters in solid tiles

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -631,6 +631,9 @@ void DrawItem(const Surface &out, int8_t itemIndex, Point targetBufferPosition)
  */
 void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBufferPosition)
 {
+	if (TileHasAny(dPiece[tilePosition.x][tilePosition.y], TileProperties::Solid))
+		return;
+
 	int mi = dMonster[tilePosition.x][tilePosition.y];
 
 	mi = std::abs(mi) - 1;


### PR DESCRIPTION
Monsters inside solid tiles, like inside the Arkaine's Valor room before it's opened up, are able to be seen with Infravision. This fixes that.