### PR TITLE
SDL1: Fix windowed video mode with sdl12-compat

### DIFF
--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -236,9 +236,12 @@ void SetVideoMode(int width, int height, int bpp, uint32_t flags)
 	if (ghMainWnd == nullptr) {
 		ErrSdl();
 	}
-	const SDL_VideoInfo &current = *SDL_GetVideoInfo();
-	Log("Video mode is now {}x{} bpp={} flags=0x{:08X}",
-	    current.current_w, current.current_h, current.vfmt->BitsPerPixel, SDL_GetVideoSurface()->flags);
+	const SDL_Surface *surface = SDL_GetVideoSurface();
+	if (surface == nullptr) {
+		ErrSdl();
+	}
+	Log("Video surface is now {}x{} bpp={} flags=0x{:08X}",
+	    surface->w, surface->h, surface->format->BitsPerPixel, surface->flags);
 }
 
 void SetVideoModeToPrimary(bool fullscreen, int width, int height)
@@ -410,9 +413,11 @@ void ReinitializeRenderer()
 		return;
 
 #ifdef USE_SDL1
-	const SDL_VideoInfo &current = *SDL_GetVideoInfo();
-	Size windowSize = { current.current_w, current.current_h };
-	AdjustToScreenGeometry(windowSize);
+	const SDL_Surface *surface = SDL_GetVideoSurface();
+	if (surface == nullptr) {
+		ErrSdl();
+	}
+	AdjustToScreenGeometry(Size(surface->w, surface->h));
 #else
 	if (texture)
 		texture.reset();


### PR DESCRIPTION
On Ubuntu 24.04, which uses [sdl12-compat](https://github.com/libsdl-org/sdl12-compat), when running in a window, `SDL_GetVideoInfo` returns the display size rather than the window size, resulting in incorrect scaling.

Using `SDL_GetVideoSurface` instead of `SDL_GetVideoInfo` fixes this.