### PR TITLE
Ensure that network timeout info shows up in the info panel

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1189,12 +1189,12 @@ void FreeControlPan()
 void DrawInfoBox(const Surface &out)
 {
 	DrawPanelBox(out, { 177, 62, InfoBoxSize.width, InfoBoxSize.height }, GetMainPanel().position + InfoBoxTopLeft);
-	if (!panelflag && !trigflag && pcursinvitem == -1 && pcursstashitem == StashStruct::EmptyCell && !spselflag) {
+	if (!panelflag && !trigflag && pcursinvitem == -1 && pcursstashitem == StashStruct::EmptyCell && !spselflag && pcurs != CURSOR_HOURGLASS) {
 		InfoString = StringOrView {};
 		InfoColor = UiFlags::ColorWhite;
 	}
 	Player &myPlayer = *MyPlayer;
-	if (spselflag || trigflag) {
+	if (spselflag || trigflag || pcurs == CURSOR_HOURGLASS) {
 		InfoColor = UiFlags::ColorWhite;
 	} else if (!myPlayer.HoldItem.isEmpty()) {
 		if (myPlayer.HoldItem._itype == ItemType::Gold) {


### PR DESCRIPTION
The `TimeoutCursor()` function sets up the info panel to display basic information about why the game is lagging.

https://github.com/diasurgical/devilutionX/blob/15e44a19c3e0d0e80cb6185103e0a4b4286d40a9/Source/diablo.cpp#L1476-L1478

This text was being overwritten by the logic in `DrawInfoBox()` unless the player was highlighting an item or something that would skip that logic. This means the text sometimes shows up and sometimes doesn't. This PR simply adjusts the logic in `DrawInfoBox()` to detect when the game is lagging and avoid clearing the info text, overwriting it with something else, or using the wrong text color.