### PR TITLE
[Android] Force app to overlap with the display cutout

### DIFF
--- a/android-project/app/src/main/java/org/diasurgical/devilutionx/DevilutionXSDLActivity.java
+++ b/android-project/app/src/main/java/org/diasurgical/devilutionx/DevilutionXSDLActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.ViewTreeObserver;
+import android.view.WindowManager;
 
 import org.libsdl.app.SDLActivity;
 
@@ -22,6 +23,10 @@ public class DevilutionXSDLActivity extends SDLActivity {
 		// for fullscreen apps after Android 7.0
 		if (Build.VERSION.SDK_INT >= 25)
 			trackVisibleSpace();
+
+		// Force app to overlap with the display cutout
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+			getWindow().getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
 
 		fileManager = new ExternalFilesManager(this);
 


### PR DESCRIPTION
Using my Pixel 6a as an example, the display is 2400x1080. When SDL creates the surface on which to display the game, that surface ends up avoiding the "display cutout" region which prevents the app from rendering behind my front-facing camera lens. This means the app only has access to a 2268x1080 region, which causes some problems like the one described in #7172. That is to say, Integer Scaling + Fit to Screen is not supposed to have a letterbox.

Based on the assumption that the screen's obstructions likely won't overlap with anything important at the edge of a widescreen display, this PR just arbitrarily forces the app to use the full screen space.