### PR TITLE
Fix order of events when drawing timeout cursor

### DIFF
--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1636,8 +1636,8 @@ void scrollrt_draw_game_screen()
 
 	const Surface &out = GlobalBackBuffer();
 	UndrawCursor(out);
-	DrawMain(hgt, false, false, false, false, false);
 	DrawCursor(out);
+	DrawMain(hgt, false, false, false, false, false);
 
 	RenderPresent();
 }


### PR DESCRIPTION
This resolves an issue when using software cursor where the hourglass is mostly invisible, flickering onto the screen only briefly every 500 ms or so.

The order of events in `scrollrt_draw_game_screen()` was reversed in 680ab5e such that the cursor is removed from the back buffer, the back buffer is drawn to the output surface, and then the cursor is redrawn to the back buffer. The original intent was to draw the cursor onto the back buffer so it can be drawn to the output surface, then restore the back buffer to its previous state. If you do it in reverse order, the cursor doesn't get drawn onto the output surface and remains invisible for most of its duration, flickering onto the screen only when `DrawAndBlit()` is called every 500 ms or so.

However in cb9da2c, the order of events was changed in `DrawAndBlit()`, presumably because some systems can render directly to the output surface. On those systems, the back buffer is the same as the output surface and we draw the cursor directly onto it. Because we don't have a separate back buffer, `DrawMain()` does nothing, and restoring the back buffer to its previous state would cause the cursor to disappear from the output surface.

So the correct thing to do for this PR is to match the order of events in `DrawAndBlit()`. We remove the cursor from the back buffer and immediately redraw it in the new location before calling `DrawMain()`. This ensures that the cursor is on the output surface after `DrawMain()` whether we put it on there when redrawing the cursor or when copying it from the back buffer.

Note that the flickering hourglass would only show up on systems that do not draw directly to the output surface.