### PR TITLE
Greatly simplify outline rendering

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -36,6 +36,7 @@
 #include "engine/load_cel.hpp"
 #include "engine/load_file.hpp"
 #include "engine/random.hpp"
+#include "engine/render/clx_render.hpp"
 #include "engine/sound.h"
 #include "gamemenu.h"
 #include "gmenu.h"
@@ -2860,6 +2861,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	MakeLightTable();
 	SetDungeonMicros();
 	LoadLvlGFX();
+	ClearClxDrawCache();
 	IncProgress();
 
 	if (firstflag) {

--- a/Source/engine/render/clx_render.hpp
+++ b/Source/engine/render/clx_render.hpp
@@ -121,6 +121,13 @@ bool IsPointWithinClx(Point position, ClxSprite clx);
  */
 std::pair<int, int> ClxMeasureSolidHorizontalBounds(ClxSprite clx);
 
+/**
+ * @brief Clears the CLX draw cache.
+ *
+ * Must be called whenever CLX sprites are freed.
+ */
+void ClearClxDrawCache();
+
 #ifdef DEBUG_CLX
 std::string ClxDescribe(ClxSprite clx);
 #endif

--- a/Source/utils/static_bit_vector.hpp
+++ b/Source/utils/static_bit_vector.hpp
@@ -1,0 +1,92 @@
+#include <algorithm>
+#include <climits>
+#include <cstddef>
+
+#include "utils/attributes.h"
+
+namespace devilution {
+
+/**
+ * @brief A stack-allocated bit-vector with a fixed capacity and a fixed size < capacity.
+ *
+ * @tparam N capacity.
+ */
+template <size_t N, typename Word = unsigned long> // NOLINT(google-runtime-int)
+class StaticBitVector {
+public:
+	explicit StaticBitVector(size_t size)
+	    : size_(size)
+	    , num_words_(size / BitsPerWord + ((size % BitsPerWord) == 0 ? 0 : 1))
+	{
+	}
+
+	[[nodiscard]] bool test(size_t pos) const { return (word(pos) & maskBit(pos)) != 0; }
+
+	void set() { std::fill_n(words_, num_words_, ~Word { 0 }); }
+	void set(size_t pos) { word(pos) |= maskBit(pos); }
+
+	// Sets all bits in the [begin, begin+length) range to 1.
+	// Length must not be zero.
+	void set(size_t begin, size_t length)
+	{
+		DVL_ASSUME(length != 0);
+		const size_t firstWord = begin / BitsPerWord;
+		const size_t lastWord = (begin + length - 1) / BitsPerWord;
+		const Word firstWordMask = onesFrom(begin);
+		const Word lastWordMask = onesUpTo(begin + length - 1);
+		if (firstWord == lastWord) {
+			words_[firstWord] |= firstWordMask & lastWordMask;
+			return;
+		}
+		words_[firstWord] |= firstWordMask;
+		std::fill(&words_[firstWord + 1], &words_[lastWord], ~Word { 0 });
+		words_[lastWord] |= lastWordMask;
+	}
+
+	void reset() { std::fill_n(words_, num_words_, Word { 0 }); }
+	void reset(size_t pos) { word(pos) &= ~maskBit(pos); }
+
+	// Sets all bits in the [begin, begin+length) range to 0.
+	// Length must not be zero.
+	void reset(size_t begin, size_t length)
+	{
+		DVL_ASSUME(length != 0);
+		const size_t firstWord = begin / BitsPerWord;
+		const size_t lastWord = (begin + length - 1) / BitsPerWord;
+		const Word firstWordMask = onesFrom(begin);
+		const Word lastWordMask = onesUpTo(begin + length - 1);
+		if (firstWord == lastWord) {
+			words_[firstWord] &= ~(firstWordMask & lastWordMask);
+			return;
+		}
+		words_[firstWord] &= ~firstWordMask;
+		std::fill(&words_[firstWord + 1], &words_[lastWord], Word { 0 });
+		words_[lastWord] &= ~lastWordMask;
+	}
+
+private:
+	static constexpr Word onesFrom(size_t begin)
+	{
+		return (~Word { 0 }) << (begin % BitsPerWord);
+	}
+	static constexpr Word onesUpTo(size_t last)
+	{
+		return (~Word { 0 }) >> (BitsPerWord - (last % BitsPerWord) - 1);
+	}
+
+	static constexpr Word maskBit(size_t pos)
+	{
+		return Word { 1 } << (pos % BitsPerWord);
+	}
+	Word word(size_t pos) const { return words_[pos / BitsPerWord]; }
+	Word &word(size_t pos) { return words_[pos / BitsPerWord]; }
+
+	static constexpr unsigned BitsPerWord = CHAR_BIT * sizeof(Word);
+	static constexpr unsigned MaxNumWords = N / BitsPerWord + ((N % BitsPerWord) == 0 ? 0 : 1);
+	Word words_[MaxNumWords] = {};
+
+	size_t size_;
+	size_t num_words_;
+};
+
+} // namespace devilution

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -75,6 +75,14 @@ public:
 		return *data_[pos].ptr();
 	}
 
