### PR TITLE
Rename Missile::_mirange to Missile::duration

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -761,7 +761,7 @@ void LoadMissile(LoadHelper *file)
 	missile._miLightFlag = file->NextBool32();
 	missile._miPreFlag = file->NextBool32();
 	missile._miUniqTrans = file->NextLE<uint32_t>();
-	missile._mirange = file->NextLE<int32_t>();
+	missile._miduration = file->NextLE<int32_t>();
 	missile._misource = file->NextLE<int32_t>();
 	missile._micaster = static_cast<mienemy_type>(file->NextLE<int32_t>());
 	missile._midam = file->NextLE<int32_t>();
@@ -1549,7 +1549,7 @@ void SaveMissile(SaveHelper *file, const Missile &missile)
 	file->WriteLE<uint32_t>(missile._miLightFlag ? 1 : 0);
 	file->WriteLE<uint32_t>(missile._miPreFlag ? 1 : 0);
 	file->WriteLE<uint32_t>(missile._miUniqTrans);
-	file->WriteLE<int32_t>(missile._mirange);
+	file->WriteLE<int32_t>(missile._miduration);
 	file->WriteLE<int32_t>(missile._misource);
 	file->WriteLE<int32_t>(missile._micaster);
 	file->WriteLE<int32_t>(missile._midam);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -761,7 +761,7 @@ void LoadMissile(LoadHelper *file)
 	missile._miLightFlag = file->NextBool32();
 	missile._miPreFlag = file->NextBool32();
 	missile._miUniqTrans = file->NextLE<uint32_t>();
-	missile._miduration = file->NextLE<int32_t>();
+	missile.duration = file->NextLE<int32_t>();
 	missile._misource = file->NextLE<int32_t>();
 	missile._micaster = static_cast<mienemy_type>(file->NextLE<int32_t>());
 	missile._midam = file->NextLE<int32_t>();
@@ -1549,7 +1549,7 @@ void SaveMissile(SaveHelper *file, const Missile &missile)
 	file->WriteLE<uint32_t>(missile._miLightFlag ? 1 : 0);
 	file->WriteLE<uint32_t>(missile._miPreFlag ? 1 : 0);
 	file->WriteLE<uint32_t>(missile._miUniqTrans);
-	file->WriteLE<int32_t>(missile._miduration);
+	file->WriteLE<int32_t>(missile.duration);
 	file->WriteLE<int32_t>(missile._misource);
 	file->WriteLE<int32_t>(missile._micaster);
 	file->WriteLE<int32_t>(missile._midam);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -428,7 +428,7 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 
 	if (isMonsterHit) {
 		if (!dontDeleteOnCollision)
-			missile._mirange = 0;
+			missile._miduration = 0;
 		missile._miHitFlag = true;
 	}
 
@@ -454,7 +454,7 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 		if (gbIsHellfire && blocked) {
 			RotateBlockedMissile(missile);
 		} else if (!dontDeleteOnCollision) {
-			missile._mirange = 0;
+			missile._miduration = 0;
 		}
 		missile._miHitFlag = true;
 	}
@@ -466,12 +466,12 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 		}
 
 		if (!dontDeleteOnCollision)
-			missile._mirange = 0;
+			missile._miduration = 0;
 		missile._miHitFlag = false;
 	}
 
 	const MissileData &missileData = GetMissileData(missile._mitype);
-	if (missile._mirange == 0 && missileData.hitSound != SfxID::None)
+	if (missile._miduration == 0 && missileData.hitSound != SfxID::None)
 		PlaySfxLoc(missileData.hitSound, missile.position.tile);
 }
 
@@ -568,7 +568,7 @@ void MoveMissileAndCheckMissileCol(Missile &missile, DamageType damageType, int 
 		CheckMissileCol(missile, damageType, mindam, maxdam, false, tile, false);
 
 		// Did missile hit anything?
-		if (missile._mirange != 0)
+		if (missile._miduration != 0)
 			return true;
 
 		if (missile._miHitFlag && GetMissileData(missile._mitype).movementDistribution == MissileMovementDistribution::Blockable)
@@ -717,7 +717,7 @@ void SyncPositionWithParent(Missile &missile, const AddMissileParameter &paramet
 
 void SpawnLightning(Missile &missile, int dam)
 {
-	missile._mirange--;
+	missile._miduration--;
 	MoveMissile(
 	    missile, [&](Point tile) {
 		    assert(InDungeonBounds(tile));
@@ -726,7 +726,7 @@ void SpawnLightning(Missile &missile, int dam)
 
 		    if (!missile.IsTrap() || tile != missile.position.start) {
 			    if (TileHasAny(tile, TileProperties::BlockMissile)) {
-				    missile._mirange = 0;
+				    missile._miduration = 0;
 				    return false;
 			    }
 		    }
@@ -757,7 +757,7 @@ void SpawnLightning(Missile &missile, int dam)
 		}
 	}
 
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 	}
 }
@@ -1266,7 +1266,7 @@ void AddBerserk(Missile &missile, AddMissileParameter &parameter)
 void AddHorkSpawn(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 8);
-	missile._mirange = 9;
+	missile._miduration = 9;
 	missile.var1 = static_cast<int32_t>(parameter.midir);
 	PutMissile(missile);
 }
@@ -1418,7 +1418,7 @@ void AddSpectralArrow(Missile &missile, AddMissileParameter &parameter)
 			av += 8;
 	}
 
-	missile._mirange = 1;
+	missile._miduration = 1;
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
 	missile.var3 = av;
@@ -1479,7 +1479,7 @@ void AddWarp(Missile &missile, AddMissileParameter &parameter)
 			tile = candidate;
 		}
 	}
-	missile._mirange = 2;
+	missile._miduration = 2;
 	std::optional<Point> teleportDestination = FindClosestValidPosition(
 	    [&player](Point target) {
 		    for (int i = 0; i < numtrigs; i++) {
@@ -1503,7 +1503,7 @@ void AddLightningWall(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile._miAnimFrame = RandomIntBetween(1, 8);
-	missile._mirange = 255 * (missile._mispllvl + 1);
+	missile._miduration = 255 * (missile._mispllvl + 1);
 	switch (missile.sourceType()) {
 	case MissileSource::Trap:
 		missile.var1 = missile.position.start.x;
@@ -1534,7 +1534,7 @@ void AddBigExplosion(Missile &missile, AddMissileParameter & /*parameter*/)
 	}
 	missile._mlid = AddLight(missile.position.start, 8);
 	SetMissDir(missile, 0);
-	missile._mirange = missile._miAnimLen - 1;
+	missile._miduration = missile._miAnimLen - 1;
 }
 
 void AddImmolation(Missile &missile, AddMissileParameter &parameter)
@@ -1549,7 +1549,7 @@ void AddImmolation(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, sp);
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._mirange = 256;
+	missile._miduration = 256;
 	missile._mlid = AddLight(missile.position.start, 8);
 }
 
@@ -1561,7 +1561,7 @@ void AddLightningBow(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, 32);
 	missile._miAnimFrame = RandomIntBetween(1, 8);
-	missile._mirange = 255;
+	missile._miduration = 255;
 	if (missile._misource < 0) {
 		missile.var1 = missile.position.start.x;
 		missile.var2 = missile.position.start.y;
@@ -1611,7 +1611,7 @@ void AddRingOfFire(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
-	missile._mirange = 7;
+	missile._miduration = 7;
 }
 
 void AddSearch(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -1623,14 +1623,14 @@ void AddSearch(Missile &missile, AddMissileParameter & /*parameter*/)
 	int lvl = 2;
 	if (missile._misource >= 0)
 		lvl = player.getCharacterLevel() * 2;
-	missile._mirange = lvl + 10 * missile._mispllvl + 245;
+	missile._miduration = lvl + 10 * missile._mispllvl + 245;
 
 	for (auto &other : Missiles) {
 		if (&other != &missile && missile.isSameSource(other) && other._mitype == MissileID::Search) {
-			int r1 = missile._mirange;
-			int r2 = other._mirange;
+			int r1 = missile._miduration;
+			int r2 = other._miduration;
 			if (r2 < INT_MAX - r1)
-				other._mirange = r1 + r2;
+				other._miduration = r1 + r2;
 			missile._miDelFlag = true;
 			break;
 		}
@@ -1653,7 +1653,7 @@ void AddChargedBoltBow(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, dst, 8);
 	missile.var1 = 5;
 	missile.var2 = static_cast<int32_t>(parameter.midir);
-	missile._mirange = 256;
+	missile._miduration = 256;
 }
 
 void AddElementalArrow(Missile &missile, AddMissileParameter &parameter)
@@ -1687,7 +1687,7 @@ void AddElementalArrow(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, dst, av);
 
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._mirange = 256;
+	missile._miduration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 5);
@@ -1724,7 +1724,7 @@ void AddArrow(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, av);
 	missile._miAnimFrame = static_cast<int>(GetDirection16(missile.position.start, dst)) + 1;
-	missile._mirange = 256;
+	missile._miduration = 256;
 }
 
 void UpdateVileMissPos(Missile &missile, Point dst)
@@ -1745,7 +1745,7 @@ void UpdateVileMissPos(Missile &missile, Point dst)
 
 void AddPhasing(Missile &missile, AddMissileParameter &parameter)
 {
-	missile._mirange = 2;
+	missile._miduration = 2;
 
 	Player &player = Players[missile._misource];
 
@@ -1796,7 +1796,7 @@ void AddFirebolt(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, sp);
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._mirange = 256;
+	missile._miduration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -1824,9 +1824,9 @@ void AddMagmaBall(Missile &missile, AddMissileParameter &parameter)
 	missile.position.traveled.deltaY += 3 * missile.position.velocity.deltaY;
 	UpdateMissilePos(missile);
 	if (!gbIsHellfire || (missile.position.velocity.deltaX & 0xFFFF0000) != 0 || (missile.position.velocity.deltaY & 0xFFFF0000) != 0)
-		missile._mirange = 256;
+		missile._miduration = 256;
 	else
-		missile._mirange = 1;
+		missile._miduration = 1;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -1858,7 +1858,7 @@ void AddTeleport(Missile &missile, AddMissileParameter &parameter)
 	if (teleportDestination) {
 		missile.position.tile = *teleportDestination;
 		missile.position.start = *teleportDestination;
-		missile._mirange = 2;
+		missile._miduration = 2;
 	} else {
 		missile._miDelFlag = true;
 		parameter.spellFizzled = true;
@@ -1869,7 +1869,7 @@ void AddNovaBall(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile._miAnimFrame = RandomIntBetween(1, 8);
-	missile._mirange = 255;
+	missile._miduration = 255;
 	const WorldTilePosition position = missile._misource < 0 ? missile.position.start : Players[missile._misource].position.tile;
 	missile.var1 = position.x;
 	missile.var2 = position.y;
@@ -1882,13 +1882,13 @@ void AddFireWall(Missile &missile, AddMissileParameter &parameter)
 	missile._midam <<= 3;
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	int i = missile._mispllvl;
-	missile._mirange = 10;
+	missile._miduration = 10;
 	if (i > 0)
-		missile._mirange *= i + 1;
+		missile._miduration *= i + 1;
 	if (missile._micaster == TARGET_PLAYERS || missile._misource < 0)
-		missile._mirange += currlevel;
-	missile._mirange *= 16;
-	missile.var1 = missile._mirange - missile._miAnimLen;
+		missile._miduration += currlevel;
+	missile._miduration *= 16;
+	missile.var1 = missile._miduration - missile._miAnimLen;
 }
 
 void AddFireball(Missile &missile, AddMissileParameter &parameter)
@@ -1907,7 +1907,7 @@ void AddFireball(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, sp);
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._mirange = 256;
+	missile._miduration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -1919,7 +1919,7 @@ void AddLightningControl(Missile &missile, AddMissileParameter &parameter)
 	missile.var2 = missile.position.start.y;
 	UpdateMissileVelocity(missile, parameter.dst, 32);
 	missile._miAnimFrame = RandomIntBetween(1, 8);
-	missile._mirange = 256;
+	missile._miduration = 256;
 }
 
 void AddLightning(Missile &missile, AddMissileParameter &parameter)
@@ -1932,11 +1932,11 @@ void AddLightning(Missile &missile, AddMissileParameter &parameter)
 
 	if (missile._micaster == TARGET_PLAYERS || missile.IsTrap()) {
 		if (missile.IsTrap() || Monsters[missile._misource].type().type == MT_FAMILIAR)
-			missile._mirange = 8;
+			missile._miduration = 8;
 		else
-			missile._mirange = 10;
+			missile._miduration = 10;
 	} else {
-		missile._mirange = (missile._mispllvl / 2) + 6;
+		missile._miduration = (missile._mispllvl / 2) + 6;
 	}
 	missile._mlid = AddLight(missile.position.tile, 4);
 }
@@ -1968,7 +1968,7 @@ void AddMissileExplosion(Missile &missile, AddMissileParameter &parameter)
 	missile.position.start = parent.position.start;
 	missile.position.offset = parent.position.offset;
 	missile.position.traveled = parent.position.traveled;
-	missile._mirange = missile._miAnimLen;
+	missile._miduration = missile._miAnimLen;
 }
 
 void AddWeaponExplosion(Missile &missile, AddMissileParameter &parameter)
@@ -1978,7 +1978,7 @@ void AddWeaponExplosion(Missile &missile, AddMissileParameter &parameter)
 		SetMissAnim(missile, MissileGraphicID::MagmaBallExplosion);
 	else
 		SetMissAnim(missile, MissileGraphicID::ChargedBolt);
-	missile._mirange = missile._miAnimLen - 1;
+	missile._miduration = missile._miAnimLen - 1;
 }
 
 void AddTownPortal(Missile &missile, AddMissileParameter &parameter)
