### PR TITLE
Hiddens are no longer omniscient

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -2384,10 +2384,7 @@ void ButcherAi(Monster &monster)
 
 void SneakAi(Monster &monster)
 {
-	if (monster.mode != MonsterMode::Stand) {
-		return;
-	}
-	if (dLight[monster.position.tile.x][monster.position.tile.y] == LightsMax) {
+	if (monster.mode != MonsterMode::Stand || monster.activeForTicks == 0) {
 		return;
 	}
 


### PR DESCRIPTION
From Jarulf's Guide:
> The Hiddens have the ability to disappear. They are always active and can always see you, even with max reduced light radius, regardless of whether or not you have a line of sight to them and regardless of the distance.

From the DSF buglist (https://www.lurkerlounge.com/forums/thread-12422.html):
> Monsters that use Hidden AI are always active. Unless there's a barrier between them and the player (e.g. closed door, barrels completely blocking a path), they'll reach the player without any action on the player's part.

Neither of these descriptions really capture the nuance, and they're both technically wrong. First, I'd like to point out there is a pattern used throughout the AI routines to determine whether a monster is active. Here is one example.

https://github.com/diasurgical/devilutionX/blob/692365fe8c6990977840e8fd28aeaf964dcdcb0d/Source/monster.cpp#L1874-L1876

This prevents the monster's AI routine from doing anything if the monster is standing still and has not been activated by the player. `activeForTicks` gets set to 255 when a monster is in line of sight of the player and decreases by 1 every game tick when they are not. This means that a monster stays active for nearly 13 seconds after the player loses line of sight.

There are only two AI routines that do not follow this same general pattern. The first is `ZombieAi()`, which uses `IsTileVisible()` instead, meaning that Zombies do not remain active when they leave the player's line of sight. The second is `SneakAi()` used by the Hiddens, which uses the following.

https://github.com/diasurgical/devilutionX/blob/692365fe8c6990977840e8fd28aeaf964dcdcb0d/Source/monster.cpp#L2387-L2392

In this case, Hiddens will be active so long as they are in a tile that is not _completely_ dark. In the case where a Hidden is nowhere near the player but within range of a light source, the `SneakAi()` function will call `GetMonsterDirection()` which determines the direction a monster must go in order to get closer to its target. This suggests either that the monster is aware of the player's location simply by virtue of being near a light source or that there is an error. The direction is passed into the `RandomWalk()` routine, causing the monster to move in the general direction of the player, which I assume is why both Jarulf and DSF suggest that the monster will always see/reach you.

Further adding to the confusion around this function, it seems that three of the variants of Hiddens have the `SEARCH` flag set. This is defined in monstdat, meaning it applies directly to the type of monster.

https://github.com/diasurgical/devilutionX/blob/692365fe8c6990977840e8fd28aeaf964dcdcb0d/assets/txtdata/monsters/monstdat.tsv#L31-L34

The search flag activates a special routine called `AiPlanPath()` that allows the monster to more intelligently search for the player when they lose sight of them, like when the player closes a door or goes around a corner.

https://github.com/diasurgical/devilutionX/blob/692365fe8c6990977840e8fd28aeaf964dcdcb0d/Source/monster.cpp#L4089

One of the things this `AiPlanPath()` function does is check the `activeForTicks` variable to determine if the monster is active. Monsters which are not active do not plan their paths.

https://github.com/diasurgical/devilutionX/blob/692365fe8c6990977840e8fd28aeaf964dcdcb0d/Source/monster.cpp#L1722-L1723

So despite the fact that Hiddens are apparently aware of exactly where the player is so long as they're under a light source, three of the four variants still change their behavior when they enter the player's range of vision which.. I'm not sure what that would suggest. It's like they have some extremely accurate and yet dormant awareness of the player's exact location until they actually see the player at which point they have another level of awareness?

Note that the `dLight` array is affected by the player's light radius, meaning that Hiddens shrouded in complete darkness would be roused by the player entering their proximity, just as they would if they entered the player's vision. Furthermore, because the `dLight` array does not have a countdown like the `activeForTicks` field does, a Hidden without the `SEARCH` flag who retreats into complete darkness would instantly go dormant.

After digging through the code around this, I think it's actually possible that Blizzard intended to implement something similar to vision but using the player's light radius directly so it would reach through obstructions. Regardless, I feel like it's pretty clear they botched it pretty badly so I'm submitting this PR for consideration.