### PR TITLE
Fix visually overlapping sprites for wall spells

### DIFF
--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -225,7 +225,7 @@ tl::expected<MissileData::AddFn, std::string> ParseMissileAddFn(std::string_view
 	if (value == "AddHealOther") return AddHealOther;
 	if (value == "AddElemental") return AddElemental;
 	if (value == "AddIdentify") return AddIdentify;
-	if (value == "AddFireWallControl") return AddFireWallControl;
+	if (value == "AddWallControl") return AddWallControl;
 	if (value == "AddInfravision") return AddInfravision;
 	if (value == "AddFlameWaveControl") return AddFlameWaveControl;
 	if (value == "AddNova") return AddNova;
@@ -265,7 +265,6 @@ tl::expected<MissileData::ProcessFn, std::string> ParseMissileProcessFn(std::str
 	if (value == "ProcessLightningBow") return ProcessLightningBow;
 	if (value == "ProcessRingOfFire") return ProcessRingOfFire;
 	if (value == "ProcessSearch") return ProcessSearch;
-	if (value == "ProcessLightningWallControl") return ProcessLightningWallControl;
 	if (value == "ProcessImmolation") return ProcessImmolation;
 	if (value == "ProcessSpectralArrow") return ProcessSpectralArrow;
 	if (value == "ProcessLightningControl") return ProcessLightningControl;
@@ -283,7 +282,7 @@ tl::expected<MissileData::ProcessFn, std::string> ParseMissileProcessFn(std::str
 	if (value == "ProcessStoneCurse") return ProcessStoneCurse;
 	if (value == "ProcessApocalypseBoom") return ProcessApocalypseBoom;
 	if (value == "ProcessRhino") return ProcessRhino;
-	if (value == "ProcessFireWallControl") return ProcessFireWallControl;
+	if (value == "ProcessWallControl") return ProcessWallControl;
 	if (value == "ProcessInfravision") return ProcessInfravision;
 	if (value == "ProcessApocalypse") return ProcessApocalypse;
 	if (value == "ProcessFlameWaveControl") return ProcessFlameWaveControl;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3189,24 +3189,32 @@ void ProcessLightningWallControl(Missile &missile)
 	int lvl = !missile.IsTrap() ? Players[id].getCharacterLevel() : 0;
 	int dmg = 16 * (GenerateRndSum(10, 2) + lvl + 2);
 
-	Point position1 = { missile.var1, missile.var2 };
-	Point target1 = position1 + static_cast<Direction>(missile.var3);
+	// Defines the current position of the control missile moving towards var3 direction.
+	// This is used to make sure the opposite side does not create walls where walls have already been created.
+	Point currentPosition = { missile.var1, missile.var2 };
 
-	if (!missile.limitReached && GrowWall(id, position1, target1, MissileID::LightningWall, missile._mispllvl, dmg)) {
-		missile.var1 = target1.x;
-		missile.var2 = target1.y;
-	} else {
-		missile.limitReached = true;
+	{
+		Point position = { missile.var1, missile.var2 };
+		Point target = position + static_cast<Direction>(missile.var3);
+
+		if (!missile.limitReached && GrowWall(id, position, target, MissileID::LightningWall, missile._mispllvl, dmg)) {
+			missile.var1 = target.x;
+			missile.var2 = target.y;
+		} else {
+			missile.limitReached = true;
+		}
 	}
 
-	Point position2 = { missile.var5, missile.var6 };
-	Point target2 = position2 + static_cast<Direction>(missile.var4);
+	{
+		Point position = { missile.var5, missile.var6 };
+		Point target = position + static_cast<Direction>(missile.var4);
 
-	if (missile.var7 == 0 && GrowWall(id, position2, target2, MissileID::LightningWall, missile._mispllvl, dmg, position1 == position2)) {
-		missile.var5 = target2.x;
-		missile.var6 = target2.y;
-	} else {
-		missile.var7 = 1;
+		if (missile.var7 == 0 && GrowWall(id, position2, target, MissileID::LightningWall, missile._mispllvl, dmg, position == currentPosition)) {
+			missile.var5 = target.x;
+			missile.var6 = target.y;
+		} else {
+			missile.var7 = 1;
+		}
 	}
 }
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2456,7 +2456,6 @@ void AddWallControl(Missile &missile, AddMissileParameter &parameter)
 	missile.var3 = static_cast<int>(Left(Left(parameter.midir)));
 	missile.var4 = static_cast<int>(Right(Right(parameter.midir)));
 	missile._mirange = 7;
-	missile._mitype = missile._miAnimType == MissileGraphicID::FireWall ? MissileID::FireWall : MissileID::LightningWall;
 }
 
 void AddInfravision(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -3738,8 +3737,20 @@ void ProcessWallControl(Missile &missile)
 		return;
 	}
 
-	MissileID type = missile._mitype;
-	type = MissileID::FireWall;
+	MissileID type;
+
+	switch (missile._mitype) {
+	case MissileID::FireWallControl:
+		type = MissileID::FireWall;
+		break;
+	case MissileID::LightningWallControl:
+		type = MissileID::LightningWall;
+		break;
+	default:
+		type = MissileID::Null;
+		break;
+	}
+
 	const int sourceIdx = missile._misource;
 	int lvl = 0;
 	int dmg = 0;
@@ -3749,11 +3760,10 @@ void ProcessWallControl(Missile &missile)
 		dmg = 16 * (GenerateRndSum(10, 2) + lvl + 2);
 	}
 
+	const Point leftPosition = { missile.var1, missile.var2 };
+	const Point rightPosition = { missile.var5, missile.var6 };
+
 	ProcessWallControlLeft(missile, sourceIdx, type, dmg);
-
-	Point leftPosition = { missile.var1, missile.var2 };
-	Point rightPosition = { missile.var3, missile.var4 };
-
 	ProcessWallControlRight(missile, sourceIdx, type, dmg, leftPosition == rightPosition);
 }
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -690,7 +690,7 @@ bool GuardianTryFireAt(Missile &missile, Point target)
 	return true;
 }
 
