### PR TITLE
Add single-argument logging overloads

### DIFF
--- a/Source/utils/log.hpp
+++ b/Source/utils/log.hpp
@@ -63,11 +63,21 @@ std::string format(std::string_view fmt, Args &&...args)
 
 } // namespace detail
 
+inline void Log(std::string_view str)
+{
+	SDL_Log("%.*s", static_cast<int>(str.size()), str.data());
+}
+
 template <typename... Args>
 void Log(std::string_view fmt, Args &&...args)
 {
 	auto str = detail::format(fmt, std::forward<Args>(args)...);
 	SDL_Log("%s", str.c_str());
+}
+
+inline void LogVerbose(LogCategory category, std::string_view str)
+{
+	SDL_LogVerbose(static_cast<int>(category), "%.*s", static_cast<int>(str.size()), str.data());
 }
 
 template <typename... Args>
@@ -84,6 +94,11 @@ void LogVerbose(std::string_view fmt, Args &&...args)
 	LogVerbose(defaultCategory, fmt, std::forward<Args>(args)...);
 }
 
+inline void LogDebug(LogCategory category, std::string_view str)
+{
+	SDL_LogDebug(static_cast<int>(category), "%.*s", static_cast<int>(str.size()), str.data());
+}
+
 template <typename... Args>
 void LogDebug(LogCategory category, std::string_view fmt, Args &&...args)
 {
@@ -96,6 +111,11 @@ template <typename... Args>
 void LogDebug(std::string_view fmt, Args &&...args)
 {
 	LogDebug(defaultCategory, fmt, std::forward<Args>(args)...);
+}
+
+inline void LogInfo(LogCategory category, std::string_view str)
+{
+	SDL_LogInfo(static_cast<int>(category), "%.*s", static_cast<int>(str.size()), str.data());
 }
 
 template <typename... Args>
@@ -111,6 +131,11 @@ void LogInfo(std::string_view fmt, Args &&...args)
 	LogInfo(defaultCategory, fmt, std::forward<Args>(args)...);
 }
 
+inline void LogWarn(LogCategory category, std::string_view str)
+{
+	SDL_LogWarn(static_cast<int>(category), "%.*s", static_cast<int>(str.size()), str.data());
+}
+
 template <typename... Args>
 void LogWarn(LogCategory category, std::string_view fmt, Args &&...args)
 {
@@ -122,6 +147,11 @@ template <typename... Args>
 void LogWarn(std::string_view fmt, Args &&...args)
 {
 	LogWarn(defaultCategory, fmt, std::forward<Args>(args)...);
+}
+
+inline void LogError(LogCategory category, std::string_view str)
+{
+	SDL_LogError(static_cast<int>(category), "%.*s", static_cast<int>(str.size()), str.data());
 }
 
 template <typename... Args>
@@ -137,6 +167,11 @@ void LogError(std::string_view fmt, Args &&...args)
 	LogError(defaultCategory, fmt, std::forward<Args>(args)...);
 }
 
+inline void LogCritical(LogCategory category, std::string_view str)
+{
+	SDL_LogCritical(static_cast<int>(category), "%.*s", static_cast<int>(str.size()), str.data());
+}
+
 template <typename... Args>
 void LogCritical(LogCategory category, std::string_view fmt, Args &&...args)
 {
@@ -148,6 +183,12 @@ template <typename... Args>
 void LogCritical(std::string_view fmt, Args &&...args)
 {
 	LogCritical(defaultCategory, fmt, std::forward<Args>(args)...);
+}
+
+inline void LogMessageV(LogCategory category, LogPriority priority, std::string_view str)
+{
+	SDL_LogMessage(static_cast<int>(category), static_cast<SDL_LogPriority>(priority),
+	    "%.*s", static_cast<int>(str.size()), str.data());
 }
 
 template <typename... Args>


### PR DESCRIPTION
Avoids going through `fmt` for single-argument log calls.