### PR TITLE
Make a few libraries standalone

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -179,7 +179,6 @@ set(libdevilutionx_SRCS
   utils/cl2_to_clx.cpp
   utils/console.cpp
   utils/display.cpp
-  utils/file_util.cpp
   utils/format_int.cpp
   utils/language.cpp
   utils/logged_fstream.cpp
@@ -315,6 +314,24 @@ if(SCREEN_READER_INTEGRATION AND WIN32)
   target_compile_definitions(libdevilutionx PRIVATE Tolk)
 endif()
 
+add_devilutionx_object_library(libdevilutionx_file_util
+  utils/file_util.cpp
+)
+target_link_libraries(libdevilutionx_file_util PRIVATE
+  DevilutionX::SDL
+  libdevilutionx_log
+  ${DEVILUTIONX_PLATFORM_LINK_LIBRARIES}
+)
+
+add_library(libdevilutionx_log INTERFACE)
+target_include_directories(libdevilutionx_log INTERFACE
+  ${PROJECT_SOURCE_DIR}/Source)
+target_link_libraries(libdevilutionx_log INTERFACE
+  DevilutionX::SDL
+  fmt::fmt
+  libdevilutionx_strings
+)
+
 add_devilutionx_object_library(libdevilutionx_parse_int
   utils/parse_int.cpp
 )
@@ -343,6 +360,7 @@ target_link_libraries(libdevilutionx PUBLIC
   libsmackerdec
   simpleini::simpleini
   tl
+  libdevilutionx_file_util
   libdevilutionx_parse_int
   libdevilutionx_strings
   libdevilutionx_utf8

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -188,8 +188,6 @@ set(libdevilutionx_SRCS
   utils/pcx_to_clx.cpp
   utils/sdl_bilinear_scale.cpp
   utils/sdl_thread.cpp
-  utils/str_cat.cpp
-  utils/str_case.cpp
   utils/surface_to_clx.cpp
   utils/timer.cpp)
 
@@ -325,6 +323,13 @@ target_link_libraries(libdevilutionx_utf8 PRIVATE
   hoehrmann_utf8
 )
 
+add_devilutionx_object_library(libdevilutionx_strings
+  utils/str_cat.cpp
+  utils/str_case.cpp
+)
+target_link_libraries(libdevilutionx_strings PRIVATE
+  fmt::fmt)
+
 target_link_libraries(libdevilutionx PUBLIC
   Threads::Threads
   DevilutionX::SDL
@@ -332,6 +337,7 @@ target_link_libraries(libdevilutionx PUBLIC
   libsmackerdec
   simpleini::simpleini
   tl
+  libdevilutionx_strings
   libdevilutionx_utf8
   ${libdevilutionx_DEPS}
 )

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -184,7 +184,6 @@ set(libdevilutionx_SRCS
   utils/language.cpp
   utils/logged_fstream.cpp
   utils/paths.cpp
-  utils/parse_int.cpp
   utils/pcx_to_clx.cpp
   utils/sdl_bilinear_scale.cpp
   utils/sdl_thread.cpp
@@ -316,6 +315,13 @@ if(SCREEN_READER_INTEGRATION AND WIN32)
   target_compile_definitions(libdevilutionx PRIVATE Tolk)
 endif()
 
+add_devilutionx_object_library(libdevilutionx_parse_int
+  utils/parse_int.cpp
+)
+target_link_libraries(libdevilutionx_parse_int PUBLIC
+  tl
+)
+
 add_devilutionx_object_library(libdevilutionx_utf8
   utils/utf8.cpp
 )
@@ -337,6 +343,7 @@ target_link_libraries(libdevilutionx PUBLIC
   libsmackerdec
   simpleini::simpleini
   tl
+  libdevilutionx_parse_int
   libdevilutionx_strings
   libdevilutionx_utf8
   ${libdevilutionx_DEPS}

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -191,8 +191,7 @@ set(libdevilutionx_SRCS
   utils/str_cat.cpp
   utils/str_case.cpp
   utils/surface_to_clx.cpp
-  utils/timer.cpp
-  utils/utf8.cpp)
+  utils/timer.cpp)
 
 # These files are responsible for most of the runtime in Debug mode.
 # Apply some optimizations to them even in Debug mode to get reasonable performance.
@@ -319,6 +318,13 @@ if(SCREEN_READER_INTEGRATION AND WIN32)
   target_compile_definitions(libdevilutionx PRIVATE Tolk)
 endif()
 
+add_devilutionx_object_library(libdevilutionx_utf8
+  utils/utf8.cpp
+)
+target_link_libraries(libdevilutionx_utf8 PRIVATE
+  hoehrmann_utf8
+)
+
 target_link_libraries(libdevilutionx PUBLIC
   Threads::Threads
   DevilutionX::SDL
@@ -326,7 +332,7 @@ target_link_libraries(libdevilutionx PUBLIC
   libsmackerdec
   simpleini::simpleini
   tl
-  hoehrmann_utf8
+  libdevilutionx_utf8
   ${libdevilutionx_DEPS}
 )
 

--- a/Source/utils/log.hpp
+++ b/Source/utils/log.hpp
@@ -15,7 +15,7 @@
 namespace devilution {
 
 // Local definition to fix compilation issue due to header conflict.
-[[noreturn]] void app_fatal(std::string_view);
+[[noreturn]] extern void app_fatal(std::string_view);
 
 enum class LogCategory {
 	Application = SDL_LOG_CATEGORY_APPLICATION,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,7 +32,6 @@ set(tests
   missiles_test
   pack_test
   path_test
-  parse_int_test
   player_test
   quests_test
   random_test
@@ -42,8 +41,8 @@ set(tests
   timedemo_test
   writehero_test
 )
-set(
-  standalone_tests
+set(standalone_tests
+  parse_int_test
   str_cat_test
   utf8_test
 )
@@ -68,7 +67,8 @@ foreach(test_target ${standalone_tests})
   target_include_directories(${test_target} PRIVATE "${PROJECT_SOURCE_DIR}/Source")
 endforeach()
 
-target_link_libraries(utf8_test PRIVATE libdevilutionx_utf8)
+target_link_libraries(parse_int_test PRIVATE libdevilutionx_parse_int)
 target_link_libraries(str_cat_test PRIVATE libdevilutionx_strings)
+target_link_libraries(utf8_test PRIVATE libdevilutionx_utf8)
 
 target_include_directories(writehero_test PRIVATE ../3rdParty/PicoSHA2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,6 @@ set(tests
   drlg_l3_test
   drlg_l4_test
   effects_test
-  file_util_test
   format_int_test
   inv_test
   lighting_test
@@ -42,6 +41,7 @@ set(tests
   writehero_test
 )
 set(standalone_tests
+  file_util_test
   parse_int_test
   str_cat_test
   utf8_test
@@ -67,6 +67,10 @@ foreach(test_target ${standalone_tests})
   target_include_directories(${test_target} PRIVATE "${PROJECT_SOURCE_DIR}/Source")
 endforeach()
 
+add_library(app_fatal_for_testing OBJECT app_fatal_for_testing.cpp)
+target_sources(app_fatal_for_testing INTERFACE $<TARGET_OBJECTS:app_fatal_for_testing>)
+
+target_link_libraries(file_util_test PRIVATE libdevilutionx_file_util app_fatal_for_testing)
 target_link_libraries(parse_int_test PRIVATE libdevilutionx_parse_int)
 target_link_libraries(str_cat_test PRIVATE libdevilutionx_strings)
 target_link_libraries(utf8_test PRIVATE libdevilutionx_utf8)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,11 +41,11 @@ set(tests
   stores_test
   str_cat_test
   timedemo_test
-  utf8_test
   writehero_test
 )
 set(
   standalone_tests
+  utf8_test
 )
 
 include(Fixtures.cmake)
@@ -64,8 +64,10 @@ foreach(test_target ${tests})
 endforeach()
 
 foreach(test_target ${standalone_tests})
-  target_link_libraries(${test_target} GTest::gtest_main)
+  target_link_libraries(${test_target} PRIVATE GTest::gtest_main)
   target_include_directories(${test_target} PRIVATE "${PROJECT_SOURCE_DIR}/Source")
 endforeach()
+
+target_link_libraries(utf8_test PRIVATE libdevilutionx_utf8)
 
 target_include_directories(writehero_test PRIVATE ../3rdParty/PicoSHA2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,12 +39,12 @@ set(tests
   rectangle_test
   scrollrt_test
   stores_test
-  str_cat_test
   timedemo_test
   writehero_test
 )
 set(
   standalone_tests
+  str_cat_test
   utf8_test
 )
 
@@ -69,5 +69,6 @@ foreach(test_target ${standalone_tests})
 endforeach()
 
 target_link_libraries(utf8_test PRIVATE libdevilutionx_utf8)
+target_link_libraries(str_cat_test PRIVATE libdevilutionx_strings)
 
 target_include_directories(writehero_test PRIVATE ../3rdParty/PicoSHA2)

--- a/test/app_fatal_for_testing.cpp
+++ b/test/app_fatal_for_testing.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include <string_view>
+
+namespace devilution {
+
+[[noreturn]] void app_fatal(std::string_view str)
+{
+	std::cerr << "app_fatal: " << str << std::endl;
+	std::abort();
+}
+
+} // namespace devilution


### PR DESCRIPTION
This allows the tests for these libraries to be built without linking all of libdevilutionx, improving build times and cache efficiency.