### PR TITLE
Revise PVP Block and Hit Recovery handling

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1867,6 +1867,39 @@ size_t OnPlayerDamage(const TCmd *pCmd, Player &player)
 	return sizeof(message);
 }
 
+size_t OnPlayerInflictBlock(const TCmd *pCmd, Player &player)
+{
+	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
+	const uint16_t pid = SDL_SwapLE16(message.wParam1);
+
+	Player &target = Players[pid];
+	if (leveltype != DTYPE_TOWN && gbBufferMsgs != 1) {
+		if (player.isOnActiveLevel() && target._pHitPoints >> 6 > 0) {
+			Direction dir = GetDirection(target.position.tile, player.position.tile);
+			StartPlrBlock(target, dir);
+		}
+	}
+
+	return sizeof(message);
+}
+
+size_t OnPlayerInflictRecovery(const TCmd *pCmd, Player &player)
+{
+	const auto &message = *reinterpret_cast<const TCmdParam2 *>(pCmd);
+	const uint16_t pid = SDL_SwapLE16(message.wParam1);
+	const uint16_t dam = SDL_SwapLE16(message.wParam2);
+
+	Player &target = Players[pid];
+	if (leveltype != DTYPE_TOWN && gbBufferMsgs != 1) {
+		if (player.isOnActiveLevel() && target._pHitPoints >> 6 > 0) {
+			Direction dir = GetDirection(target.position.tile, player.position.tile);
+			StartPlrHit(target, dam, false);
+		}
+	}
+
+	return sizeof(message);
+}
+
 size_t OnOperateObject(const TCmd &pCmd, Player &player)
 {
 	const auto &message = reinterpret_cast<const TCmdLoc &>(pCmd);
@@ -3295,6 +3328,10 @@ size_t ParseCmd(uint8_t pnum, const TCmd *pCmd)
 		return OnPlayerDeath(pCmd, player);
 	case CMD_PLRDAMAGE:
 		return OnPlayerDamage(pCmd, player);
+	case CMD_PLRINFLICTBLOCK:
+		return OnPlayerInflictBlock(pCmd, player);
+	case CMD_PLRINFLICTRECOVERY:
+		return OnPlayerInflictRecovery(pCmd, player);
 	case CMD_OPENDOOR:
 	case CMD_CLOSEDOOR:
 	case CMD_OPERATEOBJ:

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -281,6 +281,14 @@ enum _cmd_id : uint8_t {
 	//
 	// body (TCmdDamage)
 	CMD_PLRDAMAGE,
+	// Make target player block.
+	//
+	// body (TCmdParam1)
+	CMD_PLRINFLICTBLOCK,
+	// Make target player enter hit recovery.
+	//
+	// body (TCmdParam1)
+	CMD_PLRINFLICTRECOVERY,
 	// Set player level.
 	//
 	// body (TCmdParam1):

--- a/Source/player.h
+++ b/Source/player.h
@@ -984,5 +984,6 @@ void SetPlrDex(Player &player, int v);
 void SetPlrVit(Player &player, int v);
 void InitDungMsgs(Player &player);
 void PlayDungMsgs();
+bool TryPlayerBlock(const Player &attacker, const Player &target, bool shift = false);
 
 } // namespace devilution


### PR DESCRIPTION
This is an effort to combat desync in player vs player interactions. In vanilla, damage is sent via network message by the attacker, but blocking and hit recovery are handled client sided, leading to desync. This ensures that when the attacker successfully hits (or I guess starts the sequence of events that leads to damage/blocking/hit recovery), only then will PvP based hit recovery and blocking take place. Additionally, this also fixes the issue caused by unsynced RNG, where the result of a block calculation will be different per client. The attacker will perform the calculation, and the defender will receive the result of that calculation and be forced to block accordingly.

I have also cleaned up `Plr2PlrMHit()` and `PlrHitPlr()` during my effort to avoid any bugs during this implementation.