### PR TITLE
Don't draw non-item cursors as items

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -577,7 +577,7 @@ void NewCursor(int cursId)
 void DrawSoftwareCursor(const Surface &out, Point position, int cursId)
 {
 	const ClxSprite sprite = GetInvItemSprite(cursId);
-	if (!MyPlayer->HoldItem.isEmpty()) {
+	if (cursId >= CURSOR_FIRSTITEM && !MyPlayer->HoldItem.isEmpty()) {
 		const auto &heldItem = MyPlayer->HoldItem;
 		ClxDrawOutline(out, GetOutlineColor(heldItem, true), position, sprite);
 		DrawItem(heldItem, out, position, sprite);


### PR DESCRIPTION
This PR ensures that the cursor is actually an item cursor before attempting to draw it as an item.

When holding an item on the cursor, if the game lags and displays the hourglass, the hourglass cursor would be drawn as an item. This would cause the game to draw an outline around the hourglass and, if the player cannot use the item they are holding, apply the Infravision TRN to the hourglass sprite.