+	void clear()
+	{
+		for (std::size_t pos = 0; pos < size_; ++pos) {
+			std::destroy_at(data_[pos].ptr());
+		}
+		size_ = 0;
+	}
+
 	~StaticVector()
 	{
 		for (std::size_t pos = 0; pos < size_; ++pos) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,17 +44,29 @@ set(tests
   utf8_test
   writehero_test
 )
+set(
+  standalone_tests
+  static_bit_vector_test
+)
 
 include(Fixtures.cmake)
 
-foreach(test_target ${tests})
+foreach(test_target ${tests} ${standalone_tests})
   add_executable(${test_target} "${test_target}.cpp")
   gtest_discover_tests(${test_target})
-  target_link_libraries(${test_target} PRIVATE test_main)
   set_target_properties(${test_target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
   if(GPERF)
     target_link_libraries(${test_target} PUBLIC ${GPERFTOOLS_LIBRARIES})
   endif()
+endforeach()
+
+foreach(test_target ${tests})
+  target_link_libraries(${test_target} PRIVATE test_main)
+endforeach()
+
+foreach(test_target ${standalone_tests})
+  target_link_libraries(${test_target} GTest::gtest_main)
+  target_include_directories(${test_target} PRIVATE "${PROJECT_SOURCE_DIR}/Source")
 endforeach()
 
 target_include_directories(writehero_test PRIVATE ../3rdParty/PicoSHA2)

--- a/test/static_bit_vector_test.cpp
+++ b/test/static_bit_vector_test.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+
+#include "utils/static_bit_vector.hpp"
+
+namespace devilution {
+namespace {
+
+TEST(StaticBitVectorTest, SetSingleTest)
+{
+	StaticBitVector<500> v(100);
+	EXPECT_FALSE(v.test(97));
+	v.set(97);
+	EXPECT_TRUE(v.test(97));
+}
+
+TEST(StaticBitVectorTest, SetRangeTest)
+{
+	StaticBitVector<500> v(100);
+	EXPECT_FALSE(v.test(97));
+	v.set(50, 50);
+	for (size_t i = 0; i < 50; ++i) {
+		EXPECT_FALSE(v.test(i)) << i;
+	}
+	for (size_t i = 50; i < 100; ++i) {
+		EXPECT_TRUE(v.test(i)) << i;
+	}
+}
+
+} // namespace
+} // namespace devilution


### PR DESCRIPTION
The new algorithm is a lot less code, slightly faster, and results in a smaller binary (-40 KiB on rg99).

The previous algorithm filled all the pixels around every solid pixel. The new algorithm only fills pixels that will be visible.

We first collect the outline pixels into an array (which may contain a small amount of duplicates). Then, we render the entire array in a single loop. This turns out to be slightly faster than rendering inline, at the cost of ~4 KiB of stack (basically free).

To collect the pixels, we go through the CLX sprite, keeping track of the solid runs in the current row, and the filled pixels on the line above and the line below.

To be able to quickly test the pixels above and below, we introduce a new data structure, `StaticBitVector`. It is similar to a bitset, except the size is determined at runtime (capacity is fixed), and it supports quick updates of entire subspans.

In the future, we can further simplify it by using solid runs above and below for testing rather than individual pixels in a bitset.