### PR TITLE
Respect hell and hellfire color maps for fully lit and fully dark tiles

### DIFF
--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -284,12 +284,12 @@ DVL_ALWAYS_INLINE Clip CalculateClip(int_fast16_t x, int_fast16_t y, int_fast16_
 
 DVL_ALWAYS_INLINE bool IsFullyDark(const uint8_t *DVL_RESTRICT tbl)
 {
-	return tbl == LightTables[LightsMax].data();
+	return tbl == FullyDarkLightTable;
 }
 
 DVL_ALWAYS_INLINE bool IsFullyLit(const uint8_t *DVL_RESTRICT tbl)
 {
-	return tbl == LightTables[0].data();
+	return tbl == FullyLitLightTable;
 }
 
 template <LightType Light, bool Transparent>

--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -282,6 +282,16 @@ DVL_ALWAYS_INLINE Clip CalculateClip(int_fast16_t x, int_fast16_t y, int_fast16_
 	return clip;
 }
 
+DVL_ALWAYS_INLINE bool IsFullyDark(const uint8_t *DVL_RESTRICT tbl)
+{
+	return tbl == LightTables[LightsMax].data();
+}
+
+DVL_ALWAYS_INLINE bool IsFullyLit(const uint8_t *DVL_RESTRICT tbl)
+{
+	return tbl == LightTables[0].data();
+}
+
 template <LightType Light, bool Transparent>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderSquareFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
 {
@@ -923,9 +933,9 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTileType(TileType tile, uint8_t *
 template <bool OpaquePrefix, int8_t PrefixIncrement>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquareDispatch(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
 {
-	if (tbl == LightTables[LightsMax].data()) {
+	if (IsFullyDark(tbl)) {
 		RenderTransparentSquare<LightType::FullyDark, OpaquePrefix, PrefixIncrement>(dst, dstPitch, src, tbl, clip);
-	} else if (tbl == LightTables[0].data()) {
+	} else if (IsFullyLit(tbl)) {
 		RenderTransparentSquare<LightType::FullyLit, OpaquePrefix, PrefixIncrement>(dst, dstPitch, src, tbl, clip);
 	} else {
 		RenderTransparentSquare<LightType::PartiallyLit, OpaquePrefix, PrefixIncrement>(dst, dstPitch, src, tbl, clip);
@@ -965,9 +975,9 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidOrTransparentSquare
 template <bool OpaquePrefix, int8_t PrefixIncrement>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidOrTransparentSquareDispatch(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
 {
-	if (tbl == LightTables[LightsMax].data()) {
+	if (IsFullyDark(tbl)) {
 		RenderLeftTrapezoidOrTransparentSquare<LightType::FullyDark, OpaquePrefix, PrefixIncrement>(tile, dst, dstPitch, src, tbl, clip);
-	} else if (tbl == LightTables[0].data()) {
+	} else if (IsFullyLit(tbl)) {
 		RenderLeftTrapezoidOrTransparentSquare<LightType::FullyLit, OpaquePrefix, PrefixIncrement>(tile, dst, dstPitch, src, tbl, clip);
 	} else {
 		RenderLeftTrapezoidOrTransparentSquare<LightType::PartiallyLit, OpaquePrefix, PrefixIncrement>(tile, dst, dstPitch, src, tbl, clip);
@@ -977,9 +987,9 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidOrTransparentSquareD
 template <bool OpaquePrefix, int8_t PrefixIncrement>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidOrTransparentSquareDispatch(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
 {
-	if (tbl == LightTables[LightsMax].data()) {
+	if (IsFullyDark(tbl)) {
 		RenderRightTrapezoidOrTransparentSquare<LightType::FullyDark, OpaquePrefix, PrefixIncrement>(tile, dst, dstPitch, src, tbl, clip);
-	} else if (tbl == LightTables[0].data()) {
+	} else if (IsFullyLit(tbl)) {
 		RenderRightTrapezoidOrTransparentSquare<LightType::FullyLit, OpaquePrefix, PrefixIncrement>(tile, dst, dstPitch, src, tbl, clip);
 	} else {
 		RenderRightTrapezoidOrTransparentSquare<LightType::PartiallyLit, OpaquePrefix, PrefixIncrement>(tile, dst, dstPitch, src, tbl, clip);
@@ -989,9 +999,9 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidOrTransparentSquare
 template <bool Transparent>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTileDispatch(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
 {
-	if (tbl == LightTables[LightsMax].data()) {
+	if (IsFullyDark(tbl)) {
 		RenderTileType<LightType::FullyDark, Transparent>(tile, dst, dstPitch, src, tbl, clip);
-	} else if (tbl == LightTables[0].data()) {
+	} else if (IsFullyLit(tbl)) {
 		RenderTileType<LightType::FullyLit, Transparent>(tile, dst, dstPitch, src, tbl, clip);
 	} else {
 		RenderTileType<LightType::PartiallyLit, Transparent>(tile, dst, dstPitch, src, tbl, clip);

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -49,6 +49,10 @@ extern std::array<uint8_t, MAXLIGHTS> ActiveLights;
 extern int ActiveLightCount;
 constexpr char LightsMax = 15;
 extern std::array<std::array<uint8_t, 256>, NumLightingLevels> LightTables;
+/** @brief Contains a pointer to a light table that is fully lit (no color mapping is required). Can be null in hell. */
+extern uint8_t *FullyLitLightTable;
+/** @brief Contains a pointer to a light table that is fully dark (every color result to 0/black). Can be null in hellfire levels. */
+extern uint8_t *FullyDarkLightTable;
 extern std::array<uint8_t, 256> InfravisionTable;
 extern std::array<uint8_t, 256> StoneTable;
 extern std::array<uint8_t, 256> PauseTable;


### PR DESCRIPTION
Fixes #6535

## Background
- The renderer has a optimization for fully lit and fully dark tiles.
  - For fully lit tiles (light table index 0) the color map is ignored and a simple copy of the pixels is made
  - For fully dark tiles (light table index 15) the color map is ignored and all pixels are filled with black.
- This optimization assumes that the color map always maps to the same color (fully lit) or maps always maps to black (fully dark). This is not true.
  - Hell levels have a color map for fully lit tiles to support the ceiling animation.
  - Hellfire levels there do not have a fully dark color map.
- In #6535 one ceiling tile has a dLight value of 0 (fully lit).
  - This happens more often in devilutionX, because the light is updated more often since b7424a0068f59cfa253c959dd27accbdd317156a.
  - The bug is more visible when + light radius items are equipped.

## Changes
- Added a helper (`IsFullyDark`/`IsFullyLit`) to check if the optimization can be used.
- Don't use incompatible optimizations for the affected levels.
- Added an assert to check if the optimizations are correctly enabled/disabled.

## Notes
- We can change the way hellfire levels are handled. Currently they mostly use the color `1` for completely dark tiles. We could change this to pure black (`0`) and still use the optimization.