### PR TITLE
Fix OOB when debugging megatile data near the edge of the dungeon

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -208,16 +208,20 @@ bool GetDebugGridText(Point dungeonCoords, char *debugGridTextBuffer)
 		info = TileHasAny(dungeonCoords, TileProperties::Trap);
 		break;
 	case DebugGridTextItem::AutomapView:
-		info = AutomapView[megaCoords.x][megaCoords.y];
+		if (megaCoords.x >= 0 && megaCoords.x < DMAXX && megaCoords.y >= 0 && megaCoords.y < DMAXY)
+			info = AutomapView[megaCoords.x][megaCoords.y];
 		break;
 	case DebugGridTextItem::dungeon:
-		info = dungeon[megaCoords.x][megaCoords.y];
+		if (megaCoords.x >= 0 && megaCoords.x < DMAXX && megaCoords.y >= 0 && megaCoords.y < DMAXY)
+			info = dungeon[megaCoords.x][megaCoords.y];
 		break;
 	case DebugGridTextItem::pdungeon:
-		info = pdungeon[megaCoords.x][megaCoords.y];
+		if (megaCoords.x >= 0 && megaCoords.x < DMAXX && megaCoords.y >= 0 && megaCoords.y < DMAXY)
+			info = pdungeon[megaCoords.x][megaCoords.y];
 		break;
 	case DebugGridTextItem::Protected:
-		info = Protected.test(megaCoords.x, megaCoords.y);
+		if (megaCoords.x >= 0 && megaCoords.x < DMAXX && megaCoords.y >= 0 && megaCoords.y < DMAXY)
+			info = Protected.test(megaCoords.x, megaCoords.y);
 		break;
 	case DebugGridTextItem::None:
 		return false;


### PR DESCRIPTION
Dungeon coordinates can extend into the 16-tile padding around arrays that use `dungeonCoords` like `dPiece`, but the megatile arrays have no padding. If `dungeonCoords` points to a location in the padded area, it will produce a value for `megaCoords` that is out of bounds. This was causing my game to crash when using `dev.display.tileData("Protected")` near the edge of the dungeon.