### PR TITLE
Update vcpkg baseline to get libsodium 1.0.20

### DIFF
--- a/.github/workflows/Windows_MSVC_x64.yml
+++ b/.github/workflows/Windows_MSVC_x64.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Restore or setup vcpkg
       uses: lukka/run-vcpkg@v11.5
       with:
-        vcpkgGitCommitId: '37c3e63a1306562f7f59c4c3c8892ddd50fdf992'
+        vcpkgGitCommitId: 'dee924de74e81388140a53c32a919ecec57d20ab'
 
     - name: Fetch test data
       run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,7 @@
 		"simpleini",
 		"lua"
 	],
-	"builtin-baseline": "37c3e63a1306562f7f59c4c3c8892ddd50fdf992",
+	"builtin-baseline": "dee924de74e81388140a53c32a919ecec57d20ab",
 	"features": {
 		"sdl1": {
 			"description": "Use SDL1.2 instead of SDL2",


### PR DESCRIPTION
When I attempted to build DevilutionX on my laptop for the first time in a long while, I encountered the error described in https://github.com/microsoft/vcpkg/issues/38947.

From what I gathered, the vcpkg port for libsodium 1.0.19 was pointed to the `1.0.19` tag in libsodium which is a moving target. The tag changed, which invalidated their hash. They fixed it by targeting the `1.0.20-RELEASE` tag which is a more stable target, but it does nothing to resolve the 1.0.19 hash.

Anyone who has already downloaded the 1.0.19 package should be unaffected. Anyone who hasn't already downloaded it is going to encounter the error and be unable to build. So we don't have much choice but to update.