### PR TITLE
Don't dereference nullopt in DebugCmdLevelUp()

### DIFF
--- a/Source/lua/modules/dev/player/stats.cpp
+++ b/Source/lua/modules/dev/player/stats.cpp
@@ -16,12 +16,12 @@ namespace {
 
 std::string DebugCmdLevelUp(std::optional<int> levels)
 {
-	if (!levels.has_value()) *levels = 1;
-	if (*levels <= 0) return "amount must be positive";
+	const int levelsToAdd = levels.value_or(1);
+	if (levelsToAdd <= 0) return "amount must be positive";
 	Player &myPlayer = *MyPlayer;
-	for (int i = 0; i < *levels; i++)
+	for (int i = 0; i < levelsToAdd; i++)
 		NetSendCmd(true, CMD_CHEAT_EXPERIENCE);
-	return StrCat("New character level: ", myPlayer.getCharacterLevel() + *levels);
+	return StrCat("New character level: ", myPlayer.getCharacterLevel() + levelsToAdd);
 }
 
 std::string DebugCmdMaxStats()


### PR DESCRIPTION
Attempting to assign to the parameter on line 19 caused an error when I was debugging. The correct approach would have been `levels.emplace(1)`, but I switched over to `levels.value_or(1)` to be more consistent with the pattern used by other debug functions.