### PR TITLE
Allow for more flexible translations of "Book of {SpellName}"

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2299,11 +2299,8 @@ StringOrView GetTranslatedItemName(const Item &item)
 	if (item._iCreateInfo == 0) {
 		return _(baseItemData.iName);
 	} else if (item._iMiscId == IMISC_BOOK) {
-		std::string name;
 		const std::string_view spellName = pgettext("spell", GetSpellData(item._iSpell).sNameText);
-		StrAppend(name, _(baseItemData.iName));
-		StrAppend(name, spellName);
-		return name;
+		return fmt::format(fmt::runtime(_(/* TRANSLATORS: {:s} will be a spell name */ "Book of {:s}")), spellName);
 	} else if (item._iMiscId == IMISC_EAR) {
 		return fmt::format(fmt::runtime(_(/* TRANSLATORS: {:s} will be a Character Name */ "Ear of {:s}")), item._iIName);
 	} else if (item._iMiscId > IMISC_OILFIRST && item._iMiscId < IMISC_OILLAST) {


### PR DESCRIPTION
This allows the translator to change the order of the inserted string.
Todo: update existing translation
Note that this does make the "Book of " string in the TSV data unused, but that isn't to different from how for example oils work.