### PR TITLE
Parse TCP host using hostname:port format

### DIFF
--- a/Source/dvlnet/abstract_net.h
+++ b/Source/dvlnet/abstract_net.h
@@ -16,8 +16,8 @@ using provider_t = unsigned long;
 
 class abstract_net {
 public:
-	virtual int create(std::string addrstr) = 0;
-	virtual int join(std::string addrstr) = 0;
+	virtual int create(std::string_view addrstr) = 0;
+	virtual int join(std::string_view addrstr) = 0;
 	virtual bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) = 0;
 	virtual bool SNetSendMessage(uint8_t dest, void *data, size_t size) = 0;
 	virtual bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) = 0;

--- a/Source/dvlnet/base_protocol.h
+++ b/Source/dvlnet/base_protocol.h
@@ -15,8 +15,8 @@ namespace devilution::net {
 template <class P>
 class base_protocol : public base {
 public:
-	int create(std::string addrstr) override;
-	int join(std::string addrstr) override;
+	int create(std::string_view addrstr) override;
+	int join(std::string_view addrstr) override;
 	tl::expected<void, PacketError> poll() override;
 	tl::expected<void, PacketError> send(packet &pkt) override;
 	void DisconnectNet(plr_t plr) override;
@@ -161,7 +161,7 @@ tl::expected<void, PacketError> base_protocol<P>::wait_join()
 }
 
 template <class P>
-int base_protocol<P>::create(std::string addrstr)
+int base_protocol<P>::create(std::string_view addrstr)
 {
 	gamename = addrstr;
 	isGameHost_ = true;
@@ -183,7 +183,7 @@ int base_protocol<P>::create(std::string addrstr)
 }
 
 template <class P>
-int base_protocol<P>::join(std::string addrstr)
+int base_protocol<P>::join(std::string_view addrstr)
 {
 	gamename = addrstr;
 	isGameHost_ = false;

--- a/Source/dvlnet/cdwrap.cpp
+++ b/Source/dvlnet/cdwrap.cpp
@@ -17,13 +17,13 @@ void cdwrap::reset()
 		dvlnet_wrap->SNetRegisterEventHandler(eventType, eventHandler);
 }
 
-int cdwrap::create(std::string addrstr)
+int cdwrap::create(std::string_view addrstr)
 {
 	reset();
 	return dvlnet_wrap->create(addrstr);
 }
 
-int cdwrap::join(std::string addrstr)
+int cdwrap::join(std::string_view addrstr)
 {
 	game_init_info = buffer_t();
 	reset();

--- a/Source/dvlnet/cdwrap.h
+++ b/Source/dvlnet/cdwrap.h
@@ -32,8 +32,8 @@ public:
 		reset();
 	}
 
-	int create(std::string addrstr) override;
-	int join(std::string addrstr) override;
+	int create(std::string_view addrstr) override;
+	int join(std::string_view addrstr) override;
 	bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) override;
 	bool SNetSendMessage(uint8_t dest, void *data, size_t size) override;
 	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;

--- a/Source/dvlnet/loopback.cpp
+++ b/Source/dvlnet/loopback.cpp
@@ -9,13 +9,13 @@
 
 namespace devilution::net {
 
-int loopback::create(std::string /*addrstr*/)
+int loopback::create(std::string_view /*addrstr*/)
 {
 	IsLoopback = true;
 	return plr_single;
 }
 
-int loopback::join(std::string /*addrstr*/)
+int loopback::join(std::string_view /*addrstr*/)
 {
 	ABORT();
 }

--- a/Source/dvlnet/loopback.h
+++ b/Source/dvlnet/loopback.h
@@ -17,8 +17,8 @@ private:
 public:
 	loopback() = default;
 
-	int create(std::string addrstr) override;
-	int join(std::string addrstr) override;
+	int create(std::string_view addrstr) override;
+	int join(std::string_view addrstr) override;
 	bool SNetReceiveMessage(uint8_t *sender, void **data, size_t *size) override;
 	bool SNetSendMessage(uint8_t dest, void *data, size_t size) override;
 	bool SNetReceiveTurns(char **data, size_t *size, uint32_t *status) override;

--- a/Source/dvlnet/tcp_client.h
+++ b/Source/dvlnet/tcp_client.h
@@ -27,8 +27,8 @@ namespace devilution::net {
 
 class tcp_client : public base {
 public:
-	int create(std::string addrstr) override;
-	int join(std::string addrstr) override;
+	int create(std::string_view addrstr) override;
+	int join(std::string_view addrstr) override;
 
 	tl::expected<void, PacketError> poll() override;
 	tl::expected<void, PacketError> send(packet &pkt) override;


### PR DESCRIPTION
When joining TCP games, instead of using the port setting from the local INI file to determine the port used by the remote host, parse the port from the host string entered by the user. This format resembles the format used for URLs. If the host has changed their port, the guest shouldn't need to modify their INI file to join.