-bool GrowWall(int id, Point position, Point target, MissileID type, int spellLevel, int damage)
+bool GrowWall(int id, Point position, Point target, MissileID type, int spellLevel, int damage, bool skip = false)
 {
 	[[maybe_unused]] int dp = dPiece[position.x][position.y];
 	assert(dp <= MAXTILES && dp >= 0);
@@ -699,7 +699,8 @@ bool GrowWall(int id, Point position, Point target, MissileID type, int spellLev
 		return false;
 	}
 
-	AddMissile(position, position, Direction::South, type, TARGET_BOTH, id, damage, spellLevel);
+	if (!skip)
+		AddMissile(position, position, Direction::South, type, TARGET_BOTH, id, damage, spellLevel);
 	return true;
 }
 
@@ -3188,28 +3189,29 @@ void ProcessLightningWallControl(Missile &missile)
 	int lvl = !missile.IsTrap() ? Players[id].getCharacterLevel() : 0;
 	int dmg = 16 * (GenerateRndSum(10, 2) + lvl + 2);
 
-	{
-		Point position = { missile.var1, missile.var2 };
-		Point target = position + static_cast<Direction>(missile.var3);
+	Point position1 = { missile.var1, missile.var2 };
+	Point target1 = position1 + static_cast<Direction>(missile.var3);
 
-		if (!missile.limitReached && GrowWall(id, position, target, MissileID::LightningWall, missile._mispllvl, dmg)) {
-			missile.var1 = target.x;
-			missile.var2 = target.y;
-		} else {
-			missile.limitReached = true;
-		}
+	if (!missile.limitReached && GrowWall(id, position1, target1, MissileID::LightningWall, missile._mispllvl, dmg)) {
+		missile.var1 = target1.x;
+		missile.var2 = target1.y;
+	} else {
+		missile.limitReached = true;
 	}
 
-	{
-		Point position = { missile.var5, missile.var6 };
-		Point target = position + static_cast<Direction>(missile.var4);
+	Point position2 = { missile.var5, missile.var6 };
+	Point target2 = position2 + static_cast<Direction>(missile.var4);
 
-		if (missile.var7 == 0 && GrowWall(id, position, target, MissileID::LightningWall, missile._mispllvl, dmg)) {
-			missile.var5 = target.x;
-			missile.var6 = target.y;
-		} else {
-			missile.var7 = 1;
-		}
+	bool skip = false;
+
+	if (position1 == position2)
+		skip = true;
+
+	if (missile.var7 == 0 && GrowWall(id, position2, target2, MissileID::LightningWall, missile._mispllvl, dmg)) {
+		missile.var5 = target2.x;
+		missile.var6 = target2.y;
+	} else {
+		missile.var7 = 1;
 	}
 }
 
@@ -3734,28 +3736,29 @@ void ProcessFireWallControl(Missile &missile)
 
 	int id = missile._misource;
 
-	{
-		Point position = { missile.var1, missile.var2 };
-		Point target = position + static_cast<Direction>(missile.var3);
+	Point position1 = { missile.var1, missile.var2 };
+	Point target1 = position1 + static_cast<Direction>(missile.var3);
 
-		if (!missile.limitReached && GrowWall(id, position, target, MissileID::FireWall, missile._mispllvl, 0)) {
-			missile.var1 = target.x;
-			missile.var2 = target.y;
-		} else {
-			missile.limitReached = true;
-		}
+	if (!missile.limitReached && GrowWall(id, position1, target1, MissileID::FireWall, missile._mispllvl, 0)) {
+		missile.var1 = target1.x;
+		missile.var2 = target1.y;
+	} else {
+		missile.limitReached = true;
 	}
 
-	{
-		Point position = { missile.var5, missile.var6 };
-		Point target = position + static_cast<Direction>(missile.var4);
+	Point position2 = { missile.var5, missile.var6 };
+	Point target2 = position2 + static_cast<Direction>(missile.var4);
 
-		if (missile.var7 == 0 && GrowWall(id, position, target, MissileID::FireWall, missile._mispllvl, 0)) {
-			missile.var5 = target.x;
-			missile.var6 = target.y;
-		} else {
-			missile.var7 = 1;
-		}
+	bool skip = false;
+
+	if (position1 == position2)
+		skip = true;
+
+	if (missile.var7 == 0 && GrowWall(id, position2, target2, MissileID::FireWall, missile._mispllvl, 0, skip)) {
+		missile.var5 = target2.x;
+		missile.var6 = target2.y;
+	} else {
+		missile.var7 = 1;
 	}
 }
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3731,24 +3731,32 @@ void ProcessFireWallControl(Missile &missile)
 
 	int id = missile._misource;
 
-	Point position1 = { missile.var1, missile.var2 };
-	Point target1 = position1 + static_cast<Direction>(missile.var3);
+	// Defines the current position of the control missile moving towards var3 direction.
+	// This is used to make sure the opposite side does not create walls where walls have already been created.
+	Point currentPosition = { missile.var1, missile.var2 };
 
-	if (!missile.limitReached && GrowWall(id, position1, target1, MissileID::FireWall, missile._mispllvl, 0)) {
-		missile.var1 = target1.x;
-		missile.var2 = target1.y;
-	} else {
-		missile.limitReached = true;
+	{
+		Point position = { missile.var1, missile.var2 };
+		Point target = position + static_cast<Direction>(missile.var3);
+
+		if (!missile.limitReached && GrowWall(id, position, target, MissileID::FireWall, missile._mispllvl, 0)) {
+			missile.var1 = target.x;
+			missile.var2 = target.y;
+		} else {
+			missile.limitReached = true;
+		}
 	}
 
-	Point position2 = { missile.var5, missile.var6 };
-	Point target2 = position2 + static_cast<Direction>(missile.var4);
+	{
+		Point position = { missile.var5, missile.var6 };
+		Point target = position + static_cast<Direction>(missile.var4);
 
-	if (missile.var7 == 0 && GrowWall(id, position2, target2, MissileID::FireWall, missile._mispllvl, 0, position1 == position2)) {
-		missile.var5 = target2.x;
-		missile.var6 = target2.y;
-	} else {
-		missile.var7 = 1;
+		if (missile.var7 == 0 && GrowWall(id, position, target, MissileID::FireWall, missile._mispllvl, 0, position == currentPosition)) {
+			missile.var5 = target.x;
+			missile.var6 = target.y;
+		} else {
+			missile.var7 = 1;
+		}
 	}
 }
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3691,16 +3691,15 @@ void ProcessRhino(Missile &missile)
 /*
  * @brief Moves the control missile towards the right and grows walls.
  * @param missile The control missile.
- * @param sourceIdx The source index of the wall missile.
  * @param type The missile ID of the wall missile.
  * @param dmg The damage of the wall missile.
  */
-static void ProcessWallControlLeft(Missile &missile, const int sourceIdx, const MissileID type, const int dmg)
+static void ProcessWallControlLeft(Missile &missile, const MissileID type, const int dmg)
 {
 	const Point leftPosition = { missile.var1, missile.var2 };
 	const Point target = leftPosition + static_cast<Direction>(missile.var3);
 
-	if (!missile.limitReached && GrowWall(sourceIdx, leftPosition, target, type, missile._mispllvl, dmg)) {
+	if (!missile.limitReached && GrowWall(missile._misource, leftPosition, target, type, missile._mispllvl, dmg)) {
 		missile.var1 = target.x;
 		missile.var2 = target.y;
 	} else {
@@ -3711,17 +3710,16 @@ static void ProcessWallControlLeft(Missile &missile, const int sourceIdx, const 
 /*
  * @brief Moves the control missile towards the right and grows walls.
  * @param missile The control missile.
- * @param sourceIdx The source index of the wall missile.
  * @param type The missile ID of the wall missile.
  * @param dmg The damage of the wall missile.
  * @param skipTile Should the tile be skipped.
  */
-static void ProcessWallControlRight(Missile &missile, const int sourceIdx, const MissileID type, const int dmg, const bool skipWall = false)
+static void ProcessWallControlRight(Missile &missile, const MissileID type, const int dmg, const bool skipWall = false)
 {
 	const Point rightPosition = { missile.var5, missile.var6 };
 	const Point target = rightPosition + static_cast<Direction>(missile.var4);
 
-	if (missile.var7 == 0 && GrowWall(sourceIdx, rightPosition, target, type, missile._mispllvl, dmg, skipWall)) {
+	if (missile.var7 == 0 && GrowWall(missile._misource, rightPosition, target, type, missile._mispllvl, dmg, skipWall)) {
 		missile.var5 = target.x;
 		missile.var6 = target.y;
 	} else {
@@ -3762,8 +3760,8 @@ void ProcessWallControl(Missile &missile)
 	const Point leftPosition = { missile.var1, missile.var2 };
 	const Point rightPosition = { missile.var5, missile.var6 };
 
-	ProcessWallControlLeft(missile, sourceIdx, type, dmg);
-	ProcessWallControlRight(missile, sourceIdx, type, dmg, leftPosition == rightPosition);
+	ProcessWallControlLeft(missile, type, dmg);
+	ProcessWallControlRight(missile, type, dmg, leftPosition == rightPosition);
 }
 
 void ProcessInfravision(Missile &missile)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3736,6 +3736,9 @@ void ProcessWallControl(Missile &missile)
 	}
 
 	MissileID type;
+	const int sourceIdx = missile._misource;
+	int lvl = 0;
+	int dmg = 0;
 
 	switch (missile._mitype) {
 	case MissileID::FireWallControl:
@@ -3743,18 +3746,11 @@ void ProcessWallControl(Missile &missile)
 		break;
 	case MissileID::LightningWallControl:
 		type = MissileID::LightningWall;
+		lvl = !missile.IsTrap() ? Players[sourceIdx].getCharacterLevel() : 0;
+		dmg = 16 * (GenerateRndSum(10, 2) + lvl + 2);
 		break;
 	default:
 		app_fatal("ProcessWallControl: Invalid missile type for control missile");
-	}
-
-	const int sourceIdx = missile._misource;
-	int lvl = 0;
-	int dmg = 0;
-
-	if (type == MissileID::LightningWall) {
-		lvl = !missile.IsTrap() ? Players[sourceIdx].getCharacterLevel() : 0;
-		dmg = 16 * (GenerateRndSum(10, 2) + lvl + 2);
 	}
 
 	const Point leftPosition = { missile.var1, missile.var2 };

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3209,7 +3209,7 @@ void ProcessLightningWallControl(Missile &missile)
 		Point position = { missile.var5, missile.var6 };
 		Point target = position + static_cast<Direction>(missile.var4);
 
-		if (missile.var7 == 0 && GrowWall(id, position2, target, MissileID::LightningWall, missile._mispllvl, dmg, position == currentPosition)) {
+		if (missile.var7 == 0 && GrowWall(id, position, target, MissileID::LightningWall, missile._mispllvl, dmg, position == currentPosition)) {
 			missile.var5 = target.x;
 			missile.var6 = target.y;
 		} else {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3191,7 +3191,7 @@ void ProcessLightningWallControl(Missile &missile)
 
 	// Defines the current position of the control missile moving towards var3 direction.
 	// This is used to make sure the opposite side does not create walls where walls have already been created.
-	Point currentPosition = { missile.var1, missile.var2 };
+	const Point currentPosition = { missile.var1, missile.var2 };
 
 	{
 		Point position = { missile.var1, missile.var2 };

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3202,12 +3202,7 @@ void ProcessLightningWallControl(Missile &missile)
 	Point position2 = { missile.var5, missile.var6 };
 	Point target2 = position2 + static_cast<Direction>(missile.var4);
 
-	bool skip = false;
-
-	if (position1 == position2)
-		skip = true;
-
-	if (missile.var7 == 0 && GrowWall(id, position2, target2, MissileID::LightningWall, missile._mispllvl, dmg, skip)) {
+	if (missile.var7 == 0 && GrowWall(id, position2, target2, MissileID::LightningWall, missile._mispllvl, dmg, position1 == position2)) {
 		missile.var5 = target2.x;
 		missile.var6 = target2.y;
 	} else {
@@ -3749,12 +3744,7 @@ void ProcessFireWallControl(Missile &missile)
 	Point position2 = { missile.var5, missile.var6 };
 	Point target2 = position2 + static_cast<Direction>(missile.var4);
 
-	bool skip = false;
-
-	if (position1 == position2)
-		skip = true;
-
-	if (missile.var7 == 0 && GrowWall(id, position2, target2, MissileID::FireWall, missile._mispllvl, 0, skip)) {
+	if (missile.var7 == 0 && GrowWall(id, position2, target2, MissileID::FireWall, missile._mispllvl, 0, position1 == position2)) {
 		missile.var5 = target2.x;
 		missile.var6 = target2.y;
 	} else {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -690,7 +690,7 @@ bool GuardianTryFireAt(Missile &missile, Point target)
 	return true;
 }
 
-bool GrowWall(int id, Point position, Point target, MissileID type, int spellLevel, int damage, bool skipTile = false)
+bool GrowWall(int id, Point position, Point target, MissileID type, int spellLevel, int damage, bool skipWall = false)
 {
 	[[maybe_unused]] int dp = dPiece[position.x][position.y];
 	assert(dp <= MAXTILES && dp >= 0);
@@ -699,7 +699,7 @@ bool GrowWall(int id, Point position, Point target, MissileID type, int spellLev
 		return false;
 	}
 
-	if (!skipTile)
+	if (!skipWall)
 		AddMissile(position, position, Direction::South, type, TARGET_BOTH, id, damage, spellLevel);
 	return true;
 }
@@ -3716,12 +3716,12 @@ static void ProcessWallControlLeft(Missile &missile, const int sourceIdx, const 
  * @param dmg The damage of the wall missile.
  * @param skipTile Should the tile be skipped.
  */
-static void ProcessWallControlRight(Missile &missile, const int sourceIdx, const MissileID type, const int dmg, const bool skipTile = false)
+static void ProcessWallControlRight(Missile &missile, const int sourceIdx, const MissileID type, const int dmg, const bool skipWall = false)
 {
 	const Point rightPosition = { missile.var5, missile.var6 };
 	const Point target = rightPosition + static_cast<Direction>(missile.var4);
 
-	if (missile.var7 == 0 && GrowWall(sourceIdx, rightPosition, target, type, missile._mispllvl, dmg, skipTile)) {
+	if (missile.var7 == 0 && GrowWall(sourceIdx, rightPosition, target, type, missile._mispllvl, dmg, skipWall)) {
 		missile.var5 = target.x;
 		missile.var6 = target.y;
 	} else {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3207,7 +3207,7 @@ void ProcessLightningWallControl(Missile &missile)
 	if (position1 == position2)
 		skip = true;
 
-	if (missile.var7 == 0 && GrowWall(id, position2, target2, MissileID::LightningWall, missile._mispllvl, dmg)) {
+	if (missile.var7 == 0 && GrowWall(id, position2, target2, MissileID::LightningWall, missile._mispllvl, dmg, skip)) {
 		missile.var5 = target2.x;
 		missile.var6 = target2.y;
 	} else {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3747,8 +3747,7 @@ void ProcessWallControl(Missile &missile)
 		type = MissileID::LightningWall;
 		break;
 	default:
-		type = MissileID::Null;
-		break;
+		app_fatal("ProcessWallControl: Invalid missile type for control missile");
 	}
 
 	const int sourceIdx = missile._misource;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -363,7 +363,7 @@ void AddIdentify(Missile &missile, AddMissileParameter &parameter);
  * var5: X coordinate of the second wave
  * var6: Y coordinate of the second wave
  */
-void AddFireWallControl(Missile &missile, AddMissileParameter &parameter);
+void AddWallControl(Missile &missile, AddMissileParameter &parameter);
 void AddInfravision(Missile &missile, AddMissileParameter &parameter);
 
 /**
@@ -421,7 +421,6 @@ void ProcessBigExplosion(Missile &missile);
 void ProcessLightningBow(Missile &missile);
 void ProcessRingOfFire(Missile &missile);
 void ProcessSearch(Missile &missile);
-void ProcessLightningWallControl(Missile &missile);
 void ProcessImmolation(Missile &missile);
 void ProcessSpectralArrow(Missile &missile);
 void ProcessLightningControl(Missile &missile);
@@ -439,7 +438,7 @@ void ProcessTeleport(Missile &missile);
 void ProcessStoneCurse(Missile &missile);
 void ProcessApocalypseBoom(Missile &missile);
 void ProcessRhino(Missile &missile);
-void ProcessFireWallControl(Missile &missile);
+void ProcessWallControl(Missile &missile);
 void ProcessInfravision(Missile &missile);
 void ProcessApocalypse(Missile &missile);
 void ProcessFlameWaveControl(Missile &missile);

--- a/assets/txtdata/missiles/misdat.tsv
+++ b/assets/txtdata/missiles/misdat.tsv
@@ -37,7 +37,7 @@ Etherealize			SpellEtherealize		Etherealize	Physical
 Spurt					Spurt	Physical	
 ApocalypseBoom	AddApocalypseBoom	ProcessApocalypseBoom			ApocalypseBoom	Physical	
 Healing	AddHealing					Physical,Invisible	
-FireWallControl	AddFireWallControl	ProcessFireWallControl			FireWall	Fire,Invisible	
+FireWallControl	AddWallControl	ProcessWallControl			FireWall	Fire,Invisible	
 Infravision	AddInfravision	ProcessInfravision	SpellInfravision			Physical,Invisible	
 Identify	AddIdentify					Physical,Invisible	
 FlameWaveControl	AddFlameWaveControl	ProcessFlameWaveControl	SpellFlameWave		FireWall	Fire	
@@ -70,7 +70,7 @@ DiabloApocalypse	AddDiabloApocalypse					Physical,Invisible
 Mana	AddMana					Physical,Invisible	
 Magi	AddMagi					Physical,Invisible	
 LightningWall	AddLightningWall	ProcessLightningWall	SpellLightningWall	SpellLightningHit	Lightning	Lightning	
-LightningWallControl	AddFireWallControl	ProcessLightningWallControl			Lightning	Lightning,Invisible	
+LightningWallControl	AddWallControl	ProcessWallControl			Lightning	Lightning,Invisible	
 Immolation	AddNova	ProcessImmolation	SpellFirebolt	SpellFireHit	Fireball	Fire	
 SpectralArrow	AddSpectralArrow	ProcessSpectralArrow			Arrow	Physical,Arrow	
 FireballBow	AddImmolation	ProcessFireball	ShootFireballBow	SpellFireHit	Fireball	Fire	Blockable


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/issues/7205

Fixes the problem where wall spells create visible missiles that overlap in the center of the wall, resulting in double damage.