### PR TITLE
Increase OutlinePixels limit from 1024 to 1536

### DIFF
--- a/Source/engine/render/clx_render.cpp
+++ b/Source/engine/render/clx_render.cpp
@@ -250,7 +250,7 @@ void DoRenderBackwards(
 	}
 }
 
-constexpr size_t MaxOutlinePixels = 1024;
+constexpr size_t MaxOutlinePixels = 1536;
 constexpr size_t MaxOutlineSpriteWidth = 253;
 using OutlinePixels = StaticVector<PointOf<uint8_t>, MaxOutlinePixels>;
 using OutlineRowSolidRuns = StaticVector<std::pair<uint8_t, uint8_t>, MaxOutlineSpriteWidth / 2 + 1>;


### PR DESCRIPTION
@Trihedraf reported that the game crashed when killing Diablo.

1536 should be enough for Diablo and any custom sprites (if not, we can increase it further).