### PR TITLE
Don't validate items in Single Player

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1027,6 +1027,9 @@ bool IsGItemValid(const TCmdGItem &message)
 
 bool IsPItemValid(const TCmdPItem &message, const Player &player)
 {
+	if (!gbIsMultiplayer)
+		return true;
+
 	const Point position { message.x, message.y };
 
 	if (!InDungeonBounds(position))


### PR DESCRIPTION
I recently received a copy of a Veil of Steel that had been generated in vanilla Hellfire with ilvl 25 and both the `CF_UNIQUE` flag and the `CF_SMITHPREMIUM` flag. Here is a character save with a copy of the item: [single_0.hsv.zip](https://github.com/user-attachments/files/15946593/single_0.hsv.zip).

This is basically the same issue as described in #6560, except in this case the function is `SpawnUnique()` which doesn't use `item[0]` but rather gets an available item using the `itemavail` array.

> In vanilla, `LoadGameLevel()` calls `InitItems()`. This calls `GetItemAttrs()` on `item[0]`, passing in `IDI_GOLD` and ilvl 1. You'd think that would set the creation flags to 1, but it seems this ilvl only gets used for books and oils. It doesn't modify creation flags at all.

Basically, for Single Player quest reward items created using either `SpawnUnique()` or `CreateItem()` in vanilla Diablo/Hellfire, the create info will be inherited from whatever happens to have been in the `item` array before the quest reward item's creation. In this case, it was one of Griswold's premium items. It adds the `CF_UNIQUE` flag which creates an invalid combination of flags on the item, thereby causing the item to fail validation in DevilutionX.

Since these quest reward items from vanilla can only be found in Single Player, we can solve this by simply disabling the validation logic in Single Player. Given that the intent of validation is to mitigate the proliferation of invalid items in Multiplayer games, I doubt we even intended for this logic to apply to Single Player in the first place.