### PR TITLE
Fix illegal spell levels

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -396,10 +396,10 @@ void LoadPlayer(LoadHelper &file, Player &player)
 		if (GetSpellData(spl).sBookLvl != -1)
 			player._pSplLvl[i] = file.NextLE<uint8_t>();
 		else
-			player._pSplLvl[i] = 0;
+			file.Skip<uint8_t>();
 	}
 	for (int i = static_cast<int>(SpellID::LAST); i < 64; i++)
-		player._pSplLvl[i] = 0;
+		file.Skip<uint8_t>();
 	if (!gbIsHellfire) {
 		player._pSplLvl[static_cast<uint8_t>(SpellID::Apocalypse)] = 0;
 		player._pSplLvl[static_cast<uint8_t>(SpellID::Nova)] = 0;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -390,8 +390,14 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	file.Skip(3); // Alignment
 	player._pSBkSpell = static_cast<SpellID>(file.NextLE<int32_t>());
 	file.Skip<int8_t>(); // Skip _pSBkSplType
-	for (uint8_t &spellLevel : player._pSplLvl)
-		spellLevel = file.NextLE<uint8_t>();
+
+	for (int i = 0; i < 64; i++) {
+		if (GetSpellData(static_cast<SpellID>(i)).sBookLvl != -1)
+			player._pSplLvl[i] = file.NextLE<uint8_t>();
+		else
+			player._pSplLvl[i] = 0;
+	}
+
 	file.Skip(7); // Alignment
 	player._pMemSpells = file.NextLE<uint64_t>();
 	player._pAblSpells = file.NextLE<uint64_t>();
@@ -1212,8 +1218,12 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int32_t>(static_cast<int8_t>(player._pSBkSpell));
 	file.Skip<int8_t>(); // Skip _pSBkSplType
 
-	for (uint8_t spellLevel : player._pSplLvl)
-		file.WriteLE<uint8_t>(spellLevel);
+	for (int i = 0; i < 64; i++) {
+		if (GetSpellData(static_cast<SpellID>(i)).sBookLvl != -1)
+			file.WriteLE<uint8_t>(player._pSplLvl[i]);
+		else
+			file.WriteLE<uint8_t>(0);
+	}
 
 	file.Skip(7); // Alignment
 	file.WriteLE<uint64_t>(player._pMemSpells);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1225,15 +1225,8 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int32_t>(static_cast<int8_t>(player._pSBkSpell));
 	file.Skip<int8_t>(); // Skip _pSBkSplType
 
-	for (int i = 0; i < static_cast<int>(SpellID::LAST); i++) {
-		auto spl = static_cast<SpellID>(i);
-		if (GetSpellData(spl).sBookLvl == -1)
-			file.WriteLE<uint8_t>(0);
-		else
-			file.WriteLE<uint8_t>(player._pSplLvl[i]);
-	}
-	for (int i = static_cast<int>(SpellID::LAST); i < 64; i++)
-		file.WriteLE<uint8_t>(0);
+	for (uint8_t spellLevel : player._pSplLvl)
+		file.WriteLE<uint8_t>(spellLevel);
 
 	file.Skip(7); // Alignment
 	file.WriteLE<uint64_t>(player._pMemSpells);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -391,6 +391,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player._pSBkSpell = static_cast<SpellID>(file.NextLE<int32_t>());
 	file.Skip<int8_t>(); // Skip _pSBkSplType
 
+	// Only read spell levels for learnable spells
 	for (int i = 0; i < static_cast<int>(SpellID::LAST); i++) {
 		auto spl = static_cast<SpellID>(i);
 		if (GetSpellData(spl).sBookLvl != -1)
@@ -398,8 +399,10 @@ void LoadPlayer(LoadHelper &file, Player &player)
 		else
 			file.Skip<uint8_t>();
 	}
+	// Skip unused spells
 	for (int i = static_cast<int>(SpellID::LAST); i < 64; i++)
 		file.Skip<uint8_t>();
+	// These spells are unavailable in Diablo as learnable spells
 	if (!gbIsHellfire) {
 		player._pSplLvl[static_cast<uint8_t>(SpellID::Apocalypse)] = 0;
 		player._pSplLvl[static_cast<uint8_t>(SpellID::Nova)] = 0;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -393,10 +393,10 @@ void LoadPlayer(LoadHelper &file, Player &player)
 
 	for (int i = 0; i < static_cast<int>(SpellID::LAST); i++) {
 		auto spl = static_cast<SpellID>(i);
-		if (GetSpellData(spl).sBookLvl == -1)
-			player._pSplLvl[i] = 0;
-		else
+		if (GetSpellData(spl).sBookLvl != -1)
 			player._pSplLvl[i] = file.NextLE<uint8_t>();
+		else
+			player._pSplLvl[i] = 0;
 	}
 	for (int i = static_cast<int>(SpellID::LAST); i < 64; i++)
 		player._pSplLvl[i] = 0;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -399,7 +399,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 		else
 			file.Skip<uint8_t>();
 	}
-	// Skip unused spells
+	// Skip indices that are unused
 	for (int i = static_cast<int>(SpellID::LAST); i < 64; i++)
 		file.Skip<uint8_t>();
 	// These spells are unavailable in Diablo as learnable spells

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -391,12 +391,18 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player._pSBkSpell = static_cast<SpellID>(file.NextLE<int32_t>());
 	file.Skip<int8_t>(); // Skip _pSBkSplType
 
-	for (int i = 0; i < 64; i++) {
+	for (int i = 0; i < static_cast<int>(SpellID::LAST); i++) {
 		auto spl = static_cast<SpellID>(i);
-		if (GetSpellData(spl).sBookLvl == -1 || (!gbIsHellfire && IsAnyOf(spl, SpellID::Apocalypse, SpellID::Nova)))
+		if (GetSpellData(spl).sBookLvl == -1)
 			player._pSplLvl[i] = 0;
 		else
 			player._pSplLvl[i] = file.NextLE<uint8_t>();
+	}
+	for (int i = static_cast<int>(SpellID::LAST); i < 64; i++)
+		player._pSplLvl[i] = 0;
+	if (!gbIsHellfire) {
+		player._pSplLvl[static_cast<uint8_t>(SpellID::Apocalypse)] = 0;
+		player._pSplLvl[static_cast<uint8_t>(SpellID::Nova)] = 0;
 	}
 
 	file.Skip(7); // Alignment
@@ -1219,13 +1225,15 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int32_t>(static_cast<int8_t>(player._pSBkSpell));
 	file.Skip<int8_t>(); // Skip _pSBkSplType
 
-	for (int i = 0; i < 64; i++) {
+	for (int i = 0; i < static_cast<int>(SpellID::LAST); i++) {
 		auto spl = static_cast<SpellID>(i);
-		if (GetSpellData(spl).sBookLvl == -1 || (!gbIsHellfire && IsAnyOf(spl, SpellID::Apocalypse, SpellID::Nova)))
+		if (GetSpellData(spl).sBookLvl == -1)
 			file.WriteLE<uint8_t>(0);
 		else
 			file.WriteLE<uint8_t>(player._pSplLvl[i]);
 	}
+	for (int i = static_cast<int>(SpellID::LAST); i < 64; i++)
+		file.WriteLE<uint8_t>(0);
 
 	file.Skip(7); // Alignment
 	file.WriteLE<uint64_t>(player._pMemSpells);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -392,10 +392,11 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	file.Skip<int8_t>(); // Skip _pSBkSplType
 
 	for (int i = 0; i < 64; i++) {
-		if (GetSpellData(static_cast<SpellID>(i)).sBookLvl != -1)
-			player._pSplLvl[i] = file.NextLE<uint8_t>();
-		else
+		auto spl = static_cast<SpellID>(i);
+		if (GetSpellData(spl).sBookLvl == -1 || (!gbIsHellfire && IsAnyOf(spl, SpellID::Apocalypse, SpellID::Nova)))
 			player._pSplLvl[i] = 0;
+		else
+			player._pSplLvl[i] = file.NextLE<uint8_t>();
 	}
 
 	file.Skip(7); // Alignment
@@ -1219,10 +1220,11 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.Skip<int8_t>(); // Skip _pSBkSplType
 
 	for (int i = 0; i < 64; i++) {
-		if (GetSpellData(static_cast<SpellID>(i)).sBookLvl != -1)
-			file.WriteLE<uint8_t>(player._pSplLvl[i]);
-		else
+		auto spl = static_cast<SpellID>(i);
+		if (GetSpellData(spl).sBookLvl == -1 || (!gbIsHellfire && IsAnyOf(spl, SpellID::Apocalypse, SpellID::Nova)))
 			file.WriteLE<uint8_t>(0);
+		else	
+			file.WriteLE<uint8_t>(player._pSplLvl[i]);
 	}
 
 	file.Skip(7); // Alignment

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1223,7 +1223,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 		auto spl = static_cast<SpellID>(i);
 		if (GetSpellData(spl).sBookLvl == -1 || (!gbIsHellfire && IsAnyOf(spl, SpellID::Apocalypse, SpellID::Nova)))
 			file.WriteLE<uint8_t>(0);
-		else	
+		else
 			file.WriteLE<uint8_t>(player._pSplLvl[i]);
 	}
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -484,6 +484,7 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 	player._pManaBase = std::min<int32_t>(player._pManaBase, player._pMaxManaBase);
 	player._pMemSpells = SDL_SwapLE64(packed.pMemSpells);
 
+	// Only read spell levels for learnable spells (Diablo)
 	for (int i = 0; i < 37; i++) { // Should be MAX_SPELLS but set to 36 to make save games compatible
 		auto spl = static_cast<SpellID>(i);
 		if (GetSpellData(spl).sBookLvl != -1)
@@ -491,6 +492,7 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 		else
 			player._pSplLvl[i] = 0;
 	}
+	// Only read spell levels for learnable spells (Hellfire)
 	for (int i = 37; i < 47; i++) {
 		auto spl = static_cast<SpellID>(i);
 		if (GetSpellData(spl).sBookLvl != -1)
@@ -498,6 +500,7 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 		else
 			player._pSplLvl[i] = 0;
 	}
+	// These spells are unavailable in Diablo as learnable spells
 	if (!gbIsHellfire) {
 		player._pSplLvl[static_cast<uint8_t>(SpellID::Apocalypse)] = 0;
 		player._pSplLvl[static_cast<uint8_t>(SpellID::Nova)] = 0;

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -277,13 +277,18 @@ void PackPlayer(PlayerPack &packed, const Player &player)
 
 	for (int i = 0; i < 37; i++) { // Should be MAX_SPELLS but set to 37 to make save games compatible
 		auto spl = static_cast<SpellID>(i);
-		if (GetSpellData(spl).sBookLvl == -1 || (!gbIsHellfire && IsAnyOf(spl, SpellID::Apocalypse, SpellID::Nova)))
+		if (GetSpellData(spl).sBookLvl == -1)
 			packed.pSplLvl[i] = 0;
 		else
 			packed.pSplLvl[i] = player._pSplLvl[i];
 	}
-	for (int i = 37; i < 47; i++)
-		packed.pSplLvl2[i - 37] = player._pSplLvl[i];
+	for (int i = 37; i < 47; i++) {
+		auto spl = static_cast<SpellID>(i);
+		if (GetSpellData(spl).sBookLvl == -1)
+			packed.pSplLvl2[i - 37] = 0;
+		else
+			packed.pSplLvl2[i - 37] = player._pSplLvl[i];
+	}
 
 	for (int i = 0; i < NUM_INVLOC; i++)
 		PackItem(packed.InvBody[i], player.InvBody[i], gbIsHellfire);
@@ -491,13 +496,22 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 
 	for (int i = 0; i < 37; i++) { // Should be MAX_SPELLS but set to 36 to make save games compatible
 		auto spl = static_cast<SpellID>(i);
-		if (GetSpellData(spl).sBookLvl == -1 || (!gbIsHellfire && IsAnyOf(spl, SpellID::Apocalypse, SpellID::Nova)))
+		if (GetSpellData(spl).sBookLvl == -1)
 			player._pSplLvl[i] = 0;
 		else
 			player._pSplLvl[i] = packed.pSplLvl[i];
 	}
-	for (int i = 37; i < 47; i++)
-		player._pSplLvl[i] = packed.pSplLvl2[i - 37];
+	for (int i = 37; i < 47; i++) {
+		auto spl = static_cast<SpellID>(i);
+		if (GetSpellData(spl).sBookLvl == -1)
+			player._pSplLvl[i] = 0;
+		else
+			player._pSplLvl[i] = packed.pSplLvl2[i - 37];
+	}
+	if (!gbIsHellfire) {
+		player._pSplLvl[static_cast<uint8_t>(SpellID::Apocalypse)] = 0;
+		player._pSplLvl[static_cast<uint8_t>(SpellID::Nova)] = 0;
+	}
 
 	bool isHellfire = packed.bIsHellfire != 0;
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -486,10 +486,10 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 
 	for (int i = 0; i < 37; i++) { // Should be MAX_SPELLS but set to 36 to make save games compatible
 		auto spl = static_cast<SpellID>(i);
-		if (GetSpellData(spl).sBookLvl == -1)
-			player._pSplLvl[i] = 0;
-		else
+		if (GetSpellData(spl).sBookLvl != -1)
 			player._pSplLvl[i] = packed.pSplLvl[i];
+		else
+			player._pSplLvl[i] = 0;
 	}
 	for (int i = 37; i < 47; i++) {
 		auto spl = static_cast<SpellID>(i);

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -275,8 +275,13 @@ void PackPlayer(PlayerPack &packed, const Player &player)
 	packed.pMaxManaBase = SDL_SwapLE32(player._pMaxManaBase);
 	packed.pMemSpells = SDL_SwapLE64(player._pMemSpells);
 
-	for (int i = 0; i < 37; i++) // Should be MAX_SPELLS but set to 37 to make save games compatible
-		packed.pSplLvl[i] = player._pSplLvl[i];
+	for (int i = 0; i < 37; i++) { // Should be MAX_SPELLS but set to 37 to make save games compatible
+		auto spl = static_cast<SpellID>(i);
+		if (GetSpellData(spl).sBookLvl == -1 || (!gbIsHellfire && IsAnyOf(spl, SpellID::Apocalypse, SpellID::Nova)))
+			packed.pSplLvl[i] = 0;
+		else
+			packed.pSplLvl[i] = player._pSplLvl[i];
+	}
 	for (int i = 37; i < 47; i++)
 		packed.pSplLvl2[i - 37] = player._pSplLvl[i];
 
@@ -484,8 +489,13 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 	player._pManaBase = std::min<int32_t>(player._pManaBase, player._pMaxManaBase);
 	player._pMemSpells = SDL_SwapLE64(packed.pMemSpells);
 
-	for (int i = 0; i < 37; i++) // Should be MAX_SPELLS but set to 36 to make save games compatible
-		player._pSplLvl[i] = packed.pSplLvl[i];
+	for (int i = 0; i < 37; i++) { // Should be MAX_SPELLS but set to 36 to make save games compatible
+		auto spl = static_cast<SpellID>(i);
+		if (GetSpellData(spl).sBookLvl == -1 || (!gbIsHellfire && IsAnyOf(spl, SpellID::Apocalypse, SpellID::Nova)))
+			player._pSplLvl[i] = 0;
+		else
+			player._pSplLvl[i] = packed.pSplLvl[i];
+	}
 	for (int i = 37; i < 47; i++)
 		player._pSplLvl[i] = packed.pSplLvl2[i - 37];
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -275,20 +275,10 @@ void PackPlayer(PlayerPack &packed, const Player &player)
 	packed.pMaxManaBase = SDL_SwapLE32(player._pMaxManaBase);
 	packed.pMemSpells = SDL_SwapLE64(player._pMemSpells);
 
-	for (int i = 0; i < 37; i++) { // Should be MAX_SPELLS but set to 37 to make save games compatible
-		auto spl = static_cast<SpellID>(i);
-		if (GetSpellData(spl).sBookLvl == -1)
-			packed.pSplLvl[i] = 0;
-		else
-			packed.pSplLvl[i] = player._pSplLvl[i];
-	}
-	for (int i = 37; i < 47; i++) {
-		auto spl = static_cast<SpellID>(i);
-		if (GetSpellData(spl).sBookLvl == -1)
-			packed.pSplLvl2[i - 37] = 0;
-		else
-			packed.pSplLvl2[i - 37] = player._pSplLvl[i];
-	}
+	for (int i = 0; i < 37; i++) // Should be MAX_SPELLS but set to 37 to make save games compatible
+		packed.pSplLvl[i] = player._pSplLvl[i];
+	for (int i = 37; i < 47; i++)
+		packed.pSplLvl2[i - 37] = player._pSplLvl[i];
 
 	for (int i = 0; i < NUM_INVLOC; i++)
 		PackItem(packed.InvBody[i], player.InvBody[i], gbIsHellfire);

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -493,10 +493,10 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 	}
 	for (int i = 37; i < 47; i++) {
 		auto spl = static_cast<SpellID>(i);
-		if (GetSpellData(spl).sBookLvl == -1)
-			player._pSplLvl[i] = 0;
-		else
+		if (GetSpellData(spl).sBookLvl != -1)
 			player._pSplLvl[i] = packed.pSplLvl2[i - 37];
+		else
+			player._pSplLvl[i] = 0;
 	}
 	if (!gbIsHellfire) {
 		player._pSplLvl[static_cast<uint8_t>(SpellID::Apocalypse)] = 0;


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/issues/7111

When loading/unpacking player data, spells with a book level of -1 are set to spell level 0, and if the game mode isn't Hellfire, Apocalypse and Nova get set to spell level 0. Additionally, all indices of `_pSplLvl[64]` which do not have a `SpellID` enumerator are automatically loaded/unpacked as spell level 0.