### PR TITLE
Clean up store inferface

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -310,18 +310,18 @@ void PrintStoreItem(const Item &item, int l, UiFlags flags, bool cursIndent = fa
 		else if (item._iClass == ICLASS_ARMOR)
 			productLine = fmt::format(fmt::runtime(_("Armor: {:d}  ")), item._iAC);
 		if (item._iMaxDur != DUR_INDESTRUCTIBLE && item._iMaxDur != 0)
-			productLine += fmt::format(fmt::runtime(_("Dur: {:d}/{:d},  ")), item._iDurability, item._iMaxDur);
+			productLine += fmt::format(fmt::runtime(_("Dur: {:d}/{:d}")), item._iDurability, item._iMaxDur);
 		else
-			productLine.append(_("Indestructible,  "));
+			productLine.append(_("Indestructible"));
 	}
 
 	int8_t str = item._iMinStr;
 	uint8_t mag = item._iMinMag;
 	int8_t dex = item._iMinDex;
 
-	if (str == 0 && mag == 0 && dex == 0) {
-		productLine.append(_("No required attributes"));
-	} else {
+	if (str != 0 || mag != 0 || dex != 0) {
+		if (!productLine.empty())
+			productLine.append(_(",  "));
 		productLine.append(_("Required:"));
 		if (str != 0)
 			productLine.append(fmt::format(fmt::runtime(_(" {:d} Str")), str));


### PR DESCRIPTION
![image](https://github.com/diasurgical/devilutionX/assets/68359262/ea21bcac-6d2d-4ad2-b396-584c0b3a559e)

Gets rid of the "No required attributes". This provides unnecessary information, as a lack of required attributes signals no required attributes. This also makes it easier to read through shops, as it's less text spam. This could even reduces the amount of lines displayed in the shop by 50%.

![image](https://github.com/diasurgical/devilutionX/assets/68359262/09055f36-d1d2-493d-9fac-52cd10fac04d)
