### PR TITLE
Demomode: Set scancode for keyboard events

### DIFF
--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -270,6 +270,7 @@ bool CreateSdlEvent(const DemoMsg &dmsg, SDL_Event &event, uint16_t &modState)
 	case DemoMsg::KeyUpEvent:
 		event.type = type == DemoMsg::KeyDownEvent ? SDL_KEYDOWN : SDL_KEYUP;
 		event.key.state = type == DemoMsg::KeyDownEvent ? SDL_PRESSED : SDL_RELEASED;
+		event.key.keysym.scancode = SDL_GetScancodeFromKey(dmsg.key.sym);
 		event.key.keysym.sym = dmsg.key.sym;
 		event.key.keysym.mod = dmsg.key.mod;
 		return true;


### PR DESCRIPTION
We were previously not setting it all which was incorrect but did not cause any issues because we had not used it. We do check scancode for the debug console key. This caused a sanitizer warning when running the demo in debug mode.