### PR TITLE
Bugfix: Invisible monsters/towners in solid tiles in vision range

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -646,12 +646,7 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 		return;
 	}
 
-	// Draw no monsters for tiles outside vision while player has no Infravision.
-	if (!IsTileLit(tilePosition) && !MyPlayer->_pInfraFlag)
-		return;
-
-	// Draw no monsters for tiles outside vision that are solid while player has Infravision.
-	if (!IsTileLit(tilePosition) && MyPlayer->_pInfraFlag && TileHasAny(dPiece[tilePosition.x][tilePosition.y], TileProperties::Solid))
+	if (!IsTileLit(tilePosition) && (!MyPlayer->_pInfraFlag || TileHasAny(dPiece[tilePosition.x][tilePosition.y], TileProperties::Solid)))
 		return;
 
 	if (static_cast<size_t>(mi) >= MaxMonsters) {

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -631,9 +631,6 @@ void DrawItem(const Surface &out, int8_t itemIndex, Point targetBufferPosition)
  */
 void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBufferPosition)
 {
-	if (TileHasAny(dPiece[tilePosition.x][tilePosition.y], TileProperties::Solid))
-		return;
-
 	int mi = dMonster[tilePosition.x][tilePosition.y];
 
 	mi = std::abs(mi) - 1;
@@ -649,7 +646,12 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 		return;
 	}
 
+	// Draw no monsters for tiles outside vision while player has no Infravision.
 	if (!IsTileLit(tilePosition) && !MyPlayer->_pInfraFlag)
+		return;
+
+	// Draw no monsters for tiles outside vision that are solid while player has Infravision.
+	if (!IsTileLit(tilePosition) && MyPlayer->_pInfraFlag && TileHasAny(dPiece[tilePosition.x][tilePosition.y], TileProperties::Solid))
 		return;
 
 	if (static_cast<size_t>(mi) >= MaxMonsters) {


### PR DESCRIPTION
Corrects a bug caused by https://github.com/diasurgical/devilutionX/pull/7075.

New logic:

Tile in vision = draw monster

Tile not in vision + no infravision + (monster either in solid tile or not) = no draw monster
Tile not in vision + (either infravision or no infravision) + monster in solid tile = no draw monster
