### PR TITLE
Add southwalk bug to arena

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2626,7 +2626,7 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 
 	WorldTilePosition pos = player.position.tile;
 	if (player.isOnArenaLevel() && player.isWalking() && IsAnyOf(player._pdir, Direction::SouthWest, Direction::South, Direction::SouthEast) && PosOkPlayer(player, pos + pd)) {
-		pos += player._pdir;
+		pos += pd;
 		player.position.tile = pos;
 	}
 	player._pmode = PM_GOTHIT;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2624,10 +2624,17 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 
 	NewPlrAnim(player, player_graphic::Hit, pd, AnimationDistributionFlags::None, skippedAnimationFrames);
 
+	bool isWalking = player.isWalking();
 	player._pmode = PM_GOTHIT;
 	FixPlayerLocation(player, pd);
 	FixPlrWalkTags(player);
-	player.occupyTile(player.position.tile, false);
+	WorldTilePosition pos = player.position.tile;
+	if (player.isOnArenaLevel() && isWalking && IsAnyOf(player._pdir, Direction::SouthWest, Direction::South, Direction::SouthEast) && PosOkPlayer(player, pos + player._pdir)) {
+		SDL_Log("true");
+		pos += player._pdir;
+		player.position.tile = pos;
+	}
+	player.occupyTile(pos, false);
 	SetPlayerOld(player);
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2624,9 +2624,8 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 
 	NewPlrAnim(player, player_graphic::Hit, pd, AnimationDistributionFlags::None, skippedAnimationFrames);
 
-	bool isWalking = player.isWalking();
 	WorldTilePosition pos = player.position.tile;
-	if (player.isOnArenaLevel() && isWalking && IsAnyOf(player._pdir, Direction::SouthWest, Direction::South, Direction::SouthEast) && PosOkPlayer(player, pos + pd)) {
+	if (player.isOnArenaLevel() && player.isWalking() && IsAnyOf(player._pdir, Direction::SouthWest, Direction::South, Direction::SouthEast) && PosOkPlayer(player, pos + pd)) {
 		pos += player._pdir;
 		player.position.tile = pos;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2625,15 +2625,14 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 	NewPlrAnim(player, player_graphic::Hit, pd, AnimationDistributionFlags::None, skippedAnimationFrames);
 
 	bool isWalking = player.isWalking();
-	player._pmode = PM_GOTHIT;
-	FixPlayerLocation(player, pd);
-	FixPlrWalkTags(player);
 	WorldTilePosition pos = player.position.tile;
-	if (player.isOnArenaLevel() && isWalking && IsAnyOf(player._pdir, Direction::SouthWest, Direction::South, Direction::SouthEast) && PosOkPlayer(player, pos + player._pdir)) {
-		SDL_Log("true");
+	if (player.isOnArenaLevel() && isWalking && IsAnyOf(player._pdir, Direction::SouthWest, Direction::South, Direction::SouthEast) && PosOkPlayer(player, pos + pd)) {
 		pos += player._pdir;
 		player.position.tile = pos;
 	}
+	player._pmode = PM_GOTHIT;
+	FixPlayerLocation(player, pd);
+	FixPlrWalkTags(player);
 	player.occupyTile(pos, false);
 	SetPlayerOld(player);
 }


### PR DESCRIPTION
The southwalk bug is crucial for PVP. Without it, PVP is not viable in any capacity. This adds the exact functionality from the bug as a feature without reintroducing bad logic.