### PR TITLE
Fix a few more warnings

### DIFF
--- a/Source/dvlnet/base.h
+++ b/Source/dvlnet/base.h
@@ -33,7 +33,7 @@ public:
 	virtual tl::expected<void, PacketError> send(packet &pkt) = 0;
 	virtual void DisconnectNet(plr_t plr);
 
-	void setup_gameinfo(buffer_t info);
+	void setup_gameinfo(buffer_t info) override;
 
 	void setup_password(std::string pw) override;
 	void clear_password() override;

--- a/Source/spelldat.cpp
+++ b/Source/spelldat.cpp
@@ -17,11 +17,6 @@
 namespace devilution {
 
 namespace {
-const auto Fire = SpellDataFlags::Fire;
-const auto Lightning = SpellDataFlags::Lightning;
-const auto Magic = SpellDataFlags::Magic;
-const auto Targeted = SpellDataFlags::Targeted;
-const auto AllowedInTown = SpellDataFlags::AllowedInTown;
 
 void AddNullSpell()
 {

--- a/Source/utils/attributes.h
+++ b/Source/utils/attributes.h
@@ -18,6 +18,12 @@
 #define DVL_PRINTF_ATTRIBUTE(fmtargnum, firstarg)
 #endif
 
+#if DVL_HAVE_ATTRIBUTE(pure)
+#define DVL_PURE __attribute__((pure))
+#else
+#define DVL_PURE
+#endif
+
 #if DVL_HAVE_ATTRIBUTE(always_inline)
 #define DVL_ALWAYS_INLINE inline __attribute__((always_inline))
 #elif defined(_MSC_VER)

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "appfat.h"
+#include "utils/attributes.h"
 
 namespace devilution {
 
@@ -36,7 +37,7 @@ public:
 
 	[[nodiscard]] size_t size() const { return size_; }
 
-	[[nodiscard]] bool empty() const { return size_ == 0; }
+	[[nodiscard]] bool empty() const DVL_PURE { return size_ == 0; }
 
 	[[nodiscard]] const T &back() const { return (*this)[size_ - 1]; }
 	[[nodiscard]] T &back() { return (*this)[size_ - 1]; }


### PR DESCRIPTION
The pure attribute on `StaticVector#empty` is needed so that it can be used in `DVL_ASSUME` without a warning about side-effects in assume.