@@ -2017,11 +2017,11 @@ void AddTownPortal(Missile &missile, AddMissileParameter &parameter)
 		}
 	}
 
-	missile._mirange = 100;
-	missile.var1 = missile._mirange - missile._miAnimLen;
+	missile._miduration = 100;
+	missile.var1 = missile._miduration - missile._miAnimLen;
 	for (auto &other : Missiles) {
 		if (other._mitype == MissileID::TownPortal && &other != &missile && missile.isSameSource(other))
-			other._mirange = 0;
+			other._miduration = 0;
 	}
 	PutMissile(missile);
 	if (missile.sourcePlayer() == MyPlayer && !missile._miDelFlag && leveltype != DTYPE_TOWN) {
@@ -2050,7 +2050,7 @@ void AddFlashBottom(Missile &missile, AddMissileParameter & /*parameter*/)
 		break;
 	}
 
-	missile._mirange = 19;
+	missile._miduration = 19;
 }
 
 void AddFlashTop(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -2066,7 +2066,7 @@ void AddFlashTop(Missile &missile, AddMissileParameter & /*parameter*/)
 		}
 	}
 	missile._miPreFlag = true;
-	missile._mirange = 19;
+	missile._miduration = 19;
 }
 
 void AddManaShield(Missile &missile, AddMissileParameter &parameter)
@@ -2089,7 +2089,7 @@ void AddFlameWave(Missile &missile, AddMissileParameter &parameter)
 {
 	missile._midam = GenerateRnd(10) + Players[missile._misource].getCharacterLevel() + 1;
 	UpdateMissileVelocity(missile, parameter.dst, 16);
-	missile._mirange = 255;
+	missile._miduration = 255;
 
 	// Adjust missile's position for rendering
 	missile.position.tile += Direction::South;
@@ -2134,15 +2134,15 @@ void AddGuardian(Missile &missile, AddMissileParameter &parameter)
 	missile.position.start = *spawnPosition;
 
 	missile._mlid = AddLight(missile.position.tile, 1);
-	missile._mirange = missile._mispllvl + (player.getCharacterLevel() / 2);
+	missile._miduration = missile._mispllvl + (player.getCharacterLevel() / 2);
 
-	if (missile._mirange > 30)
-		missile._mirange = 30;
-	missile._mirange <<= 4;
-	if (missile._mirange < 30)
-		missile._mirange = 30;
+	if (missile._miduration > 30)
+		missile._miduration = 30;
+	missile._miduration <<= 4;
+	if (missile._miduration < 30)
+		missile._miduration = 30;
 
-	missile.var1 = missile._mirange - missile._miAnimLen;
+	missile.var1 = missile._miduration - missile._miAnimLen;
 	missile.var3 = 1;
 }
 
@@ -2150,7 +2150,7 @@ void AddChainLightning(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
-	missile._mirange = 1;
+	missile._miduration = 1;
 }
 
 namespace {
@@ -2170,7 +2170,7 @@ void InitMissileAnimationFromMonster(Missile &mis, Direction midir, const Monste
 	mis.var1 = 0;
 	mis.var2 = 0;
 	mis._miLightFlag = true;
-	mis._mirange = 256;
+	mis._miduration = 256;
 }
 } // namespace
 
@@ -2201,7 +2201,7 @@ void AddGenericMagicMissile(Missile &missile, AddMissileParameter &parameter)
 		dst += parameter.midir;
 	}
 	UpdateMissileVelocity(missile, dst, 16);
-	missile._mirange = 256;
+	missile._miduration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -2243,9 +2243,9 @@ void AddAcid(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	SetMissDir(missile, GetDirection16(missile.position.start, parameter.dst));
 	if (!gbIsHellfire || (missile.position.velocity.deltaX & 0xFFFF0000) != 0 || (missile.position.velocity.deltaY & 0xFFFF0000) != 0)
-		missile._mirange = 5 * (Monsters[missile._misource].intelligence + 4);
+		missile._miduration = 5 * (Monsters[missile._misource].intelligence + 4);
 	else
-		missile._mirange = 1;
+		missile._miduration = 1;
 	missile._mlid = NO_LIGHT;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
@@ -2269,7 +2269,7 @@ void AddAcidPuddle(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	missile._miLightFlag = true;
 	int monst = missile._misource;
-	missile._mirange = GenerateRnd(15) + 40 * (Monsters[monst].intelligence + 1);
+	missile._miduration = GenerateRnd(15) + 40 * (Monsters[monst].intelligence + 1);
 	missile._miPreFlag = true;
 }
 
@@ -2322,11 +2322,11 @@ void AddStoneCurse(Missile &missile, AddMissileParameter &parameter)
 	// And set up the missile to unpetrify it in the future
 	missile.position.tile = *targetMonsterPosition;
 	missile.position.start = missile.position.tile;
-	missile._mirange = missile._mispllvl + 6;
+	missile._miduration = missile._mispllvl + 6;
 
-	if (missile._mirange > 15)
-		missile._mirange = 15;
-	missile._mirange <<= 4;
+	if (missile._miduration > 15)
+		missile._miduration = 15;
+	missile._miduration <<= 4;
 }
 
 void AddGolem(Missile &missile, AddMissileParameter &parameter)
@@ -2357,7 +2357,7 @@ void AddApocalypseBoom(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.position.tile = parameter.dst;
 	missile.position.start = parameter.dst;
-	missile._mirange = missile._miAnimLen;
+	missile._miduration = missile._miAnimLen;
 }
 
 void AddHealing(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -2408,7 +2408,7 @@ void AddElemental(Missile &missile, AddMissileParameter &parameter)
 
 	UpdateMissileVelocity(missile, dst, 16);
 	SetMissDir(missile, GetDirection(missile.position.start, dst));
-	missile._mirange = 256;
+	missile._miduration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile.var4 = dst.x;
@@ -2456,19 +2456,19 @@ void AddWallControl(Missile &missile, AddMissileParameter &parameter)
 	missile.var6 = spreadPosition->y;
 	missile.var3 = static_cast<int>(Left(Left(parameter.midir)));
 	missile.var4 = static_cast<int>(Right(Right(parameter.midir)));
-	missile._mirange = 7;
+	missile._miduration = 7;
 }
 
 void AddInfravision(Missile &missile, AddMissileParameter & /*parameter*/)
 {
-	missile._mirange = ScaleSpellEffect(1584, missile._mispllvl);
+	missile._miduration = ScaleSpellEffect(1584, missile._mispllvl);
 }
 
 void AddFlameWaveControl(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
-	missile._mirange = 1;
+	missile._miduration = 1;
 	missile._miAnimFrame = 4;
 }
 
@@ -2485,7 +2485,7 @@ void AddNova(Missile &missile, AddMissileParameter &parameter)
 		missile._midam = (currlevel / 2) + GenerateRndSum(3, 3);
 	}
 
-	missile._mirange = 1;
+	missile._miduration = 1;
 }
 
 void AddRage(Missile &missile, AddMissileParameter &parameter)
@@ -2503,7 +2503,7 @@ void AddRage(Missile &missile, AddMissileParameter &parameter)
 	player._pSpellFlags |= SpellFlag::RageActive;
 	missile.var2 = tmp;
 	int lvl = player.getCharacterLevel() * 2;
-	missile._mirange = lvl + 10 * missile._mispllvl + 245;
+	missile._miduration = lvl + 10 * missile._mispllvl + 245;
 	CalcPlrItemVals(player, true);
 	RedrawEverything();
 	player.Say(HeroSpeech::Aaaaargh);
@@ -2571,7 +2571,7 @@ void AddApocalypse(Missile &missile, AddMissileParameter & /*parameter*/)
 	missile.var6 = missile.var4;
 	int playerLevel = player.getCharacterLevel();
 	missile._midam = GenerateRndSum(6, playerLevel) + playerLevel;
-	missile._mirange = 255;
+	missile._miduration = 255;
 }
 
 void AddInferno(Missile &missile, AddMissileParameter &parameter)
@@ -2581,7 +2581,7 @@ void AddInferno(Missile &missile, AddMissileParameter &parameter)
 
 	SyncPositionWithParent(missile, parameter);
 
-	missile._mirange = missile.var2 + 20;
+	missile._miduration = missile.var2 + 20;
 	missile._mlid = AddLight(missile.position.start, 1);
 	if (missile._micaster == TARGET_MONSTERS) {
 		int i = GenerateRnd(Players[missile._misource].getCharacterLevel()) + GenerateRnd(2);
@@ -2601,7 +2601,7 @@ void AddInfernoControl(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, dst, 32);
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
-	missile._mirange = 256;
+	missile._miduration = 256;
 }
 
 void AddChargedBolt(Missile &missile, AddMissileParameter &parameter)
@@ -2619,7 +2619,7 @@ void AddChargedBolt(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, dst, 8);
 	missile.var1 = 5;
 	missile.var2 = static_cast<int>(parameter.midir);
-	missile._mirange = 256;
+	missile._miduration = 256;
 }
 
 void AddHolyBolt(Missile &missile, AddMissileParameter &parameter)
@@ -2637,7 +2637,7 @@ void AddHolyBolt(Missile &missile, AddMissileParameter &parameter)
 
 	UpdateMissileVelocity(missile, dst, sp);
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._mirange = 256;
+	missile._miduration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -2660,7 +2660,7 @@ void AddResurrectBeam(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.position.tile = parameter.dst;
 	missile.position.start = parameter.dst;
-	missile._mirange = GetMissileSpriteData(MissileGraphicID::Resurrect).animLen(0);
+	missile._miduration = GetMissileSpriteData(MissileGraphicID::Resurrect).animLen(0);
 }
 
 void AddTelekinesis(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -2680,7 +2680,7 @@ void AddBoneSpirit(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, 16);
 	SetMissDir(missile, GetDirection(missile.position.start, dst));
-	missile._mirange = 256;
+	missile._miduration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile.var4 = dst.x;
@@ -2690,7 +2690,7 @@ void AddBoneSpirit(Missile &missile, AddMissileParameter &parameter)
 
 void AddRedPortal(Missile &missile, AddMissileParameter & /*parameter*/)
 {
-	missile._mirange = 100;
+	missile._miduration = 100;
 	missile.var1 = 100 - missile._miAnimLen;
 	PutMissile(missile);
 }
@@ -2765,7 +2765,7 @@ Missile *AddMissile(WorldTilePosition src, WorldTilePosition dst, Direction midi
 
 void ProcessElementalArrow(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	if (missile._miAnimType == MissileGraphicID::ChargedBolt || missile._miAnimType == MissileGraphicID::MagmaBallExplosion) {
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame + 5);
 	} else {
@@ -2790,9 +2790,9 @@ void ProcessElementalArrow(Missile &missile)
 			maxd = GenerateRnd(10) + 1 + currlevel * 2;
 		}
 		MoveMissileAndCheckMissileCol(missile, DamageType::Physical, mind, maxd, true, false);
-		if (missile._mirange == 0) {
+		if (missile._miduration == 0) {
 			missile._mimfnum = 0;
-			missile._mirange = missile._miAnimLen - 1;
+			missile._miduration = missile._miAnimLen - 1;
 			missile.position.StopMissile();
 
 			int eMind;
@@ -2840,7 +2840,7 @@ void ProcessElementalArrow(Missile &missile)
 			}
 		}
 	}
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -2849,7 +2849,7 @@ void ProcessElementalArrow(Missile &missile)
 
 void ProcessArrow(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	missile._midist++;
 
 	int mind;
@@ -2873,17 +2873,17 @@ void ProcessArrow(Missile &missile)
 		break;
 	}
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), mind, maxd, true, false);
-	if (missile._mirange == 0)
+	if (missile._miduration == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
 }
 
 void ProcessGenericProjectile(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, true);
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		Point dst = { 0, 0 };
 		auto dir = static_cast<Direction>(missile._mimfnum);
