### PR TITLE
blit_impl: Add length assumptions and use O2 even in Release

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -196,6 +196,8 @@ set(libdevilutionx_SRCS
 
 # These files are responsible for most of the runtime in Debug mode.
 # Apply some optimizations to them even in Debug mode to get reasonable performance.
+#
+# They also perform better with -O2 rather than -O3 even in Release mode.
 set(_optimize_in_debug_srcs
   engine/render/clx_render.cpp
   engine/render/dun_render.cpp
@@ -203,9 +205,9 @@ set(_optimize_in_debug_srcs
   utils/cel_to_clx.cpp
   utils/cl2_to_clx.cpp
   utils/pcx_to_clx.cpp)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set_source_files_properties(${_optimize_in_debug_srcs} PROPERTIES COMPILE_OPTIONS "-O2;--param=max-vartrack-size=900000000")
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   set_source_files_properties(${_optimize_in_debug_srcs} PROPERTIES COMPILE_OPTIONS "-O2")
 endif()
 

--- a/Source/engine/render/blit_impl.hpp
+++ b/Source/engine/render/blit_impl.hpp
@@ -18,11 +18,13 @@ namespace devilution {
 
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillDirect(uint8_t *dst, unsigned length, uint8_t color)
 {
+	DVL_ASSUME(length >= 2);
 	std::memset(dst, color, length);
 }
 
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsDirect(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, unsigned length)
 {
+	DVL_ASSUME(length != 0);
 	std::memcpy(dst, src, length);
 }
 
@@ -39,19 +41,19 @@ struct BlitDirect {
 
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillWithMap(uint8_t *dst, unsigned length, uint8_t color, const uint8_t *DVL_RESTRICT colorMap)
 {
-	assert(length != 0);
+	DVL_ASSUME(length >= 2);
 	std::memset(dst, colorMap[color], length);
 }
 
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsWithMap(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, unsigned length, const uint8_t *DVL_RESTRICT colorMap)
 {
-	assert(length != 0);
+	DVL_ASSUME(length != 0);
 	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY src, src + length, dst, [colorMap](uint8_t srcColor) { return colorMap[srcColor]; });
 }
 
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillBlended(uint8_t *dst, unsigned length, uint8_t color)
 {
-	assert(length != 0);
+	DVL_ASSUME(length >= 2);
 	std::for_each(DEVILUTIONX_BLIT_EXECUTION_POLICY dst, dst + length, [tbl = paletteTransparencyLookup[color]](uint8_t &dstColor) {
 		dstColor = tbl[dstColor];
 	});
@@ -59,7 +61,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillBlended(uint8_t *dst, unsigned 
 
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsBlended(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, unsigned length)
 {
-	assert(length != 0);
+	DVL_ASSUME(length != 0);
 	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY src, src + length, dst, dst, [pal = paletteTransparencyLookup](uint8_t srcColor, uint8_t dstColor) {
 		return pal[srcColor][dstColor];
 	});
@@ -80,7 +82,7 @@ struct BlitWithMap {
 
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsBlendedWithMap(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, unsigned length, const uint8_t *DVL_RESTRICT colorMap)
 {
-	assert(length != 0);
+	DVL_ASSUME(length != 0);
 	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY src, src + length, dst, dst, [colorMap, pal = paletteTransparencyLookup](uint8_t srcColor, uint8_t dstColor) {
 		return pal[dstColor][colorMap[srcColor]];
 	});

--- a/Source/utils/attributes.h
+++ b/Source/utils/attributes.h
@@ -62,3 +62,29 @@
 #else
 #define DVL_RESTRICT __restrict__
 #endif
+
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(assume) >= 202207L
+#define DVL_ASSUME(...) [[assume(__VA_ARGS__)]]
+#endif
+#endif
+#ifndef DVL_ASSUME
+#if defined(__clang__)
+#define DVL_ASSUME(...)                \
+	do {                               \
+		__builtin_assume(__VA_ARGS__); \
+	} while (false)
+#elif defined(_MSC_VER)
+#define DVL_ASSUME(...)        \
+	do {                       \
+		__assume(__VA_ARGS__); \
+	} while (false)
+#elif defined(__GNUC__)
+#if __GNUC__ >= 13
+#define DVL_ASSUME(...) __attribute__((__assume__(__VA_ARGS__)))
+#endif
+#endif
+#endif
+#ifndef DVL_ASSUME
+#define DVL_ASSUME(...)
+#endif


### PR DESCRIPTION
We know that length is never 0.
Letting the compiler know that allows it to optimize one instruction away.

Moreover, for Fill runs, we also know that the length is at least 2.

https://godbolt.org/z/aM4zTjeYM

Additionally, switches to using `-O2` even in Release mode:

-O3 tries to vectorize blit loops too aggressively, but our blit calls mostly loop only a few times.

`measure_timedemo_performance` on my machine:

* O1: 6.606 ± 0.060 seconds, 1109.520 ± 9.843 FPS
* O2: 6.484 ± 0.063 seconds, 1130.220 ± 10.909 FPS
* O3: 6.746 ± 0.017 seconds, 1086.260 ± 2.170 FPS