### PR TITLE
Add CPack NSIS Windows Installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ option(ENABLE_CODECOVERAGE "Instrument code for code coverage (only enabled with
 # Packaging options
 RELEASE_OPTION(CPACK "Configure CPack")
 option(MACOSX_STANDALONE_APP_BUNDLE "Generate a portable app bundle to use on other devices (requires sudo)" OFF)
+option(WIN_NSIS "Generate an NSIS installer" OFF)
 
 # Network options
 cmake_dependent_option(DISABLE_TCP "Disable TCP multiplayer option" OFF "NOT NONET" ON)
@@ -528,9 +529,21 @@ if(CPACK AND (APPLE OR BUILD_ASSETS_MPQ OR SRC_DIST))
       "${SDL2_WIN32_LICENSES_DIR}/LICENSE*.txt"
       "${SDL2_WIN32_LICENSES_DIR}/README*.txt")
 
-    set(CPACK_PACKAGE_FILE_NAME "devilutionx")
     set(CPACK_PACKAGE_NAME ${project_name})
-    set(CPACK_GENERATOR "ZIP")
+    if(WIN_NSIS)
+      set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}_${PROJECT_VERSION}_Installer")
+      set(CPACK_GENERATOR "NSIS")
+      set(CPACK_PACKAGE_INSTALL_DIRECTORY "${PROJECT_NAME}")
+      set(CPACK_NSIS_MUI_ICON "${PROJECT_SOURCE_DIR}/Packaging/windows/icon.ico")
+      set(CPACK_NSIS_MUI_UNIICON "${PROJECT_SOURCE_DIR}/Packaging/windows/icon.ico")
+      set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE.md")
+      set(CPACK_NSIS_EXECUTABLES_DIRECTORY ".")
+      set(CPACK_PACKAGE_EXECUTABLES "devilutionx" "DevilutionX")
+      set(CPACK_NSIS_MUI_FINISHPAGE_RUN "${BIN_TARGET}")
+    else()
+      set(CPACK_PACKAGE_FILE_NAME "devilutionx")
+      set(CPACK_GENERATOR "ZIP")
+    endif()
     set(CPACK_STRIP_FILES TRUE)
     install(TARGETS ${BIN_TARGET} DESTINATION .)
     install(FILES "${PROJECT_SOURCE_DIR}/Packaging/windows/README.txt"


### PR DESCRIPTION
This adds a CPack Generator for a Windows Installer. To add to cmake command is -DWIN_NSIS=ON.

<details><summary>Install</summary>
<p>

![Screenshot 2024-06-06 231353](https://github.com/diasurgical/devilutionX/assets/26759970/7b3311f3-c4c4-4548-977a-fc19e1ae155e)

![Screenshot 2024-06-06 231427](https://github.com/diasurgical/devilutionX/assets/26759970/7a276373-7b9e-4bcd-8407-6ed08df91148)

![Screenshot 2024-06-06 231444](https://github.com/diasurgical/devilutionX/assets/26759970/95b229a7-a618-4f02-99bc-8ebf31fb787a)

![Screenshot 2024-06-06 231459](https://github.com/diasurgical/devilutionX/assets/26759970/783a6507-93f0-45cd-b130-cdb994a3f453)

![Screenshot 2024-06-06 231515](https://github.com/diasurgical/devilutionX/assets/26759970/4535a678-7bc6-4d5f-9429-8d802401a2c5)

</p>
</details> 
<details><summary>Uninstall</summary>
<p>

![Screenshot 2024-06-06 231543](https://github.com/diasurgical/devilutionX/assets/26759970/15e473c2-78be-4eba-b8d6-75b778054976)

![Screenshot 2024-06-06 231555](https://github.com/diasurgical/devilutionX/assets/26759970/96383415-6ffb-457d-928d-dc94403378c6)


</p>
</details> 


