### PR TITLE
Fix Knockback

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -203,7 +203,7 @@ int ProjectileTrapDamage()
 	return currlevel + GenerateRnd(2 * currlevel);
 }
 
-bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, int dist, MissileID t, DamageType damageType, bool shift)
+bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, int dist, MissileID t, WorldTilePosition startPos, DamageType damageType, bool shift)
 {
 	Monster &monster = Monsters[monsterId];
 
@@ -268,7 +268,7 @@ bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, in
 		PlayEffect(monster, MonsterSound::Hit);
 	} else {
 		if (monster.mode != MonsterMode::Petrified && missileData.isArrow() && HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback))
-			M_GetKnockback(monster, player.position.tile);
+			M_GetKnockback(monster, startPos);
 		if (monster.type().type != MT_GOLEM)
 			M_StartHit(monster, player, dam);
 	}
@@ -422,7 +422,7 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 			// then the missile can potentially hit this target
 			isMonsterHit = MonsterTrapHit(mid, minDamage, maxDamage, missile._midist, missile._mitype, damageType, isDamageShifted);
 		} else if (IsAnyOf(missile._micaster, TARGET_BOTH, TARGET_MONSTERS)) {
-			isMonsterHit = MonsterMHit(*missile.sourcePlayer(), mid, minDamage, maxDamage, missile._midist, missile._mitype, damageType, isDamageShifted);
+			isMonsterHit = MonsterMHit(*missile.sourcePlayer(), mid, minDamage, maxDamage, missile._midist, missile._mitype, missile.position.start, damageType, isDamageShifted);
 		}
 	}
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -268,7 +268,7 @@ bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, in
 		PlayEffect(monster, MonsterSound::Hit);
 	} else {
 		if (monster.mode != MonsterMode::Petrified && missileData.isArrow() && HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback))
-			M_GetKnockback(monster);
+			M_GetKnockback(monster, player.position.tile);
 		if (monster.type().type != MT_GOLEM)
 			M_StartHit(monster, player, dam);
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3735,7 +3735,7 @@ void M_ClearSquares(const Monster &monster)
 
 void M_GetKnockback(Monster &monster, WorldTilePosition attackerStartPos)
 {
-	auto dir = GetDirection(attackerStartPos, monster.position.tile);
+	Direction dir = GetDirection(attackerStartPos, monster.position.tile);
 	if (!IsRelativeMoveOK(monster, monster.position.old, dir)) {
 		return;
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4448,7 +4448,7 @@ void MissToMonst(Missile &missile, Point position)
 
 		if (player->_pmode != PM_GOTHIT && player->_pmode != PM_DEATH)
 			StartPlrHit(*player, 0, true);
-		Point newPosition = oldPosition + monster.direction;
+		Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
 		if (PosOkPlayer(*player, newPosition)) {
 			player->position.tile = newPosition;
 			FixPlayerLocation(*player, player->_pdir);
@@ -4469,7 +4469,7 @@ void MissToMonst(Missile &missile, Point position)
 	if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
 		return;
 
-	Point newPosition = oldPosition + monster.direction;
+	Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
 	if (IsTileAvailable(*target, newPosition)) {
 		monster.occupyTile(newPosition, false);
 		dMonster[oldPosition.x][oldPosition.y] = 0;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3735,7 +3735,7 @@ void M_ClearSquares(const Monster &monster)
 
 void M_GetKnockback(Monster &monster, WorldTilePosition attackerStartPos)
 {
-	auto dir = GetDirection(attackerStartPos, monster.position.future);
+	auto dir = GetDirection(attackerStartPos, monster.position.tile);
 	if (!IsRelativeMoveOK(monster, monster.position.old, dir)) {
 		return;
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3733,9 +3733,9 @@ void M_ClearSquares(const Monster &monster)
 	}
 }
 
-void M_GetKnockback(Monster &monster, WorldTilePosition playerPos)
+void M_GetKnockback(Monster &monster, WorldTilePosition attackerStartPos)
 {
-	auto dir = GetDirection(playerPos, monster.position.future);
+	auto dir = GetDirection(attackerStartPos, monster.position.future);
 	if (!IsRelativeMoveOK(monster, monster.position.old, dir)) {
 		return;
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3733,9 +3733,9 @@ void M_ClearSquares(const Monster &monster)
 	}
 }
 
-void M_GetKnockback(Monster &monster)
+void M_GetKnockback(Monster &monster, WorldTilePosition playerPos)
 {
-	Direction dir = Opposite(monster.direction);
+	auto dir = GetDirection(playerPos, monster.position.future);
 	if (!IsRelativeMoveOK(monster, monster.position.old, dir)) {
 		return;
 	}

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -514,7 +514,7 @@ void ApplyMonsterDamage(DamageType damageType, Monster &monster, int damage);
 bool M_Talker(const Monster &monster);
 void M_StartStand(Monster &monster, Direction md);
 void M_ClearSquares(const Monster &monster);
-void M_GetKnockback(Monster &monster, WorldTilePosition playerPos);
+void M_GetKnockback(Monster &monster, WorldTilePosition attackerStartPos);
 void M_StartHit(Monster &monster, int dam);
 void M_StartHit(Monster &monster, const Player &player, int dam);
 void StartMonsterDeath(Monster &monster, const Player &player, bool sendmsg);

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -514,7 +514,7 @@ void ApplyMonsterDamage(DamageType damageType, Monster &monster, int damage);
 bool M_Talker(const Monster &monster);
 void M_StartStand(Monster &monster, Direction md);
 void M_ClearSquares(const Monster &monster);
-void M_GetKnockback(Monster &monster);
+void M_GetKnockback(Monster &monster, WorldTilePosition playerPos);
 void M_StartHit(Monster &monster, int dam);
 void M_StartHit(Monster &monster, const Player &player, int dam);
 void StartMonsterDeath(Monster &monster, const Player &player, bool sendmsg);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1659,7 +1659,7 @@ size_t OnKnockback(const TCmd *pCmd, Player &player)
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && monsterIdx < MaxMonsters) {
 		Monster &monster = Monsters[monsterIdx];
-		M_GetKnockback(monster);
+		M_GetKnockback(monster, player.position.tile);
 		M_StartHit(monster, player, 0);
 	}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -678,7 +678,7 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 		M_StartKill(monster, player);
 	} else {
 		if (monster.mode != MonsterMode::Petrified && HasAnyOf(player._pIFlags, ItemSpecialEffect::Knockback))
-			M_GetKnockback(monster);
+			M_GetKnockback(monster, player.position.tile);
 		M_StartHit(monster, player, dam);
 	}
 	return true;


### PR DESCRIPTION
This fixes the problem with knockback. Knockback always pushes monsters in the opposite direction that the monster is facing. This can result in monsters being pushed in the wrong direction if they aren't facing the attacking player/missile.

Melee attacks and Telekinesis will calculate a direction based on the player tile and monster future tile upon initiating knockback.

Missiles will calculate a direction based on the missile start tile and monster future tile upon initiating knockback.