@@ -2933,35 +2933,35 @@ void ProcessGenericProjectile(Missile &missile)
 void ProcessNovaBall(Missile &missile)
 {
 	Point targetPosition = { missile.var1, missile.var2 };
-	missile._mirange--;
-	int j = missile._mirange;
+	missile._miduration--;
+	int j = missile._miduration;
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, false, false);
 	if (missile._miHitFlag)
-		missile._mirange = j;
+		missile._miduration = j;
 
 	if (missile.position.tile == targetPosition) {
 		Object *object = FindObjectAtPosition(targetPosition);
 		if (object != nullptr && object->IsShrine()) {
-			missile._mirange = j;
+			missile._miduration = j;
 		}
 	}
-	if (missile._mirange == 0)
+	if (missile._miduration == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
 }
 
 void ProcessAcidPuddle(Missile &missile)
 {
-	missile._mirange--;
-	int range = missile._mirange;
+	missile._miduration--;
+	int range = missile._miduration;
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
-	missile._mirange = range;
+	missile._miduration = range;
 	if (range == 0) {
 		if (missile._mimfnum != 0) {
 			missile._miDelFlag = true;
 		} else {
 			SetMissDir(missile, 1);
-			missile._mirange = missile._miAnimLen;
+			missile._miduration = missile._miAnimLen;
 		}
 	}
 	PutMissile(missile);
@@ -2971,22 +2971,22 @@ void ProcessFireWall(Missile &missile)
 {
 	constexpr int ExpLight[14] = { 2, 3, 4, 5, 5, 6, 7, 8, 9, 10, 11, 12, 12 };
 
-	missile._mirange--;
-	if (missile._mirange == missile.var1) {
+	missile._miduration--;
+	if (missile._miduration == missile.var1) {
 		SetMissDir(missile, 1);
 		missile._miAnimFrame = GenerateRnd(11) + 1;
 	}
-	if (missile._mirange == missile._miAnimLen - 1) {
+	if (missile._miduration == missile._miAnimLen - 1) {
 		SetMissDir(missile, 0);
 		missile._miAnimFrame = 13;
 		missile._miAnimAdd = -1;
 	}
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, true);
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
-	if (missile._mimfnum != 0 && missile._mirange != 0 && missile._miAnimAdd != -1 && missile.var2 < 12) {
+	if (missile._mimfnum != 0 && missile._miduration != 0 && missile._miAnimAdd != -1 && missile.var2 < 12) {
 		if (missile.var2 == 0)
 			missile._mlid = AddLight(missile.position.tile, ExpLight[0]);
 		ChangeLight(missile._mlid, missile.position.tile, ExpLight[missile.var2]);
@@ -2997,10 +2997,10 @@ void ProcessFireWall(Missile &missile)
 
 void ProcessFireball(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 
 	if (missile._miAnimType == MissileGraphicID::BigExplosion) {
-		if (missile._mirange == 0) {
+		if (missile._miduration == 0) {
 			missile._miDelFlag = true;
 			AddUnLight(missile._mlid);
 		}
@@ -3015,7 +3015,7 @@ void ProcessFireball(Missile &missile)
 		}
 		const DamageType damageType = GetMissileData(missile._mitype).damageType();
 		MoveMissileAndCheckMissileCol(missile, damageType, minDam, maxDam, true, false);
-		if (missile._mirange == 0) {
+		if (missile._miduration == 0) {
 			const Point missilePosition = missile.position.tile;
 			ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
 
@@ -3052,7 +3052,7 @@ void ProcessFireball(Missile &missile)
 			}
 			missile._mimfnum = 0;
 			SetMissAnim(missile, MissileGraphicID::BigExplosion);
-			missile._mirange = missile._miAnimLen - 1;
+			missile._miduration = missile._miAnimLen - 1;
 			missile.position.velocity = {};
 		} else if (missile.position.tile != Point { missile.var1, missile.var2 }) {
 			missile.var1 = missile.position.tile.x;
@@ -3066,9 +3066,9 @@ void ProcessFireball(Missile &missile)
 
 void ProcessHorkSpawn(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), 0, 0, false, missile.position.tile, false);
-	if (missile._mirange <= 0) {
+	if (missile._miduration <= 0) {
 		missile._miDelFlag = true;
 
 		std::optional<Point> spawnPosition = FindClosestValidPosition(
@@ -3109,20 +3109,20 @@ void ProcessRune(Missile &missile)
 
 void ProcessLightningWall(Missile &missile)
 {
-	missile._mirange--;
-	int range = missile._mirange;
+	missile._miduration--;
+	int range = missile._miduration;
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
 	if (missile._miHitFlag)
-		missile._mirange = range;
-	if (missile._mirange == 0)
+		missile._miduration = range;
+	if (missile._miduration == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
 }
 
 void ProcessBigExplosion(Missile &missile)
 {
-	missile._mirange--;
-	if (missile._mirange <= 0) {
+	missile._miduration--;
+	if (missile._miduration <= 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3166,8 +3166,8 @@ void ProcessRingOfFire(Missile &missile)
 
 void ProcessSearch(Missile &missile)
 {
-	missile._mirange--;
-	if (missile._mirange != 0)
+	missile._miduration--;
+	if (missile._miduration != 0)
 		return;
 
 	const Player &player = Players[missile._misource];
@@ -3197,8 +3197,8 @@ void ProcessNovaCommon(Missile &missile, MissileID projectileType)
 		for (WorldTileDisplacement offset : offsets)
 			AddMissile(src, src + offset, dir, projectileType, en, id, dam, missile._mispllvl);
 	}
-	missile._mirange--;
-	if (missile._mirange == 0)
+	missile._miduration--;
+	if (missile._miduration == 0)
 		missile._miDelFlag = true;
 }
 
@@ -3247,14 +3247,14 @@ void ProcessSpectralArrow(Missile &missile)
 		AddMissile(src, dst, dir, mitype, micaster, id, dam, spllvl);
 		AddMissile(src, dst, dir, mitype, micaster, id, dam, spllvl);
 	}
-	missile._mirange--;
-	if (missile._mirange == 0)
+	missile._miduration--;
+	if (missile._miduration == 0)
 		missile._miDelFlag = true;
 }
 
 void ProcessLightningControl(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 
 	int dam;
 	if (missile.IsTrap()) {
@@ -3273,13 +3273,13 @@ void ProcessLightningControl(Missile &missile)
 
 void ProcessLightning(Missile &missile)
 {
-	missile._mirange--;
-	int j = missile._mirange;
+	missile._miduration--;
+	int j = missile._miduration;
 	if (missile.position.tile != missile.position.start)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
 	if (missile._miHitFlag)
-		missile._mirange = j;
-	if (missile._mirange == 0) {
+		missile._miduration = j;
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3290,11 +3290,11 @@ void ProcessTownPortal(Missile &missile)
 {
 	int expLight[17] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 15 };
 
-	if (missile._mirange > 1)
-		missile._mirange--;
-	if (missile._mirange == missile.var1)
+	if (missile._miduration > 1)
+		missile._miduration--;
+	if (missile._miduration == missile.var1)
 		SetMissDir(missile, 1);
-	if (leveltype != DTYPE_TOWN && missile._mimfnum != 1 && missile._mirange != 0) {
+	if (leveltype != DTYPE_TOWN && missile._mimfnum != 1 && missile._miduration != 0) {
 		if (missile.var2 == 0)
 			missile._mlid = AddLight(missile.position.tile, 1);
 		ChangeLight(missile._mlid, missile.position.tile, expLight[missile.var2]);
@@ -3311,7 +3311,7 @@ void ProcessTownPortal(Missile &missile)
 		}
 	}
 
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3324,7 +3324,7 @@ void ProcessFlashBottom(Missile &missile)
 		if (!missile.IsTrap())
 			Players[missile._misource]._pInvincible = true;
 	}
-	missile._mirange--;
+	missile._miduration--;
 
 	constexpr Direction Offsets[] = {
 		Direction::NorthWest,
@@ -3337,7 +3337,7 @@ void ProcessFlashBottom(Missile &missile)
 	for (Direction offset : Offsets)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile + offset, true);
 
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		if (missile._micaster == TARGET_MONSTERS) {
 			if (!missile.IsTrap())
@@ -3353,7 +3353,7 @@ void ProcessFlashTop(Missile &missile)
 		if (!missile.IsTrap())
 			Players[missile._misource]._pInvincible = true;
 	}
-	missile._mirange--;
+	missile._miduration--;
 
 	constexpr Direction Offsets[] = {
 		Direction::North,
@@ -3363,7 +3363,7 @@ void ProcessFlashTop(Missile &missile)
 	for (Direction offset : Offsets)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile + offset, true);
 
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		if (missile._micaster == TARGET_MONSTERS) {
 			if (!missile.IsTrap())
@@ -3386,15 +3386,15 @@ void ProcessFlameWave(Missile &missile)
 		SetMissDir(missile, 1);
 		missile._miAnimFrame = GenerateRnd(11) + 1;
 	}
-	int j = missile._mirange;
+	int j = missile._miduration;
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, false, false);
 	if (missile._miHitFlag)
-		missile._mirange = j;
-	if (missile._mirange == 0) {
+		missile._miduration = j;
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
-	if (missile._mimfnum != 0 || missile._mirange == 0) {
+	if (missile._mimfnum != 0 || missile._miduration == 0) {
 		if (missile.position.tile != Point { missile.var3, missile.var4 }) {
 			missile.var3 = missile.position.tile.x;
 			missile.var4 = missile.position.tile.y;
@@ -3414,18 +3414,18 @@ void ProcessFlameWave(Missile &missile)
 
 void ProcessGuardian(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 
 	if (missile.var2 > 0) {
 		missile.var2--;
 	}
-	if (missile._mirange == missile.var1 || (missile._mimfnum == 2 && missile.var2 == 0)) {
+	if (missile._miduration == missile.var1 || (missile._mimfnum == 2 && missile.var2 == 0)) {
 		SetMissDir(missile, 1);
 	}
 
 	Point position = missile.position.tile;
 
-	if ((missile._mirange % 16) == 0) {
+	if ((missile._miduration % 16) == 0) {
 		// Guardians pick a target by working backwards along lines originally based on VisionCrawlTable.
 		// Because of their rather unique behaviour the points checked have been unrolled here
 		constexpr std::array<WorldTileDisplacement, 48> guardianArc {
@@ -3461,7 +3461,7 @@ void ProcessGuardian(Missile &missile)
 		}
 	}
 
-	if (missile._mirange == 14) {
+	if (missile._miduration == 14) {
 		SetMissDir(missile, 0);
 		missile._miAnimFrame = 15;
 		missile._miAnimAdd = -1;
@@ -3475,7 +3475,7 @@ void ProcessGuardian(Missile &missile)
 		ChangeLight(missile._mlid, position, missile.var3);
 	}
 
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3499,8 +3499,8 @@ void ProcessChainLightning(Missile &missile)
 		}
 		return false;
 	});
-	missile._mirange--;
-	if (missile._mirange == 0)
+	missile._miduration--;
+	if (missile._miduration == 0)
 		missile._miDelFlag = true;
 }
 
@@ -3508,7 +3508,7 @@ void ProcessWeaponExplosion(Missile &missile)
 {
 	constexpr int ExpLight[10] = { 9, 10, 11, 12, 11, 10, 8, 6, 4, 2 };
 
-	missile._mirange--;
+	missile._miduration--;
 	const Player &player = Players[missile._misource];
 	int mind;
 	int maxd;
@@ -3528,11 +3528,11 @@ void ProcessWeaponExplosion(Missile &missile)
 	if (missile.var1 == 0) {
 		missile._mlid = AddLight(missile.position.tile, 9);
 	} else {
-		if (missile._mirange != 0)
+		if (missile._miduration != 0)
 			ChangeLight(missile._mlid, missile.position.tile, ExpLight[missile.var1]);
 	}
 	missile.var1++;
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	} else {
@@ -3544,8 +3544,8 @@ void ProcessMissileExplosion(Missile &missile)
 {
 	constexpr int ExpLight[] = { 9, 10, 11, 12, 11, 10, 8, 6, 4, 2, 1, 0, 0, 0, 0 };
 
-	missile._mirange--;
-	if (missile._mirange == 0) {
+	missile._miduration--;
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	} else {
@@ -3560,12 +3560,12 @@ void ProcessMissileExplosion(Missile &missile)
 
 void ProcessAcidSplate(Missile &missile)
 {
-	if (missile._mirange == missile._miAnimLen) {
+	if (missile._miduration == missile._miAnimLen) {
 		missile.position.tile += Displacement { 1, 1 };
 		missile.position.offset.deltaY -= 32;
 	}
-	missile._mirange--;
-	if (missile._mirange == 0) {
+	missile._miduration--;
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		int monst = missile._misource;
 		int dam = (Monsters[monst].data().level >= 2 ? 2 : 1);
@@ -3577,8 +3577,8 @@ void ProcessAcidSplate(Missile &missile)
 
 void ProcessTeleport(Missile &missile)
 {
-	missile._mirange--;
-	if (missile._mirange <= 0) {
+	missile._miduration--;
+	if (missile._miduration <= 0) {
 		missile._miDelFlag = true;
 		return;
 	}
@@ -3614,20 +3614,20 @@ void ProcessTeleport(Missile &missile)
 
 void ProcessStoneCurse(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	Monster &monster = Monsters[missile.var2];
 	if (monster.hitPoints == 0 && missile._miAnimType != MissileGraphicID::StoneCurseShatter) {
 		missile._mimfnum = 0;
 		missile._miDrawFlag = true;
 		SetMissAnim(missile, MissileGraphicID::StoneCurseShatter);
-		missile._mirange = 11;
+		missile._miduration = 11;
 	}
 	if (monster.mode != MonsterMode::Petrified) {
 		missile._miDelFlag = true;
 		return;
 	}
 
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		if (monster.hitPoints > 0) {
 			monster.mode = static_cast<MonsterMode>(missile.var1);
@@ -3642,12 +3642,12 @@ void ProcessStoneCurse(Missile &missile)
 
 void ProcessApocalypseBoom(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	if (missile.var1 == 0)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, false, missile.position.tile, true);
 	if (missile._miHitFlag)
 		missile.var1 = 1;
-	if (missile._mirange == 0)
+	if (missile._miduration == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
 }
@@ -3730,8 +3730,8 @@ static void ProcessWallControlRight(Missile &missile, const MissileID type, cons
 
 void ProcessWallControl(Missile &missile)
 {
-	missile._mirange--;
-	if (missile._mirange == 0) {
+	missile._miduration--;
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		return;
 	}
@@ -3764,9 +3764,9 @@ void ProcessWallControl(Missile &missile)
 void ProcessInfravision(Missile &missile)
 {
 	Player &player = Players[missile._misource];
-	missile._mirange--;
+	missile._miduration--;
 	player._pInfraFlag = true;
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		CalcPlrItemVals(player, true);
 	}
@@ -3835,16 +3835,16 @@ void ProcessFlameWaveControl(Missile &missile)
 		}
 	}
 
-	missile._mirange--;
-	if (missile._mirange == 0)
+	missile._miduration--;
+	if (missile._miduration == 0)
 		missile._miDelFlag = true;
 }
 
 void ProcessRage(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 
-	if (missile._mirange != 0) {
+	if (missile._miduration != 0) {
 		return;
 	}
 
@@ -3856,7 +3856,7 @@ void ProcessRage(Missile &missile)
 		player._pSpellFlags &= ~SpellFlag::RageActive;
 		player._pSpellFlags |= SpellFlag::RageCooldown;
 		int lvl = player.getCharacterLevel() * 2;
-		missile._mirange = lvl + 10 * missile._mispllvl + 245;
+		missile._miduration = lvl + 10 * missile._mispllvl + 245;
 	} else {
 		player._pSpellFlags &= ~SpellFlag::RageCooldown;
 		missile._miDelFlag = true;
@@ -3871,12 +3871,12 @@ void ProcessRage(Missile &missile)
 
 void ProcessInferno(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	missile.var2--;
-	int k = missile._mirange;
+	int k = missile._miduration;
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
-	if (missile._mirange == 0 && missile._miHitFlag)
-		missile._mirange = k;
+	if (missile._miduration == 0 && missile._miHitFlag)
+		missile._miduration = k;
 	if (missile.var2 == 0)
 		missile._miAnimFrame = 20;
 	if (missile.var2 <= 0) {
@@ -3885,7 +3885,7 @@ void ProcessInferno(Missile &missile)
 			k = 24 - k;
 		ChangeLight(missile._mlid, missile.position.tile, k);
 	}
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3895,7 +3895,7 @@ void ProcessInferno(Missile &missile)
 
 void ProcessInfernoControl(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	missile.position.traveled += missile.position.velocity;
 	UpdateMissilePos(missile);
 	if (missile.position.tile != Point { missile.var1, missile.var2 }) {
@@ -3911,19 +3911,19 @@ void ProcessInfernoControl(Missile &missile)
 			    missile._mispllvl,
 			    &missile);
 		} else {
-			missile._mirange = 0;
+			missile._miduration = 0;
 		}
 		missile.var1 = missile.position.tile.x;
 		missile.var2 = missile.position.tile.y;
 		missile.var3++;
 	}
-	if (missile._mirange == 0 || missile.var3 == 3)
+	if (missile._miduration == 0 || missile.var3 == 3)
 		missile._miDelFlag = true;
 }
 
 void ProcessChargedBolt(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	if (missile._miAnimType != MissileGraphicID::Lightning) {
 		if (missile.var3 == 0) {
 			constexpr int BPath[16] = { -1, 0, 1, -1, 0, 1, -1, -1, 0, 0, 1, 1, 0, 1, -1, 0 };
@@ -3951,11 +3951,11 @@ void ProcessChargedBolt(Missile &missile)
 			missile.position.offset = { 0, 0 };
 			missile.position.velocity = {};
 			SetMissAnim(missile, MissileGraphicID::Lightning);
-			missile._mirange = missile._miAnimLen;
+			missile._miduration = missile._miAnimLen;
 		}
 		ChangeLight(missile._mlid, missile.position.tile, missile.var1);
 	}
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3964,14 +3964,14 @@ void ProcessChargedBolt(Missile &missile)
 
 void ProcessHolyBolt(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	if (missile._miAnimType != MissileGraphicID::HolyBoltExplosion) {
 		int dam = missile._midam;
 		MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), dam, dam, true, true);
-		if (missile._mirange == 0) {
+		if (missile._miduration == 0) {
 			missile._mimfnum = 0;
 			SetMissAnim(missile, MissileGraphicID::HolyBoltExplosion);
-			missile._mirange = missile._miAnimLen - 1;
+			missile._miduration = missile._miAnimLen - 1;
 			missile.position.StopMissile();
 		} else {
 			if (missile.position.tile != Point { missile.var1, missile.var2 }) {
@@ -3982,7 +3982,7 @@ void ProcessHolyBolt(Missile &missile)
 		}
 	} else {
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame + 7);
-		if (missile._mirange == 0) {
+		if (missile._miduration == 0) {
 			missile._miDelFlag = true;
 			AddUnLight(missile._mlid);
 		}
@@ -3992,7 +3992,7 @@ void ProcessHolyBolt(Missile &missile)
 
 void ProcessElemental(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	int dam = missile._midam;
 	const Point missilePosition = missile.position.tile;
 	if (missile._miAnimType == MissileGraphicID::BigExplosion) {
@@ -4015,7 +4015,7 @@ void ProcessElemental(Missile &missile)
 				CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), dam, dam, true, missilePosition + offset, true);
 		}
 
-		if (missile._mirange == 0) {
+		if (missile._miduration == 0) {
 			missile._miDelFlag = true;
 			AddUnLight(missile._mlid);
 		}
@@ -4025,7 +4025,7 @@ void ProcessElemental(Missile &missile)
 			missile.var3 = 1;
 		if (missile.var3 == 1) {
 			missile.var3 = 2;
-			missile._mirange = 255;
+			missile._miduration = 255;
 			auto *nextMonster = FindClosest(missilePosition, 19);
 			if (nextMonster != nullptr) {
 				Direction sd = GetDirection(missilePosition, nextMonster->position.tile);
@@ -4042,10 +4042,10 @@ void ProcessElemental(Missile &missile)
 			missile.var2 = missilePosition.y;
 			ChangeLight(missile._mlid, missilePosition, 8);
 		}
-		if (missile._mirange == 0) {
+		if (missile._miduration == 0) {
 			missile._mimfnum = 0;
 			SetMissAnim(missile, MissileGraphicID::BigExplosion);
-			missile._mirange = missile._miAnimLen - 1;
+			missile._miduration = missile._miAnimLen - 1;
 			missile.position.StopMissile();
 		}
 	}
@@ -4054,11 +4054,11 @@ void ProcessElemental(Missile &missile)
 
 void ProcessBoneSpirit(Missile &missile)
 {
-	missile._mirange--;
+	missile._miduration--;
 	int dam = missile._midam;
 	if (missile._mimfnum == 8) {
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
-		if (missile._mirange == 0) {
+		if (missile._miduration == 0) {
 			missile._miDelFlag = true;
 			AddUnLight(missile._mlid);
 		}
@@ -4070,7 +4070,7 @@ void ProcessBoneSpirit(Missile &missile)
 			missile.var3 = 1;
 		if (missile.var3 == 1) {
 			missile.var3 = 2;
-			missile._mirange = 255;
+			missile._miduration = 255;
 			auto *monster = FindClosest(c, 19);
 			if (monster != nullptr) {
 				missile._midam = monster->hitPoints >> 7;
@@ -4087,10 +4087,10 @@ void ProcessBoneSpirit(Missile &missile)
 			missile.var2 = c.y;
 			ChangeLight(missile._mlid, c, 8);
 		}
-		if (missile._mirange == 0) {
+		if (missile._miduration == 0) {
 			SetMissDir(missile, 8);
 			missile.position.velocity = {};
-			missile._mirange = 7;
+			missile._miduration = 7;
 		}
 		PutMissile(missile);
 	}
@@ -4098,8 +4098,8 @@ void ProcessBoneSpirit(Missile &missile)
 
 void ProcessResurrectBeam(Missile &missile)
 {
-	missile._mirange--;
-	if (missile._mirange == 0)
+	missile._miduration--;
+	if (missile._miduration == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
 }
@@ -4108,18 +4108,18 @@ void ProcessRedPortal(Missile &missile)
 {
 	int expLight[17] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 15 };
 
-	if (missile._mirange > 1)
-		missile._mirange--;
-	if (missile._mirange == missile.var1)
+	if (missile._miduration > 1)
+		missile._miduration--;
+	if (missile._miduration == missile.var1)
 		SetMissDir(missile, 1);
 
-	if (leveltype != DTYPE_TOWN && missile._mimfnum != 1 && missile._mirange != 0) {
+	if (leveltype != DTYPE_TOWN && missile._mimfnum != 1 && missile._miduration != 0) {
 		if (missile.var2 == 0)
 			missile._mlid = AddLight(missile.position.tile, 1);
 		ChangeLight(missile._mlid, missile.position.tile, expLight[missile.var2]);
 		missile.var2++;
 	}
-	if (missile._mirange == 0) {
+	if (missile._miduration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -428,7 +428,7 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 
 	if (isMonsterHit) {
 		if (!dontDeleteOnCollision)
-			missile._miduration = 0;
+			missile.duration = 0;
 		missile._miHitFlag = true;
 	}
 
@@ -454,7 +454,7 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 		if (gbIsHellfire && blocked) {
 			RotateBlockedMissile(missile);
 		} else if (!dontDeleteOnCollision) {
-			missile._miduration = 0;
+			missile.duration = 0;
 		}
 		missile._miHitFlag = true;
 	}
@@ -466,12 +466,12 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 		}
 
 		if (!dontDeleteOnCollision)
-			missile._miduration = 0;
+			missile.duration = 0;
 		missile._miHitFlag = false;
 	}
 
 	const MissileData &missileData = GetMissileData(missile._mitype);
-	if (missile._miduration == 0 && missileData.hitSound != SfxID::None)
+	if (missile.duration == 0 && missileData.hitSound != SfxID::None)
 		PlaySfxLoc(missileData.hitSound, missile.position.tile);
 }
 
@@ -568,7 +568,7 @@ void MoveMissileAndCheckMissileCol(Missile &missile, DamageType damageType, int 
 		CheckMissileCol(missile, damageType, mindam, maxdam, false, tile, false);
 
 		// Did missile hit anything?
-		if (missile._miduration != 0)
+		if (missile.duration != 0)
 			return true;
 
 		if (missile._miHitFlag && GetMissileData(missile._mitype).movementDistribution == MissileMovementDistribution::Blockable)
@@ -717,7 +717,7 @@ void SyncPositionWithParent(Missile &missile, const AddMissileParameter &paramet
 
 void SpawnLightning(Missile &missile, int dam)
 {
-	missile._miduration--;
+	missile.duration--;
 	MoveMissile(
 	    missile, [&](Point tile) {
 		    assert(InDungeonBounds(tile));
@@ -726,7 +726,7 @@ void SpawnLightning(Missile &missile, int dam)
 
 		    if (!missile.IsTrap() || tile != missile.position.start) {
 			    if (TileHasAny(tile, TileProperties::BlockMissile)) {
-				    missile._miduration = 0;
+				    missile.duration = 0;
 				    return false;
 			    }
 		    }
@@ -757,7 +757,7 @@ void SpawnLightning(Missile &missile, int dam)
 		}
 	}
 
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 	}
 }
@@ -1266,7 +1266,7 @@ void AddBerserk(Missile &missile, AddMissileParameter &parameter)
 void AddHorkSpawn(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 8);
-	missile._miduration = 9;
+	missile.duration = 9;
 	missile.var1 = static_cast<int32_t>(parameter.midir);
 	PutMissile(missile);
 }
@@ -1418,7 +1418,7 @@ void AddSpectralArrow(Missile &missile, AddMissileParameter &parameter)
 			av += 8;
 	}
 
-	missile._miduration = 1;
+	missile.duration = 1;
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
 	missile.var3 = av;
@@ -1479,7 +1479,7 @@ void AddWarp(Missile &missile, AddMissileParameter &parameter)
 			tile = candidate;
 		}
 	}
-	missile._miduration = 2;
+	missile.duration = 2;
 	std::optional<Point> teleportDestination = FindClosestValidPosition(
 	    [&player](Point target) {
 		    for (int i = 0; i < numtrigs; i++) {
@@ -1503,7 +1503,7 @@ void AddLightningWall(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile._miAnimFrame = RandomIntBetween(1, 8);
-	missile._miduration = 255 * (missile._mispllvl + 1);
+	missile.duration = 255 * (missile._mispllvl + 1);
 	switch (missile.sourceType()) {
 	case MissileSource::Trap:
 		missile.var1 = missile.position.start.x;
@@ -1534,7 +1534,7 @@ void AddBigExplosion(Missile &missile, AddMissileParameter & /*parameter*/)
 	}
 	missile._mlid = AddLight(missile.position.start, 8);
 	SetMissDir(missile, 0);
-	missile._miduration = missile._miAnimLen - 1;
+	missile.duration = missile._miAnimLen - 1;
 }
 
 void AddImmolation(Missile &missile, AddMissileParameter &parameter)
@@ -1549,7 +1549,7 @@ void AddImmolation(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, sp);
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._miduration = 256;
+	missile.duration = 256;
 	missile._mlid = AddLight(missile.position.start, 8);
 }
 
@@ -1561,7 +1561,7 @@ void AddLightningBow(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, 32);
 	missile._miAnimFrame = RandomIntBetween(1, 8);
-	missile._miduration = 255;
+	missile.duration = 255;
 	if (missile._misource < 0) {
 		missile.var1 = missile.position.start.x;
 		missile.var2 = missile.position.start.y;
@@ -1611,7 +1611,7 @@ void AddRingOfFire(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
-	missile._miduration = 7;
+	missile.duration = 7;
 }
 
 void AddSearch(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -1623,14 +1623,14 @@ void AddSearch(Missile &missile, AddMissileParameter & /*parameter*/)
 	int lvl = 2;
 	if (missile._misource >= 0)
 		lvl = player.getCharacterLevel() * 2;
-	missile._miduration = lvl + 10 * missile._mispllvl + 245;
+	missile.duration = lvl + 10 * missile._mispllvl + 245;
 
 	for (auto &other : Missiles) {
 		if (&other != &missile && missile.isSameSource(other) && other._mitype == MissileID::Search) {
-			int r1 = missile._miduration;
-			int r2 = other._miduration;
+			int r1 = missile.duration;
+			int r2 = other.duration;
 			if (r2 < INT_MAX - r1)
-				other._miduration = r1 + r2;
+				other.duration = r1 + r2;
 			missile._miDelFlag = true;
 			break;
 		}
@@ -1653,7 +1653,7 @@ void AddChargedBoltBow(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, dst, 8);
 	missile.var1 = 5;
 	missile.var2 = static_cast<int32_t>(parameter.midir);
-	missile._miduration = 256;
+	missile.duration = 256;
 }
 
 void AddElementalArrow(Missile &missile, AddMissileParameter &parameter)
@@ -1687,7 +1687,7 @@ void AddElementalArrow(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, dst, av);
 
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._miduration = 256;
+	missile.duration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 5);
@@ -1724,7 +1724,7 @@ void AddArrow(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, av);
 	missile._miAnimFrame = static_cast<int>(GetDirection16(missile.position.start, dst)) + 1;
-	missile._miduration = 256;
+	missile.duration = 256;
 }
 
 void UpdateVileMissPos(Missile &missile, Point dst)
@@ -1745,7 +1745,7 @@ void UpdateVileMissPos(Missile &missile, Point dst)
 
 void AddPhasing(Missile &missile, AddMissileParameter &parameter)
 {
-	missile._miduration = 2;
+	missile.duration = 2;
 
 	Player &player = Players[missile._misource];
 
@@ -1796,7 +1796,7 @@ void AddFirebolt(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, sp);
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._miduration = 256;
+	missile.duration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -1824,9 +1824,9 @@ void AddMagmaBall(Missile &missile, AddMissileParameter &parameter)
 	missile.position.traveled.deltaY += 3 * missile.position.velocity.deltaY;
 	UpdateMissilePos(missile);
 	if (!gbIsHellfire || (missile.position.velocity.deltaX & 0xFFFF0000) != 0 || (missile.position.velocity.deltaY & 0xFFFF0000) != 0)
-		missile._miduration = 256;
+		missile.duration = 256;
 	else
-		missile._miduration = 1;
+		missile.duration = 1;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -1858,7 +1858,7 @@ void AddTeleport(Missile &missile, AddMissileParameter &parameter)
 	if (teleportDestination) {
 		missile.position.tile = *teleportDestination;
 		missile.position.start = *teleportDestination;
-		missile._miduration = 2;
+		missile.duration = 2;
 	} else {
 		missile._miDelFlag = true;
 		parameter.spellFizzled = true;
@@ -1869,7 +1869,7 @@ void AddNovaBall(Missile &missile, AddMissileParameter &parameter)
 {
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	missile._miAnimFrame = RandomIntBetween(1, 8);
-	missile._miduration = 255;
+	missile.duration = 255;
 	const WorldTilePosition position = missile._misource < 0 ? missile.position.start : Players[missile._misource].position.tile;
 	missile.var1 = position.x;
 	missile.var2 = position.y;
@@ -1882,13 +1882,13 @@ void AddFireWall(Missile &missile, AddMissileParameter &parameter)
 	missile._midam <<= 3;
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	int i = missile._mispllvl;
-	missile._miduration = 10;
+	missile.duration = 10;
 	if (i > 0)
-		missile._miduration *= i + 1;
+		missile.duration *= i + 1;
 	if (missile._micaster == TARGET_PLAYERS || missile._misource < 0)
-		missile._miduration += currlevel;
-	missile._miduration *= 16;
-	missile.var1 = missile._miduration - missile._miAnimLen;
+		missile.duration += currlevel;
+	missile.duration *= 16;
+	missile.var1 = missile.duration - missile._miAnimLen;
 }
 
 void AddFireball(Missile &missile, AddMissileParameter &parameter)
@@ -1907,7 +1907,7 @@ void AddFireball(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, sp);
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._miduration = 256;
+	missile.duration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -1919,7 +1919,7 @@ void AddLightningControl(Missile &missile, AddMissileParameter &parameter)
 	missile.var2 = missile.position.start.y;
 	UpdateMissileVelocity(missile, parameter.dst, 32);
 	missile._miAnimFrame = RandomIntBetween(1, 8);
-	missile._miduration = 256;
+	missile.duration = 256;
 }
 
 void AddLightning(Missile &missile, AddMissileParameter &parameter)
@@ -1932,11 +1932,11 @@ void AddLightning(Missile &missile, AddMissileParameter &parameter)
 
 	if (missile._micaster == TARGET_PLAYERS || missile.IsTrap()) {
 		if (missile.IsTrap() || Monsters[missile._misource].type().type == MT_FAMILIAR)
-			missile._miduration = 8;
+			missile.duration = 8;
 		else
-			missile._miduration = 10;
+			missile.duration = 10;
 	} else {
-		missile._miduration = (missile._mispllvl / 2) + 6;
+		missile.duration = (missile._mispllvl / 2) + 6;
 	}
 	missile._mlid = AddLight(missile.position.tile, 4);
 }
@@ -1968,7 +1968,7 @@ void AddMissileExplosion(Missile &missile, AddMissileParameter &parameter)
 	missile.position.start = parent.position.start;
 	missile.position.offset = parent.position.offset;
 	missile.position.traveled = parent.position.traveled;
-	missile._miduration = missile._miAnimLen;
+	missile.duration = missile._miAnimLen;
 }
 
 void AddWeaponExplosion(Missile &missile, AddMissileParameter &parameter)
@@ -1978,7 +1978,7 @@ void AddWeaponExplosion(Missile &missile, AddMissileParameter &parameter)
 		SetMissAnim(missile, MissileGraphicID::MagmaBallExplosion);
 	else
 		SetMissAnim(missile, MissileGraphicID::ChargedBolt);
-	missile._miduration = missile._miAnimLen - 1;
+	missile.duration = missile._miAnimLen - 1;
 }
 
 void AddTownPortal(Missile &missile, AddMissileParameter &parameter)
@@ -2017,11 +2017,11 @@ void AddTownPortal(Missile &missile, AddMissileParameter &parameter)
 		}
 	}
 
-	missile._miduration = 100;
-	missile.var1 = missile._miduration - missile._miAnimLen;
+	missile.duration = 100;
+	missile.var1 = missile.duration - missile._miAnimLen;
 	for (auto &other : Missiles) {
 		if (other._mitype == MissileID::TownPortal && &other != &missile && missile.isSameSource(other))
-			other._miduration = 0;
+			other.duration = 0;
 	}
 	PutMissile(missile);
 	if (missile.sourcePlayer() == MyPlayer && !missile._miDelFlag && leveltype != DTYPE_TOWN) {
@@ -2050,7 +2050,7 @@ void AddFlashBottom(Missile &missile, AddMissileParameter & /*parameter*/)
 		break;
 	}
 
-	missile._miduration = 19;
+	missile.duration = 19;
 }
 
 void AddFlashTop(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -2066,7 +2066,7 @@ void AddFlashTop(Missile &missile, AddMissileParameter & /*parameter*/)
 		}
 	}
 	missile._miPreFlag = true;
-	missile._miduration = 19;
+	missile.duration = 19;
 }
 
 void AddManaShield(Missile &missile, AddMissileParameter &parameter)
@@ -2089,7 +2089,7 @@ void AddFlameWave(Missile &missile, AddMissileParameter &parameter)
 {
 	missile._midam = GenerateRnd(10) + Players[missile._misource].getCharacterLevel() + 1;
 	UpdateMissileVelocity(missile, parameter.dst, 16);
-	missile._miduration = 255;
+	missile.duration = 255;
 
 	// Adjust missile's position for rendering
 	missile.position.tile += Direction::South;
@@ -2134,15 +2134,15 @@ void AddGuardian(Missile &missile, AddMissileParameter &parameter)
 	missile.position.start = *spawnPosition;
 
 	missile._mlid = AddLight(missile.position.tile, 1);
-	missile._miduration = missile._mispllvl + (player.getCharacterLevel() / 2);
+	missile.duration = missile._mispllvl + (player.getCharacterLevel() / 2);
 
-	if (missile._miduration > 30)
-		missile._miduration = 30;
-	missile._miduration <<= 4;
-	if (missile._miduration < 30)
-		missile._miduration = 30;
+	if (missile.duration > 30)
+		missile.duration = 30;
+	missile.duration <<= 4;
+	if (missile.duration < 30)
+		missile.duration = 30;
 
-	missile.var1 = missile._miduration - missile._miAnimLen;
+	missile.var1 = missile.duration - missile._miAnimLen;
 	missile.var3 = 1;
 }
 
@@ -2150,7 +2150,7 @@ void AddChainLightning(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
-	missile._miduration = 1;
+	missile.duration = 1;
 }
 
 namespace {
@@ -2170,7 +2170,7 @@ void InitMissileAnimationFromMonster(Missile &mis, Direction midir, const Monste
 	mis.var1 = 0;
 	mis.var2 = 0;
 	mis._miLightFlag = true;
-	mis._miduration = 256;
+	mis.duration = 256;
 }
 } // namespace
 
@@ -2201,7 +2201,7 @@ void AddGenericMagicMissile(Missile &missile, AddMissileParameter &parameter)
 		dst += parameter.midir;
 	}
 	UpdateMissileVelocity(missile, dst, 16);
-	missile._miduration = 256;
+	missile.duration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -2243,9 +2243,9 @@ void AddAcid(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, parameter.dst, 16);
 	SetMissDir(missile, GetDirection16(missile.position.start, parameter.dst));
 	if (!gbIsHellfire || (missile.position.velocity.deltaX & 0xFFFF0000) != 0 || (missile.position.velocity.deltaY & 0xFFFF0000) != 0)
-		missile._miduration = 5 * (Monsters[missile._misource].intelligence + 4);
+		missile.duration = 5 * (Monsters[missile._misource].intelligence + 4);
 	else
-		missile._miduration = 1;
+		missile.duration = 1;
 	missile._mlid = NO_LIGHT;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
@@ -2269,7 +2269,7 @@ void AddAcidPuddle(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	missile._miLightFlag = true;
 	int monst = missile._misource;
-	missile._miduration = GenerateRnd(15) + 40 * (Monsters[monst].intelligence + 1);
+	missile.duration = GenerateRnd(15) + 40 * (Monsters[monst].intelligence + 1);
 	missile._miPreFlag = true;
 }
 
@@ -2322,11 +2322,11 @@ void AddStoneCurse(Missile &missile, AddMissileParameter &parameter)
 	// And set up the missile to unpetrify it in the future
 	missile.position.tile = *targetMonsterPosition;
 	missile.position.start = missile.position.tile;
-	missile._miduration = missile._mispllvl + 6;
+	missile.duration = missile._mispllvl + 6;
 
-	if (missile._miduration > 15)
-		missile._miduration = 15;
-	missile._miduration <<= 4;
+	if (missile.duration > 15)
+		missile.duration = 15;
+	missile.duration <<= 4;
 }
 
 void AddGolem(Missile &missile, AddMissileParameter &parameter)
@@ -2357,7 +2357,7 @@ void AddApocalypseBoom(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.position.tile = parameter.dst;
 	missile.position.start = parameter.dst;
-	missile._miduration = missile._miAnimLen;
+	missile.duration = missile._miAnimLen;
 }
 
 void AddHealing(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -2408,7 +2408,7 @@ void AddElemental(Missile &missile, AddMissileParameter &parameter)
 
 	UpdateMissileVelocity(missile, dst, 16);
 	SetMissDir(missile, GetDirection(missile.position.start, dst));
-	missile._miduration = 256;
+	missile.duration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile.var4 = dst.x;
@@ -2456,19 +2456,19 @@ void AddWallControl(Missile &missile, AddMissileParameter &parameter)
 	missile.var6 = spreadPosition->y;
 	missile.var3 = static_cast<int>(Left(Left(parameter.midir)));
 	missile.var4 = static_cast<int>(Right(Right(parameter.midir)));
-	missile._miduration = 7;
+	missile.duration = 7;
 }
 
 void AddInfravision(Missile &missile, AddMissileParameter & /*parameter*/)
 {
-	missile._miduration = ScaleSpellEffect(1584, missile._mispllvl);
+	missile.duration = ScaleSpellEffect(1584, missile._mispllvl);
 }
 
 void AddFlameWaveControl(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.var1 = parameter.dst.x;
 	missile.var2 = parameter.dst.y;
-	missile._miduration = 1;
+	missile.duration = 1;
 	missile._miAnimFrame = 4;
 }
 
@@ -2485,7 +2485,7 @@ void AddNova(Missile &missile, AddMissileParameter &parameter)
 		missile._midam = (currlevel / 2) + GenerateRndSum(3, 3);
 	}
 
-	missile._miduration = 1;
+	missile.duration = 1;
 }
 
 void AddRage(Missile &missile, AddMissileParameter &parameter)
@@ -2503,7 +2503,7 @@ void AddRage(Missile &missile, AddMissileParameter &parameter)
 	player._pSpellFlags |= SpellFlag::RageActive;
 	missile.var2 = tmp;
 	int lvl = player.getCharacterLevel() * 2;
-	missile._miduration = lvl + 10 * missile._mispllvl + 245;
+	missile.duration = lvl + 10 * missile._mispllvl + 245;
 	CalcPlrItemVals(player, true);
 	RedrawEverything();
 	player.Say(HeroSpeech::Aaaaargh);
@@ -2571,7 +2571,7 @@ void AddApocalypse(Missile &missile, AddMissileParameter & /*parameter*/)
 	missile.var6 = missile.var4;
 	int playerLevel = player.getCharacterLevel();
 	missile._midam = GenerateRndSum(6, playerLevel) + playerLevel;
-	missile._miduration = 255;
+	missile.duration = 255;
 }
 
 void AddInferno(Missile &missile, AddMissileParameter &parameter)
@@ -2581,7 +2581,7 @@ void AddInferno(Missile &missile, AddMissileParameter &parameter)
 
 	SyncPositionWithParent(missile, parameter);
 
-	missile._miduration = missile.var2 + 20;
+	missile.duration = missile.var2 + 20;
 	missile._mlid = AddLight(missile.position.start, 1);
 	if (missile._micaster == TARGET_MONSTERS) {
 		int i = GenerateRnd(Players[missile._misource].getCharacterLevel()) + GenerateRnd(2);
@@ -2601,7 +2601,7 @@ void AddInfernoControl(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, dst, 32);
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
-	missile._miduration = 256;
+	missile.duration = 256;
 }
 
 void AddChargedBolt(Missile &missile, AddMissileParameter &parameter)
@@ -2619,7 +2619,7 @@ void AddChargedBolt(Missile &missile, AddMissileParameter &parameter)
 	UpdateMissileVelocity(missile, dst, 8);
 	missile.var1 = 5;
 	missile.var2 = static_cast<int>(parameter.midir);
-	missile._miduration = 256;
+	missile.duration = 256;
 }
 
 void AddHolyBolt(Missile &missile, AddMissileParameter &parameter)
@@ -2637,7 +2637,7 @@ void AddHolyBolt(Missile &missile, AddMissileParameter &parameter)
 
 	UpdateMissileVelocity(missile, dst, sp);
 	SetMissDir(missile, GetDirection16(missile.position.start, dst));
-	missile._miduration = 256;
+	missile.duration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -2660,7 +2660,7 @@ void AddResurrectBeam(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.position.tile = parameter.dst;
 	missile.position.start = parameter.dst;
-	missile._miduration = GetMissileSpriteData(MissileGraphicID::Resurrect).animLen(0);
+	missile.duration = GetMissileSpriteData(MissileGraphicID::Resurrect).animLen(0);
 }
 
 void AddTelekinesis(Missile &missile, AddMissileParameter & /*parameter*/)
@@ -2680,7 +2680,7 @@ void AddBoneSpirit(Missile &missile, AddMissileParameter &parameter)
 	}
 	UpdateMissileVelocity(missile, dst, 16);
 	SetMissDir(missile, GetDirection(missile.position.start, dst));
-	missile._miduration = 256;
+	missile.duration = 256;
 	missile.var1 = missile.position.start.x;
 	missile.var2 = missile.position.start.y;
 	missile.var4 = dst.x;
@@ -2690,7 +2690,7 @@ void AddBoneSpirit(Missile &missile, AddMissileParameter &parameter)
 
 void AddRedPortal(Missile &missile, AddMissileParameter & /*parameter*/)
 {
-	missile._miduration = 100;
+	missile.duration = 100;
 	missile.var1 = 100 - missile._miAnimLen;
 	PutMissile(missile);
 }
@@ -2765,7 +2765,7 @@ Missile *AddMissile(WorldTilePosition src, WorldTilePosition dst, Direction midi
 
 void ProcessElementalArrow(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	if (missile._miAnimType == MissileGraphicID::ChargedBolt || missile._miAnimType == MissileGraphicID::MagmaBallExplosion) {
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame + 5);
 	} else {
@@ -2790,9 +2790,9 @@ void ProcessElementalArrow(Missile &missile)
 			maxd = GenerateRnd(10) + 1 + currlevel * 2;
 		}
 		MoveMissileAndCheckMissileCol(missile, DamageType::Physical, mind, maxd, true, false);
-		if (missile._miduration == 0) {
+		if (missile.duration == 0) {
 			missile._mimfnum = 0;
-			missile._miduration = missile._miAnimLen - 1;
+			missile.duration = missile._miAnimLen - 1;
 			missile.position.StopMissile();
 
 			int eMind;
@@ -2840,7 +2840,7 @@ void ProcessElementalArrow(Missile &missile)
 			}
 		}
 	}
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -2849,7 +2849,7 @@ void ProcessElementalArrow(Missile &missile)
 
 void ProcessArrow(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	missile._midist++;
 
 	int mind;
@@ -2873,17 +2873,17 @@ void ProcessArrow(Missile &missile)
 		break;
 	}
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), mind, maxd, true, false);
-	if (missile._miduration == 0)
+	if (missile.duration == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
 }
 
 void ProcessGenericProjectile(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, true);
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		Point dst = { 0, 0 };
 		auto dir = static_cast<Direction>(missile._mimfnum);
@@ -2933,35 +2933,35 @@ void ProcessGenericProjectile(Missile &missile)
 void ProcessNovaBall(Missile &missile)
 {
 	Point targetPosition = { missile.var1, missile.var2 };
-	missile._miduration--;
-	int j = missile._miduration;
+	missile.duration--;
+	int j = missile.duration;
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, false, false);
 	if (missile._miHitFlag)
-		missile._miduration = j;
+		missile.duration = j;
 
 	if (missile.position.tile == targetPosition) {
 		Object *object = FindObjectAtPosition(targetPosition);
 		if (object != nullptr && object->IsShrine()) {
-			missile._miduration = j;
+			missile.duration = j;
 		}
 	}
-	if (missile._miduration == 0)
+	if (missile.duration == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
 }
 
 void ProcessAcidPuddle(Missile &missile)
 {
-	missile._miduration--;
-	int range = missile._miduration;
+	missile.duration--;
+	int range = missile.duration;
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
-	missile._miduration = range;
+	missile.duration = range;
 	if (range == 0) {
 		if (missile._mimfnum != 0) {
 			missile._miDelFlag = true;
 		} else {
 			SetMissDir(missile, 1);
-			missile._miduration = missile._miAnimLen;
+			missile.duration = missile._miAnimLen;
 		}
 	}
 	PutMissile(missile);
@@ -2971,22 +2971,22 @@ void ProcessFireWall(Missile &missile)
 {
 	constexpr int ExpLight[14] = { 2, 3, 4, 5, 5, 6, 7, 8, 9, 10, 11, 12, 12 };
 
-	missile._miduration--;
-	if (missile._miduration == missile.var1) {
+	missile.duration--;
+	if (missile.duration == missile.var1) {
 		SetMissDir(missile, 1);
 		missile._miAnimFrame = GenerateRnd(11) + 1;
 	}
-	if (missile._miduration == missile._miAnimLen - 1) {
+	if (missile.duration == missile._miAnimLen - 1) {
 		SetMissDir(missile, 0);
 		missile._miAnimFrame = 13;
 		missile._miAnimAdd = -1;
 	}
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, true);
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
-	if (missile._mimfnum != 0 && missile._miduration != 0 && missile._miAnimAdd != -1 && missile.var2 < 12) {
+	if (missile._mimfnum != 0 && missile.duration != 0 && missile._miAnimAdd != -1 && missile.var2 < 12) {
 		if (missile.var2 == 0)
 			missile._mlid = AddLight(missile.position.tile, ExpLight[0]);
 		ChangeLight(missile._mlid, missile.position.tile, ExpLight[missile.var2]);
@@ -2997,10 +2997,10 @@ void ProcessFireWall(Missile &missile)
 
 void ProcessFireball(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 
 	if (missile._miAnimType == MissileGraphicID::BigExplosion) {
-		if (missile._miduration == 0) {
+		if (missile.duration == 0) {
 			missile._miDelFlag = true;
 			AddUnLight(missile._mlid);
 		}
@@ -3015,7 +3015,7 @@ void ProcessFireball(Missile &missile)
 		}
 		const DamageType damageType = GetMissileData(missile._mitype).damageType();
 		MoveMissileAndCheckMissileCol(missile, damageType, minDam, maxDam, true, false);
-		if (missile._miduration == 0) {
+		if (missile.duration == 0) {
 			const Point missilePosition = missile.position.tile;
 			ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
 
@@ -3052,7 +3052,7 @@ void ProcessFireball(Missile &missile)
 			}
 			missile._mimfnum = 0;
 			SetMissAnim(missile, MissileGraphicID::BigExplosion);
-			missile._miduration = missile._miAnimLen - 1;
+			missile.duration = missile._miAnimLen - 1;
 			missile.position.velocity = {};
 		} else if (missile.position.tile != Point { missile.var1, missile.var2 }) {
 			missile.var1 = missile.position.tile.x;
@@ -3066,9 +3066,9 @@ void ProcessFireball(Missile &missile)
 
 void ProcessHorkSpawn(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), 0, 0, false, missile.position.tile, false);
-	if (missile._miduration <= 0) {
+	if (missile.duration <= 0) {
 		missile._miDelFlag = true;
 
 		std::optional<Point> spawnPosition = FindClosestValidPosition(
@@ -3109,20 +3109,20 @@ void ProcessRune(Missile &missile)
 
 void ProcessLightningWall(Missile &missile)
 {
-	missile._miduration--;
-	int range = missile._miduration;
+	missile.duration--;
+	int range = missile.duration;
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
 	if (missile._miHitFlag)
-		missile._miduration = range;
-	if (missile._miduration == 0)
+		missile.duration = range;
+	if (missile.duration == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
 }
 
 void ProcessBigExplosion(Missile &missile)
 {
-	missile._miduration--;
-	if (missile._miduration <= 0) {
+	missile.duration--;
+	if (missile.duration <= 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3166,8 +3166,8 @@ void ProcessRingOfFire(Missile &missile)
 
 void ProcessSearch(Missile &missile)
 {
-	missile._miduration--;
-	if (missile._miduration != 0)
+	missile.duration--;
+	if (missile.duration != 0)
 		return;
 
 	const Player &player = Players[missile._misource];
@@ -3197,8 +3197,8 @@ void ProcessNovaCommon(Missile &missile, MissileID projectileType)
 		for (WorldTileDisplacement offset : offsets)
 			AddMissile(src, src + offset, dir, projectileType, en, id, dam, missile._mispllvl);
 	}
-	missile._miduration--;
-	if (missile._miduration == 0)
+	missile.duration--;
+	if (missile.duration == 0)
 		missile._miDelFlag = true;
 }
 
@@ -3247,14 +3247,14 @@ void ProcessSpectralArrow(Missile &missile)
 		AddMissile(src, dst, dir, mitype, micaster, id, dam, spllvl);
 		AddMissile(src, dst, dir, mitype, micaster, id, dam, spllvl);
 	}
-	missile._miduration--;
-	if (missile._miduration == 0)
+	missile.duration--;
+	if (missile.duration == 0)
 		missile._miDelFlag = true;
 }
 
 void ProcessLightningControl(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 
 	int dam;
 	if (missile.IsTrap()) {
@@ -3273,13 +3273,13 @@ void ProcessLightningControl(Missile &missile)
 
 void ProcessLightning(Missile &missile)
 {
-	missile._miduration--;
-	int j = missile._miduration;
+	missile.duration--;
+	int j = missile.duration;
 	if (missile.position.tile != missile.position.start)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
 	if (missile._miHitFlag)
-		missile._miduration = j;
-	if (missile._miduration == 0) {
+		missile.duration = j;
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3290,11 +3290,11 @@ void ProcessTownPortal(Missile &missile)
 {
 	int expLight[17] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 15 };
 
-	if (missile._miduration > 1)
-		missile._miduration--;
-	if (missile._miduration == missile.var1)
+	if (missile.duration > 1)
+		missile.duration--;
+	if (missile.duration == missile.var1)
 		SetMissDir(missile, 1);
-	if (leveltype != DTYPE_TOWN && missile._mimfnum != 1 && missile._miduration != 0) {
+	if (leveltype != DTYPE_TOWN && missile._mimfnum != 1 && missile.duration != 0) {
 		if (missile.var2 == 0)
 			missile._mlid = AddLight(missile.position.tile, 1);
 		ChangeLight(missile._mlid, missile.position.tile, expLight[missile.var2]);
@@ -3311,7 +3311,7 @@ void ProcessTownPortal(Missile &missile)
 		}
 	}
 
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3324,7 +3324,7 @@ void ProcessFlashBottom(Missile &missile)
 		if (!missile.IsTrap())
 			Players[missile._misource]._pInvincible = true;
 	}
-	missile._miduration--;
+	missile.duration--;
 
 	constexpr Direction Offsets[] = {
 		Direction::NorthWest,
@@ -3337,7 +3337,7 @@ void ProcessFlashBottom(Missile &missile)
 	for (Direction offset : Offsets)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile + offset, true);
 
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		if (missile._micaster == TARGET_MONSTERS) {
 			if (!missile.IsTrap())
@@ -3353,7 +3353,7 @@ void ProcessFlashTop(Missile &missile)
 		if (!missile.IsTrap())
 			Players[missile._misource]._pInvincible = true;
 	}
-	missile._miduration--;
+	missile.duration--;
 
 	constexpr Direction Offsets[] = {
 		Direction::North,
@@ -3363,7 +3363,7 @@ void ProcessFlashTop(Missile &missile)
 	for (Direction offset : Offsets)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile + offset, true);
 
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		if (missile._micaster == TARGET_MONSTERS) {
 			if (!missile.IsTrap())
@@ -3386,15 +3386,15 @@ void ProcessFlameWave(Missile &missile)
 		SetMissDir(missile, 1);
 		missile._miAnimFrame = GenerateRnd(11) + 1;
 	}
-	int j = missile._miduration;
+	int j = missile.duration;
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, false, false);
 	if (missile._miHitFlag)
-		missile._miduration = j;
-	if (missile._miduration == 0) {
+		missile.duration = j;
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
-	if (missile._mimfnum != 0 || missile._miduration == 0) {
+	if (missile._mimfnum != 0 || missile.duration == 0) {
 		if (missile.position.tile != Point { missile.var3, missile.var4 }) {
 			missile.var3 = missile.position.tile.x;
 			missile.var4 = missile.position.tile.y;
@@ -3414,18 +3414,18 @@ void ProcessFlameWave(Missile &missile)
 
 void ProcessGuardian(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 
 	if (missile.var2 > 0) {
 		missile.var2--;
 	}
-	if (missile._miduration == missile.var1 || (missile._mimfnum == 2 && missile.var2 == 0)) {
+	if (missile.duration == missile.var1 || (missile._mimfnum == 2 && missile.var2 == 0)) {
 		SetMissDir(missile, 1);
 	}
 
 	Point position = missile.position.tile;
 
-	if ((missile._miduration % 16) == 0) {
+	if ((missile.duration % 16) == 0) {
 		// Guardians pick a target by working backwards along lines originally based on VisionCrawlTable.
 		// Because of their rather unique behaviour the points checked have been unrolled here
 		constexpr std::array<WorldTileDisplacement, 48> guardianArc {
@@ -3461,7 +3461,7 @@ void ProcessGuardian(Missile &missile)
 		}
 	}
 
-	if (missile._miduration == 14) {
+	if (missile.duration == 14) {
 		SetMissDir(missile, 0);
 		missile._miAnimFrame = 15;
 		missile._miAnimAdd = -1;
@@ -3475,7 +3475,7 @@ void ProcessGuardian(Missile &missile)
 		ChangeLight(missile._mlid, position, missile.var3);
 	}
 
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3499,8 +3499,8 @@ void ProcessChainLightning(Missile &missile)
 		}
 		return false;
 	});
-	missile._miduration--;
-	if (missile._miduration == 0)
+	missile.duration--;
+	if (missile.duration == 0)
 		missile._miDelFlag = true;
 }
 
@@ -3508,7 +3508,7 @@ void ProcessWeaponExplosion(Missile &missile)
 {
 	constexpr int ExpLight[10] = { 9, 10, 11, 12, 11, 10, 8, 6, 4, 2 };
 
-	missile._miduration--;
+	missile.duration--;
 	const Player &player = Players[missile._misource];
 	int mind;
 	int maxd;
@@ -3528,11 +3528,11 @@ void ProcessWeaponExplosion(Missile &missile)
 	if (missile.var1 == 0) {
 		missile._mlid = AddLight(missile.position.tile, 9);
 	} else {
-		if (missile._miduration != 0)
+		if (missile.duration != 0)
 			ChangeLight(missile._mlid, missile.position.tile, ExpLight[missile.var1]);
 	}
 	missile.var1++;
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	} else {
@@ -3544,8 +3544,8 @@ void ProcessMissileExplosion(Missile &missile)
 {
 	constexpr int ExpLight[] = { 9, 10, 11, 12, 11, 10, 8, 6, 4, 2, 1, 0, 0, 0, 0 };
 
-	missile._miduration--;
-	if (missile._miduration == 0) {
+	missile.duration--;
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	} else {
@@ -3560,12 +3560,12 @@ void ProcessMissileExplosion(Missile &missile)
 
 void ProcessAcidSplate(Missile &missile)
 {
-	if (missile._miduration == missile._miAnimLen) {
+	if (missile.duration == missile._miAnimLen) {
 		missile.position.tile += Displacement { 1, 1 };
 		missile.position.offset.deltaY -= 32;
 	}
-	missile._miduration--;
-	if (missile._miduration == 0) {
+	missile.duration--;
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		int monst = missile._misource;
 		int dam = (Monsters[monst].data().level >= 2 ? 2 : 1);
@@ -3577,8 +3577,8 @@ void ProcessAcidSplate(Missile &missile)
 
 void ProcessTeleport(Missile &missile)
 {
-	missile._miduration--;
-	if (missile._miduration <= 0) {
+	missile.duration--;
+	if (missile.duration <= 0) {
 		missile._miDelFlag = true;
 		return;
 	}
@@ -3614,20 +3614,20 @@ void ProcessTeleport(Missile &missile)
 
 void ProcessStoneCurse(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	Monster &monster = Monsters[missile.var2];
 	if (monster.hitPoints == 0 && missile._miAnimType != MissileGraphicID::StoneCurseShatter) {
 		missile._mimfnum = 0;
 		missile._miDrawFlag = true;
 		SetMissAnim(missile, MissileGraphicID::StoneCurseShatter);
-		missile._miduration = 11;
+		missile.duration = 11;
 	}
 	if (monster.mode != MonsterMode::Petrified) {
 		missile._miDelFlag = true;
 		return;
 	}
 
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		if (monster.hitPoints > 0) {
 			monster.mode = static_cast<MonsterMode>(missile.var1);
@@ -3642,12 +3642,12 @@ void ProcessStoneCurse(Missile &missile)
 
 void ProcessApocalypseBoom(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	if (missile.var1 == 0)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, false, missile.position.tile, true);
 	if (missile._miHitFlag)
 		missile.var1 = 1;
-	if (missile._miduration == 0)
+	if (missile.duration == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
 }
@@ -3730,8 +3730,8 @@ static void ProcessWallControlRight(Missile &missile, const MissileID type, cons
 
 void ProcessWallControl(Missile &missile)
 {
-	missile._miduration--;
-	if (missile._miduration == 0) {
+	missile.duration--;
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		return;
 	}
@@ -3764,9 +3764,9 @@ void ProcessWallControl(Missile &missile)
 void ProcessInfravision(Missile &missile)
 {
 	Player &player = Players[missile._misource];
-	missile._miduration--;
+	missile.duration--;
 	player._pInfraFlag = true;
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		CalcPlrItemVals(player, true);
 	}
@@ -3835,16 +3835,16 @@ void ProcessFlameWaveControl(Missile &missile)
 		}
 	}
 
-	missile._miduration--;
-	if (missile._miduration == 0)
+	missile.duration--;
+	if (missile.duration == 0)
 		missile._miDelFlag = true;
 }
 
 void ProcessRage(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 
-	if (missile._miduration != 0) {
+	if (missile.duration != 0) {
 		return;
 	}
 
@@ -3856,7 +3856,7 @@ void ProcessRage(Missile &missile)
 		player._pSpellFlags &= ~SpellFlag::RageActive;
 		player._pSpellFlags |= SpellFlag::RageCooldown;
 		int lvl = player.getCharacterLevel() * 2;
-		missile._miduration = lvl + 10 * missile._mispllvl + 245;
+		missile.duration = lvl + 10 * missile._mispllvl + 245;
 	} else {
 		player._pSpellFlags &= ~SpellFlag::RageCooldown;
 		missile._miDelFlag = true;
@@ -3871,12 +3871,12 @@ void ProcessRage(Missile &missile)
 
 void ProcessInferno(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	missile.var2--;
-	int k = missile._miduration;
+	int k = missile.duration;
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
-	if (missile._miduration == 0 && missile._miHitFlag)
-		missile._miduration = k;
+	if (missile.duration == 0 && missile._miHitFlag)
+		missile.duration = k;
 	if (missile.var2 == 0)
 		missile._miAnimFrame = 20;
 	if (missile.var2 <= 0) {
@@ -3885,7 +3885,7 @@ void ProcessInferno(Missile &missile)
 			k = 24 - k;
 		ChangeLight(missile._mlid, missile.position.tile, k);
 	}
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3895,7 +3895,7 @@ void ProcessInferno(Missile &missile)
 
 void ProcessInfernoControl(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	missile.position.traveled += missile.position.velocity;
 	UpdateMissilePos(missile);
 	if (missile.position.tile != Point { missile.var1, missile.var2 }) {
@@ -3911,19 +3911,19 @@ void ProcessInfernoControl(Missile &missile)
 			    missile._mispllvl,
 			    &missile);
 		} else {
-			missile._miduration = 0;
+			missile.duration = 0;
 		}
 		missile.var1 = missile.position.tile.x;
 		missile.var2 = missile.position.tile.y;
 		missile.var3++;
 	}
-	if (missile._miduration == 0 || missile.var3 == 3)
+	if (missile.duration == 0 || missile.var3 == 3)
 		missile._miDelFlag = true;
 }
 
 void ProcessChargedBolt(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	if (missile._miAnimType != MissileGraphicID::Lightning) {
 		if (missile.var3 == 0) {
 			constexpr int BPath[16] = { -1, 0, 1, -1, 0, 1, -1, -1, 0, 0, 1, 1, 0, 1, -1, 0 };
@@ -3951,11 +3951,11 @@ void ProcessChargedBolt(Missile &missile)
 			missile.position.offset = { 0, 0 };
 			missile.position.velocity = {};
 			SetMissAnim(missile, MissileGraphicID::Lightning);
-			missile._miduration = missile._miAnimLen;
+			missile.duration = missile._miAnimLen;
 		}
 		ChangeLight(missile._mlid, missile.position.tile, missile.var1);
 	}
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}
@@ -3964,14 +3964,14 @@ void ProcessChargedBolt(Missile &missile)
 
 void ProcessHolyBolt(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	if (missile._miAnimType != MissileGraphicID::HolyBoltExplosion) {
 		int dam = missile._midam;
 		MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), dam, dam, true, true);
-		if (missile._miduration == 0) {
+		if (missile.duration == 0) {
 			missile._mimfnum = 0;
 			SetMissAnim(missile, MissileGraphicID::HolyBoltExplosion);
-			missile._miduration = missile._miAnimLen - 1;
+			missile.duration = missile._miAnimLen - 1;
 			missile.position.StopMissile();
 		} else {
 			if (missile.position.tile != Point { missile.var1, missile.var2 }) {
@@ -3982,7 +3982,7 @@ void ProcessHolyBolt(Missile &missile)
 		}
 	} else {
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame + 7);
-		if (missile._miduration == 0) {
+		if (missile.duration == 0) {
 			missile._miDelFlag = true;
 			AddUnLight(missile._mlid);
 		}
@@ -3992,7 +3992,7 @@ void ProcessHolyBolt(Missile &missile)
 
 void ProcessElemental(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	int dam = missile._midam;
 	const Point missilePosition = missile.position.tile;
 	if (missile._miAnimType == MissileGraphicID::BigExplosion) {
@@ -4015,7 +4015,7 @@ void ProcessElemental(Missile &missile)
 				CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), dam, dam, true, missilePosition + offset, true);
 		}
 
-		if (missile._miduration == 0) {
+		if (missile.duration == 0) {
 			missile._miDelFlag = true;
 			AddUnLight(missile._mlid);
 		}
@@ -4025,7 +4025,7 @@ void ProcessElemental(Missile &missile)
 			missile.var3 = 1;
 		if (missile.var3 == 1) {
 			missile.var3 = 2;
-			missile._miduration = 255;
+			missile.duration = 255;
 			auto *nextMonster = FindClosest(missilePosition, 19);
 			if (nextMonster != nullptr) {
 				Direction sd = GetDirection(missilePosition, nextMonster->position.tile);
@@ -4042,10 +4042,10 @@ void ProcessElemental(Missile &missile)
 			missile.var2 = missilePosition.y;
 			ChangeLight(missile._mlid, missilePosition, 8);
 		}
-		if (missile._miduration == 0) {
+		if (missile.duration == 0) {
 			missile._mimfnum = 0;
 			SetMissAnim(missile, MissileGraphicID::BigExplosion);
-			missile._miduration = missile._miAnimLen - 1;
+			missile.duration = missile._miAnimLen - 1;
 			missile.position.StopMissile();
 		}
 	}
@@ -4054,11 +4054,11 @@ void ProcessElemental(Missile &missile)
 
 void ProcessBoneSpirit(Missile &missile)
 {
-	missile._miduration--;
+	missile.duration--;
 	int dam = missile._midam;
 	if (missile._mimfnum == 8) {
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
-		if (missile._miduration == 0) {
+		if (missile.duration == 0) {
 			missile._miDelFlag = true;
 			AddUnLight(missile._mlid);
 		}
@@ -4070,7 +4070,7 @@ void ProcessBoneSpirit(Missile &missile)
 			missile.var3 = 1;
 		if (missile.var3 == 1) {
 			missile.var3 = 2;
-			missile._miduration = 255;
+			missile.duration = 255;
 			auto *monster = FindClosest(c, 19);
 			if (monster != nullptr) {
 				missile._midam = monster->hitPoints >> 7;
@@ -4087,10 +4087,10 @@ void ProcessBoneSpirit(Missile &missile)
 			missile.var2 = c.y;
 			ChangeLight(missile._mlid, c, 8);
 		}
-		if (missile._miduration == 0) {
+		if (missile.duration == 0) {
 			SetMissDir(missile, 8);
 			missile.position.velocity = {};
-			missile._miduration = 7;
+			missile.duration = 7;
 		}
 		PutMissile(missile);
 	}
@@ -4098,8 +4098,8 @@ void ProcessBoneSpirit(Missile &missile)
 
 void ProcessResurrectBeam(Missile &missile)
 {
-	missile._miduration--;
-	if (missile._miduration == 0)
+	missile.duration--;
+	if (missile.duration == 0)
 		missile._miDelFlag = true;
 	PutMissile(missile);
 }
@@ -4108,18 +4108,18 @@ void ProcessRedPortal(Missile &missile)
 {
 	int expLight[17] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 15 };
 
-	if (missile._miduration > 1)
-		missile._miduration--;
-	if (missile._miduration == missile.var1)
+	if (missile.duration > 1)
+		missile.duration--;
+	if (missile.duration == missile.var1)
 		SetMissDir(missile, 1);
 
-	if (leveltype != DTYPE_TOWN && missile._mimfnum != 1 && missile._miduration != 0) {
+	if (leveltype != DTYPE_TOWN && missile._mimfnum != 1 && missile.duration != 0) {
 		if (missile.var2 == 0)
 			missile._mlid = AddLight(missile.position.tile, 1);
 		ChangeLight(missile._mlid, missile.position.tile, expLight[missile.var2]);
 		missile.var2++;
 	}
-	if (missile._miduration == 0) {
+	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
 	}

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -119,7 +119,7 @@ struct Missile {
 	bool _miLightFlag;
 	bool _miPreFlag;
 	uint32_t _miUniqTrans;
-	int _mirange; // Time to live for the missile in game ticks, oncs 0 the missile will be marked for deletion via _miDelFlag
+	int _miduration; // Time to live for the missile in game ticks, oncs 0 the missile will be marked for deletion via _miDelFlag
 	int _misource;
 	mienemy_type _micaster;
 	int _midam;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -119,7 +119,7 @@ struct Missile {
 	bool _miLightFlag;
 	bool _miPreFlag;
 	uint32_t _miUniqTrans;
-	int _miduration; // Time to live for the missile in game ticks, oncs 0 the missile will be marked for deletion via _miDelFlag
+	int _miduration; // Time to live for the missile in game ticks; once 0, the missile will be marked for deletion via _miDelFlag
 	int _misource;
 	mienemy_type _micaster;
 	int _midam;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -119,7 +119,8 @@ struct Missile {
 	bool _miLightFlag;
 	bool _miPreFlag;
 	uint32_t _miUniqTrans;
-	int _miduration; // Time to live for the missile in game ticks; once 0, the missile will be marked for deletion via _miDelFlag
+	/** @brief Time to live for the missile in game ticks; once 0, the missile will be marked for deletion via _miDelFlag */
+	int duration;
 	int _misource;
 	mienemy_type _micaster;
 	int _midam;

--- a/test/fixtures/memory_map/missile.txt
+++ b/test/fixtures/memory_map/missile.txt
@@ -27,7 +27,7 @@ R 32 _miDrawFlag
 R 32 _miLightFlag
 R 32 _miPreFlag
 R 32 _miUniqTrans
-R 32 _miduration
+R 32 duration
 R 32 _misource
 R 32 _micaster
 R 32 _midam

--- a/test/fixtures/memory_map/missile.txt
+++ b/test/fixtures/memory_map/missile.txt
@@ -27,7 +27,7 @@ R 32 _miDrawFlag
 R 32 _miLightFlag
 R 32 _miPreFlag
 R 32 _miUniqTrans
-R 32 _mirange
+R 32 _miduration
 R 32 _misource
 R 32 _micaster
 R 32 _midam


### PR DESCRIPTION
`_mirange` is a bit confusing. `duration` adequately describes what the missile is used for, as the intent is the amount of ticks the missile exists for, often decremented every tick until it hits 0, when the missile is destroyed.