### PR TITLE
Rename Player struct variables

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1271,9 +1271,9 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset, i
 {
 	const Player &player = *MyPlayer;
 	Point tile = player.position.tile;
-	if (player._pmode == PM_WALK_SIDEWAYS) {
+	if (player.mode == PM_WALK_SIDEWAYS) {
 		tile = player.position.future;
-		if (player._pdir == Direction::West)
+		if (player.direction == Direction::West)
 			tile.x++;
 		else
 			tile.y++;
@@ -1326,7 +1326,7 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, cons
 
 	Displacement playerOffset = {};
 	if (player.isWalking())
-		playerOffset = GetOffsetForWalking(player.AnimInfo, player._pdir);
+		playerOffset = GetOffsetForWalking(player.animationInfo, player.direction);
 
 	int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
 
@@ -1345,7 +1345,7 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, cons
 	}
 	base.y -= AmLine(AmLineLength::DoubleTile);
 
-	switch (player._pdir) {
+	switch (player.direction) {
 	case Direction::North: {
 		const Point point = base + AmOffset(AmWidthOffset::None, AmHeightOffset::FullTileUp);
 		DrawMapLineNS(out, point, AmLine(AmLineLength::DoubleTile), playerColor);
@@ -1747,7 +1747,7 @@ void DrawAutomap(const Surface &out)
 	const Player &myPlayer = *MyPlayer;
 	Displacement myPlayerOffset = {};
 	if (myPlayer.isWalking())
-		myPlayerOffset = GetOffsetForWalking(myPlayer.AnimInfo, myPlayer._pdir, true);
+		myPlayerOffset = GetOffsetForWalking(myPlayer.animationInfo, myPlayer.direction, true);
 
 	int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
 	int d = (scale * 64) / 100;
@@ -1831,7 +1831,7 @@ void DrawAutomap(const Surface &out)
 	}
 
 	for (const Player &player : Players) {
-		if (player.isOnActiveLevel() && player.plractive && !player._pLvlChanging && (&player == MyPlayer || player.friendlyMode)) {
+		if (player.isOnActiveLevel() && player.isPlayerActive && !player.isChangingLevel && (&player == MyPlayer || player.isFriendlyMode)) {
 			DrawAutomapPlr(out, myPlayerOffset, player);
 		}
 	}

--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -119,15 +119,15 @@ void DrawSpellsCircleMenuHint(const Surface &out, const Point &origin)
 		hintBoxPositions[2] + spellIconDisplacement,
 		hintBoxPositions[3] + spellIconDisplacement,
 	};
-	uint64_t spells = myPlayer._pAblSpells | myPlayer._pMemSpells | myPlayer._pScrlSpells | myPlayer._pISpells;
+	uint64_t spells = myPlayer.skills | myPlayer.learnedSpells | myPlayer.scrollSpells | myPlayer.staffSpells;
 	SpellID splId;
 	SpellType splType;
 
 	for (int slot = 0; slot < 4; ++slot) {
-		splId = myPlayer._pSplHotKey[slot];
+		splId = myPlayer.hotkeySpell[slot];
 
 		if (IsValidSpell(splId) && (spells & GetSpellBitmask(splId)) != 0)
-			splType = (leveltype == DTYPE_TOWN && !GetSpellData(splId).isAllowedInTown()) ? SpellType::Invalid : myPlayer._pSplTHotKey[slot];
+			splType = (leveltype == DTYPE_TOWN && !GetSpellData(splId).isAllowedInTown()) ? SpellType::Invalid : myPlayer.hotkeySpellType[slot];
 		else {
 			splType = SpellType::Invalid;
 			splId = SpellID::Null;

--- a/Source/controls/touch/event_handlers.cpp
+++ b/Source/controls/touch/event_handlers.cpp
@@ -90,7 +90,7 @@ bool HandleSpeedBookInteraction(const SDL_Event &event)
 
 void HandleBottomPanelInteraction(const SDL_Event &event)
 {
-	if (!gbRunGame || !MyPlayer->HoldItem.isEmpty())
+	if (!gbRunGame || !MyPlayer->heldItem.isEmpty())
 		return;
 
 	ClearPanBtn();
@@ -119,7 +119,7 @@ void HandleCharacterPanelInteraction(const SDL_Event &event)
 
 void HandleStashPanelInteraction(const SDL_Event &event)
 {
-	if (!IsStashOpen || !MyPlayer->HoldItem.isEmpty())
+	if (!IsStashOpen || !MyPlayer->heldItem.isEmpty())
 		return;
 
 	if (event.type != SDL_FINGERUP) {

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -160,7 +160,7 @@ void LoadPotionArt(ButtonTexture *potionArt, SDL_Renderer *renderer)
 bool InteractsWithCharButton(Point point)
 {
 	Player &myPlayer = *MyPlayer;
-	if (myPlayer._pStatPts == 0)
+	if (myPlayer.statPoints == 0)
 		return false;
 	for (auto attribute : enum_values<CharacterAttribute>()) {
 		if (myPlayer.GetBaseAttributeValue(attribute) >= myPlayer.GetMaximumAttributeValue(attribute))
@@ -286,7 +286,7 @@ void VirtualMenuPanelRenderer::Render(RenderFunction renderFunction)
 	int width = virtualMenuPanel->area.size.width;
 	int height = virtualMenuPanel->area.size.height;
 	SDL_Rect rect { x, y, width, height };
-	renderFunction(MyPlayer->_pStatPts == 0 ? menuArt : menuArtLevelUp, nullptr, &rect);
+	renderFunction(MyPlayer->statPoints == 0 ? menuArt : menuArtLevelUp, nullptr, &rect);
 }
 
 void VirtualDirectionPadRenderer::Render(RenderFunction renderFunction)
@@ -377,7 +377,7 @@ void PotionButtonRenderer::RenderPotion(RenderFunction renderFunction, const But
 
 std::optional<VirtualGamepadPotionType> PotionButtonRenderer::GetPotionType()
 {
-	for (const Item &item : InspectPlayer->SpdList) {
+	for (const Item &item : InspectPlayer->beltSlot) {
 		if (item.isEmpty()) {
 			continue;
 		}
@@ -486,7 +486,7 @@ VirtualGamepadButtonType SecondaryActionButtonRenderer::GetButtonType()
 
 VirtualGamepadButtonType SpellActionButtonRenderer::GetButtonType()
 {
-	if (!MyPlayer->HoldItem.isEmpty())
+	if (!MyPlayer->heldItem.isEmpty())
 		return GetDropButtonType(virtualPadButton->isHeld);
 
 	if (invflag && pcursinvitem != -1 && pcurs == CURSOR_HAND) {

--- a/Source/discord/discord.cpp
+++ b/Source/discord/discord.cpp
@@ -110,13 +110,13 @@ std::string GetStateString()
 
 std::string GetTooltipString()
 {
-	return StrCat(MyPlayer->_pName, " - ", GetCharacterString());
+	return StrCat(MyPlayer->name, " - ", GetCharacterString());
 }
 
 std::string GetPlayerAssetString()
 {
 	char chars[5] {
-		CharChar[static_cast<int>(MyPlayer->_pClass)],
+		CharChar[static_cast<int>(MyPlayer->heroClass)],
 		ArmourChar[tracked_data.playerGfx >> 4],
 		WepChar[tracked_data.playerGfx & 0xF],
 		'a',
@@ -141,7 +141,7 @@ void UpdateGame()
 		return;
 
 	auto newData = PlayerData {
-		leveltype, setlvlnum, currlevel, MyPlayer->getCharacterLevel(), MyPlayer->_pgfxnum
+		leveltype, setlvlnum, currlevel, MyPlayer->getCharacterLevel(), MyPlayer->graphic
 	};
 	if (newData != tracked_data) {
 		tracked_data = newData;

--- a/Source/dvlnet/base_protocol.h
+++ b/Source/dvlnet/base_protocol.h
@@ -396,8 +396,8 @@ tl::expected<void, PacketError> base_protocol<P>::recv_ingame(packet &pkt, endpo
 				buf.resize(game_init_info.size() + (PlayerNameLength * MAX_PLRS) + gamename.size());
 				std::memcpy(buf.data(), &game_init_info[0], game_init_info.size());
 				for (size_t i = 0; i < Players.size(); i++) {
-					if (Players[i].plractive) {
-						std::memcpy(buf.data() + game_init_info.size() + (i * PlayerNameLength), &Players[i]._pName, PlayerNameLength);
+					if (Players[i].isPlayerActive) {
+						std::memcpy(buf.data() + game_init_info.size() + (i * PlayerNameLength), &Players[i].name, PlayerNameLength);
 					} else {
 						std::memset(buf.data() + game_init_info.size() + (i * PlayerNameLength), '\0', PlayerNameLength);
 					}

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -65,7 +65,7 @@ void StreamUpdate()
 
 void PlaySfxPriv(TSFX *pSFX, bool loc, Point position)
 {
-	if (MyPlayer->pLvlLoad != 0 && gbIsMultiplayer) {
+	if (MyPlayer->levelLoading != 0 && gbIsMultiplayer) {
 		return;
 	}
 	if (!gbSndInited || !gbSoundOn || gbBufferMsgs != 0) {
@@ -267,7 +267,7 @@ void sound_init()
 		if (gbIsHellfire)
 			mask |= sfx_MONK;
 	} else {
-		switch (MyPlayer->_pClass) {
+		switch (MyPlayer->heroClass) {
 		case HeroClass::Warrior:
 		case HeroClass::Barbarian:
 			mask |= sfx_WARRIOR;

--- a/Source/engine/actor_position.cpp
+++ b/Source/engine/actor_position.cpp
@@ -104,38 +104,38 @@ constexpr std::array<const WalkParameter, 8> WalkParameters { {
 
 } // namespace
 
-DisplacementOf<int8_t> ActorPosition::CalculateWalkingOffset(Direction dir, const AnimationInfo &animInfo) const
+DisplacementOf<int8_t> ActorPosition::CalculateWalkingOffset(Direction dir, const PlayerAnimationInfo &animationInfo) const
 {
-	DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animInfo);
+	DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animationInfo);
 	return { static_cast<int8_t>(offset.deltaX >> 4), static_cast<int8_t>(offset.deltaY >> 4) };
 }
 
-DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted4(Direction dir, const AnimationInfo &animInfo) const
+DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted4(Direction dir, const PlayerAnimationInfo &animationInfo) const
 {
-	int16_t velocityProgress = static_cast<int16_t>(animInfo.getAnimationProgress()) * animInfo.numberOfFrames / AnimationInfo::baseValueFraction;
+	int16_t velocityProgress = static_cast<int16_t>(animationInfo.getAnimationProgress()) * animationInfo.numberOfFrames / PlayerAnimationInfo::baseValueFraction;
 	const WalkParameter &walkParameter = WalkParameters[static_cast<size_t>(dir)];
-	DisplacementOf<int16_t> velocity = walkParameter.getVelocity(animInfo.numberOfFrames);
+	DisplacementOf<int16_t> velocity = walkParameter.getVelocity(animationInfo.numberOfFrames);
 	DisplacementOf<int16_t> offset = (velocity * velocityProgress);
 	return offset;
 }
 
-DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted8(Direction dir, const AnimationInfo &animInfo) const
+DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted8(Direction dir, const PlayerAnimationInfo &animationInfo) const
 {
-	DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animInfo);
+	DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animationInfo);
 	offset.deltaX <<= 4;
 	offset.deltaY <<= 4;
 	return offset;
 }
 
-DisplacementOf<int16_t> ActorPosition::GetWalkingVelocityShifted4(Direction dir, const AnimationInfo &animInfo) const
+DisplacementOf<int16_t> ActorPosition::GetWalkingVelocityShifted4(Direction dir, const PlayerAnimationInfo &animationInfo) const
 {
 	const WalkParameter &walkParameter = WalkParameters[static_cast<size_t>(dir)];
-	return walkParameter.getVelocity(animInfo.numberOfFrames);
+	return walkParameter.getVelocity(animationInfo.numberOfFrames);
 }
 
-DisplacementOf<int16_t> ActorPosition::GetWalkingVelocityShifted8(Direction dir, const AnimationInfo &animInfo) const
+DisplacementOf<int16_t> ActorPosition::GetWalkingVelocityShifted8(Direction dir, const PlayerAnimationInfo &animationInfo) const
 {
-	DisplacementOf<int16_t> velocity = GetWalkingVelocityShifted4(dir, animInfo);
+	DisplacementOf<int16_t> velocity = GetWalkingVelocityShifted4(dir, animationInfo);
 	velocity.deltaX <<= 4;
 	velocity.deltaY <<= 4;
 	return velocity;

--- a/Source/engine/actor_position.hpp
+++ b/Source/engine/actor_position.hpp
@@ -20,15 +20,15 @@ struct ActorPosition {
 	WorldTilePosition temp;
 
 	/** @brief Calculates the offset for the walking animation. */
-	DisplacementOf<int8_t> CalculateWalkingOffset(Direction dir, const AnimationInfo &animInfo) const;
+	DisplacementOf<int8_t> CalculateWalkingOffset(Direction dir, const PlayerAnimationInfo &animationInfo) const;
 	/** @brief Calculates the offset for the walking animation. */
-	DisplacementOf<int16_t> CalculateWalkingOffsetShifted4(Direction dir, const AnimationInfo &animInfo) const;
+	DisplacementOf<int16_t> CalculateWalkingOffsetShifted4(Direction dir, const PlayerAnimationInfo &animationInfo) const;
 	/** @brief Calculates the offset for the walking animation. */
-	DisplacementOf<int16_t> CalculateWalkingOffsetShifted8(Direction dir, const AnimationInfo &animInfo) const;
+	DisplacementOf<int16_t> CalculateWalkingOffsetShifted8(Direction dir, const PlayerAnimationInfo &animationInfo) const;
 	/** @brief Returns Pixel velocity while walking. */
-	DisplacementOf<int16_t> GetWalkingVelocityShifted4(Direction dir, const AnimationInfo &animInfo) const;
+	DisplacementOf<int16_t> GetWalkingVelocityShifted4(Direction dir, const PlayerAnimationInfo &animationInfo) const;
 	/** @brief Returns Pixel velocity while walking. */
-	DisplacementOf<int16_t> GetWalkingVelocityShifted8(Direction dir, const AnimationInfo &animInfo) const;
+	DisplacementOf<int16_t> GetWalkingVelocityShifted8(Direction dir, const PlayerAnimationInfo &animationInfo) const;
 };
 
 } // namespace devilution

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -15,7 +15,7 @@
 
 namespace devilution {
 
-int8_t AnimationInfo::getFrameToUseForRendering() const
+int8_t PlayerAnimationInfo::getFrameToUseForRendering() const
 {
 	// Normal logic is used,
 	// - if no frame-skipping is required and so we have exactly one Animationframe per game tick
@@ -59,7 +59,7 @@ int8_t AnimationInfo::getFrameToUseForRendering() const
 	return absoluteAnimationFrame;
 }
 
-uint8_t AnimationInfo::getAnimationProgress() const
+uint8_t PlayerAnimationInfo::getAnimationProgress() const
 {
 	int16_t ticksSinceSequenceStarted = std::max<int16_t>(0, ticksSinceSequenceStarted_);
 	int32_t tickModifier = tickModifier_;
@@ -78,7 +78,7 @@ uint8_t AnimationInfo::getAnimationProgress() const
 	return static_cast<uint8_t>(animationFraction);
 }
 
-void AnimationInfo::setNewAnimation(OptionalClxSpriteList celSprite, int8_t numberOfFrames, int8_t ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int8_t numSkippedFrames /*= 0*/, int8_t distributeFramesBeforeFrame /*= 0*/, uint8_t previewShownGameTickFragments /*= 0*/)
+void PlayerAnimationInfo::setNewAnimation(OptionalClxSpriteList celSprite, int8_t numberOfFrames, int8_t ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int8_t numSkippedFrames /*= 0*/, int8_t distributeFramesBeforeFrame /*= 0*/, uint8_t previewShownGameTickFragments /*= 0*/)
 {
 	if ((flags & AnimationDistributionFlags::RepeatedAction) == AnimationDistributionFlags::RepeatedAction && distributeFramesBeforeFrame != 0 && this->numberOfFrames == numberOfFrames && currentFrame + 1 >= distributeFramesBeforeFrame && currentFrame != this->numberOfFrames - 1) {
 		// We showed the same Animation (for example a melee attack) before but truncated the Animation.
@@ -107,9 +107,9 @@ void AnimationInfo::setNewAnimation(OptionalClxSpriteList celSprite, int8_t numb
 		// Animation Frames that will be adjusted for the skipped Frames/game ticks
 		int8_t relevantAnimationFramesForDistributing = numberOfFrames;
 		if (distributeFramesBeforeFrame != 0) {
-			// After an attack hits (_pAFNum or _pSFNum) it can be canceled or another attack can be queued and this means the animation is canceled.
+			// After an attack hits (attackActionFrame or spellActionFrame) it can be canceled or another attack can be queued and this means the animation is canceled.
 			// In normal attacks frame skipping always happens before the attack actual hit.
-			// This has the advantage that the sword or bow always points to the enemy when the hit happens (_pAFNum or _pSFNum).
+			// This has the advantage that the sword or bow always points to the enemy when the hit happens (attackActionFrame or spellActionFrame).
 			// Our distribution logic must also regard this behaviour, so we are not allowed to distribute the skipped animations after the actual hit (_pAnimStopDistributingAfterFrame).
 			relevantAnimationFramesForDistributing = distributeFramesBeforeFrame - 1;
 		}
@@ -177,7 +177,7 @@ void AnimationInfo::setNewAnimation(OptionalClxSpriteList celSprite, int8_t numb
 	}
 }
 
-void AnimationInfo::changeAnimationData(OptionalClxSpriteList celSprite, int8_t numberOfFrames, int8_t ticksPerFrame)
+void PlayerAnimationInfo::changeanimationData(OptionalClxSpriteList celSprite, int8_t numberOfFrames, int8_t ticksPerFrame)
 {
 	if (numberOfFrames != this->numberOfFrames || ticksPerFrame != this->ticksPerFrame) {
 		// Ensure that the currentFrame is still valid and that we disable ADL cause the calculcated values (for example tickModifier_) could be wrong
@@ -195,7 +195,7 @@ void AnimationInfo::changeAnimationData(OptionalClxSpriteList celSprite, int8_t 
 	this->sprites = celSprite;
 }
 
-void AnimationInfo::processAnimation(bool reverseAnimation /*= false*/)
+void PlayerAnimationInfo::processAnimation(bool reverseAnimation /*= false*/)
 {
 	tickCounterOfCurrentFrame++;
 	ticksSinceSequenceStarted_ += baseValueFraction;
@@ -217,7 +217,7 @@ void AnimationInfo::processAnimation(bool reverseAnimation /*= false*/)
 	}
 }
 
-uint8_t AnimationInfo::getProgressToNextGameTick() const
+uint8_t PlayerAnimationInfo::getProgressToNextGameTick() const
 {
 	if (isPetrified)
 		return 0;

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -34,7 +34,7 @@ enum AnimationDistributionFlags : uint8_t {
 /**
  * @brief Contains the core animation information and related logic
  */
-class AnimationInfo {
+class PlayerAnimationInfo {
 public:
 	/**
 	 * @brief Animation sprite
@@ -100,7 +100,7 @@ public:
 	 * @param numberOfFrames Number of Frames in Animation
 	 * @param ticksPerFrame How many game ticks are needed to advance one Animation Frame
 	 */
-	void changeAnimationData(OptionalClxSpriteList sprites, int8_t numberOfFrames, int8_t ticksPerFrame);
+	void changeanimationData(OptionalClxSpriteList sprites, int8_t numberOfFrames, int8_t ticksPerFrame);
 
 	/**
 	 * @brief Process the Animation for a game tick (for example advances the frame)
@@ -109,7 +109,7 @@ public:
 	void processAnimation(bool reverseAnimation = false);
 
 	/**
-	 * @brief Fractions in AnimationInfo are stored as fixed point (baseValueFraction/128 correspondents to 1/100%).
+	 * @brief Fractions in PlayerAnimationInfo are stored as fixed point (baseValueFraction/128 correspondents to 1/100%).
 	 */
 	constexpr static uint8_t baseValueFraction = 128;
 

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -660,8 +660,8 @@ bool GetRunGameLoop(bool &drawGame, bool &processInput)
 				DemoModeLastTick = currentTickCount;
 			}
 		} else {
-			int32_t fraction = ticksElapsed * AnimationInfo::baseValueFraction / gnTickDelay;
-			fraction = std::clamp<int32_t>(fraction, 0, AnimationInfo::baseValueFraction);
+			int32_t fraction = ticksElapsed * PlayerAnimationInfo::baseValueFraction / gnTickDelay;
+			fraction = std::clamp<int32_t>(fraction, 0, PlayerAnimationInfo::baseValueFraction);
 			uint8_t progressToNextGameTick = static_cast<uint8_t>(fraction);
 			if (dmsg.type == DemoMsg::GameTick || dmsg.progressToNextGameTick > progressToNextGameTick) {
 				// we are ahead of the replay => add a additional rendering for smoothness

--- a/Source/engine/render/scrollrt.h
+++ b/Source/engine/render/scrollrt.h
@@ -23,7 +23,7 @@ extern bool frameflag;
  * @param dir walking direction
  * @param cameraMode Adjusts the offset relative to the camera
  */
-Displacement GetOffsetForWalking(const AnimationInfo &animationInfo, const Direction dir, bool cameraMode = false);
+Displacement GetOffsetForWalking(const PlayerAnimationInfo &animationInfo, const Direction dir, bool cameraMode = false);
 
 /**
  * @brief Clear cursor state

--- a/Source/engine/trn.cpp
+++ b/Source/engine/trn.cpp
@@ -33,7 +33,7 @@ std::optional<std::array<uint8_t, 256>> GetClassTRN(Player &player)
 	std::array<uint8_t, 256> trn;
 	const char *path;
 
-	switch (player._pClass) {
+	switch (player.heroClass) {
 	case HeroClass::Warrior:
 		path = "plrgfx\\warrior.trn";
 		break;

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -84,7 +84,7 @@ void GamemenuUpdateSingle()
 {
 	sgSingleMenu[3].setEnabled(gbValidSaveFile);
 
-	bool enable = MyPlayer->_pmode != PM_DEATH && !MyPlayerIsDead;
+	bool enable = MyPlayer->mode != PM_DEATH && !MyPlayerIsDead;
 
 	sgSingleMenu[0].setEnabled(enable);
 }
@@ -102,8 +102,8 @@ void GamemenuPrevious(bool /*bActivate*/)
 void GamemenuNewGame(bool /*bActivate*/)
 {
 	for (Player &player : Players) {
-		player._pmode = PM_QUIT;
-		player._pInvincible = true;
+		player.mode = PM_QUIT;
+		player.isInvincible = true;
 	}
 
 	MyPlayerIsDead = false;
@@ -322,7 +322,7 @@ void gamemenu_save_game(bool /*bActivate*/)
 		return;
 	}
 
-	if (MyPlayer->_pmode == PM_DEATH || MyPlayerIsDead) {
+	if (MyPlayer->mode == PM_DEATH || MyPlayerIsDead) {
 		gamemenu_off();
 		return;
 	}

--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -123,7 +123,7 @@ bool SetHardwareCursorFromClxSprite(ClxSprite sprite, HotpointPosition hotpointP
 
 bool SetHardwareCursorFromSprite(int pcurs)
 {
-	const bool isItem = !MyPlayer->HoldItem.isEmpty();
+	const bool isItem = !MyPlayer->heldItem.isEmpty();
 	if (isItem && !*sgOptions.Graphics.hardwareCursorForItems)
 		return false;
 

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -83,7 +83,7 @@ Cutscenes PickCutscene(interface_mode uMsg)
 	case WM_DIABPREVLVL:
 	case WM_DIABTOWNWARP:
 	case WM_DIABTWARPUP: {
-		int lvl = MyPlayer->plrlevel;
+		int lvl = MyPlayer->dungeonLevel;
 		if (lvl == 1 && uMsg == WM_DIABNEXTLVL)
 			return CutTown;
 		if (lvl == 16 && uMsg == WM_DIABNEXTLVL)
@@ -339,7 +339,7 @@ void ShowProgress(interface_mode uMsg)
 		IncProgress();
 		break;
 	case WM_DIABNEWGAME:
-		myPlayer.pOriginalCathedral = !gbIsHellfire;
+		myPlayer.originalCathedral = !gbIsHellfire;
 		IncProgress();
 		FreeGameMem();
 		IncProgress();
@@ -358,7 +358,7 @@ void ShowProgress(interface_mode uMsg)
 		IncProgress();
 		FreeGameMem();
 		setlevel = false;
-		currlevel = myPlayer.plrlevel;
+		currlevel = myPlayer.dungeonLevel;
 		leveltype = GetLevelType(currlevel);
 		IncProgress();
 		LoadGameLevel(false, ENTRY_MAIN);
@@ -440,7 +440,7 @@ void ShowProgress(interface_mode uMsg)
 		IncProgress();
 		FreeGameMem();
 		setlevel = false;
-		currlevel = myPlayer.plrlevel;
+		currlevel = myPlayer.dungeonLevel;
 		leveltype = GetLevelType(currlevel);
 		IncProgress();
 		LoadGameLevel(false, ENTRY_TWARPDN);
@@ -455,7 +455,7 @@ void ShowProgress(interface_mode uMsg)
 		}
 		IncProgress();
 		FreeGameMem();
-		currlevel = myPlayer.plrlevel;
+		currlevel = myPlayer.dungeonLevel;
 		leveltype = GetLevelType(currlevel);
 		IncProgress();
 		LoadGameLevel(false, ENTRY_TWARPUP);
@@ -471,7 +471,7 @@ void ShowProgress(interface_mode uMsg)
 		IncProgress();
 		FreeGameMem();
 		setlevel = false;
-		currlevel = myPlayer.plrlevel;
+		currlevel = myPlayer.dungeonLevel;
 		leveltype = GetLevelType(currlevel);
 		IncProgress();
 		LoadGameLevel(false, ENTRY_MAIN);
@@ -500,7 +500,7 @@ void ShowProgress(interface_mode uMsg)
 	assert(previousHandler == DisableInputEventHandler);
 	IsProgress = false;
 
-	NetSendCmdLocParam2(true, CMD_PLAYER_JOINLEVEL, myPlayer.position.tile, myPlayer.plrlevel, myPlayer.plrIsOnSetLevel ? 1 : 0);
+	NetSendCmdLocParam2(true, CMD_PLAYER_JOINLEVEL, myPlayer.position.tile, myPlayer.dungeonLevel, myPlayer.isOnSetLevel ? 1 : 0);
 	DelayPlrMessages(SDL_GetTicks() - delayStart);
 
 	if (gbSomebodyWonGameKludge && myPlayer.isOnLevel(16)) {

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1406,7 +1406,7 @@ bool AutoPlaceItemInInventory(Player &player, const Item &item, bool persistItem
 std::vector<int> SortItemsBySize(Player &player)
 {
 	std::vector<std::pair<Size, int>> itemSizes; // Pair of item size and its index in inventorySlot
-	itemSizes.reserve(player.numInventoryItems);          // Reserves space for the number of items in the player's inventory
+	itemSizes.reserve(player.numInventoryItems); // Reserves space for the number of items in the player's inventory
 
 	for (int i = 0; i < player.numInventoryItems; i++) {
 		Size size = GetInventorySize(player.inventorySlot[i]);
@@ -1437,7 +1437,7 @@ void ReorganizeInventory(Player &player)
 
 	// Temporary storage for items and a copy of inventoryGrid
 	std::vector<Item> tempStorage(player.numInventoryItems);
-	std::array<int8_t, 40> originalinventoryGrid;                                                       // Declare an array for inventoryGrid copy
+	std::array<int8_t, 40> originalinventoryGrid;                                                                   // Declare an array for inventoryGrid copy
 	std::copy(std::begin(player.inventoryGrid), std::end(player.inventoryGrid), std::begin(originalinventoryGrid)); // Copy inventoryGrid to originalinventoryGrid
 
 	// Move items to temporary storage and clear inventory slots
@@ -1445,7 +1445,7 @@ void ReorganizeInventory(Player &player)
 		tempStorage[i] = player.inventorySlot[i];
 		player.inventorySlot[i] = {};
 	}
-	player.numInventoryItems = 0;                                                // Reset inventory count
+	player.numInventoryItems = 0;                                                   // Reset inventory count
 	std::fill(std::begin(player.inventoryGrid), std::end(player.inventoryGrid), 0); // Clear inventoryGrid
 
 	// Attempt to place items back, now from the temp storage

--- a/Source/inv_iterators.hpp
+++ b/Source/inv_iterators.hpp
@@ -205,7 +205,7 @@ public:
 
 	[[nodiscard]] Iterator begin() const
 	{
-		return Iterator { &player_->InvBody[0], containerSize(), 0 };
+		return Iterator { &player_->bodySlot[0], containerSize(), 0 };
 	}
 
 	[[nodiscard]] Iterator end() const
@@ -216,7 +216,7 @@ public:
 private:
 	[[nodiscard]] std::size_t containerSize() const
 	{
-		return sizeof(player_->InvBody) / sizeof(player_->InvBody[0]);
+		return sizeof(player_->bodySlot) / sizeof(player_->bodySlot[0]);
 	}
 
 	PlayerT *player_;
@@ -240,7 +240,7 @@ public:
 
 	[[nodiscard]] Iterator begin() const
 	{
-		return Iterator { &player_->InvList[0], containerSize(), 0 };
+		return Iterator { &player_->inventorySlot[0], containerSize(), 0 };
 	}
 
 	[[nodiscard]] Iterator end() const
@@ -251,7 +251,7 @@ public:
 private:
 	[[nodiscard]] std::size_t containerSize() const
 	{
-		return static_cast<std::size_t>(player_->_pNumInv);
+		return static_cast<std::size_t>(player_->numInventoryItems);
 	}
 
 	PlayerT *player_;
@@ -275,7 +275,7 @@ public:
 
 	[[nodiscard]] Iterator begin() const
 	{
-		return Iterator { &player_->SpdList[0], containerSize(), 0 };
+		return Iterator { &player_->beltSlot[0], containerSize(), 0 };
 	}
 
 	[[nodiscard]] Iterator end() const
@@ -286,7 +286,7 @@ public:
 private:
 	[[nodiscard]] std::size_t containerSize() const
 	{
-		return sizeof(player_->SpdList) / sizeof(player_->SpdList[0]);
+		return sizeof(player_->beltSlot) / sizeof(player_->beltSlot[0]);
 	}
 
 	PlayerT *player_;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -461,7 +461,7 @@ void AddInitItems()
 
 		item._iCreateInfo = curlv | CF_PREGEN;
 		SetupItem(item);
-		item.AnimInfo.currentFrame = item.AnimInfo.numberOfFrames - 1;
+		item.animationInfo.currentFrame = item.animationInfo.numberOfFrames - 1;
 		item._iAnimFlag = false;
 		item._iSelFlag = 1;
 		DeltaAddItem(ii);
@@ -507,9 +507,9 @@ void CalcSelfItems(Player &player)
 	bool changeflag;
 	do {
 		// cap stats to 0
-		const int currstr = std::max(0, sa + player._pBaseStr);
-		const int currmag = std::max(0, ma + player._pBaseMag);
-		const int currdex = std::max(0, da + player._pBaseDex);
+		const int currstr = std::max(0, sa + player.baseStrength);
+		const int currmag = std::max(0, ma + player.baseMagic);
+		const int currdex = std::max(0, da + player.baseDexterity);
 
 		changeflag = false;
 		for (Item &equipment : EquippedPlayerItemsRange(player)) {
@@ -1031,12 +1031,12 @@ int SaveItemPower(const Player &player, Item &item, ItemPower &power)
 		item._iDamAcFlags |= ItemSpecialEffectHf::ACAgainstUndead;
 		break;
 	case IPL_MANATOLIFE: {
-		int portion = ((player._pMaxManaBase >> 6) * 50 / 100) << 6;
+		int portion = ((player.baseMaxMana >> 6) * 50 / 100) << 6;
 		item._iPLMana -= portion;
 		item._iPLHP += portion;
 	} break;
 	case IPL_LIFETOMANA: {
-		int portion = ((player._pMaxHPBase >> 6) * 40 / 100) << 6;
+		int portion = ((player.baseMaxLife >> 6) * 40 / 100) << 6;
 		item._iPLHP -= portion;
 		item._iPLMana += portion;
 	} break;
@@ -1665,7 +1665,7 @@ void SpawnRock()
 	SetupItem(item);
 	item._iSelFlag = 2;
 	item._iPostDraw = true;
-	item.AnimInfo.currentFrame = 10;
+	item.animationInfo.currentFrame = 10;
 	item._iCreateInfo |= CF_PREGEN;
 
 	DeltaAddItem(ii);
@@ -1991,9 +1991,9 @@ _item_indexes RndPremiumItem(const Player &player, int minlvl, int maxlvl)
 
 void SpawnOnePremium(Item &premiumItem, int plvl, const Player &player)
 {
-	int strength = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Strength), player._pStrength);
-	int dexterity = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Dexterity), player._pDexterity);
-	int magic = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Magic), player._pMagic);
+	int strength = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Strength), player.strength);
+	int dexterity = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Dexterity), player.dexterity);
+	int magic = std::max(player.GetMaximumAttributeValue(CharacterAttribute::Magic), player.magic);
 	strength += strength / 5;
 	dexterity += dexterity / 5;
 	magic += magic / 5;
@@ -2108,13 +2108,13 @@ bool HealerItemOk(const Player &player, const ItemData &item)
 
 	if (!gbIsMultiplayer) {
 		if (item.iMiscId == IMISC_ELIXSTR)
-			return !gbIsHellfire || player._pBaseStr < player.GetMaximumAttributeValue(CharacterAttribute::Strength);
+			return !gbIsHellfire || player.baseStrength < player.GetMaximumAttributeValue(CharacterAttribute::Strength);
 		if (item.iMiscId == IMISC_ELIXMAG)
-			return !gbIsHellfire || player._pBaseMag < player.GetMaximumAttributeValue(CharacterAttribute::Magic);
+			return !gbIsHellfire || player.baseMagic < player.GetMaximumAttributeValue(CharacterAttribute::Magic);
 		if (item.iMiscId == IMISC_ELIXDEX)
-			return !gbIsHellfire || player._pBaseDex < player.GetMaximumAttributeValue(CharacterAttribute::Dexterity);
+			return !gbIsHellfire || player.baseDexterity < player.GetMaximumAttributeValue(CharacterAttribute::Dexterity);
 		if (item.iMiscId == IMISC_ELIXVIT)
-			return !gbIsHellfire || player._pBaseVit < player.GetMaximumAttributeValue(CharacterAttribute::Vitality);
+			return !gbIsHellfire || player.baseVitality < player.GetMaximumAttributeValue(CharacterAttribute::Vitality);
 	}
 
 	if (item.iMiscId == IMISC_REJUV)
@@ -2569,35 +2569,35 @@ void CalcPlrDamage(Player &player, int minDamage, int maxDamage)
 			maxDamage = 3;
 		}
 
-		if (player._pClass == HeroClass::Monk) {
+		if (player.heroClass == HeroClass::Monk) {
 			minDamage = std::max(minDamage, playerLevel / 2);
 			maxDamage = std::max<int>(maxDamage, playerLevel);
 		}
 	}
 
-	player._pIMinDam = minDamage;
-	player._pIMaxDam = maxDamage;
+	player.minDamage = minDamage;
+	player.maxDamage = maxDamage;
 }
 
 void CalcPlrPrimaryStats(Player &player, int strength, int &magic, int dexterity, int &vitality)
 {
 	const uint8_t playerLevel = player.getCharacterLevel();
 
-	if (HasAnyOf(player._pSpellFlags, SpellFlag::RageActive)) {
+	if (HasAnyOf(player.spellFlags, SpellFlag::RageActive)) {
 		strength += 2 * playerLevel;
 		dexterity += playerLevel + playerLevel / 2;
 		vitality += 2 * playerLevel;
 	}
-	if (HasAnyOf(player._pSpellFlags, SpellFlag::RageCooldown)) {
+	if (HasAnyOf(player.spellFlags, SpellFlag::RageCooldown)) {
 		strength -= 2 * playerLevel;
 		dexterity -= playerLevel + playerLevel / 2;
 		vitality -= 2 * playerLevel;
 	}
 
-	player._pStrength = std::max(0, strength + player._pBaseStr);
-	player._pMagic = std::max(0, magic + player._pBaseMag);
-	player._pDexterity = std::max(0, dexterity + player._pBaseDex);
-	player._pVitality = std::max(0, vitality + player._pBaseVit);
+	player.strength = std::max(0, strength + player.baseStrength);
+	player.magic = std::max(0, magic + player.baseMagic);
+	player.dexterity = std::max(0, dexterity + player.baseDexterity);
+	player.vitality = std::max(0, vitality + player.baseVitality);
 }
 
 void CalcPlrLightRadius(Player &player, int lrad)
@@ -2605,61 +2605,61 @@ void CalcPlrLightRadius(Player &player, int lrad)
 {
 	lrad = std::clamp(lrad, 2, 15);
 
-	if (player._pLightRad != lrad) {
+	if (player.lightRadius != lrad) {
 		ChangeLightRadius(player.lightId, lrad);
 		ChangeVisionRadius(player.getId(), lrad);
-		player._pLightRad = lrad;
+		player.lightRadius = lrad;
 	}
 }
 
 void CalcPlrDamageMod(Player &player)
 {
 	const uint8_t playerLevel = player.getCharacterLevel();
-	const Item &leftHandItem = player.InvBody[INVLOC_HAND_LEFT];
-	const Item &rightHandItem = player.InvBody[INVLOC_HAND_RIGHT];
-	const int strMod = playerLevel * player._pStrength;
-	const int strDexMod = playerLevel * (player._pStrength + player._pDexterity);
+	const Item &leftHandItem = player.bodySlot[INVLOC_HAND_LEFT];
+	const Item &rightHandItem = player.bodySlot[INVLOC_HAND_RIGHT];
+	const int strMod = playerLevel * player.strength;
+	const int strDexMod = playerLevel * (player.strength + player.dexterity);
 
-	switch (player._pClass) {
+	switch (player.heroClass) {
 	case HeroClass::Rogue:
-		player._pDamageMod = strDexMod / 200;
+		player.damageModifier = strDexMod / 200;
 		return;
 	case HeroClass::Monk:
 		if (player.isHoldingItem(ItemType::Staff) || (leftHandItem.isEmpty() && rightHandItem.isEmpty())) {
-			player._pDamageMod = strDexMod / 150;
+			player.damageModifier = strDexMod / 150;
 		} else {
-			player._pDamageMod = strDexMod / 300;
+			player.damageModifier = strDexMod / 300;
 		}
 		return;
 	case HeroClass::Bard:
 		if (player.isHoldingItem(ItemType::Sword)) {
-			player._pDamageMod = strDexMod / 150;
+			player.damageModifier = strDexMod / 150;
 		} else if (player.isHoldingItem(ItemType::Bow)) {
-			player._pDamageMod = strDexMod / 250;
+			player.damageModifier = strDexMod / 250;
 		} else {
-			player._pDamageMod = strMod / 100;
+			player.damageModifier = strMod / 100;
 		}
 		return;
 	case HeroClass::Barbarian:
 		if (player.isHoldingItem(ItemType::Axe) || player.isHoldingItem(ItemType::Mace)) {
-			player._pDamageMod = strMod / 75;
+			player.damageModifier = strMod / 75;
 		} else if (player.isHoldingItem(ItemType::Bow)) {
-			player._pDamageMod = strMod / 300;
+			player.damageModifier = strMod / 300;
 		} else {
-			player._pDamageMod = strMod / 100;
+			player.damageModifier = strMod / 100;
 		}
 		if (player.isHoldingItem(ItemType::Shield)) {
 			if (leftHandItem._itype == ItemType::Shield)
-				player._pIAC -= leftHandItem._iAC / 2;
+				player.armorClass -= leftHandItem._iAC / 2;
 			else if (rightHandItem._itype == ItemType::Shield)
-				player._pIAC -= rightHandItem._iAC / 2;
+				player.armorClass -= rightHandItem._iAC / 2;
 		} else if (!player.isHoldingItem(ItemType::Staff) && !player.isHoldingItem(ItemType::Bow)) {
-			player._pDamageMod += playerLevel * player._pVitality / 100;
+			player.damageModifier += playerLevel * player.vitality / 100;
 		}
-		player._pIAC += playerLevel / 4;
+		player.armorClass += playerLevel / 4;
 		return;
 	default:
-		player._pDamageMod = strMod / 100;
+		player.damageModifier = strMod / 100;
 		return;
 	}
 }
@@ -2668,13 +2668,13 @@ void CalcPlrResistances(Player &player, ItemSpecialEffect iflgs, int fire, int l
 {
 	const uint8_t playerLevel = player.getCharacterLevel();
 
-	if (player._pClass == HeroClass::Barbarian) {
+	if (player.heroClass == HeroClass::Barbarian) {
 		magic += playerLevel;
 		fire += playerLevel;
 		lightning += playerLevel;
 	}
 
-	if (HasAnyOf(player._pSpellFlags, SpellFlag::RageCooldown)) {
+	if (HasAnyOf(player.spellFlags, SpellFlag::RageCooldown)) {
 		magic -= playerLevel;
 		fire -= playerLevel;
 		lightning -= playerLevel;
@@ -2687,9 +2687,9 @@ void CalcPlrResistances(Player &player, ItemSpecialEffect iflgs, int fire, int l
 		lightning = 0;
 	}
 
-	player._pMagResist = std::clamp(magic, 0, MaxResistance);
-	player._pFireResist = std::clamp(fire, 0, MaxResistance);
-	player._pLghtResist = std::clamp(lightning, 0, MaxResistance);
+	player.resistMagic = std::clamp(magic, 0, MaxResistance);
+	player.resistFire = std::clamp(fire, 0, MaxResistance);
+	player.resistLightning = std::clamp(lightning, 0, MaxResistance);
 }
 
 void CalcPlrLifeMana(Player &player, int vitality, int magic, int life, int mana)
@@ -2701,40 +2701,40 @@ void CalcPlrLifeMana(Player &player, int vitality, int magic, int life, int mana
 	magic = (magic * playerClassAttributes.itmMana) >> 6;
 	mana += (magic << 6);
 
-	player._pMaxHP = life + player._pMaxHPBase;
-	player._pHitPoints = std::min(life + player._pHPBase, player._pMaxHP);
+	player.maxLife = life + player.baseMaxLife;
+	player.life = std::min(life + player.baseLife, player.maxLife);
 
-	if (&player == MyPlayer && (player._pHitPoints >> 6) <= 0) {
+	if (&player == MyPlayer && (player.life >> 6) <= 0) {
 		SetPlayerHitPoints(player, 0);
 	}
 
-	player._pMaxMana = mana + player._pMaxManaBase;
-	player._pMana = std::min(mana + player._pManaBase, player._pMaxMana);
+	player.maxMana = mana + player.baseMaxMana;
+	player.mana = std::min(mana + player.baseMana, player.maxMana);
 }
 
 void CalcPlrBlockFlag(Player &player)
 {
-	const auto &leftHandItem = player.InvBody[INVLOC_HAND_LEFT];
-	const auto &rightHandItem = player.InvBody[INVLOC_HAND_RIGHT];
+	const auto &leftHandItem = player.bodySlot[INVLOC_HAND_LEFT];
+	const auto &rightHandItem = player.bodySlot[INVLOC_HAND_RIGHT];
 
-	player._pBlockFlag = false;
+	player.hasBlockFlag = false;
 
-	if (player._pClass == HeroClass::Monk) {
+	if (player.heroClass == HeroClass::Monk) {
 		if (player.isHoldingItem(ItemType::Staff)) {
-			player._pBlockFlag = true;
-			player._pIFlags |= ItemSpecialEffect::FastBlock;
+			player.hasBlockFlag = true;
+			player.flags |= ItemSpecialEffect::FastBlock;
 		} else if ((leftHandItem.isEmpty() && rightHandItem.isEmpty()) || (leftHandItem._iClass == ICLASS_WEAPON && leftHandItem._iLoc != ILOC_TWOHAND && rightHandItem.isEmpty()) || (rightHandItem._iClass == ICLASS_WEAPON && rightHandItem._iLoc != ILOC_TWOHAND && leftHandItem.isEmpty())) {
-			player._pBlockFlag = true;
+			player.hasBlockFlag = true;
 		}
 	}
 
-	player._pBlockFlag = player._pBlockFlag || player.isHoldingItem(ItemType::Shield);
+	player.hasBlockFlag = player.hasBlockFlag || player.isHoldingItem(ItemType::Shield);
 }
 
 PlayerWeaponGraphic GetPlrAnimWeaponId(const Player &player)
 {
-	const Item &leftHandItem = player.InvBody[INVLOC_HAND_LEFT];
-	const Item &rightHandItem = player.InvBody[INVLOC_HAND_RIGHT];
+	const Item &leftHandItem = player.bodySlot[INVLOC_HAND_LEFT];
+	const Item &rightHandItem = player.bodySlot[INVLOC_HAND_RIGHT];
 	bool holdsShield = player.isHoldingItem(ItemType::Shield);
 	bool leftHandUsable = player.CanUseItem(leftHandItem);
 	bool rightHandUsable = player.CanUseItem(rightHandItem);
@@ -2766,29 +2766,29 @@ PlayerWeaponGraphic GetPlrAnimWeaponId(const Player &player)
 
 PlayerArmorGraphic GetPlrAnimArmorId(Player &player)
 {
-	const Item &chestItem = player.InvBody[INVLOC_CHEST];
+	const Item &chestItem = player.bodySlot[INVLOC_CHEST];
 	bool chestUsable = player.CanUseItem(chestItem);
 	const uint8_t playerLevel = player.getCharacterLevel();
 
 	if (chestUsable) {
 		switch (chestItem._itype) {
 		case ItemType::HeavyArmor:
-			if (player._pClass == HeroClass::Monk) {
+			if (player.heroClass == HeroClass::Monk) {
 				if (chestItem._iMagical == ITEM_QUALITY_UNIQUE)
-					player._pIAC += playerLevel / 2;
+					player.armorClass += playerLevel / 2;
 			}
 			return PlayerArmorGraphic::Heavy;
 		case ItemType::MediumArmor:
-			if (player._pClass == HeroClass::Monk) {
+			if (player.heroClass == HeroClass::Monk) {
 				if (chestItem._iMagical == ITEM_QUALITY_UNIQUE)
-					player._pIAC += playerLevel * 2;
+					player.armorClass += playerLevel * 2;
 				else
-					player._pIAC += playerLevel / 2;
+					player.armorClass += playerLevel / 2;
 			}
 			return PlayerArmorGraphic::Medium;
 		default:
-			if (player._pClass == HeroClass::Monk)
-				player._pIAC += playerLevel * 2;
+			if (player.heroClass == HeroClass::Monk)
+				player.armorClass += playerLevel * 2;
 			return PlayerArmorGraphic::Light;
 		}
 	}
@@ -2799,8 +2799,8 @@ PlayerArmorGraphic GetPlrAnimArmorId(Player &player)
 void CalcPlrGraphics(Player &player, PlayerWeaponGraphic animWeaponId, PlayerArmorGraphic animArmorId, bool loadgfx)
 {
 	const uint8_t gfxNum = static_cast<uint8_t>(animWeaponId) | static_cast<uint8_t>(animArmorId);
-	if (player._pgfxnum != gfxNum && loadgfx) {
-		player._pgfxnum = gfxNum;
+	if (player.graphic != gfxNum && loadgfx) {
+		player.graphic = gfxNum;
 		ResetPlayerGFX(player);
 		SetPlrAnims(player);
 		player.previewCelSprite = std::nullopt;
@@ -2811,10 +2811,10 @@ void CalcPlrGraphics(Player &player, PlayerWeaponGraphic animWeaponId, PlayerArm
 		LoadPlrGFX(player, graphic);
 		OptionalClxSpriteList sprites;
 		if (!HeadlessMode)
-			sprites = player.AnimationData[static_cast<size_t>(graphic)].spritesForDirection(player._pdir);
-		player.AnimInfo.changeAnimationData(sprites, numberOfFrames, ticksPerFrame);
+			sprites = player.animationData[static_cast<size_t>(graphic)].spritesForDirection(player.direction);
+		player.animationInfo.changeanimationData(sprites, numberOfFrames, ticksPerFrame);
 	} else {
-		player._pgfxnum = gfxNum;
+		player.graphic = gfxNum;
 	}
 }
 
@@ -2822,7 +2822,7 @@ void CalcPlrAuricBonus(Player &player)
 
 {
 	if (&player == MyPlayer) {
-		if (player.InvBody[INVLOC_AMULET].isEmpty() || player.InvBody[INVLOC_AMULET].IDidx != IDI_AURIC) {
+		if (player.bodySlot[INVLOC_AMULET].isEmpty() || player.bodySlot[INVLOC_AMULET].IDidx != IDI_AURIC) {
 			int half = MaxGold;
 			MaxGold = GOLD_MAX_LIMIT;
 
@@ -2874,7 +2874,7 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	int minLightDam = 0;
 	int maxLightDam = 0;
 
-	for (const Item &item : player.InvBody) {
+	for (const Item &item : player.bodySlot) {
 		if (!item.isEmpty() && item._iStatFlag) {
 
 			minDamage += item._iMinDam;
@@ -2915,26 +2915,26 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 
 	CalcPlrDamage(player, minDamage, maxDamage);
 	CalcPlrPrimaryStats(player, strength, magic, dexterity, vitality);
-	player._pIAC = ac;
-	player._pIBonusDam = dam;
-	player._pIBonusToHit = toHit;
-	player._pIBonusAC = bonusAc;
-	player._pIFlags = flags;
-	player.pDamAcFlags = damAcFlags;
-	player._pIBonusDamMod = damMod;
-	player._pIGetHit = getHit;
+	player.armorClass = ac;
+	player.bonusDamagePercent = dam;
+	player.bonusToHit = toHit;
+	player.bonusArmorClass = bonusAc;
+	player.flags = flags;
+	player.hellfireFlags = damAcFlags;
+	player.bonusDamage = damMod;
+	player.damageFromEnemies = getHit;
 	CalcPlrLightRadius(player, lightRadius);
 	CalcPlrDamageMod(player);
-	player._pISpells = spells;
+	player.staffSpells = spells;
 	EnsureValidReadiedSpell(player);
-	player._pISplLvlAdd = splLvlAdd;
-	player._pIEnAc = targetAc;
+	player.bonusSpellLevel = splLvlAdd;
+	player.armorPierce = targetAc;
 	CalcPlrResistances(player, flags, fireRes, lightRes, magicRes);
 	CalcPlrLifeMana(player, vitality, magic, life, mana);
-	player._pIFMinDam = minFireDam;
-	player._pIFMaxDam = maxFireDam;
-	player._pILMinDam = minLightDam;
-	player._pILMaxDam = maxLightDam;
+	player.minFireDamage = minFireDam;
+	player.maxFireDamage = maxFireDam;
+	player.minLightningDamage = minLightDam;
+	player.maxLightningDamage = maxLightDam;
 
 	CalcPlrBlockFlag(player);
 
@@ -3045,40 +3045,40 @@ void CreateStartingItem(Player &player, _item_indexes itemData)
 
 void CreatePlrItems(Player &player)
 {
-	for (auto &item : player.InvBody) {
+	for (auto &item : player.bodySlot) {
 		item.clear();
 	}
 
 	// converting this to a for loop creates a `rep stosd` instruction,
 	// so this probably actually was a memset
-	memset(&player.InvGrid, 0, sizeof(player.InvGrid));
+	memset(&player.inventoryGrid, 0, sizeof(player.inventoryGrid));
 
-	for (auto &item : player.InvList) {
+	for (auto &item : player.inventorySlot) {
 		item.clear();
 	}
 
-	player._pNumInv = 0;
+	player.numInventoryItems = 0;
 
-	for (auto &item : player.SpdList) {
+	for (auto &item : player.beltSlot) {
 		item.clear();
 	}
 
-	const PlayerStartingLoadoutData &loadout = GetPlayerStartingLoadoutForClass(player._pClass);
+	const PlayerStartingLoadoutData &loadout = GetPlayerStartingLoadoutForClass(player.heroClass);
 
 	if (loadout.spell != SpellID::Null && loadout.spellLevel > 0) {
-		player._pMemSpells = GetSpellBitmask(loadout.spell);
-		player._pRSplType = SpellType::Spell;
-		player._pRSpell = loadout.spell;
-		player._pSplLvl[static_cast<unsigned>(loadout.spell)] = loadout.spellLevel;
+		player.learnedSpells = GetSpellBitmask(loadout.spell);
+		player.selectedSpellType = SpellType::Spell;
+		player.selectedSpell = loadout.spell;
+		player.spellLevel[static_cast<unsigned>(loadout.spell)] = loadout.spellLevel;
 	} else {
-		player._pMemSpells = 0;
+		player.learnedSpells = 0;
 	}
 
 	if (loadout.skill != SpellID::Null) {
-		player._pAblSpells = GetSpellBitmask(loadout.skill);
-		if (player._pRSplType == SpellType::Invalid) {
-			player._pRSplType = SpellType::Skill;
-			player._pRSpell = loadout.skill;
+		player.skills = GetSpellBitmask(loadout.skill);
+		if (player.selectedSpellType == SpellType::Invalid) {
+			player.selectedSpellType = SpellType::Skill;
+			player.selectedSpell = loadout.skill;
 		}
 	}
 
@@ -3091,13 +3091,13 @@ void CreatePlrItems(Player &player)
 	FreeCursor();
 
 	if (loadout.gold > 0) {
-		Item &goldItem = player.InvList[player._pNumInv];
+		Item &goldItem = player.inventorySlot[player.numInventoryItems];
 		MakeGoldStack(goldItem, loadout.gold);
 
-		player._pNumInv++;
-		player.InvGrid[30] = player._pNumInv;
+		player.numInventoryItems++;
+		player.inventoryGrid[30] = player.numInventoryItems;
 
-		player._pGold = goldItem._ivalue;
+		player.gold = goldItem._ivalue;
 	}
 
 	CalcPlrItemVals(player, false);
@@ -3233,7 +3233,7 @@ void GetItemAttrs(Item &item, _item_indexes itemData, int lvl)
 
 void SetupItem(Item &item)
 {
-	item.setNewAnimation(MyPlayer != nullptr && MyPlayer->pLvlLoad == 0);
+	item.setNewAnimation(MyPlayer != nullptr && MyPlayer->levelLoading == 0);
 	item._iIdentified = false;
 }
 
@@ -3628,7 +3628,7 @@ void SpawnQuestItem(_item_indexes itemid, Point position, int randarea, int self
 	item._iPostDraw = true;
 	if (selflag != 0) {
 		item._iSelFlag = selflag;
-		item.AnimInfo.currentFrame = item.AnimInfo.numberOfFrames - 1;
+		item.animationInfo.currentFrame = item.animationInfo.numberOfFrames - 1;
 		item._iAnimFlag = false;
 	}
 
@@ -3717,18 +3717,18 @@ void ProcessItems()
 		auto &item = Items[ii];
 		if (!item._iAnimFlag)
 			continue;
-		item.AnimInfo.processAnimation();
+		item.animationInfo.processAnimation();
 		if (item._iCurs == ICURS_MAGIC_ROCK) {
-			if (item._iSelFlag == 1 && item.AnimInfo.currentFrame == 10)
-				item.AnimInfo.currentFrame = 0;
-			if (item._iSelFlag == 2 && item.AnimInfo.currentFrame == 20)
-				item.AnimInfo.currentFrame = 10;
+			if (item._iSelFlag == 1 && item.animationInfo.currentFrame == 10)
+				item.animationInfo.currentFrame = 0;
+			if (item._iSelFlag == 2 && item.animationInfo.currentFrame == 20)
+				item.animationInfo.currentFrame = 10;
 		} else {
-			if (item.AnimInfo.currentFrame == (item.AnimInfo.numberOfFrames - 1) / 2)
+			if (item.animationInfo.currentFrame == (item.animationInfo.numberOfFrames - 1) / 2)
 				PlaySfxLoc(ItemDropSnds[ItemCAnimTbl[item._iCurs]], item.position);
 
-			if (item.AnimInfo.isLastFrame()) {
-				item.AnimInfo.currentFrame = item.AnimInfo.numberOfFrames - 1;
+			if (item.animationInfo.isLastFrame()) {
+				item.animationInfo.currentFrame = item.animationInfo.numberOfFrames - 1;
 				item._iAnimFlag = false;
 				item._iSelFlag = 1;
 			}
@@ -3748,7 +3748,7 @@ void GetItemFrm(Item &item)
 {
 	int it = ItemCAnimTbl[item._iCurs];
 	if (itemanims[it])
-		item.AnimInfo.sprites.emplace(*itemanims[it]);
+		item.animationInfo.sprites.emplace(*itemanims[it]);
 }
 
 void GetItemStr(Item &item)
@@ -3767,9 +3767,9 @@ void CheckIdentify(Player &player, int cii)
 	Item *pi;
 
 	if (cii >= NUM_INVLOC)
-		pi = &player.InvList[cii - NUM_INVLOC];
+		pi = &player.inventorySlot[cii - NUM_INVLOC];
 	else
-		pi = &player.InvBody[cii];
+		pi = &player.bodySlot[cii];
 
 	pi->_iIdentified = true;
 	CalcPlrInv(player, true);
@@ -3782,9 +3782,9 @@ void DoRepair(Player &player, int cii)
 	PlaySfxLoc(SfxID::SpellRepair, player.position.tile);
 
 	if (cii >= NUM_INVLOC) {
-		pi = &player.InvList[cii - NUM_INVLOC];
+		pi = &player.inventorySlot[cii - NUM_INVLOC];
 	} else {
-		pi = &player.InvBody[cii];
+		pi = &player.bodySlot[cii];
 	}
 
 	RepairItem(*pi, player.getCharacterLevel());
@@ -3796,9 +3796,9 @@ void DoRecharge(Player &player, int cii)
 	Item *pi;
 
 	if (cii >= NUM_INVLOC) {
-		pi = &player.InvList[cii - NUM_INVLOC];
+		pi = &player.inventorySlot[cii - NUM_INVLOC];
 	} else {
-		pi = &player.InvBody[cii];
+		pi = &player.bodySlot[cii];
 	}
 
 	RechargeItem(*pi, player);
@@ -3809,9 +3809,9 @@ bool DoOil(Player &player, int cii)
 {
 	Item *pi;
 	if (cii >= NUM_INVLOC) {
-		pi = &player.InvList[cii - NUM_INVLOC];
+		pi = &player.inventorySlot[cii - NUM_INVLOC];
 	} else {
-		pi = &player.InvBody[cii];
+		pi = &player.bodySlot[cii];
 	}
 	if (!ApplyOilToItem(*pi, player))
 		return false;
@@ -4208,23 +4208,23 @@ void UseItem(Player &player, item_misc_id mid, SpellID spellID, int spellFrom)
 			// will be validated when processing the network message
 			Point target = cursPosition;
 			if (!InDungeonBounds(target))
-				target = player.position.future + Displacement(player._pdir);
+				target = player.position.future + Displacement(player.direction);
 			// Use CMD_SPELLXY because it's the same behavior as normal casting
 			assert(IsValidSpellFrom(spellFrom));
 			NetSendCmdLocParam4(true, CMD_SPELLXY, target, static_cast<int8_t>(spellID), static_cast<uint8_t>(SpellType::Scroll), spellLevel, static_cast<uint16_t>(spellFrom));
 		}
 		break;
 	case IMISC_BOOK: {
-		uint8_t newSpellLevel = player._pSplLvl[static_cast<int8_t>(spellID)] + 1;
+		uint8_t newSpellLevel = player.spellLevel[static_cast<int8_t>(spellID)] + 1;
 		if (newSpellLevel <= MaxSpellLevel) {
-			player._pSplLvl[static_cast<int8_t>(spellID)] = newSpellLevel;
+			player.spellLevel[static_cast<int8_t>(spellID)] = newSpellLevel;
 			NetSendCmdParam2(true, CMD_CHANGE_SPELL_LEVEL, static_cast<uint16_t>(spellID), newSpellLevel);
 		}
-		if (HasNoneOf(player._pIFlags, ItemSpecialEffect::NoMana)) {
-			player._pMana += GetSpellData(spellID).sManaCost << 6;
-			player._pMana = std::min(player._pMana, player._pMaxMana);
-			player._pManaBase += GetSpellData(spellID).sManaCost << 6;
-			player._pManaBase = std::min(player._pManaBase, player._pMaxManaBase);
+		if (HasNoneOf(player.flags, ItemSpecialEffect::NoMana)) {
+			player.mana += GetSpellData(spellID).sManaCost << 6;
+			player.mana = std::min(player.mana, player.maxMana);
+			player.baseMana += GetSpellData(spellID).sManaCost << 6;
+			player.baseMana = std::min(player.baseMana, player.baseMaxMana);
 		}
 		if (&player == MyPlayer) {
 			for (Item &item : InventoryPlayerItemsRange { player }) {
@@ -4249,7 +4249,7 @@ void UseItem(Player &player, item_misc_id mid, SpellID spellID, int spellFrom)
 	case IMISC_OILPERM:
 	case IMISC_OILHARD:
 	case IMISC_OILIMP:
-		player._pOilType = mid;
+		player.oilType = mid;
 		if (&player != MyPlayer) {
 			return;
 		}
@@ -4459,10 +4459,10 @@ void SpawnBoy(int lvl)
 
 	Player &myPlayer = *MyPlayer;
 
-	HeroClass pc = myPlayer._pClass;
-	int strength = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength), myPlayer._pStrength);
-	int dexterity = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity), myPlayer._pDexterity);
-	int magic = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic), myPlayer._pMagic);
+	HeroClass pc = myPlayer.heroClass;
+	int strength = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength), myPlayer.strength);
+	int dexterity = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity), myPlayer.dexterity);
+	int magic = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic), myPlayer.magic);
 	strength += strength / 5;
 	dexterity += dexterity / 5;
 	magic += magic / 5;
@@ -4611,7 +4611,7 @@ void MakeGoldStack(Item &goldItem, int value)
 int ItemNoFlippy()
 {
 	int r = ActiveItems[ActiveItemCount - 1];
-	Items[r].AnimInfo.currentFrame = Items[r].AnimInfo.numberOfFrames - 1;
+	Items[r].animationInfo.currentFrame = Items[r].animationInfo.numberOfFrames - 1;
 	Items[r]._iAnimFlag = false;
 	Items[r]._iSelFlag = 1;
 
@@ -4866,16 +4866,16 @@ void Item::setNewAnimation(bool showAnimation)
 	int8_t numberOfFrames = ItemAnimLs[it];
 	OptionalClxSpriteList sprite = itemanims[it] ? OptionalClxSpriteList { *itemanims[static_cast<size_t>(it)] } : std::nullopt;
 	if (_iCurs != ICURS_MAGIC_ROCK)
-		AnimInfo.setNewAnimation(sprite, numberOfFrames, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
+		animationInfo.setNewAnimation(sprite, numberOfFrames, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
 	else
-		AnimInfo.setNewAnimation(sprite, numberOfFrames, 1);
+		animationInfo.setNewAnimation(sprite, numberOfFrames, 1);
 	_iPostDraw = false;
 	_iRequest = false;
 	if (showAnimation) {
 		_iAnimFlag = true;
 		_iSelFlag = 0;
 	} else {
-		AnimInfo.currentFrame = AnimInfo.numberOfFrames - 1;
+		animationInfo.currentFrame = animationInfo.numberOfFrames - 1;
 		_iAnimFlag = false;
 		_iSelFlag = 1;
 	}
@@ -4885,7 +4885,7 @@ void Item::updateRequiredStatsCacheForPlayer(const Player &player)
 {
 	if (_itype == ItemType::Misc && _iMiscId == IMISC_BOOK) {
 		_iMinMag = GetSpellData(_iSpell).minInt;
-		int8_t spellLevel = player._pSplLvl[static_cast<int8_t>(_iSpell)];
+		int8_t spellLevel = player.spellLevel[static_cast<int8_t>(_iSpell)];
 		while (spellLevel != 0) {
 			_iMinMag += 20 * _iMinMag / 100;
 			spellLevel--;
@@ -4968,16 +4968,16 @@ void RechargeItem(Item &item, Player &player)
 
 	if (&player != MyPlayer)
 		return;
-	if (&item == &player.InvBody[INVLOC_HAND_LEFT]) {
+	if (&item == &player.bodySlot[INVLOC_HAND_LEFT]) {
 		NetSendCmdChItem(true, INVLOC_HAND_LEFT);
 		return;
 	}
-	if (&item == &player.InvBody[INVLOC_HAND_RIGHT]) {
+	if (&item == &player.bodySlot[INVLOC_HAND_RIGHT]) {
 		NetSendCmdChItem(true, INVLOC_HAND_RIGHT);
 		return;
 	}
-	for (int i = 0; i < player._pNumInv; i++) {
-		if (&item == &player.InvList[i]) {
+	for (int i = 0; i < player.numInventoryItems; i++) {
+		if (&item == &player.inventorySlot[i]) {
 			NetSyncInvItem(player, i);
 			break;
 		}
@@ -4998,7 +4998,7 @@ bool ApplyOilToItem(Item &item, Player &player)
 		return false;
 	}
 
-	switch (player._pOilType) {
+	switch (player.oilType) {
 	case IMISC_OILACC:
 	case IMISC_OILMAST:
 	case IMISC_OILSHARP:
@@ -5024,7 +5024,7 @@ bool ApplyOilToItem(Item &item, Player &player)
 		break;
 	}
 
-	switch (player._pOilType) {
+	switch (player.oilType) {
 	case IMISC_OILACC:
 		if (item._iPLToHit < 50) {
 			item._iPLToHit += RandomIntBetween(1, 2);

--- a/Source/items.h
+++ b/Source/items.h
@@ -186,7 +186,7 @@ struct Item {
 	/*
 	 * @brief Contains Information for current Animation
 	 */
-	AnimationInfo AnimInfo;
+	PlayerAnimationInfo animationInfo;
 	bool _iDelFlag = false; // set when item is flagged for deletion, deprecated in 1.02
 	uint8_t _iSelFlag = 0;
 	bool _iPostDraw = false;

--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -1129,9 +1129,9 @@ bool PlaceCathedralStairs(lvl_entry entry)
 	}
 
 	// Place stairs up
-	position = PlaceMiniSet(MyPlayer->pOriginalCathedral && !Quests[Q_LTBANNER].IsAvailable() ? L5STAIRSUP : STAIRSUP, DMAXX * DMAXY, true);
+	position = PlaceMiniSet(MyPlayer->originalCathedral && !Quests[Q_LTBANNER].IsAvailable() ? L5STAIRSUP : STAIRSUP, DMAXX * DMAXY, true);
 	if (!position) {
-		if (MyPlayer->pOriginalCathedral)
+		if (MyPlayer->originalCathedral)
 			return false;
 		success = false;
 	} else if (entry == ENTRY_MAIN) {

--- a/Source/levels/trigs.cpp
+++ b/Source/levels/trigs.cpp
@@ -81,11 +81,11 @@ bool IsWarpOpen(dungeon_type type)
 
 	Player &myPlayer = *MyPlayer;
 
-	if (type == DTYPE_CATACOMBS && (myPlayer.pTownWarps & 1) != 0)
+	if (type == DTYPE_CATACOMBS && (myPlayer.townWarps & 1) != 0)
 		return true;
-	if (type == DTYPE_CAVES && (myPlayer.pTownWarps & 2) != 0)
+	if (type == DTYPE_CAVES && (myPlayer.townWarps & 2) != 0)
 		return true;
-	if (type == DTYPE_HELL && (myPlayer.pTownWarps & 4) != 0)
+	if (type == DTYPE_HELL && (myPlayer.townWarps & 4) != 0)
 		return true;
 
 	if (gbIsHellfire) {
@@ -863,7 +863,7 @@ void CheckTriggers()
 {
 	Player &myPlayer = *MyPlayer;
 
-	if (myPlayer._pmode != PM_STAND)
+	if (myPlayer.mode != PM_STAND)
 		return;
 
 	for (int i = 0; i < numtrigs; i++) {

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -435,8 +435,8 @@ void ToggleLighting()
 
 	memcpy(dLight, dPreLight, sizeof(dLight));
 	for (const Player &player : Players) {
-		if (player.plractive && player.isOnActiveLevel()) {
-			DoLighting(player.position.tile, player._pLightRad, {});
+		if (player.isPlayerActive && player.isOnActiveLevel()) {
+			DoLighting(player.position.tile, player.lightRadius, {});
 		}
 	}
 }
@@ -651,7 +651,7 @@ void ProcessVisionList()
 		if (!VisionActive[id])
 			continue;
 		Light &vision = VisionList[id];
-		if (!player.plractive || !player.isOnActiveLevel()) {
+		if (!player.isPlayerActive || !player.isOnActiveLevel()) {
 			DoUnVision(vision.position.tile, vision.radius);
 			VisionActive[id] = false;
 			continue;
@@ -668,7 +668,7 @@ void ProcessVisionList()
 		Light &vision = VisionList[id];
 		MapExplorationType doautomap = MAP_EXP_SELF;
 		if (&player != MyPlayer)
-			doautomap = player.friendlyMode ? MAP_EXP_OTHERS : MAP_EXP_NONE;
+			doautomap = player.isFriendlyMode ? MAP_EXP_OTHERS : MAP_EXP_NONE;
 		DoVision(
 		    vision.position.tile,
 		    vision.radius,

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -387,9 +387,9 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	file.Skip(3);        // Alignment
 	player.selectedSpell = static_cast<SpellID>(file.NextLE<int32_t>());
 	player.selectedSpellType = static_cast<SpellType>(file.NextLE<int8_t>());
-	file.Skip(3); // Alignment
+	file.Skip(3);         // Alignment
 	file.Skip<int32_t>(); // Skip _pSBkSpell
-	file.Skip<int8_t>(); // Skip _pSBkSplType
+	file.Skip<int8_t>();  // Skip _pSBkSplType
 
 	// Only read spell levels for learnable spells
 	for (int i = 0; i < static_cast<int>(SpellID::LAST); i++) {
@@ -459,7 +459,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player.experience = file.NextLE<uint32_t>();
 	file.Skip<uint32_t>(); // Skip _pMaxExp - unused
 	file.Skip<uint32_t>(); // Skip _pNextExper, we retrieve it when needed based on characterLevel
-	file.Skip<int8_t>(); // Skip _pArmorClass - unused
+	file.Skip<int8_t>();   // Skip _pArmorClass - unused
 	player.resistMagic = file.NextLE<int8_t>();
 	player.resistFire = file.NextLE<int8_t>();
 	player.resistLightning = file.NextLE<int8_t>();
@@ -1224,9 +1224,9 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.Skip(3);        // Alignment
 	file.WriteLE<int32_t>(static_cast<int8_t>(player.selectedSpell));
 	file.WriteLE<int8_t>(static_cast<uint8_t>(player.selectedSpellType));
-	file.Skip(3); // Alignment
+	file.Skip(3);         // Alignment
 	file.Skip<int32_t>(); // Skip _pSBkSpell
-	file.Skip<int8_t>(); // Skip _pSBkSplType
+	file.Skip<int8_t>();  // Skip _pSBkSplType
 
 	for (uint8_t spellLevel : player.spellLevel)
 		file.WriteLE<uint8_t>(spellLevel);
@@ -1283,7 +1283,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<uint32_t>(player.experience);
 	file.Skip<uint32_t>();                                       // Skip _pMaxExp
 	file.WriteLE<uint32_t>(player.getNextExperienceThreshold()); // set _pNextExper for backwards compatibility
-	file.Skip<int8_t>(); // Skip _pArmorClass
+	file.Skip<int8_t>();                                         // Skip _pArmorClass
 	file.WriteLE<int8_t>(player.resistMagic);
 	file.WriteLE<int8_t>(player.resistFire);
 	file.WriteLE<int8_t>(player.resistLightning);

--- a/Source/lua/modules/dev/items.cpp
+++ b/Source/lua/modules/dev/items.cpp
@@ -20,13 +20,13 @@ std::string DebugCmdItemInfo()
 {
 	Player &myPlayer = *MyPlayer;
 	Item *pItem = nullptr;
-	if (!myPlayer.HoldItem.isEmpty()) {
-		pItem = &myPlayer.HoldItem;
+	if (!myPlayer.heldItem.isEmpty()) {
+		pItem = &myPlayer.heldItem;
 	} else if (pcursinvitem != -1) {
 		if (pcursinvitem <= INVITEM_INV_LAST)
-			pItem = &myPlayer.InvList[pcursinvitem - INVITEM_INV_FIRST];
+			pItem = &myPlayer.inventorySlot[pcursinvitem - INVITEM_INV_FIRST];
 		else
-			pItem = &myPlayer.SpdList[pcursinvitem - INVITEM_BELT_FIRST];
+			pItem = &myPlayer.beltSlot[pcursinvitem - INVITEM_BELT_FIRST];
 	} else if (pcursitem != -1) {
 		pItem = &Items[pcursitem];
 	}

--- a/Source/lua/modules/dev/level.cpp
+++ b/Source/lua/modules/dev/level.cpp
@@ -97,7 +97,7 @@ std::string DebugCmdResetLevel(uint8_t level, std::optional<int> seed)
 	if (myPlayer.isOnLevel(level))
 		return "Unable to reset dungeon levels occupied by players!";
 
-	myPlayer._pLvlVisited[level] = false;
+	myPlayer.isLevelVisted[level] = false;
 	DeltaClearLevel(level);
 
 	if (seed.has_value()) {

--- a/Source/lua/modules/dev/monsters.cpp
+++ b/Source/lua/modules/dev/monsters.cpp
@@ -74,7 +74,7 @@ std::string DebugCmdSpawnUniqueMonster(std::string name, std::optional<unsigned>
 		if (!IsTileWalkable(pos))
 			return {};
 
-		Monster *monster = AddMonster(pos, myPlayer._pdir, id, true);
+		Monster *monster = AddMonster(pos, myPlayer.direction, id, true);
 		if (monster == nullptr)
 			return StrCat("Spawned ", spawnedMonster, " monsters. (Unable to spawn more)");
 		PrepareUniqueMonst(*monster, uniqueIndex, 0, 0, UniqueMonstersData[static_cast<size_t>(uniqueIndex)]);
@@ -150,7 +150,7 @@ std::string DebugCmdSpawnMonster(std::string name, std::optional<unsigned> count
 		if (!IsTileWalkable(pos))
 			return false;
 
-		SpawnMonster(pos, myPlayer._pdir, id);
+		SpawnMonster(pos, myPlayer.direction, id);
 		spawnedMonster += 1;
 
 		return spawnedMonster == monstersToSpawn;

--- a/Source/lua/modules/dev/player.cpp
+++ b/Source/lua/modules/dev/player.cpp
@@ -22,17 +22,17 @@ std::string DebugCmdArrow(std::string_view effect)
 {
 	Player &myPlayer = *MyPlayer;
 
-	myPlayer._pIFlags &= ~ItemSpecialEffect::FireArrows;
-	myPlayer._pIFlags &= ~ItemSpecialEffect::LightningArrows;
+	myPlayer.flags &= ~ItemSpecialEffect::FireArrows;
+	myPlayer.flags &= ~ItemSpecialEffect::LightningArrows;
 
 	if (effect == "normal") {
 		// we removed the parameter at the top
 	} else if (effect == "fire") {
-		myPlayer._pIFlags |= ItemSpecialEffect::FireArrows;
+		myPlayer.flags |= ItemSpecialEffect::FireArrows;
 	} else if (effect == "lightning") {
-		myPlayer._pIFlags |= ItemSpecialEffect::LightningArrows;
+		myPlayer.flags |= ItemSpecialEffect::LightningArrows;
 	} else if (effect == "spectral") {
-		myPlayer._pIFlags |= (ItemSpecialEffect::FireArrows | ItemSpecialEffect::LightningArrows);
+		myPlayer.flags |= (ItemSpecialEffect::FireArrows | ItemSpecialEffect::LightningArrows);
 	} else {
 		return "Invalid effect!";
 	}
@@ -52,15 +52,15 @@ std::string DebugCmdPlayerInfo(std::optional<uint8_t> id)
 	if (playerId >= Players.size())
 		return StrCat("Invalid player ID (max: ", Players.size() - 1, ")");
 	Player &player = Players[playerId];
-	if (!player.plractive)
+	if (!player.isPlayerActive)
 		return StrCat("Player ", playerId, " is not active!");
 
 	const Point target = player.GetTargetPosition();
-	return StrCat("Plr ", playerId, " is ", player._pName,
-	    "\nLvl: ", player.plrlevel, " Changing: ", player._pLvlChanging,
+	return StrCat("Plr ", playerId, " is ", player.name,
+	    "\nLvl: ", player.dungeonLevel, " Changing: ", player.isChangingLevel,
 	    "\nTile.x: ", player.position.tile.x, " Tile.y: ", player.position.tile.y, " Target.x: ", target.x, " Target.y: ", target.y,
-	    "\nMode: ", player._pmode, " destAction: ", player.destAction, " walkpath[0]: ", player.walkpath[0],
-	    "\nInvincible: ", player._pInvincible ? 1 : 0, " HitPoints: ", player._pHitPoints);
+	    "\nMode: ", player.mode, " destinationAction: ", player.destinationAction, " walkPath[0]: ", player.walkPath[0],
+	    "\nInvincible: ", player.isInvincible ? 1 : 0, " HitPoints: ", player.life);
 }
 
 std::string DebugSetPlayerTrn(std::string_view path)
@@ -74,7 +74,7 @@ std::string DebugSetPlayerTrn(std::string_view path)
 	debugTRN = path;
 	Player &player = *MyPlayer;
 	InitPlayerGFX(player);
-	StartStand(player, player._pdir);
+	StartStand(player, player.direction);
 	return path.empty() ? "TRN unset" : "TRN set";
 }
 

--- a/Source/lua/modules/dev/player/gold.cpp
+++ b/Source/lua/modules/dev/player/gold.cpp
@@ -19,12 +19,12 @@ std::string DebugCmdGiveGoldCheat(std::optional<int> amount)
 	int goldToAdd = amount.value_or(GOLD_MAX_LIMIT * InventoryGridCells);
 	if (goldToAdd <= 0) return "amount must be positive";
 	Player &myPlayer = *MyPlayer;
-	const int goldAmountBefore = myPlayer._pGold;
-	for (int8_t &itemIndex : myPlayer.InvGrid) {
+	const int goldAmountBefore = myPlayer.gold;
+	for (int8_t &itemIndex : myPlayer.inventoryGrid) {
 		if (itemIndex < 0)
 			continue;
 
-		Item &item = myPlayer.InvList[itemIndex != 0 ? itemIndex - 1 : myPlayer._pNumInv];
+		Item &item = myPlayer.inventorySlot[itemIndex != 0 ? itemIndex - 1 : myPlayer.numInventoryItems];
 
 		if (itemIndex != 0) {
 			if ((!item.isGold() && !item.isEmpty()) || (item.isGold() && item._ivalue == GOLD_MAX_LIMIT))
@@ -32,26 +32,26 @@ std::string DebugCmdGiveGoldCheat(std::optional<int> amount)
 		} else {
 			if (item.isEmpty()) {
 				MakeGoldStack(item, 0);
-				myPlayer._pNumInv++;
-				itemIndex = myPlayer._pNumInv;
+				myPlayer.numInventoryItems++;
+				itemIndex = myPlayer.numInventoryItems;
 			}
 		}
 
 		int goldThatCanBeAdded = (GOLD_MAX_LIMIT - item._ivalue);
 		if (goldThatCanBeAdded >= goldToAdd) {
 			item._ivalue += goldToAdd;
-			myPlayer._pGold += goldToAdd;
+			myPlayer.gold += goldToAdd;
 			break;
 		}
 
 		item._ivalue += goldThatCanBeAdded;
 		goldToAdd -= goldThatCanBeAdded;
-		myPlayer._pGold += goldThatCanBeAdded;
+		myPlayer.gold += goldThatCanBeAdded;
 	}
 
 	CalcPlrInv(myPlayer, true);
 
-	return StrCat("Set your gold to ", myPlayer._pGold, ", added ", myPlayer._pGold - goldAmountBefore, ".");
+	return StrCat("Set your gold to ", myPlayer.gold, ", added ", myPlayer.gold - goldAmountBefore, ".");
 }
 
 std::string DebugCmdTakeGoldCheat(std::optional<int> amount)
@@ -60,31 +60,31 @@ std::string DebugCmdTakeGoldCheat(std::optional<int> amount)
 	int goldToRemove = amount.value_or(GOLD_MAX_LIMIT * InventoryGridCells);
 	if (goldToRemove <= 0) return "amount must be positive";
 
-	const int goldAmountBefore = myPlayer._pGold;
-	for (auto itemIndex : myPlayer.InvGrid) {
+	const int goldAmountBefore = myPlayer.gold;
+	for (auto itemIndex : myPlayer.inventoryGrid) {
 		itemIndex -= 1;
 
 		if (itemIndex < 0)
 			continue;
 
-		Item &item = myPlayer.InvList[itemIndex];
+		Item &item = myPlayer.inventorySlot[itemIndex];
 		if (!item.isGold())
 			continue;
 
 		if (item._ivalue >= goldToRemove) {
-			myPlayer._pGold -= goldToRemove;
+			myPlayer.gold -= goldToRemove;
 			item._ivalue -= goldToRemove;
 			if (item._ivalue == 0)
 				myPlayer.RemoveInvItem(itemIndex);
 			break;
 		}
 
-		myPlayer._pGold -= item._ivalue;
+		myPlayer.gold -= item._ivalue;
 		goldToRemove -= item._ivalue;
 		myPlayer.RemoveInvItem(itemIndex);
 	}
 
-	return StrCat("Set your gold to ", myPlayer._pGold, ", removed ", goldAmountBefore - myPlayer._pGold, ".");
+	return StrCat("Set your gold to ", myPlayer.gold, ", removed ", goldAmountBefore - myPlayer.gold, ".");
 }
 
 } // namespace

--- a/Source/lua/modules/dev/player/spells.cpp
+++ b/Source/lua/modules/dev/player/spells.cpp
@@ -22,7 +22,7 @@ std::string DebugCmdSetSpellsLevel(uint8_t level)
 		}
 	}
 	if (level == 0)
-		MyPlayer->_pMemSpells = 0;
+		MyPlayer->learnedSpells = 0;
 
 	return StrCat("Set all spell levels to ", level);
 }

--- a/Source/lua/modules/dev/player/stats.cpp
+++ b/Source/lua/modules/dev/player/stats.cpp
@@ -27,20 +27,20 @@ std::string DebugCmdLevelUp(std::optional<int> levels)
 std::string DebugCmdMaxStats()
 {
 	Player &myPlayer = *MyPlayer;
-	ModifyPlrStr(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength) - myPlayer._pBaseStr);
-	ModifyPlrMag(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic) - myPlayer._pBaseMag);
-	ModifyPlrDex(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity) - myPlayer._pBaseDex);
-	ModifyPlrVit(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Vitality) - myPlayer._pBaseVit);
+	ModifyPlrStr(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength) - myPlayer.baseStrength);
+	ModifyPlrMag(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic) - myPlayer.baseMagic);
+	ModifyPlrDex(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity) - myPlayer.baseDexterity);
+	ModifyPlrVit(myPlayer, myPlayer.GetMaximumAttributeValue(CharacterAttribute::Vitality) - myPlayer.baseVitality);
 	return "Set all character base attributes to maximum.";
 }
 
 std::string DebugCmdMinStats()
 {
 	Player &myPlayer = *MyPlayer;
-	ModifyPlrStr(myPlayer, -myPlayer._pBaseStr);
-	ModifyPlrMag(myPlayer, -myPlayer._pBaseMag);
-	ModifyPlrDex(myPlayer, -myPlayer._pBaseDex);
-	ModifyPlrVit(myPlayer, -myPlayer._pBaseVit);
+	ModifyPlrStr(myPlayer, -myPlayer.baseStrength);
+	ModifyPlrMag(myPlayer, -myPlayer.baseMagic);
+	ModifyPlrDex(myPlayer, -myPlayer.baseDexterity);
+	ModifyPlrVit(myPlayer, -myPlayer.baseVitality);
 	return "Set all character base attributes to minimum.";
 }
 
@@ -60,7 +60,7 @@ std::string DebugCmdChangeHealth(int change)
 	if (change == 0)
 		return StrCat("Enter a value not equal to 0 to change life!");
 
-	int newHealth = myPlayer._pHitPoints + (change * 64);
+	int newHealth = myPlayer.life + (change * 64);
 	SetPlayerHitPoints(myPlayer, newHealth);
 	if (newHealth <= 0)
 		SyncPlrKill(myPlayer, DeathReason::MonsterOrTrap);
@@ -74,9 +74,9 @@ std::string DebugCmdChangeMana(int change)
 	if (change == 0)
 		return StrCat("Enter a value not equal to 0 to change mana!");
 
-	int newMana = myPlayer._pMana + (change * 64);
-	myPlayer._pMana = newMana;
-	myPlayer._pManaBase = myPlayer._pMana + myPlayer._pMaxManaBase - myPlayer._pMaxMana;
+	int newMana = myPlayer.mana + (change * 64);
+	myPlayer.mana = newMana;
+	myPlayer.baseMana = myPlayer.mana + myPlayer.baseMaxMana - myPlayer.maxMana;
 	RedrawComponent(PanelDrawComponent::Mana);
 
 	return StrCat("Changed mana by ", change);

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -136,7 +136,7 @@ void InitQuestText()
 void InitQTextMsg(_speech_id m)
 {
 	SfxID sfxnr = Speeches[m].sfxnr;
-	const SfxID *classSounds = herosounds[static_cast<size_t>(MyPlayer->_pClass)];
+	const SfxID *classSounds = herosounds[static_cast<size_t>(MyPlayer->heroClass)];
 	switch (sfxnr) {
 	case SfxID::Warrior1:
 		sfxnr = classSounds[static_cast<size_t>(HeroSpeech::ChamberOfBoneLore)];

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -454,7 +454,7 @@ void ProcessBoneSpirit(Missile &missile);
 void ProcessResurrectBeam(Missile &missile);
 void ProcessRedPortal(Missile &missile);
 void ProcessMissiles();
-void SetUpMissileAnimationData();
+void SetUpMissileanimationData();
 void RedoMissileFlags();
 
 #ifdef BUILD_TESTING

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -212,7 +212,7 @@ struct Monster { // note: missing field _mAFNum
 	/**
 	 * @brief Contains information for current animation
 	 */
-	AnimationInfo animInfo;
+	PlayerAnimationInfo animationInfo;
 	int maxHitPoints;
 	int hitPoints;
 	uint32_t flags;
@@ -288,21 +288,21 @@ struct Monster { // note: missing field _mAFNum
 	 * @param graphic Animation sequence of interest
 	 * @param desiredDirection Desired desiredDirection the monster should be visually facing
 	 */
-	void changeAnimationData(MonsterGraphic graphic, Direction desiredDirection)
+	void changeanimationData(MonsterGraphic graphic, Direction desiredDirection)
 	{
 		const AnimStruct &animationData = type().getAnimData(graphic);
 
 		// Passing the frames and rate properties here is only relevant when initialising a monster, but doesn't cause any harm when switching animations.
-		this->animInfo.changeAnimationData(animationData.spritesForDirection(desiredDirection), animationData.frames, animationData.rate);
+		this->animationInfo.changeanimationData(animationData.spritesForDirection(desiredDirection), animationData.frames, animationData.rate);
 	}
 
 	/**
 	 * @brief Sets the current cell sprite to match the desired animation sequence using the direction the monster is currently facing
 	 * @param graphic Animation sequence of interest
 	 */
-	void changeAnimationData(MonsterGraphic graphic)
+	void changeanimationData(MonsterGraphic graphic)
 	{
-		this->changeAnimationData(graphic, this->direction);
+		this->changeanimationData(graphic, this->direction);
 	}
 
 	/**
@@ -460,7 +460,7 @@ struct Monster { // note: missing field _mAFNum
 	{
 		Displacement offset = { -CalculateWidth2(sprite.width()), 0 };
 		if (isWalking())
-			offset += GetOffsetForWalking(animInfo, direction);
+			offset += GetOffsetForWalking(animationInfo, direction);
 		return offset;
 	}
 

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -50,7 +50,7 @@
 	do {                                                      \
 		if (!(condition)) {                                   \
 			LogFailedPacket(#condition, #logValue, logValue); \
-			EventFailedPacket(player.name);                 \
+			EventFailedPacket(player.name);                   \
 			return false;                                     \
 		}                                                     \
 	} while (0)
@@ -59,7 +59,7 @@
 	do {                                                                               \
 		if (!(condition)) {                                                            \
 			LogFailedPacket(#condition, #logValue1, logValue1, #logValue2, logValue2); \
-			EventFailedPacket(player.name);                                          \
+			EventFailedPacket(player.name);                                            \
 			return false;                                                              \
 		}                                                                              \
 	} while (0)

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -50,7 +50,7 @@
 	do {                                                      \
 		if (!(condition)) {                                   \
 			LogFailedPacket(#condition, #logValue, logValue); \
-			EventFailedPacket(player._pName);                 \
+			EventFailedPacket(player.name);                 \
 			return false;                                     \
 		}                                                     \
 	} while (0)
@@ -59,7 +59,7 @@
 	do {                                                                               \
 		if (!(condition)) {                                                            \
 			LogFailedPacket(#condition, #logValue1, logValue1, #logValue2, logValue2); \
-			EventFailedPacket(player._pName);                                          \
+			EventFailedPacket(player.name);                                          \
 			return false;                                                              \
 		}                                                                              \
 	} while (0)
@@ -329,7 +329,7 @@ Point GetItemPosition(Point position)
 bool WasPlayerCmdAlreadyRequested(_cmd_id bCmd, Point position = {}, uint16_t wParam1 = 0, uint16_t wParam2 = 0, uint16_t wParam3 = 0, uint16_t wParam4 = 0, uint16_t wParam5 = 0)
 {
 	switch (bCmd) {
-	// All known commands that result in a changed player action (player.destAction)
+	// All known commands that result in a changed player action (player.destinationAction)
 	case _cmd_id::CMD_RATTACKID:
 	case _cmd_id::CMD_SPELLID:
 	case _cmd_id::CMD_ATTACKID:
@@ -940,7 +940,7 @@ size_t OnWalk(const TCmd *pCmd, Player &player)
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && InDungeonBounds(position)) {
 		ClrPlrPath(player);
 		MakePlrPath(player, position, true);
-		player.destAction = ACTION_NONE;
+		player.destinationAction = ACTION_NONE;
 	}
 
 	return sizeof(message);
@@ -1001,8 +1001,8 @@ size_t OnGotoGetItem(const TCmd *pCmd, Player &player)
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && InDungeonBounds(position) && SDL_SwapLE16(message.wParam1) < MAXITEMS + 1) {
 		MakePlrPath(player, position, false);
-		player.destAction = ACTION_PICKUPITEM;
-		player.destParam1 = SDL_SwapLE16(message.wParam1);
+		player.destinationAction = ACTION_PICKUPITEM;
+		player.destinationParam1 = SDL_SwapLE16(message.wParam1);
 	}
 
 	return sizeof(message);
@@ -1249,8 +1249,8 @@ size_t OnGotoAutoGetItem(const TCmd *pCmd, Player &player)
 	const uint16_t itemIdx = SDL_SwapLE16(message.wParam1);
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && InDungeonBounds(position) && itemIdx < MAXITEMS + 1) {
 		MakePlrPath(player, position, false);
-		player.destAction = ACTION_PICKUPAITEM;
-		player.destParam1 = itemIdx;
+		player.destinationAction = ACTION_PICKUPAITEM;
+		player.destinationParam1 = itemIdx;
 	}
 
 	return sizeof(message);
@@ -1407,9 +1407,9 @@ size_t OnAttackTile(const TCmd *pCmd, Player &player)
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && InDungeonBounds(position)) {
 		MakePlrPath(player, position, false);
-		player.destAction = ACTION_ATTACK;
-		player.destParam1 = position.x;
-		player.destParam2 = position.y;
+		player.destinationAction = ACTION_ATTACK;
+		player.destinationParam1 = position.x;
+		player.destinationParam2 = position.y;
 	}
 
 	return sizeof(message);
@@ -1422,9 +1422,9 @@ size_t OnStandingAttackTile(const TCmd *pCmd, Player &player)
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && InDungeonBounds(position)) {
 		ClrPlrPath(player);
-		player.destAction = ACTION_ATTACK;
-		player.destParam1 = position.x;
-		player.destParam2 = position.y;
+		player.destinationAction = ACTION_ATTACK;
+		player.destinationParam1 = position.x;
+		player.destinationParam2 = position.y;
 	}
 
 	return sizeof(message);
@@ -1437,9 +1437,9 @@ size_t OnRangedAttackTile(const TCmd *pCmd, Player &player)
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && InDungeonBounds(position)) {
 		ClrPlrPath(player);
-		player.destAction = ACTION_RATTACK;
-		player.destParam1 = position.x;
-		player.destParam2 = position.y;
+		player.destinationAction = ACTION_RATTACK;
+		player.destinationParam1 = position.x;
+		player.destinationParam2 = position.y;
 	}
 
 	return sizeof(message);
@@ -1455,11 +1455,11 @@ bool InitNewSpell(Player &player, uint16_t wParamSpellID, uint16_t wParamSpellTy
 		return false;
 	auto spellID = static_cast<SpellID>(wParamSpellID);
 	if (!IsValidSpell(spellID)) {
-		LogError(_("{:s} has cast an invalid spell."), player._pName);
+		LogError(_("{:s} has cast an invalid spell."), player.name);
 		return false;
 	}
 	if (leveltype == DTYPE_TOWN && !GetSpellData(spellID).isAllowedInTown()) {
-		LogError(_("{:s} has cast an illegal spell."), player._pName);
+		LogError(_("{:s} has cast an illegal spell."), player.name);
 		return false;
 	}
 
@@ -1498,11 +1498,11 @@ size_t OnSpellWall(const TCmd *pCmd, Player &player)
 		return sizeof(message);
 
 	ClrPlrPath(player);
-	player.destAction = ACTION_SPELLWALL;
-	player.destParam1 = position.x;
-	player.destParam2 = position.y;
-	player.destParam3 = wParamDirection;
-	player.destParam4 = SDL_SwapLE16(message.wParam4); // Spell Level
+	player.destinationAction = ACTION_SPELLWALL;
+	player.destinationParam1 = position.x;
+	player.destinationParam2 = position.y;
+	player.destinationParam3 = wParamDirection;
+	player.destinationParam4 = SDL_SwapLE16(message.wParam4); // Spell Level
 
 	return sizeof(message);
 }
@@ -1523,10 +1523,10 @@ size_t OnSpellTile(const TCmd *pCmd, Player &player)
 		return sizeof(message);
 
 	ClrPlrPath(player);
-	player.destAction = ACTION_SPELL;
-	player.destParam1 = position.x;
-	player.destParam2 = position.y;
-	player.destParam3 = SDL_SwapLE16(message.wParam3); // Spell Level
+	player.destinationAction = ACTION_SPELL;
+	player.destinationParam1 = position.x;
+	player.destinationParam2 = position.y;
+	player.destinationParam3 = SDL_SwapLE16(message.wParam3); // Spell Level
 
 	return sizeof(message);
 }
@@ -1541,8 +1541,8 @@ size_t OnObjectTileAction(const TCmd &cmd, Player &player, action_id action, boo
 		if (pathToObject)
 			MakePlrPath(player, position, !object->_oSolidFlag && !object->_oDoorFlag);
 
-		player.destAction = action;
-		player.destParam1 = object->GetId();
+		player.destinationAction = action;
+		player.destinationParam1 = object->GetId();
 	}
 
 	return sizeof(message);
@@ -1557,8 +1557,8 @@ size_t OnAttackMonster(const TCmd *pCmd, Player &player)
 		Point position = Monsters[monsterIdx].position.future;
 		if (player.position.tile.WalkingDistance(position) > 1)
 			MakePlrPath(player, position, false);
-		player.destAction = ACTION_ATTACKMON;
-		player.destParam1 = monsterIdx;
+		player.destinationAction = ACTION_ATTACKMON;
+		player.destinationParam1 = monsterIdx;
 	}
 
 	return sizeof(message);
@@ -1571,8 +1571,8 @@ size_t OnAttackPlayer(const TCmd *pCmd, Player &player)
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && playerIdx < Players.size()) {
 		MakePlrPath(player, Players[playerIdx].position.future, false);
-		player.destAction = ACTION_ATTACKPLR;
-		player.destParam1 = playerIdx;
+		player.destinationAction = ACTION_ATTACKPLR;
+		player.destinationParam1 = playerIdx;
 	}
 
 	return sizeof(message);
@@ -1585,8 +1585,8 @@ size_t OnRangedAttackMonster(const TCmd *pCmd, Player &player)
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && monsterIdx < MaxMonsters) {
 		ClrPlrPath(player);
-		player.destAction = ACTION_RATTACKMON;
-		player.destParam1 = monsterIdx;
+		player.destinationAction = ACTION_RATTACKMON;
+		player.destinationParam1 = monsterIdx;
 	}
 
 	return sizeof(message);
@@ -1599,8 +1599,8 @@ size_t OnRangedAttackPlayer(const TCmd *pCmd, Player &player)
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && playerIdx < Players.size()) {
 		ClrPlrPath(player);
-		player.destAction = ACTION_RATTACKPLR;
-		player.destParam1 = playerIdx;
+		player.destinationAction = ACTION_RATTACKPLR;
+		player.destinationParam1 = playerIdx;
 	}
 
 	return sizeof(message);
@@ -1622,9 +1622,9 @@ size_t OnSpellMonster(const TCmd *pCmd, Player &player)
 		return sizeof(message);
 
 	ClrPlrPath(player);
-	player.destAction = ACTION_SPELLMON;
-	player.destParam1 = monsterIdx;
-	player.destParam2 = SDL_SwapLE16(message.wParam4); // Spell Level
+	player.destinationAction = ACTION_SPELLMON;
+	player.destinationParam1 = monsterIdx;
+	player.destinationParam2 = SDL_SwapLE16(message.wParam4); // Spell Level
 
 	return sizeof(message);
 }
@@ -1645,9 +1645,9 @@ size_t OnSpellPlayer(const TCmd *pCmd, Player &player)
 		return sizeof(message);
 
 	ClrPlrPath(player);
-	player.destAction = ACTION_SPELLPLR;
-	player.destParam1 = playerIdx;
-	player.destParam2 = SDL_SwapLE16(message.wParam4); // Spell Level
+	player.destinationAction = ACTION_SPELLPLR;
+	player.destinationParam1 = playerIdx;
+	player.destinationParam2 = SDL_SwapLE16(message.wParam4); // Spell Level
 
 	return sizeof(message);
 }
@@ -1704,8 +1704,8 @@ size_t OnTalkXY(const TCmd *pCmd, Player &player)
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && InDungeonBounds(position) && townerIdx < NUM_TOWNERS) {
 		MakePlrPath(player, position, false);
-		player.destAction = ACTION_TALK;
-		player.destParam1 = townerIdx;
+		player.destinationAction = ACTION_TALK;
+		player.destinationParam1 = townerIdx;
 	}
 
 	return sizeof(message);
@@ -1779,7 +1779,7 @@ size_t OnKillGolem(const TCmd *pCmd, Player &player)
 			Monster &monster = Monsters[player.getId()];
 			if (player.isOnActiveLevel())
 				M_SyncStartKill(monster, position, player);
-			delta_kill_monster(monster, position, player); // BUGFIX: should be p->wParam1, plrlevel will be incorrect if golem is killed because player changed levels
+			delta_kill_monster(monster, position, player); // BUGFIX: should be p->wParam1, dungeonLevel will be incorrect if golem is killed because player changed levels
 		}
 	} else {
 		SendPacket(player, &message, sizeof(message));
@@ -1862,7 +1862,7 @@ size_t OnPlayerDamage(const TCmd *pCmd, Player &player)
 
 	Player &target = Players[message.bPlr];
 	if (&target == MyPlayer && leveltype != DTYPE_TOWN && gbBufferMsgs != 1) {
-		if (player.isOnActiveLevel() && damage <= 192000 && target._pHitPoints >> 6 > 0) {
+		if (player.isOnActiveLevel() && damage <= 192000 && target.life >> 6 > 0) {
 			ApplyPlrDamage(message.damageType, target, 0, 0, damage, DeathReason::Player);
 		}
 	}
@@ -1922,7 +1922,7 @@ size_t OnChangePlayerItems(const TCmd *pCmd, Player &player)
 	if (gbBufferMsgs == 1) {
 		SendPacket(player, &message, sizeof(message));
 	} else if (&player != MyPlayer && IsItemAvailable(static_cast<_item_indexes>(SDL_SwapLE16(message.def.wIndx)))) {
-		Item &item = player.InvBody[message.bLoc];
+		Item &item = player.bodySlot[message.bLoc];
 		item = {};
 		RecreateItem(player, message, item);
 		CheckInvSwap(player, bodyLocation);
@@ -1989,7 +1989,7 @@ size_t OnChangeBeltItems(const TCmd *pCmd, Player &player)
 	if (gbBufferMsgs == 1) {
 		SendPacket(player, &message, sizeof(message));
 	} else if (&player != MyPlayer && IsItemAvailable(static_cast<_item_indexes>(SDL_SwapLE16(message.def.wIndx)))) {
-		Item &item = player.SpdList[message.bLoc];
+		Item &item = player.beltSlot[message.bLoc];
 		item = {};
 		RecreateItem(player, message, item);
 	}
@@ -2085,15 +2085,15 @@ size_t OnPlayerJoinLevel(const TCmd *pCmd, Player &player)
 		return sizeof(message);
 	}
 
-	player._pLvlChanging = false;
-	if (player._pName[0] != '\0' && !player.plractive) {
+	player.isChangingLevel = false;
+	if (player.name[0] != '\0' && !player.isPlayerActive) {
 		ResetPlayerGFX(player);
-		player.plractive = true;
+		player.isPlayerActive = true;
 		gbActivePlayers++;
-		EventPlrMsg(fmt::format(fmt::runtime(_("Player '{:s}' (level {:d}) just joined the game")), player._pName, player.getCharacterLevel()));
+		EventPlrMsg(fmt::format(fmt::runtime(_("Player '{:s}' (level {:d}) just joined the game")), player.name, player.getCharacterLevel()));
 	}
 
-	if (player.plractive && &player != MyPlayer) {
+	if (player.isPlayerActive && &player != MyPlayer) {
 		player.position.tile = position;
 		SetPlayerOld(player);
 		if (isSetLevel)
@@ -2103,17 +2103,17 @@ size_t OnPlayerJoinLevel(const TCmd *pCmd, Player &player)
 		ResetPlayerGFX(player);
 		if (player.isOnActiveLevel()) {
 			SyncInitPlr(player);
-			if ((player._pHitPoints >> 6) > 0) {
+			if ((player.life >> 6) > 0) {
 				StartStand(player, Direction::South);
 			} else {
-				player._pgfxnum &= ~0xFU;
-				player._pmode = PM_DEATH;
+				player.graphic &= ~0xFU;
+				player.mode = PM_DEATH;
 				NewPlrAnim(player, player_graphic::Death, Direction::South);
-				player.AnimInfo.currentFrame = player.AnimInfo.numberOfFrames - 2;
+				player.animationInfo.currentFrame = player.animationInfo.numberOfFrames - 2;
 				dFlags[player.position.tile.x][player.position.tile.y] |= DungeonFlag::DeadPlayer;
 			}
 
-			ActivateVision(player.position.tile, player._pLightRad, player.getId());
+			ActivateVision(player.position.tile, player.lightRadius, player.getId());
 		}
 	}
 
@@ -2260,7 +2260,7 @@ size_t OnString(const TCmd *pCmd, Player &player)
 
 size_t OnFriendlyMode(const TCmd *pCmd, Player &player) // NOLINT(misc-unused-parameters)
 {
-	player.friendlyMode = !player.friendlyMode;
+	player.isFriendlyMode = !player.isFriendlyMode;
 	RedrawEverything();
 	return sizeof(*pCmd);
 }
@@ -2285,7 +2285,7 @@ size_t OnCheatExperience(const TCmd *pCmd, Player &player) // NOLINT(misc-unused
 	if (gbBufferMsgs == 1)
 		SendPacket(player, pCmd, sizeof(*pCmd));
 	else if (!player.isMaxCharacterLevel()) {
-		player._pExperience = player.getNextExperienceThreshold();
+		player.experience = player.getNextExperienceThreshold();
 		if (*sgOptions.Gameplay.experienceBar) {
 			RedrawEverything();
 		}
@@ -2304,8 +2304,8 @@ size_t OnChangeSpellLevel(const TCmd *pCmd, Player &player) // NOLINT(misc-unuse
 	if (gbBufferMsgs == 1) {
 		SendPacket(player, pCmd, sizeof(*pCmd));
 	} else {
-		player._pMemSpells |= GetSpellBitmask(spellID);
-		player._pSplLvl[static_cast<size_t>(spellID)] = spellLevel;
+		player.learnedSpells |= GetSpellBitmask(spellID);
+		player.spellLevel[static_cast<size_t>(spellID)] = spellLevel;
 	}
 
 	return sizeof(message);
@@ -2319,7 +2319,7 @@ size_t OnDebug(const TCmd *pCmd)
 size_t OnSetShield(const TCmd *pCmd, Player &player)
 {
 	if (gbBufferMsgs != 1)
-		player.pManaShield = true;
+		player.hasManaShield = true;
 
 	return sizeof(*pCmd);
 }
@@ -2327,7 +2327,7 @@ size_t OnSetShield(const TCmd *pCmd, Player &player)
 size_t OnRemoveShield(const TCmd *pCmd, Player &player)
 {
 	if (gbBufferMsgs != 1)
-		player.pManaShield = false;
+		player.hasManaShield = false;
 
 	return sizeof(*pCmd);
 }
@@ -2337,7 +2337,7 @@ size_t OnSetReflect(const TCmd *pCmd, Player &player)
 	const auto &message = *reinterpret_cast<const TCmdParam1 *>(pCmd);
 
 	if (gbBufferMsgs != 1)
-		player.wReflections = SDL_SwapLE16(message.wParam1);
+		player.reflections = SDL_SwapLE16(message.wParam1);
 
 	return sizeof(message);
 }
@@ -2662,17 +2662,17 @@ void DeltaSaveLevel()
 	uint8_t localLevel;
 	if (setlevel) {
 		localLevel = GetLevelForMultiplayer(static_cast<uint8_t>(setlvlnum), setlevel);
-		MyPlayer->_pSLvlVisited[static_cast<uint8_t>(setlvlnum)] = true;
+		MyPlayer->isSetLevelVisted[static_cast<uint8_t>(setlvlnum)] = true;
 	} else {
 		localLevel = GetLevelForMultiplayer(currlevel, setlevel);
-		MyPlayer->_pLvlVisited[currlevel] = true;
+		MyPlayer->isLevelVisted[currlevel] = true;
 	}
 	DeltaLeaveSync(localLevel);
 }
 
 uint8_t GetLevelForMultiplayer(const Player &player)
 {
-	return GetLevelForMultiplayer(player.plrlevel, player.plrIsOnSetLevel);
+	return GetLevelForMultiplayer(player.dungeonLevel, player.isOnSetLevel);
 }
 
 bool IsValidLevelForMultiplayer(uint8_t level)
@@ -3087,7 +3087,7 @@ void NetSendCmdChItem(bool bHiPri, uint8_t bLoc, bool forceSpellChange)
 {
 	TCmdChItem cmd {};
 
-	Item &item = MyPlayer->InvBody[bLoc];
+	Item &item = MyPlayer->bodySlot[bLoc];
 
 	cmd.bCmd = CMD_CHANGEPLRITEMS;
 	cmd.bLoc = bLoc;
@@ -3118,7 +3118,7 @@ void NetSyncInvItem(const Player &player, int invListIndex)
 		return;
 
 	for (int j = 0; j < InventoryGridCells; j++) {
-		if (player.InvGrid[j] == invListIndex + 1) {
+		if (player.inventoryGrid[j] == invListIndex + 1) {
 			NetSendCmdChInvItem(false, j);
 			break;
 		}
@@ -3129,8 +3129,8 @@ void NetSendCmdChInvItem(bool bHiPri, int invGridIndex)
 {
 	TCmdChItem cmd {};
 
-	int8_t invListIndex = std::abs(MyPlayer->InvGrid[invGridIndex]) - 1;
-	const Item &item = MyPlayer->InvList[invListIndex];
+	int8_t invListIndex = std::abs(MyPlayer->inventoryGrid[invGridIndex]) - 1;
+	const Item &item = MyPlayer->inventorySlot[invListIndex];
 
 	cmd.bCmd = CMD_CHANGEINVITEMS;
 	cmd.bLoc = invGridIndex;
@@ -3146,7 +3146,7 @@ void NetSendCmdChBeltItem(bool bHiPri, int beltIndex)
 {
 	TCmdChItem cmd {};
 
-	const Item &item = MyPlayer->SpdList[beltIndex];
+	const Item &item = MyPlayer->beltSlot[beltIndex];
 
 	cmd.bCmd = CMD_CHANGEBELTITEMS;
 	cmd.bLoc = beltIndex;

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -244,12 +244,12 @@ void nthread_UpdateProgressToNextGameTick()
 	int currentTickCount = SDL_GetTicks();
 	int ticksMissing = last_tick - currentTickCount;
 	if (ticksMissing <= 0) {
-		ProgressToNextGameTick = AnimationInfo::baseValueFraction; // game tick is due
+		ProgressToNextGameTick = PlayerAnimationInfo::baseValueFraction; // game tick is due
 		return;
 	}
 	int ticksAdvanced = gnTickDelay - ticksMissing;
-	int32_t fraction = ticksAdvanced * AnimationInfo::baseValueFraction / gnTickDelay;
-	fraction = std::clamp<int32_t>(fraction, 0, AnimationInfo::baseValueFraction);
+	int32_t fraction = ticksAdvanced * PlayerAnimationInfo::baseValueFraction / gnTickDelay;
+	fraction = std::clamp<int32_t>(fraction, 0, PlayerAnimationInfo::baseValueFraction);
 	ProgressToNextGameTick = static_cast<uint8_t>(fraction);
 }
 

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -18,7 +18,7 @@ extern uint32_t gdwTurnsInTransit;
 extern uintptr_t glpMsgTbl[MAX_PLRS];
 extern uint32_t gdwLargestMsgSize;
 extern uint32_t gdwNormalMsgSize;
-/** @brief the progress as a fraction (see AnimationInfo::baseValueFraction) in time to the next game tick */
+/** @brief the progress as a fraction (see PlayerAnimationInfo::baseValueFraction) in time to the next game tick */
 extern DVL_API_FOR_TEST uint8_t ProgressToNextGameTick;
 extern int last_tick;
 

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -21,7 +21,7 @@
 	do {                                                           \
 		if (!(condition)) {                                        \
 			LogFailedJoinAttempt(#condition, #logValue, logValue); \
-			EventFailedJoinAttempt(player._pName);                 \
+			EventFailedJoinAttempt(player.name);                 \
 			return false;                                          \
 		}                                                          \
 	} while (0)
@@ -30,7 +30,7 @@
 	do {                                                                                    \
 		if (!(condition)) {                                                                 \
 			LogFailedJoinAttempt(#condition, #logValue1, logValue1, #logValue2, logValue2); \
-			EventFailedJoinAttempt(player._pName);                                          \
+			EventFailedJoinAttempt(player.name);                                          \
 			return false;                                                                   \
 		}                                                                                   \
 	} while (0)
@@ -59,17 +59,17 @@ void LogFailedJoinAttempt(const char *condition, const char *name1, T1 value1, c
 
 void VerifyGoldSeeds(Player &player)
 {
-	for (int i = 0; i < player._pNumInv; i++) {
-		if (player.InvList[i].IDidx != IDI_GOLD)
+	for (int i = 0; i < player.numInventoryItems; i++) {
+		if (player.inventorySlot[i].IDidx != IDI_GOLD)
 			continue;
-		for (int j = 0; j < player._pNumInv; j++) {
+		for (int j = 0; j < player.numInventoryItems; j++) {
 			if (i == j)
 				continue;
-			if (player.InvList[j].IDidx != IDI_GOLD)
+			if (player.inventorySlot[j].IDidx != IDI_GOLD)
 				continue;
-			if (player.InvList[i]._iSeed != player.InvList[j]._iSeed)
+			if (player.inventorySlot[i]._iSeed != player.inventorySlot[j]._iSeed)
 				continue;
-			player.InvList[i]._iSeed = AdvanceRndSeed();
+			player.inventorySlot[i]._iSeed = AdvanceRndSeed();
 			j = -1;
 		}
 	}
@@ -249,53 +249,53 @@ void PackItem(ItemPack &packedItem, const Item &item, bool isHellfire)
 void PackPlayer(PlayerPack &packed, const Player &player)
 {
 	memset(&packed, 0, sizeof(packed));
-	packed.destAction = player.destAction;
-	packed.destParam1 = player.destParam1;
-	packed.destParam2 = player.destParam2;
-	packed.plrlevel = player.plrlevel;
+	packed.destinationAction = player.destinationAction;
+	packed.destinationParam1 = player.destinationParam1;
+	packed.destinationParam2 = player.destinationParam2;
+	packed.dungeonLevel = player.dungeonLevel;
 	packed.px = player.position.tile.x;
 	packed.py = player.position.tile.y;
 	if (gbVanilla) {
 		packed.targx = player.position.tile.x;
 		packed.targy = player.position.tile.y;
 	}
-	CopyUtf8(packed.pName, player._pName, sizeof(packed.pName));
-	packed.pClass = static_cast<uint8_t>(player._pClass);
-	packed.pBaseStr = player._pBaseStr;
-	packed.pBaseMag = player._pBaseMag;
-	packed.pBaseDex = player._pBaseDex;
-	packed.pBaseVit = player._pBaseVit;
+	CopyUtf8(packed.pName, player.name, sizeof(packed.pName));
+	packed.pClass = static_cast<uint8_t>(player.heroClass);
+	packed.pBaseStr = player.baseStrength;
+	packed.pBaseMag = player.baseMagic;
+	packed.pBaseDex = player.baseDexterity;
+	packed.pBaseVit = player.baseVitality;
 	packed.pLevel = player.getCharacterLevel();
-	packed.pStatPts = player._pStatPts;
-	packed.pExperience = SDL_SwapLE32(player._pExperience);
-	packed.pGold = SDL_SwapLE32(player._pGold);
-	packed.pHPBase = SDL_SwapLE32(player._pHPBase);
-	packed.pMaxHPBase = SDL_SwapLE32(player._pMaxHPBase);
-	packed.pManaBase = SDL_SwapLE32(player._pManaBase);
-	packed.pMaxManaBase = SDL_SwapLE32(player._pMaxManaBase);
-	packed.pMemSpells = SDL_SwapLE64(player._pMemSpells);
+	packed.pStatPts = player.statPoints;
+	packed.pExperience = SDL_SwapLE32(player.experience);
+	packed.pGold = SDL_SwapLE32(player.gold);
+	packed.pHPBase = SDL_SwapLE32(player.baseLife);
+	packed.pMaxHPBase = SDL_SwapLE32(player.baseMaxLife);
+	packed.pManaBase = SDL_SwapLE32(player.baseMana);
+	packed.pMaxManaBase = SDL_SwapLE32(player.baseMaxMana);
+	packed.pMemSpells = SDL_SwapLE64(player.learnedSpells);
 
 	for (int i = 0; i < 37; i++) // Should be MAX_SPELLS but set to 37 to make save games compatible
-		packed.pSplLvl[i] = player._pSplLvl[i];
+		packed.pSplLvl[i] = player.spellLevel[i];
 	for (int i = 37; i < 47; i++)
-		packed.pSplLvl2[i - 37] = player._pSplLvl[i];
+		packed.pSplLvl2[i - 37] = player.spellLevel[i];
 
 	for (int i = 0; i < NUM_INVLOC; i++)
-		PackItem(packed.InvBody[i], player.InvBody[i], gbIsHellfire);
+		PackItem(packed.bodySlot[i], player.bodySlot[i], gbIsHellfire);
 
-	packed._pNumInv = player._pNumInv;
-	for (int i = 0; i < packed._pNumInv; i++)
-		PackItem(packed.InvList[i], player.InvList[i], gbIsHellfire);
+	packed.numInventoryItems = player.numInventoryItems;
+	for (int i = 0; i < packed.numInventoryItems; i++)
+		PackItem(packed.inventorySlot[i], player.inventorySlot[i], gbIsHellfire);
 
 	for (int i = 0; i < InventoryGridCells; i++)
-		packed.InvGrid[i] = player.InvGrid[i];
+		packed.inventoryGrid[i] = player.inventoryGrid[i];
 
 	for (int i = 0; i < MaxBeltItems; i++)
-		PackItem(packed.SpdList[i], player.SpdList[i], gbIsHellfire);
+		PackItem(packed.beltSlot[i], player.beltSlot[i], gbIsHellfire);
 
-	packed.wReflections = SDL_SwapLE16(player.wReflections);
-	packed.pDamAcFlags = SDL_SwapLE32(static_cast<uint32_t>(player.pDamAcFlags));
-	packed.pDiabloKillLevel = SDL_SwapLE32(player.pDiabloKillLevel);
+	packed.reflections = SDL_SwapLE16(player.reflections);
+	packed.hellfireFlags = SDL_SwapLE32(static_cast<uint32_t>(player.hellfireFlags));
+	packed.difficultyCompletion = SDL_SwapLE32(player.difficultyCompletion);
 	packed.bIsHellfire = gbIsHellfire ? 1 : 0;
 }
 
@@ -316,70 +316,70 @@ void PackNetItem(const Item &item, ItemNetPack &packedItem)
 
 void PackNetPlayer(PlayerNetPack &packed, const Player &player)
 {
-	packed.plrlevel = player.plrlevel;
+	packed.dungeonLevel = player.dungeonLevel;
 	packed.px = player.position.tile.x;
 	packed.py = player.position.tile.y;
-	CopyUtf8(packed.pName, player._pName, sizeof(packed.pName));
-	packed.pClass = static_cast<uint8_t>(player._pClass);
-	packed.pBaseStr = player._pBaseStr;
-	packed.pBaseMag = player._pBaseMag;
-	packed.pBaseDex = player._pBaseDex;
-	packed.pBaseVit = player._pBaseVit;
+	CopyUtf8(packed.pName, player.name, sizeof(packed.pName));
+	packed.pClass = static_cast<uint8_t>(player.heroClass);
+	packed.pBaseStr = player.baseStrength;
+	packed.pBaseMag = player.baseMagic;
+	packed.pBaseDex = player.baseDexterity;
+	packed.pBaseVit = player.baseVitality;
 	packed.pLevel = player.getCharacterLevel();
-	packed.pStatPts = player._pStatPts;
-	packed.pExperience = SDL_SwapLE32(player._pExperience);
-	packed.pHPBase = SDL_SwapLE32(player._pHPBase);
-	packed.pMaxHPBase = SDL_SwapLE32(player._pMaxHPBase);
-	packed.pManaBase = SDL_SwapLE32(player._pManaBase);
-	packed.pMaxManaBase = SDL_SwapLE32(player._pMaxManaBase);
-	packed.pMemSpells = SDL_SwapLE64(player._pMemSpells);
+	packed.pStatPts = player.statPoints;
+	packed.pExperience = SDL_SwapLE32(player.experience);
+	packed.pHPBase = SDL_SwapLE32(player.baseLife);
+	packed.pMaxHPBase = SDL_SwapLE32(player.baseMaxLife);
+	packed.pManaBase = SDL_SwapLE32(player.baseMana);
+	packed.pMaxManaBase = SDL_SwapLE32(player.baseMaxMana);
+	packed.pMemSpells = SDL_SwapLE64(player.learnedSpells);
 
 	for (int i = 0; i < MAX_SPELLS; i++)
-		packed.pSplLvl[i] = player._pSplLvl[i];
+		packed.pSplLvl[i] = player.spellLevel[i];
 
 	for (int i = 0; i < NUM_INVLOC; i++)
-		PackNetItem(player.InvBody[i], packed.InvBody[i]);
+		PackNetItem(player.bodySlot[i], packed.bodySlot[i]);
 
-	packed._pNumInv = player._pNumInv;
-	for (int i = 0; i < packed._pNumInv; i++)
-		PackNetItem(player.InvList[i], packed.InvList[i]);
+	packed.numInventoryItems = player.numInventoryItems;
+	for (int i = 0; i < packed.numInventoryItems; i++)
+		PackNetItem(player.inventorySlot[i], packed.inventorySlot[i]);
 
 	for (int i = 0; i < InventoryGridCells; i++)
-		packed.InvGrid[i] = player.InvGrid[i];
+		packed.inventoryGrid[i] = player.inventoryGrid[i];
 
 	for (int i = 0; i < MaxBeltItems; i++)
-		PackNetItem(player.SpdList[i], packed.SpdList[i]);
+		PackNetItem(player.beltSlot[i], packed.beltSlot[i]);
 
-	packed.wReflections = SDL_SwapLE16(player.wReflections);
-	packed.pDiabloKillLevel = player.pDiabloKillLevel;
-	packed.pManaShield = player.pManaShield;
-	packed.friendlyMode = player.friendlyMode ? 1 : 0;
-	packed.isOnSetLevel = player.plrIsOnSetLevel;
+	packed.reflections = SDL_SwapLE16(player.reflections);
+	packed.difficultyCompletion = player.difficultyCompletion;
+	packed.hasManaShield = player.hasManaShield;
+	packed.isFriendlyMode = player.isFriendlyMode ? 1 : 0;
+	packed.isOnSetLevel = player.isOnSetLevel;
 
-	packed.pStrength = SDL_SwapLE32(player._pStrength);
-	packed.pMagic = SDL_SwapLE32(player._pMagic);
-	packed.pDexterity = SDL_SwapLE32(player._pDexterity);
-	packed.pVitality = SDL_SwapLE32(player._pVitality);
-	packed.pHitPoints = SDL_SwapLE32(player._pHitPoints);
-	packed.pMaxHP = SDL_SwapLE32(player._pMaxHP);
-	packed.pMana = SDL_SwapLE32(player._pMana);
-	packed.pMaxMana = SDL_SwapLE32(player._pMaxMana);
-	packed.pDamageMod = SDL_SwapLE32(player._pDamageMod);
+	packed.pStrength = SDL_SwapLE32(player.strength);
+	packed.pMagic = SDL_SwapLE32(player.magic);
+	packed.pDexterity = SDL_SwapLE32(player.dexterity);
+	packed.pVitality = SDL_SwapLE32(player.vitality);
+	packed.pHitPoints = SDL_SwapLE32(player.life);
+	packed.pMaxHP = SDL_SwapLE32(player.maxLife);
+	packed.pMana = SDL_SwapLE32(player.mana);
+	packed.pMaxMana = SDL_SwapLE32(player.maxMana);
+	packed.pDamageMod = SDL_SwapLE32(player.damageModifier);
 	// we pack base to block as a basic check that remote players are using the same playerdat values as we are
 	packed.pBaseToBlk = SDL_SwapLE32(player.getBaseToBlock());
-	packed.pIMinDam = SDL_SwapLE32(player._pIMinDam);
-	packed.pIMaxDam = SDL_SwapLE32(player._pIMaxDam);
-	packed.pIAC = SDL_SwapLE32(player._pIAC);
-	packed.pIBonusDam = SDL_SwapLE32(player._pIBonusDam);
-	packed.pIBonusToHit = SDL_SwapLE32(player._pIBonusToHit);
-	packed.pIBonusAC = SDL_SwapLE32(player._pIBonusAC);
-	packed.pIBonusDamMod = SDL_SwapLE32(player._pIBonusDamMod);
-	packed.pIGetHit = SDL_SwapLE32(player._pIGetHit);
-	packed.pIEnAc = SDL_SwapLE32(player._pIEnAc);
-	packed.pIFMinDam = SDL_SwapLE32(player._pIFMinDam);
-	packed.pIFMaxDam = SDL_SwapLE32(player._pIFMaxDam);
-	packed.pILMinDam = SDL_SwapLE32(player._pILMinDam);
-	packed.pILMaxDam = SDL_SwapLE32(player._pILMaxDam);
+	packed.pIMinDam = SDL_SwapLE32(player.minDamage);
+	packed.pIMaxDam = SDL_SwapLE32(player.maxDamage);
+	packed.pIAC = SDL_SwapLE32(player.armorClass);
+	packed.pIBonusDam = SDL_SwapLE32(player.bonusDamagePercent);
+	packed.pIBonusToHit = SDL_SwapLE32(player.bonusToHit);
+	packed.pIBonusAC = SDL_SwapLE32(player.bonusArmorClass);
+	packed.pIBonusDamMod = SDL_SwapLE32(player.bonusDamage);
+	packed.pIGetHit = SDL_SwapLE32(player.damageFromEnemies);
+	packed.pIEnAc = SDL_SwapLE32(player.armorPierce);
+	packed.pIFMinDam = SDL_SwapLE32(player.minFireDamage);
+	packed.pIFMaxDam = SDL_SwapLE32(player.maxFireDamage);
+	packed.pILMinDam = SDL_SwapLE32(player.minLightningDamage);
+	packed.pILMaxDam = SDL_SwapLE32(player.maxLightningDamage);
 }
 
 void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bool isHellfire)
@@ -447,86 +447,86 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 
 	player = {};
 	player.setCharacterLevel(packed.pLevel);
-	player._pMaxHPBase = SDL_SwapLE32(packed.pMaxHPBase);
-	player._pHPBase = SDL_SwapLE32(packed.pHPBase);
-	player._pHPBase = std::clamp<int32_t>(player._pHPBase, 0, player._pMaxHPBase);
-	player._pMaxHP = player._pMaxHPBase;
-	player._pHitPoints = player._pHPBase;
+	player.baseMaxLife = SDL_SwapLE32(packed.pMaxHPBase);
+	player.baseLife = SDL_SwapLE32(packed.pHPBase);
+	player.baseLife = std::clamp<int32_t>(player.baseLife, 0, player.baseMaxLife);
+	player.maxLife = player.baseMaxLife;
+	player.life = player.baseLife;
 	player.position.tile = position;
 	player.position.future = position;
-	player.setLevel(std::clamp<int8_t>(packed.plrlevel, 0, NUMLEVELS));
+	player.setLevel(std::clamp<int8_t>(packed.dungeonLevel, 0, NUMLEVELS));
 
-	player._pClass = static_cast<HeroClass>(std::clamp<uint8_t>(packed.pClass, 0, enum_size<HeroClass>::value - 1));
+	player.heroClass = static_cast<HeroClass>(std::clamp<uint8_t>(packed.pClass, 0, enum_size<HeroClass>::value - 1));
 
 	ClrPlrPath(player);
-	player.destAction = ACTION_NONE;
+	player.destinationAction = ACTION_NONE;
 
-	CopyUtf8(player._pName, packed.pName, sizeof(player._pName));
+	CopyUtf8(player.name, packed.pName, sizeof(player.name));
 
 	InitPlayer(player, true);
 
-	player._pBaseStr = std::min<uint8_t>(packed.pBaseStr, player.GetMaximumAttributeValue(CharacterAttribute::Strength));
-	player._pStrength = player._pBaseStr;
-	player._pBaseMag = std::min<uint8_t>(packed.pBaseMag, player.GetMaximumAttributeValue(CharacterAttribute::Magic));
-	player._pMagic = player._pBaseMag;
-	player._pBaseDex = std::min<uint8_t>(packed.pBaseDex, player.GetMaximumAttributeValue(CharacterAttribute::Dexterity));
-	player._pDexterity = player._pBaseDex;
-	player._pBaseVit = std::min<uint8_t>(packed.pBaseVit, player.GetMaximumAttributeValue(CharacterAttribute::Vitality));
-	player._pVitality = player._pBaseVit;
-	player._pStatPts = packed.pStatPts;
+	player.baseStrength = std::min<uint8_t>(packed.pBaseStr, player.GetMaximumAttributeValue(CharacterAttribute::Strength));
+	player.strength = player.baseStrength;
+	player.baseMagic = std::min<uint8_t>(packed.pBaseMag, player.GetMaximumAttributeValue(CharacterAttribute::Magic));
+	player.magic = player.baseMagic;
+	player.baseDexterity = std::min<uint8_t>(packed.pBaseDex, player.GetMaximumAttributeValue(CharacterAttribute::Dexterity));
+	player.dexterity = player.baseDexterity;
+	player.baseVitality = std::min<uint8_t>(packed.pBaseVit, player.GetMaximumAttributeValue(CharacterAttribute::Vitality));
+	player.vitality = player.baseVitality;
+	player.statPoints = packed.pStatPts;
 
-	player._pExperience = SDL_SwapLE32(packed.pExperience);
-	player._pGold = SDL_SwapLE32(packed.pGold);
-	if ((int)(player._pHPBase & 0xFFFFFFC0) < 64)
-		player._pHPBase = 64;
+	player.experience = SDL_SwapLE32(packed.pExperience);
+	player.gold = SDL_SwapLE32(packed.pGold);
+	if ((int)(player.baseLife & 0xFFFFFFC0) < 64)
+		player.baseLife = 64;
 
-	player._pMaxManaBase = SDL_SwapLE32(packed.pMaxManaBase);
-	player._pManaBase = SDL_SwapLE32(packed.pManaBase);
-	player._pManaBase = std::min<int32_t>(player._pManaBase, player._pMaxManaBase);
-	player._pMemSpells = SDL_SwapLE64(packed.pMemSpells);
+	player.baseMaxMana = SDL_SwapLE32(packed.pMaxManaBase);
+	player.baseMana = SDL_SwapLE32(packed.pManaBase);
+	player.baseMana = std::min<int32_t>(player.baseMana, player.baseMaxMana);
+	player.learnedSpells = SDL_SwapLE64(packed.pMemSpells);
 
 	// Only read spell levels for learnable spells (Diablo)
 	for (int i = 0; i < 37; i++) { // Should be MAX_SPELLS but set to 36 to make save games compatible
 		auto spl = static_cast<SpellID>(i);
 		if (GetSpellData(spl).sBookLvl != -1)
-			player._pSplLvl[i] = packed.pSplLvl[i];
+			player.spellLevel[i] = packed.pSplLvl[i];
 		else
-			player._pSplLvl[i] = 0;
+			player.spellLevel[i] = 0;
 	}
 	// Only read spell levels for learnable spells (Hellfire)
 	for (int i = 37; i < 47; i++) {
 		auto spl = static_cast<SpellID>(i);
 		if (GetSpellData(spl).sBookLvl != -1)
-			player._pSplLvl[i] = packed.pSplLvl2[i - 37];
+			player.spellLevel[i] = packed.pSplLvl2[i - 37];
 		else
-			player._pSplLvl[i] = 0;
+			player.spellLevel[i] = 0;
 	}
 	// These spells are unavailable in Diablo as learnable spells
 	if (!gbIsHellfire) {
-		player._pSplLvl[static_cast<uint8_t>(SpellID::Apocalypse)] = 0;
-		player._pSplLvl[static_cast<uint8_t>(SpellID::Nova)] = 0;
+		player.spellLevel[static_cast<uint8_t>(SpellID::Apocalypse)] = 0;
+		player.spellLevel[static_cast<uint8_t>(SpellID::Nova)] = 0;
 	}
 
 	bool isHellfire = packed.bIsHellfire != 0;
 
 	for (int i = 0; i < NUM_INVLOC; i++)
-		UnPackItem(packed.InvBody[i], player, player.InvBody[i], isHellfire);
+		UnPackItem(packed.bodySlot[i], player, player.bodySlot[i], isHellfire);
 
-	player._pNumInv = packed._pNumInv;
-	for (int i = 0; i < player._pNumInv; i++)
-		UnPackItem(packed.InvList[i], player, player.InvList[i], isHellfire);
+	player.numInventoryItems = packed.numInventoryItems;
+	for (int i = 0; i < player.numInventoryItems; i++)
+		UnPackItem(packed.inventorySlot[i], player, player.inventorySlot[i], isHellfire);
 
 	for (int i = 0; i < InventoryGridCells; i++)
-		player.InvGrid[i] = packed.InvGrid[i];
+		player.inventoryGrid[i] = packed.inventoryGrid[i];
 
 	VerifyGoldSeeds(player);
 
 	for (int i = 0; i < MaxBeltItems; i++)
-		UnPackItem(packed.SpdList[i], player, player.SpdList[i], isHellfire);
+		UnPackItem(packed.beltSlot[i], player, player.beltSlot[i], isHellfire);
 
 	CalcPlrInv(player, false);
-	player.wReflections = SDL_SwapLE16(packed.wReflections);
-	player.pDiabloKillLevel = SDL_SwapLE32(packed.pDiabloKillLevel);
+	player.reflections = SDL_SwapLE16(packed.reflections);
+	player.difficultyCompletion = SDL_SwapLE32(packed.difficultyCompletion);
 }
 
 bool UnPackNetItem(const Player &player, const ItemNetPack &packedItem, Item &item)
@@ -559,14 +559,14 @@ bool UnPackNetItem(const Player &player, const ItemNetPack &packedItem, Item &it
 
 bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 {
-	CopyUtf8(player._pName, packed.pName, sizeof(player._pName));
+	CopyUtf8(player.name, packed.pName, sizeof(player.name));
 
 	ValidateField(packed.pClass, packed.pClass < enum_size<HeroClass>::value);
-	player._pClass = static_cast<HeroClass>(packed.pClass);
+	player.heroClass = static_cast<HeroClass>(packed.pClass);
 
 	Point position { packed.px, packed.py };
 	ValidateFields(position.x, position.y, InDungeonBounds(position));
-	ValidateField(packed.plrlevel, packed.plrlevel < NUMLEVELS);
+	ValidateField(packed.dungeonLevel, packed.dungeonLevel < NUMLEVELS);
 	ValidateField(packed.pLevel, packed.pLevel >= 1 && packed.pLevel <= player.getMaxCharacterLevel());
 
 	int32_t baseHpMax = SDL_SwapLE32(packed.pMaxHPBase);
@@ -583,51 +583,51 @@ bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 	ValidateFields(packed.pClass, packed.pBaseDex, packed.pBaseDex <= player.GetMaximumAttributeValue(CharacterAttribute::Dexterity));
 	ValidateFields(packed.pClass, packed.pBaseVit, packed.pBaseVit <= player.GetMaximumAttributeValue(CharacterAttribute::Vitality));
 
-	ValidateField(packed._pNumInv, packed._pNumInv <= InventoryGridCells);
+	ValidateField(packed.numInventoryItems, packed.numInventoryItems <= InventoryGridCells);
 
 	player.setCharacterLevel(packed.pLevel);
 	player.position.tile = position;
 	player.position.future = position;
-	player.plrlevel = packed.plrlevel;
-	player.plrIsOnSetLevel = packed.isOnSetLevel != 0;
-	player._pMaxHPBase = baseHpMax;
-	player._pHPBase = baseHp;
-	player._pMaxHP = baseHpMax;
-	player._pHitPoints = baseHp;
+	player.dungeonLevel = packed.dungeonLevel;
+	player.isOnSetLevel = packed.isOnSetLevel != 0;
+	player.baseMaxLife = baseHpMax;
+	player.baseLife = baseHp;
+	player.maxLife = baseHpMax;
+	player.life = baseHp;
 
 	ClrPlrPath(player);
-	player.destAction = ACTION_NONE;
+	player.destinationAction = ACTION_NONE;
 
 	InitPlayer(player, true);
 
-	player._pBaseStr = packed.pBaseStr;
-	player._pStrength = player._pBaseStr;
-	player._pBaseMag = packed.pBaseMag;
-	player._pMagic = player._pBaseMag;
-	player._pBaseDex = packed.pBaseDex;
-	player._pDexterity = player._pBaseDex;
-	player._pBaseVit = packed.pBaseVit;
-	player._pVitality = player._pBaseVit;
-	player._pStatPts = packed.pStatPts;
+	player.baseStrength = packed.pBaseStr;
+	player.strength = player.baseStrength;
+	player.baseMagic = packed.pBaseMag;
+	player.magic = player.baseMagic;
+	player.baseDexterity = packed.pBaseDex;
+	player.dexterity = player.baseDexterity;
+	player.baseVitality = packed.pBaseVit;
+	player.vitality = player.baseVitality;
+	player.statPoints = packed.pStatPts;
 
-	player._pExperience = SDL_SwapLE32(packed.pExperience);
-	player._pMaxManaBase = baseManaMax;
-	player._pManaBase = baseMana;
-	player._pMemSpells = SDL_SwapLE64(packed.pMemSpells);
-	player.wReflections = SDL_SwapLE16(packed.wReflections);
-	player.pDiabloKillLevel = packed.pDiabloKillLevel;
-	player.pManaShield = packed.pManaShield != 0;
-	player.friendlyMode = packed.friendlyMode != 0;
+	player.experience = SDL_SwapLE32(packed.pExperience);
+	player.baseMaxMana = baseManaMax;
+	player.baseMana = baseMana;
+	player.learnedSpells = SDL_SwapLE64(packed.pMemSpells);
+	player.reflections = SDL_SwapLE16(packed.reflections);
+	player.difficultyCompletion = packed.difficultyCompletion;
+	player.hasManaShield = packed.hasManaShield != 0;
+	player.isFriendlyMode = packed.isFriendlyMode != 0;
 
 	for (int i = 0; i < MAX_SPELLS; i++)
-		player._pSplLvl[i] = packed.pSplLvl[i];
+		player.spellLevel[i] = packed.pSplLvl[i];
 
 	for (int i = 0; i < NUM_INVLOC; i++) {
-		if (!UnPackNetItem(player, packed.InvBody[i], player.InvBody[i]))
+		if (!UnPackNetItem(player, packed.bodySlot[i], player.bodySlot[i]))
 			return false;
-		if (player.InvBody[i].isEmpty())
+		if (player.bodySlot[i].isEmpty())
 			continue;
-		auto loc = static_cast<int8_t>(player.GetItemLocation(player.InvBody[i]));
+		auto loc = static_cast<int8_t>(player.GetItemLocation(player.bodySlot[i]));
 		switch (i) {
 		case INVLOC_HEAD:
 			ValidateField(loc, loc == ILOC_HELM);
@@ -649,18 +649,18 @@ bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 		}
 	}
 
-	player._pNumInv = packed._pNumInv;
-	for (int i = 0; i < player._pNumInv; i++) {
-		if (!UnPackNetItem(player, packed.InvList[i], player.InvList[i]))
+	player.numInventoryItems = packed.numInventoryItems;
+	for (int i = 0; i < player.numInventoryItems; i++) {
+		if (!UnPackNetItem(player, packed.inventorySlot[i], player.inventorySlot[i]))
 			return false;
 	}
 
 	for (int i = 0; i < InventoryGridCells; i++)
-		player.InvGrid[i] = packed.InvGrid[i];
+		player.inventoryGrid[i] = packed.inventoryGrid[i];
 
 	for (int i = 0; i < MaxBeltItems; i++) {
-		Item &item = player.SpdList[i];
-		if (!UnPackNetItem(player, packed.SpdList[i], item))
+		Item &item = player.beltSlot[i];
+		if (!UnPackNetItem(player, packed.beltSlot[i], item))
 			return false;
 		if (item.isEmpty())
 			continue;
@@ -673,33 +673,33 @@ bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 	}
 
 	CalcPlrInv(player, false);
-	player._pGold = CalculateGold(player);
+	player.gold = CalculateGold(player);
 
-	ValidateFields(player._pStrength, SDL_SwapLE32(packed.pStrength), player._pStrength == SDL_SwapLE32(packed.pStrength));
-	ValidateFields(player._pMagic, SDL_SwapLE32(packed.pMagic), player._pMagic == SDL_SwapLE32(packed.pMagic));
-	ValidateFields(player._pDexterity, SDL_SwapLE32(packed.pDexterity), player._pDexterity == SDL_SwapLE32(packed.pDexterity));
-	ValidateFields(player._pVitality, SDL_SwapLE32(packed.pVitality), player._pVitality == SDL_SwapLE32(packed.pVitality));
-	ValidateFields(player._pHitPoints, SDL_SwapLE32(packed.pHitPoints), player._pHitPoints == SDL_SwapLE32(packed.pHitPoints));
-	ValidateFields(player._pMaxHP, SDL_SwapLE32(packed.pMaxHP), player._pMaxHP == SDL_SwapLE32(packed.pMaxHP));
-	ValidateFields(player._pMana, SDL_SwapLE32(packed.pMana), player._pMana == SDL_SwapLE32(packed.pMana));
-	ValidateFields(player._pMaxMana, SDL_SwapLE32(packed.pMaxMana), player._pMaxMana == SDL_SwapLE32(packed.pMaxMana));
-	ValidateFields(player._pDamageMod, SDL_SwapLE32(packed.pDamageMod), player._pDamageMod == SDL_SwapLE32(packed.pDamageMod));
+	ValidateFields(player.strength, SDL_SwapLE32(packed.pStrength), player.strength == SDL_SwapLE32(packed.pStrength));
+	ValidateFields(player.magic, SDL_SwapLE32(packed.pMagic), player.magic == SDL_SwapLE32(packed.pMagic));
+	ValidateFields(player.dexterity, SDL_SwapLE32(packed.pDexterity), player.dexterity == SDL_SwapLE32(packed.pDexterity));
+	ValidateFields(player.vitality, SDL_SwapLE32(packed.pVitality), player.vitality == SDL_SwapLE32(packed.pVitality));
+	ValidateFields(player.life, SDL_SwapLE32(packed.pHitPoints), player.life == SDL_SwapLE32(packed.pHitPoints));
+	ValidateFields(player.maxLife, SDL_SwapLE32(packed.pMaxHP), player.maxLife == SDL_SwapLE32(packed.pMaxHP));
+	ValidateFields(player.mana, SDL_SwapLE32(packed.pMana), player.mana == SDL_SwapLE32(packed.pMana));
+	ValidateFields(player.maxMana, SDL_SwapLE32(packed.pMaxMana), player.maxMana == SDL_SwapLE32(packed.pMaxMana));
+	ValidateFields(player.damageModifier, SDL_SwapLE32(packed.pDamageMod), player.damageModifier == SDL_SwapLE32(packed.pDamageMod));
 	ValidateFields(player.getBaseToBlock(), SDL_SwapLE32(packed.pBaseToBlk), player.getBaseToBlock() == SDL_SwapLE32(packed.pBaseToBlk));
-	ValidateFields(player._pIMinDam, SDL_SwapLE32(packed.pIMinDam), player._pIMinDam == SDL_SwapLE32(packed.pIMinDam));
-	ValidateFields(player._pIMaxDam, SDL_SwapLE32(packed.pIMaxDam), player._pIMaxDam == SDL_SwapLE32(packed.pIMaxDam));
-	ValidateFields(player._pIAC, SDL_SwapLE32(packed.pIAC), player._pIAC == SDL_SwapLE32(packed.pIAC));
-	ValidateFields(player._pIBonusDam, SDL_SwapLE32(packed.pIBonusDam), player._pIBonusDam == SDL_SwapLE32(packed.pIBonusDam));
-	ValidateFields(player._pIBonusToHit, SDL_SwapLE32(packed.pIBonusToHit), player._pIBonusToHit == SDL_SwapLE32(packed.pIBonusToHit));
-	ValidateFields(player._pIBonusAC, SDL_SwapLE32(packed.pIBonusAC), player._pIBonusAC == SDL_SwapLE32(packed.pIBonusAC));
-	ValidateFields(player._pIBonusDamMod, SDL_SwapLE32(packed.pIBonusDamMod), player._pIBonusDamMod == SDL_SwapLE32(packed.pIBonusDamMod));
-	ValidateFields(player._pIGetHit, SDL_SwapLE32(packed.pIGetHit), player._pIGetHit == SDL_SwapLE32(packed.pIGetHit));
-	ValidateFields(player._pIEnAc, SDL_SwapLE32(packed.pIEnAc), player._pIEnAc == SDL_SwapLE32(packed.pIEnAc));
-	ValidateFields(player._pIFMinDam, SDL_SwapLE32(packed.pIFMinDam), player._pIFMinDam == SDL_SwapLE32(packed.pIFMinDam));
-	ValidateFields(player._pIFMaxDam, SDL_SwapLE32(packed.pIFMaxDam), player._pIFMaxDam == SDL_SwapLE32(packed.pIFMaxDam));
-	ValidateFields(player._pILMinDam, SDL_SwapLE32(packed.pILMinDam), player._pILMinDam == SDL_SwapLE32(packed.pILMinDam));
-	ValidateFields(player._pILMaxDam, SDL_SwapLE32(packed.pILMaxDam), player._pILMaxDam == SDL_SwapLE32(packed.pILMaxDam));
-	ValidateFields(player._pMaxHPBase, player.calculateBaseLife(), player._pMaxHPBase <= player.calculateBaseLife());
-	ValidateFields(player._pMaxManaBase, player.calculateBaseMana(), player._pMaxManaBase <= player.calculateBaseMana());
+	ValidateFields(player.minDamage, SDL_SwapLE32(packed.pIMinDam), player.minDamage == SDL_SwapLE32(packed.pIMinDam));
+	ValidateFields(player.maxDamage, SDL_SwapLE32(packed.pIMaxDam), player.maxDamage == SDL_SwapLE32(packed.pIMaxDam));
+	ValidateFields(player.armorClass, SDL_SwapLE32(packed.pIAC), player.armorClass == SDL_SwapLE32(packed.pIAC));
+	ValidateFields(player.bonusDamagePercent, SDL_SwapLE32(packed.pIBonusDam), player.bonusDamagePercent == SDL_SwapLE32(packed.pIBonusDam));
+	ValidateFields(player.bonusToHit, SDL_SwapLE32(packed.pIBonusToHit), player.bonusToHit == SDL_SwapLE32(packed.pIBonusToHit));
+	ValidateFields(player.bonusArmorClass, SDL_SwapLE32(packed.pIBonusAC), player.bonusArmorClass == SDL_SwapLE32(packed.pIBonusAC));
+	ValidateFields(player.bonusDamage, SDL_SwapLE32(packed.pIBonusDamMod), player.bonusDamage == SDL_SwapLE32(packed.pIBonusDamMod));
+	ValidateFields(player.damageFromEnemies, SDL_SwapLE32(packed.pIGetHit), player.damageFromEnemies == SDL_SwapLE32(packed.pIGetHit));
+	ValidateFields(player.armorPierce, SDL_SwapLE32(packed.pIEnAc), player.armorPierce == SDL_SwapLE32(packed.pIEnAc));
+	ValidateFields(player.minFireDamage, SDL_SwapLE32(packed.pIFMinDam), player.minFireDamage == SDL_SwapLE32(packed.pIFMinDam));
+	ValidateFields(player.maxFireDamage, SDL_SwapLE32(packed.pIFMaxDam), player.maxFireDamage == SDL_SwapLE32(packed.pIFMaxDam));
+	ValidateFields(player.minLightningDamage, SDL_SwapLE32(packed.pILMinDam), player.minLightningDamage == SDL_SwapLE32(packed.pILMinDam));
+	ValidateFields(player.maxLightningDamage, SDL_SwapLE32(packed.pILMaxDam), player.maxLightningDamage == SDL_SwapLE32(packed.pILMaxDam));
+	ValidateFields(player.baseMaxLife, player.calculateBaseLife(), player.baseMaxLife <= player.calculateBaseLife());
+	ValidateFields(player.baseMaxMana, player.calculateBaseMana(), player.baseMaxMana <= player.calculateBaseMana());
 
 	return true;
 }

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -21,7 +21,7 @@
 	do {                                                           \
 		if (!(condition)) {                                        \
 			LogFailedJoinAttempt(#condition, #logValue, logValue); \
-			EventFailedJoinAttempt(player.name);                 \
+			EventFailedJoinAttempt(player.name);                   \
 			return false;                                          \
 		}                                                          \
 	} while (0)
@@ -30,7 +30,7 @@
 	do {                                                                                    \
 		if (!(condition)) {                                                                 \
 			LogFailedJoinAttempt(#condition, #logValue1, logValue1, #logValue2, logValue2); \
-			EventFailedJoinAttempt(player.name);                                          \
+			EventFailedJoinAttempt(player.name);                                            \
 			return false;                                                                   \
 		}                                                                                   \
 	} while (0)

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -31,10 +31,10 @@ struct ItemPack {
 struct PlayerPack {
 	uint32_t dwLowDateTime;
 	uint32_t dwHighDateTime;
-	int8_t destAction;
-	int8_t destParam1;
-	int8_t destParam2;
-	uint8_t plrlevel;
+	int8_t destinationAction;
+	int8_t destinationParam1;
+	int8_t destinationParam2;
+	uint8_t dungeonLevel;
 	uint8_t px;
 	uint8_t py;
 	uint8_t targx;
@@ -55,27 +55,27 @@ struct PlayerPack {
 	int32_t pMaxManaBase;
 	uint8_t pSplLvl[37]; // Should be MAX_SPELLS but set to 37 to make save games compatible
 	uint64_t pMemSpells;
-	ItemPack InvBody[NUM_INVLOC];
-	ItemPack InvList[InventoryGridCells];
-	int8_t InvGrid[InventoryGridCells];
-	uint8_t _pNumInv;
-	ItemPack SpdList[MaxBeltItems];
-	int8_t pTownWarps;
-	int8_t pDungMsgs;
-	int8_t pLvlLoad;
+	ItemPack bodySlot[NUM_INVLOC];
+	ItemPack inventorySlot[InventoryGridCells];
+	int8_t inventoryGrid[InventoryGridCells];
+	uint8_t numInventoryItems;
+	ItemPack beltSlot[MaxBeltItems];
+	int8_t townWarps;
+	int8_t dungeonMessages;
+	int8_t levelLoading;
 	uint8_t pBattleNet;
-	uint8_t pManaShield;
-	uint8_t pDungMsgs2;
+	uint8_t hasManaShield;
+	uint8_t dungeonMessages2;
 	/** The format the charater is in, 0: Diablo, 1: Hellfire */
 	int8_t bIsHellfire;
 	uint8_t reserved; // For future use
-	uint16_t wReflections;
+	uint16_t reflections;
 	uint8_t reserved2[2]; // For future use
 	uint8_t pSplLvl2[10]; // Hellfire spells
 	int16_t wReserved8;   // For future use
-	uint32_t pDiabloKillLevel;
+	uint32_t difficultyCompletion;
 	uint32_t pDifficulty;
-	uint32_t pDamAcFlags;  // `ItemSpecialEffectHf` is 1 byte but this is 4 bytes.
+	uint32_t hellfireFlags;  // `ItemSpecialEffectHf` is 1 byte but this is 4 bytes.
 	uint8_t reserved3[20]; // For future use
 };
 
@@ -86,7 +86,7 @@ union ItemNetPack {
 };
 
 struct PlayerNetPack {
-	uint8_t plrlevel;
+	uint8_t dungeonLevel;
 	uint8_t px;
 	uint8_t py;
 	char pName[PlayerNameLength];
@@ -104,15 +104,15 @@ struct PlayerNetPack {
 	int32_t pMaxManaBase;
 	uint8_t pSplLvl[MAX_SPELLS];
 	uint64_t pMemSpells;
-	ItemNetPack InvBody[NUM_INVLOC];
-	ItemNetPack InvList[InventoryGridCells];
-	int8_t InvGrid[InventoryGridCells];
-	uint8_t _pNumInv;
-	ItemNetPack SpdList[MaxBeltItems];
-	uint8_t pManaShield;
-	uint16_t wReflections;
-	uint8_t pDiabloKillLevel;
-	uint8_t friendlyMode;
+	ItemNetPack bodySlot[NUM_INVLOC];
+	ItemNetPack inventorySlot[InventoryGridCells];
+	int8_t inventoryGrid[InventoryGridCells];
+	uint8_t numInventoryItems;
+	ItemNetPack beltSlot[MaxBeltItems];
+	uint8_t hasManaShield;
+	uint16_t reflections;
+	uint8_t difficultyCompletion;
+	uint8_t isFriendlyMode;
 	uint8_t isOnSetLevel;
 
 	// For validation

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -75,8 +75,8 @@ struct PlayerPack {
 	int16_t wReserved8;   // For future use
 	uint32_t difficultyCompletion;
 	uint32_t pDifficulty;
-	uint32_t hellfireFlags;  // `ItemSpecialEffectHf` is 1 byte but this is 4 bytes.
-	uint8_t reserved3[20]; // For future use
+	uint32_t hellfireFlags; // `ItemSpecialEffectHf` is 1 byte but this is 4 bytes.
+	uint8_t reserved3[20];  // For future use
 };
 
 union ItemNetPack {

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -74,24 +74,24 @@ UiFlags GetValueColor(int value, bool flip = false)
 
 UiFlags GetMaxManaColor()
 {
-	return InspectPlayer->_pMaxMana > InspectPlayer->_pMaxManaBase ? UiFlags::ColorBlue : UiFlags::ColorWhite;
+	return InspectPlayer->maxMana > InspectPlayer->baseMaxMana ? UiFlags::ColorBlue : UiFlags::ColorWhite;
 }
 
 UiFlags GetMaxHealthColor()
 {
-	return InspectPlayer->_pMaxHP > InspectPlayer->_pMaxHPBase ? UiFlags::ColorBlue : UiFlags::ColorWhite;
+	return InspectPlayer->maxLife > InspectPlayer->baseMaxLife ? UiFlags::ColorBlue : UiFlags::ColorWhite;
 }
 
 std::pair<int, int> GetDamage()
 {
-	int damageMod = InspectPlayer->_pIBonusDamMod;
-	if (InspectPlayer->InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Bow && InspectPlayer->_pClass != HeroClass::Rogue) {
-		damageMod += InspectPlayer->_pDamageMod / 2;
+	int damageMod = InspectPlayer->bonusDamage;
+	if (InspectPlayer->bodySlot[INVLOC_HAND_LEFT]._itype == ItemType::Bow && InspectPlayer->heroClass != HeroClass::Rogue) {
+		damageMod += InspectPlayer->damageModifier / 2;
 	} else {
-		damageMod += InspectPlayer->_pDamageMod;
+		damageMod += InspectPlayer->damageModifier;
 	}
-	int mindam = InspectPlayer->_pIMinDam + InspectPlayer->_pIBonusDam * InspectPlayer->_pIMinDam / 100 + damageMod;
-	int maxdam = InspectPlayer->_pIMaxDam + InspectPlayer->_pIBonusDam * InspectPlayer->_pIMaxDam / 100 + damageMod;
+	int mindam = InspectPlayer->minDamage + InspectPlayer->bonusDamagePercent * InspectPlayer->minDamage / 100 + damageMod;
+	int maxdam = InspectPlayer->maxDamage + InspectPlayer->bonusDamagePercent * InspectPlayer->maxDamage / 100 + damageMod;
 	return { mindam, maxdam };
 }
 
@@ -121,7 +121,7 @@ constexpr unsigned GoldHeaderEntryIndex = 16;
 
 PanelEntry panelEntries[] = {
 	{ "", { 9, 14 }, 150, 0,
-	    []() { return StyledText { UiFlags::ColorWhite, InspectPlayer->_pName }; } },
+	    []() { return StyledText { UiFlags::ColorWhite, InspectPlayer->name }; } },
 	{ "", { 161, 14 }, 149, 0,
 	    []() { return StyledText { UiFlags::ColorWhite, std::string(InspectPlayer->getClassName()) }; } },
 
@@ -129,8 +129,8 @@ PanelEntry panelEntries[] = {
 	    []() { return StyledText { UiFlags::ColorWhite, StrCat(InspectPlayer->getCharacterLevel()) }; } },
 	{ N_("Experience"), { TopRightLabelX, 52 }, 99, 91,
 	    []() {
-	        int spacing = ((InspectPlayer->_pExperience >= 1000000000) ? 0 : 1);
-	        return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->_pExperience), spacing };
+	        int spacing = ((InspectPlayer->experience >= 1000000000) ? 0 : 1);
+	        return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->experience), spacing };
 	    } },
 	{ N_("Next level"), { TopRightLabelX, 80 }, 99, 198,
 	    []() {
@@ -145,55 +145,55 @@ PanelEntry panelEntries[] = {
 	{ N_("Base"), { LeftColumnLabelX, /* set dynamically */ 0 }, 0, 44, {} },
 	{ N_("Now"), { 135, /* set dynamically */ 0 }, 0, 44, {} },
 	{ N_("Strength"), { LeftColumnLabelX, 135 }, 45, LeftColumnLabelWidth,
-	    []() { return StyledText { GetBaseStatColor(CharacterAttribute::Strength), StrCat(InspectPlayer->_pBaseStr) }; } },
+	    []() { return StyledText { GetBaseStatColor(CharacterAttribute::Strength), StrCat(InspectPlayer->baseStrength) }; } },
 	{ "", { 135, 135 }, 45, 0,
-	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Strength), StrCat(InspectPlayer->_pStrength) }; } },
+	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Strength), StrCat(InspectPlayer->strength) }; } },
 	{ N_("Magic"), { LeftColumnLabelX, 163 }, 45, LeftColumnLabelWidth,
-	    []() { return StyledText { GetBaseStatColor(CharacterAttribute::Magic), StrCat(InspectPlayer->_pBaseMag) }; } },
+	    []() { return StyledText { GetBaseStatColor(CharacterAttribute::Magic), StrCat(InspectPlayer->baseMagic) }; } },
 	{ "", { 135, 163 }, 45, 0,
-	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Magic), StrCat(InspectPlayer->_pMagic) }; } },
-	{ N_("Dexterity"), { LeftColumnLabelX, 191 }, 45, LeftColumnLabelWidth, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Dexterity), StrCat(InspectPlayer->_pBaseDex) }; } },
+	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Magic), StrCat(InspectPlayer->magic) }; } },
+	{ N_("Dexterity"), { LeftColumnLabelX, 191 }, 45, LeftColumnLabelWidth, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Dexterity), StrCat(InspectPlayer->baseDexterity) }; } },
 	{ "", { 135, 191 }, 45, 0,
-	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Dexterity), StrCat(InspectPlayer->_pDexterity) }; } },
-	{ N_("Vitality"), { LeftColumnLabelX, 219 }, 45, LeftColumnLabelWidth, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Vitality), StrCat(InspectPlayer->_pBaseVit) }; } },
+	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Dexterity), StrCat(InspectPlayer->dexterity) }; } },
+	{ N_("Vitality"), { LeftColumnLabelX, 219 }, 45, LeftColumnLabelWidth, []() { return StyledText { GetBaseStatColor(CharacterAttribute::Vitality), StrCat(InspectPlayer->baseVitality) }; } },
 	{ "", { 135, 219 }, 45, 0,
-	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Vitality), StrCat(InspectPlayer->_pVitality) }; } },
+	    []() { return StyledText { GetCurrentStatColor(CharacterAttribute::Vitality), StrCat(InspectPlayer->vitality) }; } },
 	{ N_("Points to distribute"), { LeftColumnLabelX, 248 }, 45, LeftColumnLabelWidth,
 	    []() {
-	        InspectPlayer->_pStatPts = std::min(CalcStatDiff(*InspectPlayer), InspectPlayer->_pStatPts);
-	        return StyledText { UiFlags::ColorRed, (InspectPlayer->_pStatPts > 0 ? StrCat(InspectPlayer->_pStatPts) : "") };
+	        InspectPlayer->statPoints = std::min(CalcStatDiff(*InspectPlayer), InspectPlayer->statPoints);
+	        return StyledText { UiFlags::ColorRed, (InspectPlayer->statPoints > 0 ? StrCat(InspectPlayer->statPoints) : "") };
 	    } },
 
 	{ N_("Gold"), { TopRightLabelX, /* set dynamically */ 0 }, 0, 98, {} },
 	{ "", { TopRightLabelX, 127 }, 99, 0,
-	    []() { return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->_pGold) }; } },
+	    []() { return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->gold) }; } },
 
 	{ N_("Armor class"), { RightColumnLabelX, 163 }, 57, RightColumnLabelWidth,
-	    []() { return StyledText { GetValueColor(InspectPlayer->_pIBonusAC), StrCat(InspectPlayer->GetArmor() + InspectPlayer->getCharacterLevel() * 2) }; } },
+	    []() { return StyledText { GetValueColor(InspectPlayer->bonusArmorClass), StrCat(InspectPlayer->GetArmor() + InspectPlayer->getCharacterLevel() * 2) }; } },
 	{ N_("To hit"), { RightColumnLabelX, 191 }, 57, RightColumnLabelWidth,
-	    []() { return StyledText { GetValueColor(InspectPlayer->_pIBonusToHit), StrCat(InspectPlayer->InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Bow ? InspectPlayer->GetRangedToHit() : InspectPlayer->GetMeleeToHit(), "%") }; } },
+	    []() { return StyledText { GetValueColor(InspectPlayer->bonusToHit), StrCat(InspectPlayer->bodySlot[INVLOC_HAND_LEFT]._itype == ItemType::Bow ? InspectPlayer->GetRangedToHit() : InspectPlayer->GetMeleeToHit(), "%") }; } },
 	{ N_("Damage"), { RightColumnLabelX, 219 }, 57, RightColumnLabelWidth,
 	    []() {
 	        const auto [dmgMin, dmgMax] = GetDamage();
 	        int spacing = ((dmgMin >= 100) ? -1 : 1);
-	        return StyledText { GetValueColor(InspectPlayer->_pIBonusDam), StrCat(dmgMin, "-", dmgMax), spacing };
+	        return StyledText { GetValueColor(InspectPlayer->bonusDamagePercent), StrCat(dmgMin, "-", dmgMax), spacing };
 	    } },
 
 	{ N_("Life"), { LeftColumnLabelX, 284 }, 45, LeftColumnLabelWidth,
-	    []() { return StyledText { GetMaxHealthColor(), StrCat(InspectPlayer->_pMaxHP >> 6) }; } },
+	    []() { return StyledText { GetMaxHealthColor(), StrCat(InspectPlayer->maxLife >> 6) }; } },
 	{ "", { 135, 284 }, 45, 0,
-	    []() { return StyledText { (InspectPlayer->_pHitPoints != InspectPlayer->_pMaxHP ? UiFlags::ColorRed : GetMaxHealthColor()), StrCat(InspectPlayer->_pHitPoints >> 6) }; } },
+	    []() { return StyledText { (InspectPlayer->life != InspectPlayer->maxLife ? UiFlags::ColorRed : GetMaxHealthColor()), StrCat(InspectPlayer->life >> 6) }; } },
 	{ N_("Mana"), { LeftColumnLabelX, 312 }, 45, LeftColumnLabelWidth,
-	    []() { return StyledText { GetMaxManaColor(), StrCat(InspectPlayer->_pMaxMana >> 6) }; } },
+	    []() { return StyledText { GetMaxManaColor(), StrCat(InspectPlayer->maxMana >> 6) }; } },
 	{ "", { 135, 312 }, 45, 0,
-	    []() { return StyledText { (InspectPlayer->_pMana != InspectPlayer->_pMaxMana ? UiFlags::ColorRed : GetMaxManaColor()), StrCat(InspectPlayer->_pMana >> 6) }; } },
+	    []() { return StyledText { (InspectPlayer->mana != InspectPlayer->maxMana ? UiFlags::ColorRed : GetMaxManaColor()), StrCat(InspectPlayer->mana >> 6) }; } },
 
 	{ N_("Resist magic"), { RightColumnLabelX, 256 }, 57, RightColumnLabelWidth,
-	    []() { return GetResistInfo(InspectPlayer->_pMagResist); } },
+	    []() { return GetResistInfo(InspectPlayer->resistMagic); } },
 	{ N_("Resist fire"), { RightColumnLabelX, 284 }, 57, RightColumnLabelWidth,
-	    []() { return GetResistInfo(InspectPlayer->_pFireResist); } },
+	    []() { return GetResistInfo(InspectPlayer->resistFire); } },
 	{ N_("Resist lightning"), { RightColumnLabelX, 313 }, 57, RightColumnLabelWidth,
-	    []() { return GetResistInfo(InspectPlayer->_pLghtResist); } },
+	    []() { return GetResistInfo(InspectPlayer->resistLightning); } },
 };
 
 OptionalOwnedClxSpriteList Panel;
@@ -253,14 +253,14 @@ void DrawShadowString(const Surface &out, const PanelEntry &entry)
 
 void DrawStatButtons(const Surface &out)
 {
-	if (InspectPlayer->_pStatPts > 0 && !IsInspectingPlayer()) {
-		if (InspectPlayer->_pBaseStr < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Strength))
+	if (InspectPlayer->statPoints > 0 && !IsInspectingPlayer()) {
+		if (InspectPlayer->baseStrength < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Strength))
 			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 137, 157 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Strength)] ? 2 : 1]);
-		if (InspectPlayer->_pBaseMag < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Magic))
+		if (InspectPlayer->baseMagic < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Magic))
 			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 137, 185 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Magic)] ? 4 : 3]);
-		if (InspectPlayer->_pBaseDex < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Dexterity))
+		if (InspectPlayer->baseDexterity < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Dexterity))
 			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 137, 214 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Dexterity)] ? 6 : 5]);
-		if (InspectPlayer->_pBaseVit < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Vitality))
+		if (InspectPlayer->baseVitality < InspectPlayer->GetMaximumAttributeValue(CharacterAttribute::Vitality))
 			ClxDraw(out, GetPanelPosition(UiPanels::Character, { 137, 242 }), (*pChrButtons)[chrbtn[static_cast<size_t>(CharacterAttribute::Vitality)] ? 8 : 7]);
 	}
 }

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -181,15 +181,15 @@ void CopySaveFile(uint32_t saveNum, std::string targetPath)
 
 void Game2UiPlayer(const Player &player, _uiheroinfo *heroinfo, bool bHasSaveFile)
 {
-	CopyUtf8(heroinfo->name, player._pName, sizeof(heroinfo->name));
+	CopyUtf8(heroinfo->name, player.name, sizeof(heroinfo->name));
 	heroinfo->level = player.getCharacterLevel();
-	heroinfo->heroclass = player._pClass;
-	heroinfo->strength = player._pStrength;
-	heroinfo->magic = player._pMagic;
-	heroinfo->dexterity = player._pDexterity;
-	heroinfo->vitality = player._pVitality;
+	heroinfo->heroclass = player.heroClass;
+	heroinfo->strength = player.strength;
+	heroinfo->magic = player.magic;
+	heroinfo->dexterity = player.dexterity;
+	heroinfo->vitality = player.vitality;
 	heroinfo->hassaved = bHasSaveFile;
-	heroinfo->herorank = player.pDiabloKillLevel;
+	heroinfo->herorank = player.difficultyCompletion;
 	heroinfo->spawned = gbIsSpawn;
 }
 
@@ -518,11 +518,11 @@ void pfile_write_hero(SaveWriter &saveWriter, bool writeGameData)
 void RemoveAllInvalidItems(Player &player)
 {
 	for (int i = 0; i < NUM_INVLOC; i++)
-		RemoveInvalidItem(player.InvBody[i]);
-	for (int i = 0; i < player._pNumInv; i++)
-		RemoveInvalidItem(player.InvList[i]);
+		RemoveInvalidItem(player.bodySlot[i]);
+	for (int i = 0; i < player.numInventoryItems; i++)
+		RemoveInvalidItem(player.inventorySlot[i]);
 	for (int i = 0; i < MaxBeltItems; i++)
-		RemoveInvalidItem(player.SpdList[i]);
+		RemoveInvalidItem(player.beltSlot[i]);
 	RemoveEmptyInventory(player);
 }
 
@@ -729,7 +729,7 @@ bool pfile_ui_save_create(_uiheroinfo *heroinfo)
 
 	Player &player = Players[0];
 	CreatePlayer(player, heroinfo->heroclass);
-	CopyUtf8(player._pName, heroinfo->name, PlayerNameLength);
+	CopyUtf8(player.name, heroinfo->name, PlayerNameLength);
 	PackPlayer(pkplr, player);
 	EncodeHero(saveWriter, &pkplr);
 	Game2UiPlayer(player, heroinfo, false);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2407,14 +2407,14 @@ void Player::_addExperience(uint32_t experience, int levelDelta)
 	const uint32_t maxExperience = GetNextExperienceThresholdForLevel(getMaxCharacterLevel());
 
 	// ensure we only add enough experience to reach the max experience cap so we don't overflow
-	experience += std::min(clampedExp, maxExperience - experience);
+	this->experience += std::min(clampedExp, maxExperience - this->experience);
 
 	if (*sgOptions.Gameplay.experienceBar) {
 		RedrawEverything();
 	}
 
 	// Increase player level if applicable
-	while (!isMaxCharacterLevel() && experience >= getNextExperienceThreshold()) {
+	while (!isMaxCharacterLevel() && this->experience >= getNextExperienceThreshold()) {
 		// NextPlrLevel increments character level which changes the next experience threshold
 		NextPlrLevel(*this);
 	}

--- a/Source/player.h
+++ b/Source/player.h
@@ -206,9 +206,13 @@ struct PlayerAnimationData {
 struct SpellCastInfo {
 	SpellID spellId;
 	SpellType spellType;
-	/* @brief Inventory location for scrolls */
+	/**
+	 * @brief Inventory location for scrolls
+	 */
 	int8_t spellFrom;
-	/* @brief Used for spell level */
+	/**
+	 * @brief Used for spell level
+	 */
 	int spellLevel;
 };
 
@@ -217,63 +221,63 @@ struct Player {
 	Player(Player &&) noexcept = default;
 	Player &operator=(Player &&) noexcept = default;
 
-	char _pName[PlayerNameLength];
-	Item InvBody[NUM_INVLOC];
-	Item InvList[InventoryGridCells];
-	Item SpdList[MaxBeltItems];
-	Item HoldItem;
+	char name[PlayerNameLength];            // _pName
+	Item bodySlot[NUM_INVLOC];              // _pInvBody
+	Item inventorySlot[InventoryGridCells]; // _pInvList
+	Item beltSlot[MaxBeltItems];            // _pSpdList
+	Item heldItem;                          // _pHoldItem
 
 	int lightId;
 
-	int _pNumInv;
-	int _pStrength;
-	int _pBaseStr;
-	int _pMagic;
-	int _pBaseMag;
-	int _pDexterity;
-	int _pBaseDex;
-	int _pVitality;
-	int _pBaseVit;
-	int _pStatPts;
-	int _pDamageMod;
-	int _pHPBase;
-	int _pMaxHPBase;
-	int _pHitPoints;
-	int _pMaxHP;
-	int _pHPPer;
-	int _pManaBase;
-	int _pMaxManaBase;
-	int _pMana;
-	int _pMaxMana;
-	int _pManaPer;
-	int _pIMinDam;
-	int _pIMaxDam;
-	int _pIAC;
-	int _pIBonusDam;
-	int _pIBonusToHit;
-	int _pIBonusAC;
-	int _pIBonusDamMod;
-	int _pIGetHit;
-	int _pIEnAc;
-	int _pIFMinDam;
-	int _pIFMaxDam;
-	int _pILMinDam;
-	int _pILMaxDam;
-	uint32_t _pExperience;
-	PLR_MODE _pmode;
-	int8_t walkpath[MaxPathLength];
-	bool plractive;
-	action_id destAction;
-	int destParam1;
-	int destParam2;
-	int destParam3;
-	int destParam4;
-	int _pGold;
+	int numInventoryItems;          // _pNumInv
+	int strength;                   // _pStrength
+	int baseStrength;               // _pBaseStr
+	int magic;                      // _pMagic
+	int baseMagic;                  // _pBaseMag
+	int dexterity;                  // _pDexterity
+	int baseDexterity;              // _pBaseDex
+	int vitality;                   // _pVitality
+	int baseVitality;               // _pBaseVit
+	int statPoints;                 // _pStatPts
+	int damageModifier;             // _pDamageMod
+	int baseLife;                   // _pHPBase
+	int baseMaxLife;                // _pMaxHPBase
+	int life;                       // _pHitPoints
+	int maxLife;                    // _pMaxHP
+	int lifePercentage;             // _pHPPer
+	int baseMana;                   // _pManaBase
+	int baseMaxMana;                // _pMaxManaBase
+	int mana;                       // _pMana
+	int maxMana;                    // _pMaxMana
+	int manaPercentage;             // _pManaPer
+	int minDamage;                  // _pIMinDam
+	int maxDamage;                  // _pIMaxDam
+	int armorClass;                 // _pIAC
+	int bonusDamagePercent;         // _pIBonusDam
+	int bonusToHit;                 // _pIBonusToHit
+	int bonusArmorClass;            // _pIBonusAC
+	int bonusDamage;                // _pIBonusDamMod
+	int damageFromEnemies;          // _pIGetHit
+	int armorPierce;                // _pIEnAc
+	int minFireDamage;              // _pIFMinDam
+	int maxFireDamage;              // _pIFMaxDam
+	int minLightningDamage;         // _pILMinDam
+	int maxLightningDamage;         // _pILMaxDam
+	uint32_t experience;            // _pExperience
+	PLR_MODE mode;                  // _pmode
+	int8_t walkPath[MaxPathLength]; // _walkpath
+	bool isPlayerActive;            // _pActive
+	action_id destinationAction;    // _pDestAction
+	int destinationParam1;          // _pDestParam1
+	int destinationParam2;          // _pDestParam2
+	int destinationParam3;          // _pDestParam3
+	int destinationParam4;          // _pDestParam4
+	int gold;                       // _pGold
 
 	/**
-	 * @brief Contains Information for current Animation
+	 * @brief Contains Information for current Animation (AnimInfo)
 	 */
-	AnimationInfo AnimInfo;
+	PlayerAnimationInfo animationInfo;
 	/**
 	 * @brief Contains a optional preview ClxSprite that is displayed until the current command is handled by the game logic
 	 */
@@ -282,105 +286,127 @@ struct Player {
 	 * @brief Contains the progress to next game tick when previewCelSprite was set
 	 */
 	int8_t progressToNextGameTickWhenPreviewWasSet;
-	/** @brief Bitmask using item_special_effect */
-	ItemSpecialEffect _pIFlags;
 	/**
-	 * @brief Contains Data (Sprites) for the different Animations
+	 * @brief Bitmask using item_special_effect (_pIFlags)
 	 */
-	std::array<PlayerAnimationData, enum_size<player_graphic>::value> AnimationData;
-	int8_t _pNFrames;
-	int8_t _pWFrames;
-	int8_t _pAFrames;
-	int8_t _pAFNum;
-	int8_t _pSFrames;
-	int8_t _pSFNum;
-	int8_t _pHFrames;
-	int8_t _pDFrames;
-	int8_t _pBFrames;
-	int8_t InvGrid[InventoryGridCells];
+	ItemSpecialEffect flags;
+	/**
+	 * @brief Contains Data (Sprites) for the different Animations (AnimationData)
+	 */
+	std::array<PlayerAnimationData, enum_size<player_graphic>::value> animationData;
+	int8_t numIdleFrames;                     // _pNFrames
+	int8_t numWalkFrames;                     // _pWFrames
+	int8_t numAttackFrames;                   // _pAFrames
+	int8_t attackActionFrame;                 // _pAFNum
+	int8_t numSpellFrames;                    // _pSFrames
+	int8_t spellActionFrame;                  // _pSFNum
+	int8_t numRecoveryFrames;                 // _pRFrames
+	int8_t numDeathFrames;                    // _pDFrames
+	int8_t numBlockFrames;                    // _pBFrames
+	int8_t inventoryGrid[InventoryGridCells]; // InvGrid
 
-	uint8_t plrlevel;
-	bool plrIsOnSetLevel;
+	uint8_t dungeonLevel; // plrlevel
+	bool isOnSetLevel;    // plrIsOnSetLvl
 	ActorPosition position;
-	Direction _pdir; // Direction faced by player (direction enum)
-	HeroClass _pClass;
+	Direction direction; // Direction faced by player (direction enum) (_pdir)
+	HeroClass heroClass; // _pClass
 
 private:
-	uint8_t _pLevel = 1; // Use get/setCharacterLevel to ensure this attribute stays within the accepted range
+	uint8_t characterLevel = 1; // Use get/setCharacterLevel to ensure this attribute stays within the accepted range (_pLevel)
 
 public:
-	uint8_t _pgfxnum; // Bitmask indicating what variant of the sprite the player is using. The 3 lower bits define weapon (PlayerWeaponGraphic) and the higher bits define armour (starting with PlayerArmorGraphic)
-	int8_t _pISplLvlAdd;
-	/** @brief Specifies whether players are in non-PvP mode. */
-	bool friendlyMode = true;
+	uint8_t graphic;        // Bitmask indicating what variant of the sprite the player is using. The 3 lower bits define weapon (PlayerWeaponGraphic) and the higher bits define armour (starting with PlayerArmorGraphic) (_pgfxnum)
+	int8_t bonusSpellLevel; // _pSplLvlAdd
+	/**
+	 * @brief Specifies whether players are in non-PvP mode. (friendlyMode)
+	 */
+	bool isFriendlyMode = true;
 
-	/** @brief The next queued spell */
+	/**
+	 * @brief The next queued spell
+	 */
 	SpellCastInfo queuedSpell;
-	/** @brief The spell that is currently being cast */
+	/**
+	 * @brief The spell that is currently being cast
+	 */
 	SpellCastInfo executedSpell;
-	/* @brief Which spell should be executed with CURSOR_TELEPORT */
+	/**
+	 * @brief Which spell should be executed with CURSOR_TELEPORT
+	 */
 	SpellID inventorySpell;
-	/* @brief Inventory location for scrolls with CURSOR_TELEPORT */
+	/**
+	 * @brief Inventory location for scrolls with CURSOR_TELEPORT
+	 */
 	int8_t spellFrom;
-	SpellID _pRSpell;
-	SpellType _pRSplType;
-	SpellID _pSBkSpell;
-	uint8_t _pSplLvl[64];
-	/** @brief Bitmask of staff spell */
-	uint64_t _pISpells;
-	/** @brief Bitmask of learned spells */
-	uint64_t _pMemSpells;
-	/** @brief Bitmask of abilities */
-	uint64_t _pAblSpells;
-	/** @brief Bitmask of spells available via scrolls */
-	uint64_t _pScrlSpells;
-	SpellFlag _pSpellFlags;
-	SpellID _pSplHotKey[NumHotkeys];
-	SpellType _pSplTHotKey[NumHotkeys];
-	bool _pBlockFlag;
-	bool _pInvincible;
-	int8_t _pLightRad;
-	/** @brief True when the player is transitioning between levels */
-	bool _pLvlChanging;
+	SpellID selectedSpell;       // _pRSpell
+	SpellType selectedSpellType; // _pRSplType
+	uint8_t spellLevel[64];      // _pSplLvl
+	/**
+	 * @brief Bitmask of staff spell (_pISpells)
+	 */
+	uint64_t staffSpells;
+	/**
+	 * @brief Bitmask of learned spells (_pMemSpells)
+	 */
+	uint64_t learnedSpells;
+	/**
+	 * @brief Bitmask of skills (_pAblSpells)
+	 */
+	uint64_t skills;
+	/**
+	 * @brief Bitmask of spells available via scrolls (_pScrlSpells)
+	 */
+	uint64_t scrollSpells;
+	SpellFlag spellFlags;                  // _pSplFlags
+	SpellID hotkeySpell[NumHotkeys];       // _pSplHotKey
+	SpellType hotkeySpellType[NumHotkeys]; // _pSplTHotKey
+	bool hasBlockFlag;                     // _pBlockFlag
+	bool isInvincible;                     // _pInvincible
+	int8_t lightRadius;                    // _pLightRad
+	/**
+	 * @brief True when the player is transitioning between levels (_pLvlChanging)
+	 */
+	bool isChangingLevel;
 
-	int8_t _pArmorClass;
-	int8_t _pMagResist;
-	int8_t _pFireResist;
-	int8_t _pLghtResist;
-	bool _pInfraFlag;
-	/** Player's direction when ending movement. Also used for casting direction of SpellID::FireWall. */
+	int8_t resistMagic;      // _pMagResist
+	int8_t resistFire;       // _pFireResist
+	int8_t resistLightning;  // _pLghtResist
+	bool hasInfravisionFlag; // _pInfraFlag
+	/**
+	 * @brief Player's direction when ending movement. Also used for casting direction of SpellID::FireWall.
+	 */
 	Direction tempDirection;
 
-	bool _pLvlVisited[NUMLEVELS];
-	bool _pSLvlVisited[NUMLEVELS]; // only 10 used
+	bool isLevelVisted[NUMLEVELS];    // _pLvlVisited
+	bool isSetLevelVisted[NUMLEVELS]; // only 10 used (_pSLvlVisited)
 
-	item_misc_id _pOilType;
-	uint8_t pTownWarps;
-	uint8_t pDungMsgs;
-	uint8_t pLvlLoad;
-	bool pManaShield;
-	uint8_t pDungMsgs2;
-	bool pOriginalCathedral;
-	uint8_t pDiabloKillLevel;
-	uint16_t wReflections;
-	ItemSpecialEffectHf pDamAcFlags;
+	item_misc_id oilType;              // _pOilType
+	uint8_t townWarps;                 // pTownWarps
+	uint8_t dungeonMessages;           // pDungMsgs
+	uint8_t levelLoading;              // pLvlLoad
+	bool hasManaShield;                // pManaShield
+	uint8_t dungeonMessages2;          // pDungMsgs2
+	bool originalCathedral;            // pOriginalCathedral
+	uint8_t difficultyCompletion;      // pDiabloKillLevel
+	uint16_t reflections;              // wReflections
+	ItemSpecialEffectHf hellfireFlags; // pDamAcFlags
 
 	/**
 	 * @brief Convenience function to get the base stats/bonuses for this player's class
 	 */
 	[[nodiscard]] const ClassAttributes &getClassAttributes() const
 	{
-		return GetClassAttributes(_pClass);
+		return GetClassAttributes(heroClass);
 	}
 
 	[[nodiscard]] const PlayerCombatData &getPlayerCombatData() const
 	{
-		return GetPlayerCombatDataForClass(_pClass);
+		return GetPlayerCombatDataForClass(heroClass);
 	}
 
 	[[nodiscard]] const PlayerData &getPlayerData() const
 	{
-		return GetPlayerDataForClass(_pClass);
+		return GetPlayerDataForClass(heroClass);
 	}
 
 	/**
@@ -400,14 +426,14 @@ public:
 
 	bool CanUseItem(const Item &item) const
 	{
-		return _pStrength >= item._iMinStr
-		    && _pMagic >= item._iMinMag
-		    && _pDexterity >= item._iMinDex;
+		return strength >= item._iMinStr
+		    && magic >= item._iMinMag
+		    && dexterity >= item._iMinDex;
 	}
 
 	bool CanCleave()
 	{
-		switch (_pClass) {
+		switch (heroClass) {
 		case HeroClass::Warrior:
 		case HeroClass::Rogue:
 		case HeroClass::Sorcerer:
@@ -415,7 +441,7 @@ public:
 		case HeroClass::Monk:
 			return isEquipped(ItemType::Staff);
 		case HeroClass::Bard:
-			return InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Sword && InvBody[INVLOC_HAND_RIGHT]._itype == ItemType::Sword;
+			return bodySlot[INVLOC_HAND_LEFT]._itype == ItemType::Sword && bodySlot[INVLOC_HAND_RIGHT]._itype == ItemType::Sword;
 		case HeroClass::Barbarian:
 			return isEquipped(ItemType::Axe) || (!isEquipped(ItemType::Shield) && (isEquipped(ItemType::Mace, true) || isEquipped(ItemType::Sword, true)));
 		default:
@@ -432,18 +458,18 @@ public:
 		case ItemType::Mace:
 		case ItemType::Shield:
 		case ItemType::Staff:
-			return (InvBody[INVLOC_HAND_LEFT]._itype == itemType && (!isTwoHanded || InvBody[INVLOC_HAND_LEFT]._iLoc == ILOC_TWOHAND))
-			    || (InvBody[INVLOC_HAND_RIGHT]._itype == itemType && (!isTwoHanded || InvBody[INVLOC_HAND_LEFT]._iLoc == ILOC_TWOHAND));
+			return (bodySlot[INVLOC_HAND_LEFT]._itype == itemType && (!isTwoHanded || bodySlot[INVLOC_HAND_LEFT]._iLoc == ILOC_TWOHAND))
+			    || (bodySlot[INVLOC_HAND_RIGHT]._itype == itemType && (!isTwoHanded || bodySlot[INVLOC_HAND_LEFT]._iLoc == ILOC_TWOHAND));
 		case ItemType::LightArmor:
 		case ItemType::MediumArmor:
 		case ItemType::HeavyArmor:
-			return InvBody[INVLOC_CHEST]._itype == itemType;
+			return bodySlot[INVLOC_CHEST]._itype == itemType;
 		case ItemType::Helm:
-			return InvBody[INVLOC_HEAD]._itype == itemType;
+			return bodySlot[INVLOC_HEAD]._itype == itemType;
 		case ItemType::Ring:
-			return InvBody[INVLOC_RING_LEFT]._itype == itemType || InvBody[INVLOC_RING_RIGHT]._itype == itemType;
+			return bodySlot[INVLOC_RING_LEFT]._itype == itemType || bodySlot[INVLOC_RING_RIGHT]._itype == itemType;
 		case ItemType::Amulet:
-			return InvBody[INVLOC_AMULET]._itype == itemType;
+			return bodySlot[INVLOC_AMULET]._itype == itemType;
 		default:
 			return false;
 		}
@@ -486,9 +512,9 @@ public:
 			return mostValuableItem;
 		};
 
-		const Item *mostValuableItem = getMostValuableItem(SpdList, SpdList + MaxBeltItems);
-		mostValuableItem = getMostValuableItem(InvBody, InvBody + inv_body_loc::NUM_INVLOC, mostValuableItem);
-		mostValuableItem = getMostValuableItem(InvList, InvList + _pNumInv, mostValuableItem);
+		const Item *mostValuableItem = getMostValuableItem(beltSlot, beltSlot + MaxBeltItems);
+		mostValuableItem = getMostValuableItem(bodySlot, bodySlot + inv_body_loc::NUM_INVLOC, mostValuableItem);
+		mostValuableItem = getMostValuableItem(inventorySlot, inventorySlot + numInventoryItems, mostValuableItem);
 
 		return mostValuableItem;
 	}
@@ -557,7 +583,7 @@ public:
 	 */
 	item_equip_type GetItemLocation(const Item &item) const
 	{
-		if (_pClass == HeroClass::Barbarian && item._iLoc == ILOC_TWOHAND && IsAnyOf(item._itype, ItemType::Sword, ItemType::Mace))
+		if (heroClass == HeroClass::Barbarian && item._iLoc == ILOC_TWOHAND && IsAnyOf(item._itype, ItemType::Sword, ItemType::Mace))
 			return ILOC_ONEHAND;
 		return item._iLoc;
 	}
@@ -567,7 +593,7 @@ public:
 	 */
 	int GetArmor() const
 	{
-		return _pIBonusAC + _pIAC + _pDexterity / 5;
+		return bonusArmorClass + armorClass + dexterity / 5;
 	}
 
 	/**
@@ -575,7 +601,7 @@ public:
 	 */
 	int GetMeleeToHit() const
 	{
-		return getCharacterLevel() + _pDexterity / 2 + _pIBonusToHit + getPlayerCombatData().baseMeleeToHit;
+		return getCharacterLevel() + dexterity / 2 + bonusToHit + getPlayerCombatData().baseMeleeToHit;
 	}
 
 	/**
@@ -586,7 +612,7 @@ public:
 		int hper = GetMeleeToHit();
 		// in hellfire armor piercing ignores % of enemy armor instead, no way to include it here
 		if (!gbIsHellfire)
-			hper += _pIEnAc;
+			hper += armorPierce;
 		return hper;
 	}
 
@@ -595,7 +621,7 @@ public:
 	 */
 	int GetRangedToHit() const
 	{
-		return getCharacterLevel() + _pDexterity + _pIBonusToHit + getPlayerCombatData().baseRangedToHit;
+		return getCharacterLevel() + dexterity + bonusToHit + getPlayerCombatData().baseRangedToHit;
 	}
 
 	int GetRangedPiercingToHit() const
@@ -603,7 +629,7 @@ public:
 		int hper = GetRangedToHit();
 		// in hellfire armor piercing ignores % of enemy armor instead, no way to include it here
 		if (!gbIsHellfire)
-			hper += _pIEnAc;
+			hper += armorPierce;
 		return hper;
 	}
 
@@ -612,7 +638,7 @@ public:
 	 */
 	int GetMagicToHit() const
 	{
-		return _pMagic + getPlayerCombatData().baseMagicToHit;
+		return magic + getPlayerCombatData().baseMagicToHit;
 	}
 
 	/**
@@ -621,7 +647,7 @@ public:
 	 */
 	int GetBlockChance(bool useLevel = true) const
 	{
-		int blkper = _pDexterity + getBaseToBlock();
+		int blkper = dexterity + getBaseToBlock();
 		if (useLevel)
 			blkper += getCharacterLevel() * 2;
 		return blkper;
@@ -641,11 +667,11 @@ public:
 	 */
 	int GetSpellLevel(SpellID spell) const
 	{
-		if (spell == SpellID::Invalid || static_cast<std::size_t>(spell) >= sizeof(_pSplLvl)) {
+		if (spell == SpellID::Invalid || static_cast<std::size_t>(spell) >= sizeof(spellLevel)) {
 			return 0;
 		}
 
-		return std::max<int>(_pISplLvlAdd + _pSplLvl[static_cast<std::size_t>(spell)], 0);
+		return std::max<int>(bonusSpellLevel + spellLevel[static_cast<std::size_t>(spell)], 0);
 	}
 
 	/**
@@ -656,15 +682,15 @@ public:
 	int CalculateArmorPierce(int monsterArmor, bool isMelee) const
 	{
 		int tmac = monsterArmor;
-		if (_pIEnAc > 0) {
+		if (armorPierce > 0) {
 			if (gbIsHellfire) {
-				int pIEnAc = _pIEnAc - 1;
+				int pIEnAc = armorPierce - 1;
 				if (pIEnAc > 0)
 					tmac >>= pIEnAc;
 				else
 					tmac -= tmac / 4;
 			}
-			if (isMelee && _pClass == HeroClass::Barbarian) {
+			if (isMelee && heroClass == HeroClass::Barbarian) {
 				tmac -= monsterArmor / 8;
 			}
 		}
@@ -678,32 +704,32 @@ public:
 	 * @brief Calculates the players current Hit Points as a percentage of their max HP and stores it for later reference
 	 *
 	 * The stored value is unused...
-	 * @see _pHPPer
+	 * @see lifePercentage
 	 * @return The players current hit points as a percentage of their maximum (from 0 to 80%)
 	 */
 	int UpdateHitPointPercentage()
 	{
-		if (_pMaxHP <= 0) { // divide by zero guard
-			_pHPPer = 0;
+		if (maxLife <= 0) { // divide by zero guard
+			lifePercentage = 0;
 		} else {
 			// Maximum achievable HP is approximately 1200. Diablo uses fixed point integers where the last 6 bits are
 			// fractional values. This means that we will never overflow HP values normally by doing this multiplication
 			// as the max value is representable in 17 bits and the multiplication result will be at most 23 bits
-			_pHPPer = std::clamp(_pHitPoints * 80 / _pMaxHP, 0, 80); // hp should never be greater than maxHP but just in case
+			lifePercentage = std::clamp(life * 80 / maxLife, 0, 80); // hp should never be greater than maxHP but just in case
 		}
 
-		return _pHPPer;
+		return lifePercentage;
 	}
 
 	int UpdateManaPercentage()
 	{
-		if (_pMaxMana <= 0) {
-			_pManaPer = 0;
+		if (maxMana <= 0) {
+			manaPercentage = 0;
 		} else {
-			_pManaPer = std::clamp(_pMana * 80 / _pMaxMana, 0, 80);
+			manaPercentage = std::clamp(mana * 80 / maxMana, 0, 80);
 		}
 
-		return _pManaPer;
+		return manaPercentage;
 	}
 
 	/**
@@ -720,8 +746,8 @@ public:
 	 */
 	void RestoreFullLife()
 	{
-		_pHitPoints = _pMaxHP;
-		_pHPBase = _pMaxHPBase;
+		life = maxLife;
+		baseLife = baseMaxLife;
 	}
 
 	/**
@@ -739,9 +765,9 @@ public:
 	 */
 	void RestoreFullMana()
 	{
-		if (HasNoneOf(_pIFlags, ItemSpecialEffect::NoMana)) {
-			_pMana = _pMaxMana;
-			_pManaBase = _pMaxManaBase;
+		if (HasNoneOf(flags, ItemSpecialEffect::NoMana)) {
+			mana = maxMana;
+			baseMana = baseMaxMana;
 		}
 	}
 	/**
@@ -756,20 +782,20 @@ public:
 	 */
 	bool UsesRangedWeapon() const
 	{
-		return static_cast<PlayerWeaponGraphic>(_pgfxnum & 0xF) == PlayerWeaponGraphic::Bow;
+		return static_cast<PlayerWeaponGraphic>(graphic & 0xF) == PlayerWeaponGraphic::Bow;
 	}
 
 	bool CanChangeAction()
 	{
-		if (_pmode == PM_STAND)
+		if (mode == PM_STAND)
 			return true;
-		if (_pmode == PM_ATTACK && AnimInfo.currentFrame >= _pAFNum)
+		if (mode == PM_ATTACK && animationInfo.currentFrame >= attackActionFrame)
 			return true;
-		if (_pmode == PM_RATTACK && AnimInfo.currentFrame >= _pAFNum)
+		if (mode == PM_RATTACK && animationInfo.currentFrame >= attackActionFrame)
 			return true;
-		if (_pmode == PM_SPELL && AnimInfo.currentFrame >= _pSFNum)
+		if (mode == PM_SPELL && animationInfo.currentFrame >= spellActionFrame)
 			return true;
-		if (isWalking() && AnimInfo.isLastFrame())
+		if (isWalking() && animationInfo.isLastFrame())
 			return true;
 		return false;
 	}
@@ -782,13 +808,13 @@ public:
 
 	[[nodiscard]] ClxSprite currentSprite() const
 	{
-		return previewCelSprite ? *previewCelSprite : AnimInfo.currentSprite();
+		return previewCelSprite ? *previewCelSprite : animationInfo.currentSprite();
 	}
 	[[nodiscard]] Displacement getRenderingOffset(const ClxSprite sprite) const
 	{
 		Displacement offset = { -CalculateWidth2(sprite.width()), 0 };
 		if (isWalking())
-			offset += GetOffsetForWalking(AnimInfo, _pdir);
+			offset += GetOffsetForWalking(animationInfo, direction);
 		return offset;
 	}
 
@@ -803,7 +829,7 @@ public:
 
 	[[nodiscard]] uint8_t getCharacterLevel() const
 	{
-		return _pLevel;
+		return characterLevel;
 	}
 
 	/**
@@ -856,27 +882,27 @@ public:
 	/** @brief Checks if the player is on the corresponding level. */
 	bool isOnLevel(uint8_t level) const
 	{
-		return !this->plrIsOnSetLevel && this->plrlevel == level;
+		return !this->isOnSetLevel && this->dungeonLevel == level;
 	}
 	/** @brief Checks if the player is on the corresponding level. */
 	bool isOnLevel(_setlevels level) const
 	{
-		return this->plrIsOnSetLevel && this->plrlevel == static_cast<uint8_t>(level);
+		return this->isOnSetLevel && this->dungeonLevel == static_cast<uint8_t>(level);
 	}
 	/** @brief Checks if the player is on a arena level. */
 	bool isOnArenaLevel() const
 	{
-		return plrIsOnSetLevel && IsArenaLevel(static_cast<_setlevels>(plrlevel));
+		return isOnSetLevel && IsArenaLevel(static_cast<_setlevels>(dungeonLevel));
 	}
 	void setLevel(uint8_t level)
 	{
-		this->plrlevel = level;
-		this->plrIsOnSetLevel = false;
+		this->dungeonLevel = level;
+		this->isOnSetLevel = false;
 	}
 	void setLevel(_setlevels level)
 	{
-		this->plrlevel = static_cast<uint8_t>(level);
-		this->plrIsOnSetLevel = true;
+		this->dungeonLevel = static_cast<uint8_t>(level);
+		this->isOnSetLevel = true;
 	}
 
 	/** @brief Returns a character's life based on starting life, character level, and base vitality. */
@@ -898,8 +924,8 @@ public:
 	/** @brief Checks if the player is holding an item of the provided type, and is usable. */
 	bool isHoldingItem(const ItemType type) const
 	{
-		const Item &leftHandItem = InvBody[INVLOC_HAND_LEFT];
-		const Item &rightHandItem = InvBody[INVLOC_HAND_RIGHT];
+		const Item &leftHandItem = bodySlot[INVLOC_HAND_LEFT];
+		const Item &rightHandItem = bodySlot[INVLOC_HAND_RIGHT];
 
 		return (type == leftHandItem._itype && leftHandItem._iStatFlag) || (type == rightHandItem._itype && rightHandItem._iStatFlag);
 	}
@@ -968,7 +994,7 @@ void ClrPlrPath(Player &player);
 bool PosOkPlayer(const Player &player, Point position);
 void MakePlrPath(Player &player, Point targetPosition, bool endspace);
 void CalcPlrStaff(Player &player);
-void CheckPlrSpell(bool isShiftHeld, SpellID spellID = MyPlayer->_pRSpell, SpellType spellType = MyPlayer->_pRSplType);
+void CheckPlrSpell(bool isShiftHeld, SpellID spellID = MyPlayer->selectedSpell, SpellType spellType = MyPlayer->selectedSpellType);
 void SyncPlrAnim(Player &player);
 void SyncInitPlrPos(Player &player);
 void SyncInitPlr(Player &player);

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -74,7 +74,7 @@ void SendPlrMsg(Player &player, std::string_view text)
 {
 	PlayerMessage &message = GetNextMessage();
 
-	std::string from = fmt::format(fmt::runtime(_("{:s} (lvl {:d}): ")), player._pName, player.getCharacterLevel());
+	std::string from = fmt::format(fmt::runtime(_("{:s} (lvl {:d}): ")), player.name, player.getCharacterLevel());
 
 	message.style = UiFlags::ColorWhite;
 	message.time = SDL_GetTicks();

--- a/Source/qol/autopickup.cpp
+++ b/Source/qol/autopickup.cpp
@@ -17,7 +17,7 @@ namespace {
 
 bool HasRoomForGold()
 {
-	for (int idx : MyPlayer->InvGrid) {
+	for (int idx : MyPlayer->inventoryGrid) {
 		// Secondary item cell. No need to check those as we'll go through the main item cells anyway.
 		if (idx < 0)
 			continue;
@@ -27,7 +27,7 @@ bool HasRoomForGold()
 			return true;
 
 		// Main item cell. Potentially a gold pile so check it.
-		auto item = MyPlayer->InvList[idx - 1];
+		auto item = MyPlayer->inventorySlot[idx - 1];
 		if (item._itype == ItemType::Gold && item._ivalue < MaxGold)
 			return true;
 	}

--- a/Source/qol/chatlog.cpp
+++ b/Source/qol/chatlog.cpp
@@ -126,7 +126,7 @@ void AddMessageToChatLog(std::string_view message, Player *player, UiFlags flags
 	if (player == nullptr) {
 		ChatLogLines.emplace_back(MultiColoredText { "{0} {1}", { { timestamp, UiFlags::ColorRed }, { std::string(message), flags } } });
 	} else {
-		std::string playerInfo = fmt::format(fmt::runtime(_("{:s} (lvl {:d}): ")), player->_pName, player->getCharacterLevel());
+		std::string playerInfo = fmt::format(fmt::runtime(_("{:s} (lvl {:d}): ")), player->name, player->getCharacterLevel());
 		UiFlags nameColor = player == MyPlayer ? UiFlags::ColorWhitegold : UiFlags::ColorBlue;
 		std::string prefix = timestamp + " - " + playerInfo;
 		std::string text = WordWrapString(prefix + std::string(message), ContentTextWidth);

--- a/Source/qol/floatingnumbers.cpp
+++ b/Source/qol/floatingnumbers.cpp
@@ -134,7 +134,7 @@ void AddFloatingNumber(DamageType damageType, const Monster &monster, int damage
 
 	Displacement offset = {};
 	if (monster.isWalking()) {
-		offset = GetOffsetForWalking(monster.animInfo, monster.direction);
+		offset = GetOffsetForWalking(monster.animationInfo, monster.direction);
 		if (monster.mode == MonsterMode::MoveSideways) {
 			if (monster.direction == Direction::West)
 				offset -= Displacement { 64, 0 };
@@ -142,8 +142,8 @@ void AddFloatingNumber(DamageType damageType, const Monster &monster, int damage
 				offset += Displacement { 64, 0 };
 		}
 	}
-	if (monster.animInfo.sprites) {
-		const ClxSprite sprite = monster.animInfo.currentSprite();
+	if (monster.animationInfo.sprites) {
+		const ClxSprite sprite = monster.animationInfo.currentSprite();
 		offset.deltaY -= sprite.height() / 2;
 	}
 
@@ -157,9 +157,9 @@ void AddFloatingNumber(DamageType damageType, const Player &player, int damage)
 
 	Displacement offset = {};
 	if (player.isWalking()) {
-		offset = GetOffsetForWalking(player.AnimInfo, player._pdir);
-		if (player._pmode == PM_WALK_SIDEWAYS) {
-			if (player._pdir == Direction::West)
+		offset = GetOffsetForWalking(player.animationInfo, player.direction);
+		if (player.mode == PM_WALK_SIDEWAYS) {
+			if (player.direction == Direction::West)
 				offset -= Displacement { 64, 0 };
 			else
 				offset += Displacement { 64, 0 };

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -118,7 +118,7 @@ void AddItemToLabelQueue(int id, Point position)
 	nameWidth += MarginX * 2;
 	int index = ItemCAnimTbl[item._iCurs];
 	if (!labelCenterOffsets[index]) {
-		const auto [xBegin, xEnd] = ClxMeasureSolidHorizontalBounds((*item.AnimInfo.sprites)[item.AnimInfo.currentFrame]);
+		const auto [xBegin, xEnd] = ClxMeasureSolidHorizontalBounds((*item.animationInfo.sprites)[item.animationInfo.currentFrame]);
 		labelCenterOffsets[index].emplace((xBegin + xEnd) / 2);
 	}
 

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -165,7 +165,7 @@ void DrawMonsterHealthBar(const Surface &out)
 		for (size_t i = 0; i < Players.size(); i++) {
 			if (((1U << i) & monster.whoHit) != 0) {
 				RenderClxSprite(out, (*playerExpTags)[i + 1], position + Displacement { tagOffset, height - 31 });
-			} else if (Players[i].plractive) {
+			} else if (Players[i].isPlayerActive) {
 				RenderClxSprite(out, (*playerExpTags)[0], position + Displacement { tagOffset, height - 31 });
 			}
 			tagOffset += (*playerExpTags)[0].width();

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -86,10 +86,10 @@ void DrawXPBar(const Surface &out)
 	const uint8_t charLevel = player.getCharacterLevel();
 
 	const uint64_t prevXp = GetNextExperienceThresholdForLevel(charLevel - 1);
-	if (player._pExperience < prevXp)
+	if (player.experience < prevXp)
 		return;
 
-	uint64_t prevXpDelta1 = player._pExperience - prevXp;
+	uint64_t prevXpDelta1 = player.experience - prevXp;
 	uint64_t prevXpDelta = GetNextExperienceThresholdForLevel(charLevel) - prevXp;
 	uint64_t fullBar = BarWidth * prevXpDelta1 / prevXpDelta;
 
@@ -128,7 +128,7 @@ bool CheckXPBarInfo()
 		// Show a maximum level indicator for max level players.
 		InfoColor = UiFlags::ColorWhitegold;
 
-		AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player._pExperience)));
+		AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player.experience)));
 		AddPanelString(_("Maximum Level"));
 
 		return true;
@@ -136,10 +136,10 @@ bool CheckXPBarInfo()
 
 	InfoColor = UiFlags::ColorWhite;
 
-	AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player._pExperience)));
+	AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player.experience)));
 	uint32_t nextExperienceThreshold = player.getNextExperienceThreshold();
 	AddPanelString(fmt::format(fmt::runtime(_("Next Level: {:s}")), FormatInteger(nextExperienceThreshold)));
-	AddPanelString(fmt::format(fmt::runtime(_("{:s} to Level {:d}")), FormatInteger(nextExperienceThreshold - player._pExperience), charLevel + 1));
+	AddPanelString(fmt::format(fmt::runtime(_("{:s} to Level {:d}")), FormatInteger(nextExperienceThreshold - player.experience), charLevel + 1));
 
 	return true;
 }

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -345,7 +345,7 @@ void CheckQuests()
 			NetSendCmdQuest(true, poisonWater);
 			StartPWaterPurify();
 		}
-	} else if (MyPlayer->_pmode == PM_STAND) {
+	} else if (MyPlayer->mode == PM_STAND) {
 		for (auto &quest : Quests) {
 			if (currlevel == quest._qlevel
 			    && quest._qslvl != 0

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -136,7 +136,7 @@ void SyncPlrInv(TSyncHeader *pHdr)
 
 	pHdr->bPInvLoc = -1;
 	assert(sgnSyncPInv > -1 && sgnSyncPInv < NUM_INVLOC);
-	const auto &item = MyPlayer->InvBody[sgnSyncPInv];
+	const auto &item = MyPlayer->bodySlot[sgnSyncPInv];
 	if (!item.isEmpty()) {
 		pHdr->bPInvLoc = sgnSyncPInv;
 		pHdr->wPInvIndx = SDL_SwapLE16(item.IDidx);
@@ -211,7 +211,7 @@ bool IsEnemyIdValid(const Monster &monster, int enemyId)
 	}
 
 	if (enemyId < MAX_PLRS) {
-		return Players[enemyId].plractive;
+		return Players[enemyId].isPlayerActive;
 	}
 
 	enemyId -= MAX_PLRS;
@@ -258,7 +258,7 @@ size_t sync_all_monsters(std::byte *pbBuf, size_t dwMaxLen)
 	if (dwMaxLen < sizeof(TSyncHeader) + sizeof(TSyncMonster)) {
 		return dwMaxLen;
 	}
-	if (MyPlayer->_pLvlChanging) {
+	if (MyPlayer->isChangingLevel) {
 		return dwMaxLen;
 	}
 
@@ -312,7 +312,7 @@ uint32_t OnSyncData(const TCmd *pCmd, const Player &player)
 	int monsterCount = wLen / sizeof(TSyncMonster);
 
 	uint8_t level = header.bLevel;
-	bool syncLocalLevel = !MyPlayer->_pLvlChanging && GetLevelForMultiplayer(*MyPlayer) == level;
+	bool syncLocalLevel = !MyPlayer->isChangingLevel && GetLevelForMultiplayer(*MyPlayer) == level;
 
 	if (IsValidLevelForMultiplayer(level)) {
 		const auto *monsterSyncs = reinterpret_cast<const TSyncMonster *>(pCmd + sizeof(header));

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -284,14 +284,14 @@ void TownerTalk(_speech_id message)
 
 void TalkToBarOwner(Player &player, Towner &barOwner)
 {
-	if (!player._pLvlVisited[0]) {
+	if (!player.isLevelVisted[0]) {
 		InitQTextMsg(TEXT_INTRO);
 		return;
 	}
 
 	auto &kingQuest = Quests[Q_SKELKING];
 	if (kingQuest._qactive != QUEST_NOTAVAIL) {
-		if (player._pLvlVisited[2] || player._pLvlVisited[4]) {
+		if (player.isLevelVisted[2] || player.isLevelVisted[4]) {
 			if (kingQuest._qvar2 == 0) {
 				kingQuest._qvar2 = 1;
 				kingQuest._qlog = true;
@@ -315,7 +315,7 @@ void TalkToBarOwner(Player &player, Towner &barOwner)
 
 	auto &bannerQuest = Quests[Q_LTBANNER];
 	if (bannerQuest._qactive != QUEST_NOTAVAIL) {
-		if ((player._pLvlVisited[3] || player._pLvlVisited[4]) && bannerQuest._qactive != QUEST_DONE) {
+		if ((player.isLevelVisted[3] || player.isLevelVisted[4]) && bannerQuest._qactive != QUEST_DONE) {
 			if (bannerQuest._qvar2 == 0) {
 				bannerQuest._qvar2 = 1;
 				if (bannerQuest._qactive == QUEST_INIT) {
@@ -365,7 +365,7 @@ void TalkToDeadguy(Player &player, Towner & /*deadguy*/)
 void TalkToBlackSmith(Player &player, Towner &blackSmith)
 {
 	if (Quests[Q_ROCK]._qactive != QUEST_NOTAVAIL) {
-		if ((player._pLvlVisited[4] || player._pLvlVisited[5]) && Quests[Q_ROCK]._qactive != QUEST_DONE) {
+		if ((player.isLevelVisted[4] || player.isLevelVisted[5]) && Quests[Q_ROCK]._qactive != QUEST_DONE) {
 			if (Quests[Q_ROCK]._qvar2 == 0) {
 				Quests[Q_ROCK]._qvar2 = 1;
 				Quests[Q_ROCK]._qlog = true;
@@ -387,7 +387,7 @@ void TalkToBlackSmith(Player &player, Towner &blackSmith)
 		}
 	}
 	if (IsNoneOf(Quests[Q_ANVIL]._qactive, QUEST_NOTAVAIL, QUEST_DONE)) {
-		if ((player._pLvlVisited[9] || player._pLvlVisited[10]) && Quests[Q_ANVIL]._qvar2 == 0) {
+		if ((player.isLevelVisted[9] || player.isLevelVisted[10]) && Quests[Q_ANVIL]._qvar2 == 0) {
 			Quests[Q_ANVIL]._qvar2 = 1;
 			Quests[Q_ANVIL]._qlog = true;
 			if (Quests[Q_ANVIL]._qactive == QUEST_INIT) {
@@ -463,7 +463,7 @@ void TalkToWitch(Player &player, Towner & /*witch*/)
 
 void TalkToBarmaid(Player &player, Towner & /*barmaid*/)
 {
-	if (!player._pLvlVisited[21] && HasInventoryItemWithId(player, IDI_MAPOFDOOM) && Quests[Q_GRAVE]._qmsg != TEXT_GRAVE8) {
+	if (!player.isLevelVisted[21] && HasInventoryItemWithId(player, IDI_MAPOFDOOM) && Quests[Q_GRAVE]._qmsg != TEXT_GRAVE8) {
 		Quests[Q_GRAVE]._qactive = QUEST_ACTIVE;
 		Quests[Q_GRAVE]._qlog = true;
 		Quests[Q_GRAVE]._qmsg = TEXT_GRAVE8;
@@ -486,7 +486,7 @@ void TalkToHealer(Player &player, Towner &healer)
 {
 	Quest &poisonWater = Quests[Q_PWATER];
 	if (poisonWater._qactive != QUEST_NOTAVAIL) {
-		if ((poisonWater._qactive == QUEST_INIT && (player._pLvlVisited[1] || player._pLvlVisited[5])) || (poisonWater._qactive == QUEST_ACTIVE && !poisonWater._qlog)) {
+		if ((poisonWater._qactive == QUEST_INIT && (player.isLevelVisted[1] || player.isLevelVisted[5])) || (poisonWater._qactive == QUEST_ACTIVE && !poisonWater._qlog)) {
 			// Play the dialog and make the quest visible in the log if the player has not started the quest but has
 			// visited the dungeon at least once, or if they've found the poison water cave before speaking to Pepin
 			poisonWater._qactive = QUEST_ACTIVE;
@@ -609,13 +609,13 @@ void TalkToFarmer(Player &player, Towner &farmer)
 			break;
 		}
 
-		if (!player._pLvlVisited[9] && player.getCharacterLevel() < 15) {
+		if (!player.isLevelVisted[9] && player.getCharacterLevel() < 15) {
 			_speech_id qt = TEXT_FARMER8;
-			if (player._pLvlVisited[2])
+			if (player.isLevelVisted[2])
 				qt = TEXT_FARMER5;
-			if (player._pLvlVisited[5])
+			if (player.isLevelVisted[5])
 				qt = TEXT_FARMER7;
-			if (player._pLvlVisited[7])
+			if (player.isLevelVisted[7])
 				qt = TEXT_FARMER9;
 			InitQTextMsg(qt);
 			break;
@@ -700,7 +700,7 @@ void TalkToCowFarmer(Player &player, Towner &cowFarmer)
 			NetSendCmdQuest(true, quest);
 		break;
 	case QUEST_HIVE_ACTIVE:
-		if (!player._pLvlVisited[9] && player.getCharacterLevel() < 15) {
+		if (!player.isLevelVisted[9] && player.getCharacterLevel() < 15) {
 			InitQTextMsg(PickRandomlyAmong({ TEXT_JERSEY9, TEXT_JERSEY10, TEXT_JERSEY11, TEXT_JERSEY12 }));
 			break;
 		}
@@ -808,7 +808,7 @@ bool IsTownerPresent(_talker_id npc)
 	case TOWN_COWFARM:
 		return gbIsHellfire && sgGameInitInfo.bCowQuest != 0;
 	case TOWN_GIRL:
-		return gbIsHellfire && sgGameInitInfo.bTheoQuest != 0 && MyPlayer->_pLvlVisited[17] && Quests[Q_GIRL]._qactive != QUEST_DONE;
+		return gbIsHellfire && sgGameInitInfo.bTheoQuest != 0 && MyPlayer->isLevelVisted[17] && Quests[Q_GIRL]._qactive != QUEST_DONE;
 	default:
 		return true;
 	}
@@ -884,7 +884,7 @@ void TalkToTowner(Player &player, int t)
 	if (player.position.tile.WalkingDistance(towner.position) >= 2)
 		return;
 
-	if (!player.HoldItem.isEmpty()) {
+	if (!player.heldItem.isEmpty()) {
 		return;
 	}
 

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -23,7 +23,7 @@ void RepeatWalk(Player &player)
 	if (!InDungeonBounds(cursPosition))
 		return;
 
-	if (player._pmode != PM_STAND && !(player.isWalking() && player.AnimInfo.getFrameToUseForRendering() > 6))
+	if (player.mode != PM_STAND && !(player.isWalking() && player.animationInfo.getFrameToUseForRendering() > 6))
 		return;
 
 	const Point target = player.GetTargetPosition();
@@ -51,8 +51,8 @@ void InvalidateTargets()
 
 	if (PlayerUnderCursor != nullptr) {
 		const Player &targetPlayer = *PlayerUnderCursor;
-		if (targetPlayer._pmode == PM_DEATH || targetPlayer._pmode == PM_QUIT || !targetPlayer.plractive
-		    || !targetPlayer.isOnActiveLevel() || targetPlayer._pHitPoints >> 6 <= 0
+		if (targetPlayer.mode == PM_DEATH || targetPlayer.mode == PM_QUIT || !targetPlayer.isPlayerActive
+		    || !targetPlayer.isOnActiveLevel() || targetPlayer.life >> 6 <= 0
 		    || !IsTileLit(targetPlayer.position.tile))
 			PlayerUnderCursor = nullptr;
 	}
@@ -73,9 +73,9 @@ void RepeatMouseAction()
 		return;
 
 	Player &myPlayer = *MyPlayer;
-	if (myPlayer.destAction != ACTION_NONE)
+	if (myPlayer.destinationAction != ACTION_NONE)
 		return;
-	if (myPlayer._pInvincible)
+	if (myPlayer.isInvincible)
 		return;
 	if (!myPlayer.CanChangeAction())
 		return;
@@ -91,12 +91,12 @@ void RepeatMouseAction()
 			NetSendCmdParam1(true, rangedAttack ? CMD_RATTACKID : CMD_ATTACKID, pcursmonst);
 		break;
 	case MouseActionType::AttackPlayerTarget:
-		if (PlayerUnderCursor != nullptr && !myPlayer.friendlyMode)
+		if (PlayerUnderCursor != nullptr && !myPlayer.isFriendlyMode)
 			NetSendCmdParam1(true, rangedAttack ? CMD_RATTACKPID : CMD_ATTACKPID, PlayerUnderCursor->getId());
 		break;
 	case MouseActionType::Spell:
 		if (ControlMode != ControlTypes::KeyboardAndMouse) {
-			UpdateSpellTarget(MyPlayer->_pRSpell);
+			UpdateSpellTarget(MyPlayer->selectedSpell);
 		}
 		CheckPlrSpell(ControlMode == ControlTypes::KeyboardAndMouse);
 		break;
@@ -105,7 +105,7 @@ void RepeatMouseAction()
 			CheckPlrSpell(false);
 		break;
 	case MouseActionType::SpellPlayerTarget:
-		if (PlayerUnderCursor != nullptr && !myPlayer.friendlyMode)
+		if (PlayerUnderCursor != nullptr && !myPlayer.isFriendlyMode)
 			CheckPlrSpell(false);
 		break;
 	case MouseActionType::OperateObject:

--- a/docs/BACKGROUND.md
+++ b/docs/BACKGROUND.md
@@ -25,7 +25,7 @@ register long rv;
 Example assert string:
 
 ```cpp
-"plr[myplr].InvGrid[i] <= plr[myplr]._pNumInv"
+"plr[myplr].inventoryGrid[i] <= plr[myplr].numInventoryItems"
 ```
 
 3. The Rich header of the PE executable, which details the exact version of the original compilers and linkers used to build `Diablo.exe` (see [[3]], [[4]]).

--- a/test/drlg_test.hpp
+++ b/test/drlg_test.hpp
@@ -55,7 +55,7 @@ void TestInitGame(bool fullQuests = true, bool originalCathedral = true)
 {
 	Players.resize(1);
 	MyPlayer = &Players[0];
-	MyPlayer->pOriginalCathedral = originalCathedral;
+	MyPlayer->originalCathedral = originalCathedral;
 
 	sgGameInitInfo.fullQuests = fullQuests ? 1 : 0;
 	gbIsMultiplayer = !fullQuests;

--- a/test/fixtures/memory_map/hero.txt
+++ b/test/fixtures/memory_map/hero.txt
@@ -1,14 +1,14 @@
 R 32 dwLowDateTime
 R 32 dwHighDateTime
-R 8 destAction
-R 8 destParam1
-R 8 destParam2
-R 8 plrlevel
+R 8 destinationAction
+R 8 destinationParam1
+R 8 destinationParam2
+R 8 dungeonLevel
 R 8 px
 R 8 py
 R 8 targx
 R 8 targy
-R 256 _pName
+R 256 name
 R 8 pClass
 R 8 pBaseStr
 R 8 pBaseMag
@@ -24,26 +24,26 @@ R 32 pManaBase
 R 32 pMaxManaBase
 M 37 8 pSplLvl
 R 64 pMemSpells
-C 7 itemPack InvBody
-C 40 itemPack InvList
-M 40 8 InvGrid
-R 8 _pNumInv
-C 8 itemPack SpdList
-R 8 pTownWarps
-R 8 pDungMsgs
-R 8 pLvlLoad
+C 7 itemPack bodySlot
+C 40 itemPack inventorySlot
+M 40 8 inventoryGrid
+R 8 numInventoryItems
+C 8 itemPack beltSlot
+R 8 townWarps
+R 8 dungeonMessages
+R 8 levelLoading
 R 8 pBattleNet
-R 8 pManaShield
-R 8 pDungMsgs2
+R 8 hasManaShield
+R 8 dungeonMessages2
 R 8 bIsHellfire
 R 8 reserved
-R 16 wReflections
+R 16 reflections
 R 16 reserved
 M 10 8 pSplLvl2
 R 16 reserved
-R 32 pDiabloKillLevel
+R 32 difficultyCompletion
 R 32 pDifficulty
-R 32 pDamAcFlags
-R 8 friendlyMode
+R 32 hellfireFlags
+R 8 isFriendlyMode
 R 8 isOnSetLevel
 M 18 8 reserved

--- a/test/fixtures/memory_map/player.txt
+++ b/test/fixtures/memory_map/player.txt
@@ -1,12 +1,12 @@
-R 32 _pmode
-M 25 8 walkpath
-R 8 plractive
+R 32 mode
+M 25 8 walkPath
+R 8 isPlayerActive
 R 16 alignment
-R 32 destAction
-R 32 destParam1
-R 32 destParam2
-R 32 destParam3
-R 32 destParam4
+R 32 destinationAction
+R 32 destinationParam1
+R 32 destinationParam2
+R 32 destinationParam3
+R 32 destinationParam4
 R 32 level
 R 32 tileX
 R 32 tileY
@@ -42,61 +42,61 @@ R 16 alignment
 R 32 _pTSpell
 R 8 _pTSplType
 R 24 alignment
-R 32 _pRSpell
-R 8 _pRSplType
+R 32 selectedSpell
+R 8 selectedSpellType
 R 24 alignment
 R 32 _pSBkSpell
 R 8 _pSBkSplType
 M 64 8 spellLevel
 R 56 alignment
-R 64 _pMemSpells
-R 64 _pAblSpells
-R 64 _pScrlSpells
-R 8 _pSpellFlags
+R 64 learnedSpells
+R 64 skills
+R 64 scrollSpells
+R 8 spellFlags
 R 24 alignment
-M 4 32 _pSplHotKey
-M 4 8 _pSplTHotKey
+M 4 32 hotkeySpell
+M 4 8 hotkeySpellType
 R 32 _pwtype
-R 8 _pBlockFlag
-R 8 _pInvincible
-R 8 _pLightRad
-R 8 _pLvlChanging
-R 256 _pName
-R 8 _pClass
+R 8 hasBlockFlag
+R 8 isInvincible
+R 8 lightRadius
+R 8 isChangingLevel
+R 256 name
+R 8 heroClass
 R 24 alignment
-R 32 _pStrength
-R 32 _pBaseStr
-R 32 _pMagic
-R 32 _pBaseMag
-R 32 _pDexterity
-R 32 _pBaseDex
-R 32 _pVitality
-R 32 _pBaseVit
-R 32 _pStatPts
-R 32 _pDamageMod
+R 32 strength
+R 32 baseStrength
+R 32 magic
+R 32 baseMagic
+R 32 dexterity
+R 32 baseDexterity
+R 32 vitality
+R 32 baseVitality
+R 32 statPoints
+R 32 damageModifier
 R 32 _pBaseToBlk
-R 32 _pHPBase
-R 32 _pMaxHPBase
-R 32 _pHitPoints
-R 32 _pMaxHP
-R 32 _pHPPer
-R 32 _pManaBase
-R 32 _pMaxManaBase
-R 32 _pMana
-R 32 _pMaxMana
-R 32 _pManaPer
-R 8 _pLevel
+R 32 baseLife
+R 32 baseMaxLife
+R 32 life
+R 32 maxLife
+R 32 lifePercentage
+R 32 baseMana
+R 32 baseMaxMana
+R 32 mana
+R 32 maxMana
+R 32 manaPercentage
+R 8 characterLevel
 R 8 _pMaxLvl
 R 16 alignment
-R 32 _pExperience
+R 32 experience
 R 32 _pMaxExp
 R 32 _pNextExper
 R 8 _pArmorClass
-R 8 _pMagResist
-R 8 _pFireResist
-R 8 _pLghtResist
-R 32 _pGold
-R 32 _pInfraFlag
+R 8 resistMagic
+R 8 resistFire
+R 8 resistLightning
+R 32 gold
+R 32 hasInfravisionFlag
 R 32 tempPositionX
 R 32 tempPositionY
 R 32 tempDirection
@@ -105,74 +105,74 @@ R 32 _pVar5
 R 32 offset2.x
 R 32 offset2.y
 R 32 actionFrame
-M_DA 17 8 _pLvlVisited
-M_HF 25 8 _pLvlVisited
-M_DA 17 8 _pSLvlVisited
-M_HF 25 8 _pSLvlVisited
+M_DA 17 8 isLevelVisted
+M_HF 25 8 isLevelVisted
+M_DA 17 8 isSetLevelVisted
+M_HF 25 8 isSetLevelVisted
 R 16 alignment
 R 32 _pGFXLoad
 M 8 32 _pNAnim
-R 32 _pNFrames
+R 32 numIdleFrames
 R 32 _pNWidth
 M 8 32 _pWAnim
 R 32 _pWWidth
 M 8 32 _pAAnim
-R 32 _pAFrames
+R 32 numAttackFrames
 R 32 _pAWidth
-R 32 _pAFNum
+R 32 attackActionFrame
 M 8 32 _pLAnim
 M 8 32 _pFAnim
 M 8 32 _pTAnim
-R 32 _pSFrames
+R 32 numSpellFrames
 R 32 _pSWidth
-R 32 _pSFNum
-R 32 _pHFrames
+R 32 spellActionFrame
+R 32 numRecoveryFrames
 M 8 32 _pHAnim
-R 32 _pHFrames
+R 32 numRecoveryFrames
 R 32 _pHWidth
 M 8 32 _pDAnim
-R 32 _pDFrames
+R 32 numDeathFrames
 R 32 _pDWidth
 M 8 32 _pBAnim
-R 32 _pBFrames
+R 32 numBlockFrames
 R 32 _pBWidth
 C 7 item
 C 40 item
-R 32 _pNumInv
-M 40 8 InvGrid
+R 32 numInventoryItems
+M 40 8 inventoryGrid
 C 8 item
 C 1 item
-R 32 _pIMinDam
-R 32 _pIMaxDam
-R 32 _pIAC
-R 32 _pIBonusDam
-R 32 _pIBonusToHit
-R 32 _pIBonusAC
-R 32 _pIBonusDamMod
+R 32 minDamage
+R 32 maxDamage
+R 32 armorClass
+R 32 bonusDamagePercent
+R 32 bonusToHit
+R 32 bonusArmorClass
+R 32 bonusDamage
 R 32 alignment
-R 64 _pISpells
-R 32 _pIFlags
-R 32 _pIGetHit
-R 8 _pISplLvlAdd
+R 64 staffSpells
+R 32 flags
+R 32 damageFromEnemies
+R 8 bonusSpellLevel
 R 8 unused
 R 16 alignment
 R 32 _pISplDur
-R 32 _pIEnAc
-R 32 _pIFMinDam
-R 32 _pIFMaxDam
-R 32 _pILMinDam
-R 32 _pILMaxDam
-R 32 _pOilType
-R 8 pTownWarps
-R 8 pDungMsgs
-R 8 pLvlLoad
-R 8 pDungMsgs2
-R 8 pManaShield
-R 8 pOriginalCathedral
+R 32 armorPierce
+R 32 minFireDamage
+R 32 maxFireDamage
+R 32 minLightningDamage
+R 32 maxLightningDamage
+R 32 oilType
+R 8 townWarps
+R 8 dungeonMessages
+R 8 levelLoading
+R 8 dungeonMessages2
+R 8 hasManaShield
+R 8 originalCathedral
 R 16 unused
-R 16 wReflections
+R 16 reflections
 R 112 unused
-R 32 pDiabloKillLevel
+R 32 difficultyCompletion
 R 32 pDifficulty
-R 32 pDamAcFlags
+R 32 hellfireFlags
 R 160 unused

--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -36,7 +36,7 @@ void set_up_scroll(Item &item, SpellID spell)
 {
 	pcurs = CURSOR_HAND;
 	leveltype = DTYPE_CATACOMBS;
-	MyPlayer->_pRSpell = static_cast<SpellID>(spell);
+	MyPlayer->selectedSpell = static_cast<SpellID>(spell);
 	item._itype = ItemType::Misc;
 	item._iMiscId = IMISC_SCROLL;
 	item._iSpell = spell;
@@ -46,24 +46,24 @@ void set_up_scroll(Item &item, SpellID spell)
 void clear_inventory()
 {
 	for (int i = 0; i < InventoryGridCells; i++) {
-		MyPlayer->InvList[i] = {};
-		MyPlayer->InvGrid[i] = 0;
+		MyPlayer->inventorySlot[i] = {};
+		MyPlayer->inventoryGrid[i] = 0;
 	}
-	MyPlayer->_pNumInv = 0;
+	MyPlayer->numInventoryItems = 0;
 }
 
 // Test that the scroll is used in the inventory in correct conditions
 TEST_F(InvTest, UseScroll_from_inventory)
 {
-	set_up_scroll(MyPlayer->InvList[2], SpellID::Firebolt);
-	MyPlayer->_pNumInv = 5;
+	set_up_scroll(MyPlayer->inventorySlot[2], SpellID::Firebolt);
+	MyPlayer->numInventoryItems = 5;
 	EXPECT_TRUE(CanUseScroll(*MyPlayer, SpellID::Firebolt));
 }
 
 // Test that the scroll is used in the belt in correct conditions
 TEST_F(InvTest, UseScroll_from_belt)
 {
-	set_up_scroll(MyPlayer->SpdList[2], SpellID::Firebolt);
+	set_up_scroll(MyPlayer->beltSlot[2], SpellID::Firebolt);
 	EXPECT_TRUE(CanUseScroll(*MyPlayer, SpellID::Firebolt));
 }
 
@@ -72,26 +72,26 @@ TEST_F(InvTest, UseScroll_from_inventory_invalid_conditions)
 {
 	// Empty the belt to prevent using a scroll from the belt
 	for (int i = 0; i < MaxBeltItems; i++) {
-		MyPlayer->SpdList[i].clear();
+		MyPlayer->beltSlot[i].clear();
 	}
 
 	// Adjust inventory size
-	MyPlayer->_pNumInv = 5;
+	MyPlayer->numInventoryItems = 5;
 
-	set_up_scroll(MyPlayer->InvList[2], SpellID::Firebolt);
+	set_up_scroll(MyPlayer->inventorySlot[2], SpellID::Firebolt);
 	leveltype = DTYPE_TOWN;
 	EXPECT_FALSE(CanUseScroll(*MyPlayer, SpellID::Firebolt));
 
-	set_up_scroll(MyPlayer->InvList[2], SpellID::Firebolt);
-	MyPlayer->_pRSpell = SpellID::Healing;
+	set_up_scroll(MyPlayer->inventorySlot[2], SpellID::Firebolt);
+	MyPlayer->selectedSpell = SpellID::Healing;
 	EXPECT_FALSE(CanUseScroll(*MyPlayer, SpellID::Healing));
 
-	set_up_scroll(MyPlayer->InvList[2], SpellID::Firebolt);
-	MyPlayer->InvList[2]._iMiscId = IMISC_STAFF;
+	set_up_scroll(MyPlayer->inventorySlot[2], SpellID::Firebolt);
+	MyPlayer->inventorySlot[2]._iMiscId = IMISC_STAFF;
 	EXPECT_FALSE(CanUseScroll(*MyPlayer, SpellID::Firebolt));
 
-	set_up_scroll(MyPlayer->InvList[2], SpellID::Firebolt);
-	MyPlayer->InvList[2].clear();
+	set_up_scroll(MyPlayer->inventorySlot[2], SpellID::Firebolt);
+	MyPlayer->inventorySlot[2].clear();
 	EXPECT_FALSE(CanUseScroll(*MyPlayer, SpellID::Firebolt));
 }
 
@@ -99,39 +99,39 @@ TEST_F(InvTest, UseScroll_from_inventory_invalid_conditions)
 TEST_F(InvTest, UseScroll_from_belt_invalid_conditions)
 {
 	// Disable the inventory to prevent using a scroll from the inventory
-	MyPlayer->_pNumInv = 0;
+	MyPlayer->numInventoryItems = 0;
 
-	set_up_scroll(MyPlayer->SpdList[2], SpellID::Firebolt);
+	set_up_scroll(MyPlayer->beltSlot[2], SpellID::Firebolt);
 	leveltype = DTYPE_TOWN;
 	EXPECT_FALSE(CanUseScroll(*MyPlayer, SpellID::Firebolt));
 
-	set_up_scroll(MyPlayer->SpdList[2], SpellID::Firebolt);
-	MyPlayer->_pRSpell = SpellID::Healing;
+	set_up_scroll(MyPlayer->beltSlot[2], SpellID::Firebolt);
+	MyPlayer->selectedSpell = SpellID::Healing;
 	EXPECT_FALSE(CanUseScroll(*MyPlayer, SpellID::Healing));
 
-	set_up_scroll(MyPlayer->SpdList[2], SpellID::Firebolt);
-	MyPlayer->SpdList[2]._iMiscId = IMISC_STAFF;
+	set_up_scroll(MyPlayer->beltSlot[2], SpellID::Firebolt);
+	MyPlayer->beltSlot[2]._iMiscId = IMISC_STAFF;
 	EXPECT_FALSE(CanUseScroll(*MyPlayer, SpellID::Firebolt));
 
-	set_up_scroll(MyPlayer->SpdList[2], SpellID::Firebolt);
-	MyPlayer->SpdList[2].clear();
+	set_up_scroll(MyPlayer->beltSlot[2], SpellID::Firebolt);
+	MyPlayer->beltSlot[2].clear();
 	EXPECT_FALSE(CanUseScroll(*MyPlayer, SpellID::Firebolt));
 }
 
 // Test gold calculation
 TEST_F(InvTest, CalculateGold)
 {
-	MyPlayer->_pNumInv = 10;
+	MyPlayer->numInventoryItems = 10;
 	// Set up 4 slots of gold in the inventory
-	MyPlayer->InvList[1]._itype = ItemType::Gold;
-	MyPlayer->InvList[5]._itype = ItemType::Gold;
-	MyPlayer->InvList[2]._itype = ItemType::Gold;
-	MyPlayer->InvList[3]._itype = ItemType::Gold;
+	MyPlayer->inventorySlot[1]._itype = ItemType::Gold;
+	MyPlayer->inventorySlot[5]._itype = ItemType::Gold;
+	MyPlayer->inventorySlot[2]._itype = ItemType::Gold;
+	MyPlayer->inventorySlot[3]._itype = ItemType::Gold;
 	// Set the gold amount to arbitrary values
-	MyPlayer->InvList[1]._ivalue = 100;
-	MyPlayer->InvList[5]._ivalue = 200;
-	MyPlayer->InvList[2]._ivalue = 3;
-	MyPlayer->InvList[3]._ivalue = 30;
+	MyPlayer->inventorySlot[1]._ivalue = 100;
+	MyPlayer->inventorySlot[5]._ivalue = 200;
+	MyPlayer->inventorySlot[2]._ivalue = 3;
+	MyPlayer->inventorySlot[3]._ivalue = 30;
 
 	EXPECT_EQ(CalculateGold(*MyPlayer), 333);
 }
@@ -146,18 +146,18 @@ TEST_F(InvTest, GoldAutoPlace)
 
 	// Put gold into the inventory:
 	// | 1000 | ... | ...
-	MyPlayer->InvList[0]._itype = ItemType::Gold;
-	MyPlayer->InvList[0]._ivalue = 1000;
-	MyPlayer->_pNumInv = 1;
+	MyPlayer->inventorySlot[0]._itype = ItemType::Gold;
+	MyPlayer->inventorySlot[0]._ivalue = 1000;
+	MyPlayer->numInventoryItems = 1;
 	// Put (max gold - 100) gold, which is 4900, into the player's hand
-	MyPlayer->HoldItem._itype = ItemType::Gold;
-	MyPlayer->HoldItem._ivalue = GOLD_MAX_LIMIT - 100;
+	MyPlayer->heldItem._itype = ItemType::Gold;
+	MyPlayer->heldItem._ivalue = GOLD_MAX_LIMIT - 100;
 
-	GoldAutoPlace(*MyPlayer, MyPlayer->HoldItem);
+	GoldAutoPlace(*MyPlayer, MyPlayer->heldItem);
 	// We expect the inventory:
 	// | 5000 | 900 | ...
-	EXPECT_EQ(MyPlayer->InvList[0]._ivalue, GOLD_MAX_LIMIT);
-	EXPECT_EQ(MyPlayer->InvList[1]._ivalue, 900);
+	EXPECT_EQ(MyPlayer->inventorySlot[0]._ivalue, GOLD_MAX_LIMIT);
+	EXPECT_EQ(MyPlayer->inventorySlot[1]._ivalue, 900);
 }
 
 // Test removing an item from inventory with no other items.
@@ -168,15 +168,15 @@ TEST_F(InvTest, RemoveInvItem)
 	clear_inventory();
 	// Put a two-slot misc item into the inventory:
 	// | (item) | (item) | ... | ...
-	MyPlayer->_pNumInv = 1;
-	MyPlayer->InvGrid[0] = 1;
-	MyPlayer->InvGrid[1] = -1;
-	MyPlayer->InvList[0]._itype = ItemType::Misc;
+	MyPlayer->numInventoryItems = 1;
+	MyPlayer->inventoryGrid[0] = 1;
+	MyPlayer->inventoryGrid[1] = -1;
+	MyPlayer->inventorySlot[0]._itype = ItemType::Misc;
 
 	MyPlayer->RemoveInvItem(0);
-	EXPECT_EQ(MyPlayer->InvGrid[0], 0);
-	EXPECT_EQ(MyPlayer->InvGrid[1], 0);
-	EXPECT_EQ(MyPlayer->_pNumInv, 0);
+	EXPECT_EQ(MyPlayer->inventoryGrid[0], 0);
+	EXPECT_EQ(MyPlayer->inventoryGrid[1], 0);
+	EXPECT_EQ(MyPlayer->numInventoryItems, 0);
 }
 
 // Test removing an item from inventory with other items in it.
@@ -187,20 +187,20 @@ TEST_F(InvTest, RemoveInvItem_other_item)
 	clear_inventory();
 	// Put a two-slot misc item and a ring into the inventory:
 	// | (item) | (item) | (ring) | ...
-	MyPlayer->_pNumInv = 2;
-	MyPlayer->InvGrid[0] = 1;
-	MyPlayer->InvGrid[1] = -1;
-	MyPlayer->InvList[0]._itype = ItemType::Misc;
+	MyPlayer->numInventoryItems = 2;
+	MyPlayer->inventoryGrid[0] = 1;
+	MyPlayer->inventoryGrid[1] = -1;
+	MyPlayer->inventorySlot[0]._itype = ItemType::Misc;
 
-	MyPlayer->InvGrid[2] = 2;
-	MyPlayer->InvList[1]._itype = ItemType::Ring;
+	MyPlayer->inventoryGrid[2] = 2;
+	MyPlayer->inventorySlot[1]._itype = ItemType::Ring;
 
 	MyPlayer->RemoveInvItem(0);
-	EXPECT_EQ(MyPlayer->InvGrid[0], 0);
-	EXPECT_EQ(MyPlayer->InvGrid[1], 0);
-	EXPECT_EQ(MyPlayer->InvGrid[2], 1);
-	EXPECT_EQ(MyPlayer->InvList[0]._itype, ItemType::Ring);
-	EXPECT_EQ(MyPlayer->_pNumInv, 1);
+	EXPECT_EQ(MyPlayer->inventoryGrid[0], 0);
+	EXPECT_EQ(MyPlayer->inventoryGrid[1], 0);
+	EXPECT_EQ(MyPlayer->inventoryGrid[2], 1);
+	EXPECT_EQ(MyPlayer->inventorySlot[0]._itype, ItemType::Ring);
+	EXPECT_EQ(MyPlayer->numInventoryItems, 1);
 }
 
 // Test removing an item from the belt
@@ -210,13 +210,13 @@ TEST_F(InvTest, RemoveSpdBarItem)
 
 	// Clear the belt
 	for (int i = 0; i < MaxBeltItems; i++) {
-		MyPlayer->SpdList[i].clear();
+		MyPlayer->beltSlot[i].clear();
 	}
 	// Put an item in the belt: | x | x | item | x | x | x | x | x |
-	MyPlayer->SpdList[3]._itype = ItemType::Misc;
+	MyPlayer->beltSlot[3]._itype = ItemType::Misc;
 
 	MyPlayer->RemoveSpdBarItem(3);
-	EXPECT_TRUE(MyPlayer->SpdList[3].isEmpty());
+	EXPECT_TRUE(MyPlayer->beltSlot[3].isEmpty());
 }
 
 // Test removing a scroll from the inventory
@@ -225,16 +225,16 @@ TEST_F(InvTest, RemoveCurrentSpellScrollFromInventory)
 	clear_inventory();
 
 	// Put a firebolt scroll into the inventory
-	MyPlayer->_pNumInv = 1;
+	MyPlayer->numInventoryItems = 1;
 	MyPlayer->executedSpell.spellId = SpellID::Firebolt;
 	MyPlayer->executedSpell.spellFrom = INVITEM_INV_FIRST;
-	MyPlayer->InvList[0]._itype = ItemType::Misc;
-	MyPlayer->InvList[0]._iMiscId = IMISC_SCROLL;
-	MyPlayer->InvList[0]._iSpell = SpellID::Firebolt;
+	MyPlayer->inventorySlot[0]._itype = ItemType::Misc;
+	MyPlayer->inventorySlot[0]._iMiscId = IMISC_SCROLL;
+	MyPlayer->inventorySlot[0]._iSpell = SpellID::Firebolt;
 
 	ConsumeScroll(*MyPlayer);
-	EXPECT_EQ(MyPlayer->InvGrid[0], 0);
-	EXPECT_EQ(MyPlayer->_pNumInv, 0);
+	EXPECT_EQ(MyPlayer->inventoryGrid[0], 0);
+	EXPECT_EQ(MyPlayer->numInventoryItems, 0);
 }
 
 // Test removing the first matching scroll from inventory
@@ -243,16 +243,16 @@ TEST_F(InvTest, RemoveCurrentSpellScrollFromInventoryFirstMatch)
 	clear_inventory();
 
 	// Put a firebolt scroll into the inventory
-	MyPlayer->_pNumInv = 1;
+	MyPlayer->numInventoryItems = 1;
 	MyPlayer->executedSpell.spellId = SpellID::Firebolt;
 	MyPlayer->executedSpell.spellFrom = 0; // any matching scroll
-	MyPlayer->InvList[0]._itype = ItemType::Misc;
-	MyPlayer->InvList[0]._iMiscId = IMISC_SCROLL;
-	MyPlayer->InvList[0]._iSpell = SpellID::Firebolt;
+	MyPlayer->inventorySlot[0]._itype = ItemType::Misc;
+	MyPlayer->inventorySlot[0]._iMiscId = IMISC_SCROLL;
+	MyPlayer->inventorySlot[0]._iSpell = SpellID::Firebolt;
 
 	ConsumeScroll(*MyPlayer);
-	EXPECT_EQ(MyPlayer->InvGrid[0], 0);
-	EXPECT_EQ(MyPlayer->_pNumInv, 0);
+	EXPECT_EQ(MyPlayer->inventoryGrid[0], 0);
+	EXPECT_EQ(MyPlayer->numInventoryItems, 0);
 }
 
 // Test removing a scroll from the belt
@@ -262,17 +262,17 @@ TEST_F(InvTest, RemoveCurrentSpellScroll_belt)
 
 	// Clear the belt
 	for (int i = 0; i < MaxBeltItems; i++) {
-		MyPlayer->SpdList[i].clear();
+		MyPlayer->beltSlot[i].clear();
 	}
 	// Put a firebolt scroll into the belt
 	MyPlayer->executedSpell.spellId = SpellID::Firebolt;
 	MyPlayer->executedSpell.spellFrom = INVITEM_BELT_FIRST + 3;
-	MyPlayer->SpdList[3]._itype = ItemType::Misc;
-	MyPlayer->SpdList[3]._iMiscId = IMISC_SCROLL;
-	MyPlayer->SpdList[3]._iSpell = SpellID::Firebolt;
+	MyPlayer->beltSlot[3]._itype = ItemType::Misc;
+	MyPlayer->beltSlot[3]._iMiscId = IMISC_SCROLL;
+	MyPlayer->beltSlot[3]._iSpell = SpellID::Firebolt;
 
 	ConsumeScroll(*MyPlayer);
-	EXPECT_TRUE(MyPlayer->SpdList[3].isEmpty());
+	EXPECT_TRUE(MyPlayer->beltSlot[3].isEmpty());
 }
 
 // Test removing the first matching scroll from the belt
@@ -282,17 +282,17 @@ TEST_F(InvTest, RemoveCurrentSpellScrollFirstMatchFromBelt)
 
 	// Clear the belt
 	for (int i = 0; i < MaxBeltItems; i++) {
-		MyPlayer->SpdList[i].clear();
+		MyPlayer->beltSlot[i].clear();
 	}
 	// Put a firebolt scroll into the belt
 	MyPlayer->executedSpell.spellId = SpellID::Firebolt;
 	MyPlayer->executedSpell.spellFrom = 0; // any matching scroll
-	MyPlayer->SpdList[3]._itype = ItemType::Misc;
-	MyPlayer->SpdList[3]._iMiscId = IMISC_SCROLL;
-	MyPlayer->SpdList[3]._iSpell = SpellID::Firebolt;
+	MyPlayer->beltSlot[3]._itype = ItemType::Misc;
+	MyPlayer->beltSlot[3]._iMiscId = IMISC_SCROLL;
+	MyPlayer->beltSlot[3]._iSpell = SpellID::Firebolt;
 
 	ConsumeScroll(*MyPlayer);
-	EXPECT_TRUE(MyPlayer->SpdList[3].isEmpty());
+	EXPECT_TRUE(MyPlayer->beltSlot[3].isEmpty());
 }
 
 TEST_F(InvTest, ItemSizeRuneOfStone)

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -31,16 +31,16 @@ void SwapLE(PlayerPack &pack)
 	pack.pManaBase = SDL_SwapLE32(pack.pManaBase);
 	pack.pMaxManaBase = SDL_SwapLE32(pack.pMaxManaBase);
 	pack.pMemSpells = SDL_SwapLE64(pack.pMemSpells);
-	for (ItemPack &item : pack.InvBody)
+	for (ItemPack &item : pack.bodySlot)
 		SwapLE(item);
-	for (ItemPack &item : pack.InvList)
+	for (ItemPack &item : pack.inventorySlot)
 		SwapLE(item);
-	for (ItemPack &item : pack.SpdList)
+	for (ItemPack &item : pack.beltSlot)
 		SwapLE(item);
-	pack.wReflections = SDL_SwapLE16(pack.wReflections);
-	pack.pDiabloKillLevel = SDL_SwapLE32(pack.pDiabloKillLevel);
+	pack.reflections = SDL_SwapLE16(pack.reflections);
+	pack.difficultyCompletion = SDL_SwapLE32(pack.difficultyCompletion);
 	pack.pDifficulty = SDL_SwapLE32(pack.pDifficulty);
-	pack.pDamAcFlags = SDL_SwapLE32(pack.pDamAcFlags);
+	pack.hellfireFlags = SDL_SwapLE32(pack.hellfireFlags);
 }
 
 ItemPack SwappedLE(const ItemPack &pack)
@@ -429,8 +429,8 @@ TEST_F(PackTest, UnPackItem_diablo)
 	gbIsMultiplayer = false;
 	gbIsSpawn = false;
 
-	MyPlayer->_pMaxManaBase = 125 << 6;
-	MyPlayer->_pMaxHPBase = 125 << 6;
+	MyPlayer->baseMaxMana = 125 << 6;
+	MyPlayer->baseMaxLife = 125 << 6;
 
 	for (size_t i = 0; i < sizeof(PackedDiabloItems) / sizeof(*PackedDiabloItems); i++) {
 		const ItemPack packed = SwappedLE(PackedDiabloItems[i]);
@@ -502,8 +502,8 @@ TEST_F(PackTest, UnPackItem_spawn)
 	gbIsMultiplayer = false;
 	gbIsSpawn = true;
 
-	MyPlayer->_pMaxManaBase = 125 << 6;
-	MyPlayer->_pMaxHPBase = 125 << 6;
+	MyPlayer->baseMaxMana = 125 << 6;
+	MyPlayer->baseMaxLife = 125 << 6;
 
 	for (size_t i = 0; i < sizeof(PackedSpawnItems) / sizeof(*PackedSpawnItems); i++) {
 		const ItemPack packed = SwappedLE(PackedSpawnItems[i]);
@@ -547,8 +547,8 @@ TEST_F(PackTest, UnPackItem_diablo_multiplayer)
 	gbIsMultiplayer = true;
 	gbIsSpawn = false;
 
-	MyPlayer->_pMaxManaBase = 125 << 6;
-	MyPlayer->_pMaxHPBase = 125 << 6;
+	MyPlayer->baseMaxMana = 125 << 6;
+	MyPlayer->baseMaxLife = 125 << 6;
 
 	for (size_t i = 0; i < sizeof(PackedDiabloMPItems) / sizeof(*PackedDiabloMPItems); i++) {
 		const ItemPack packed = SwappedLE(PackedDiabloMPItems[i]);
@@ -766,8 +766,8 @@ TEST_F(PackTest, UnPackItem_hellfire)
 	gbIsMultiplayer = false;
 	gbIsSpawn = false;
 
-	MyPlayer->_pMaxManaBase = 125 << 6;
-	MyPlayer->_pMaxHPBase = 125 << 6;
+	MyPlayer->baseMaxMana = 125 << 6;
+	MyPlayer->baseMaxLife = 125 << 6;
 
 	for (size_t i = 0; i < sizeof(PackedHellfireItems) / sizeof(*PackedHellfireItems); i++) {
 		const ItemPack packed = SwappedLE(PackedHellfireItems[i]);
@@ -1004,108 +1004,108 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_oob)
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
-TEST_F(NetPackTest, UnPackNetPlayer_invalid_plrlevel)
+TEST_F(NetPackTest, UnPackNetPlayer_invalid_dungeonLevel)
 {
-	MyPlayer->plrlevel = NUMLEVELS;
+	MyPlayer->dungeonLevel = NUMLEVELS;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_hpBase)
 {
-	MyPlayer->_pHPBase = -64;
+	MyPlayer->baseLife = -64;
 	ASSERT_FALSE(TestNetPackValidation());
 
-	MyPlayer->_pHPBase = MyPlayer->_pMaxHPBase + 64;
+	MyPlayer->baseLife = MyPlayer->baseMaxLife + 64;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_manaBase)
 {
-	MyPlayer->_pManaBase = MyPlayer->_pMaxManaBase + 64;
+	MyPlayer->baseMana = MyPlayer->baseMaxMana + 64;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_baseStr)
 {
-	MyPlayer->_pBaseStr = MyPlayer->GetMaximumAttributeValue(CharacterAttribute::Strength) + 1;
+	MyPlayer->baseStrength = MyPlayer->GetMaximumAttributeValue(CharacterAttribute::Strength) + 1;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_baseMag)
 {
-	MyPlayer->_pBaseMag = MyPlayer->GetMaximumAttributeValue(CharacterAttribute::Magic) + 1;
+	MyPlayer->baseMagic = MyPlayer->GetMaximumAttributeValue(CharacterAttribute::Magic) + 1;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_baseDex)
 {
-	MyPlayer->_pBaseDex = MyPlayer->GetMaximumAttributeValue(CharacterAttribute::Dexterity) + 1;
+	MyPlayer->baseDexterity = MyPlayer->GetMaximumAttributeValue(CharacterAttribute::Dexterity) + 1;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_baseVit)
 {
-	MyPlayer->_pBaseVit = MyPlayer->GetMaximumAttributeValue(CharacterAttribute::Vitality) + 1;
+	MyPlayer->baseVitality = MyPlayer->GetMaximumAttributeValue(CharacterAttribute::Vitality) + 1;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_numInv)
 {
-	MyPlayer->_pNumInv = InventoryGridCells + 1;
+	MyPlayer->numInventoryItems = InventoryGridCells + 1;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_strength)
 {
-	MyPlayer->_pStrength++;
+	MyPlayer->strength++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_magic)
 {
-	MyPlayer->_pMagic++;
+	MyPlayer->magic++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_dexterity)
 {
-	MyPlayer->_pDexterity++;
+	MyPlayer->dexterity++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_vitality)
 {
-	MyPlayer->_pVitality++;
+	MyPlayer->vitality++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_hitPoints)
 {
-	MyPlayer->_pHitPoints++;
+	MyPlayer->life++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_maxHP)
 {
-	MyPlayer->_pMaxHP++;
+	MyPlayer->maxLife++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_mana)
 {
-	MyPlayer->_pMana++;
+	MyPlayer->mana++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_maxMana)
 {
-	MyPlayer->_pMaxMana++;
+	MyPlayer->maxMana++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_damageMod)
 {
-	MyPlayer->_pDamageMod++;
+	MyPlayer->damageModifier++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
@@ -1119,189 +1119,189 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_baseToBlk)
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iMinDam)
 {
-	MyPlayer->_pIMinDam++;
+	MyPlayer->minDamage++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iMinDam++;
+	MyPlayer->bodySlot[INVLOC_HAND_LEFT]._iMinDam++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iMaxDam)
 {
-	MyPlayer->_pIMaxDam++;
+	MyPlayer->maxDamage++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iMaxDam++;
+	MyPlayer->bodySlot[INVLOC_HAND_LEFT]._iMaxDam++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iAC)
 {
-	MyPlayer->_pIAC++;
+	MyPlayer->armorClass++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_CHEST]._iAC++;
+	MyPlayer->bodySlot[INVLOC_CHEST]._iAC++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iBonusDam)
 {
-	MyPlayer->_pIBonusDam++;
+	MyPlayer->bonusDamagePercent++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iPLDam++;
+	MyPlayer->bodySlot[INVLOC_HAND_LEFT]._iPLDam++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iBonusToHit)
 {
-	MyPlayer->_pIBonusToHit++;
+	MyPlayer->bonusToHit++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iPLToHit++;
+	MyPlayer->bodySlot[INVLOC_HAND_LEFT]._iPLToHit++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iBonusAC)
 {
-	MyPlayer->_pIBonusAC++;
+	MyPlayer->bonusArmorClass++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_CHEST]._iPLAC++;
+	MyPlayer->bodySlot[INVLOC_CHEST]._iPLAC++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iBonusDamMod)
 {
-	MyPlayer->_pIBonusDamMod++;
+	MyPlayer->bonusDamage++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iPLDamMod++;
+	MyPlayer->bodySlot[INVLOC_HAND_LEFT]._iPLDamMod++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iGetHit)
 {
-	MyPlayer->_pIGetHit++;
+	MyPlayer->damageFromEnemies++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_CHEST]._iPLGetHit++;
+	MyPlayer->bodySlot[INVLOC_CHEST]._iPLGetHit++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iEnAc)
 {
-	MyPlayer->_pIEnAc++;
+	MyPlayer->armorPierce++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_CHEST]._iPLEnAc++;
+	MyPlayer->bodySlot[INVLOC_CHEST]._iPLEnAc++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iFMinDam)
 {
-	MyPlayer->_pIFMinDam++;
+	MyPlayer->minFireDamage++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iFMinDam++;
+	MyPlayer->bodySlot[INVLOC_HAND_LEFT]._iFMinDam++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iFMaxDam)
 {
-	MyPlayer->_pIFMaxDam++;
+	MyPlayer->maxFireDamage++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iFMaxDam++;
+	MyPlayer->bodySlot[INVLOC_HAND_LEFT]._iFMaxDam++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iLMinDam)
 {
-	MyPlayer->_pILMinDam++;
+	MyPlayer->minLightningDamage++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iLMinDam++;
+	MyPlayer->bodySlot[INVLOC_HAND_LEFT]._iLMinDam++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_iLMaxDam)
 {
-	MyPlayer->_pILMaxDam++;
+	MyPlayer->maxLightningDamage++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iLMaxDam++;
+	MyPlayer->bodySlot[INVLOC_HAND_LEFT]._iLMaxDam++;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_maxHPBase)
 {
-	MyPlayer->_pMaxHPBase++;
+	MyPlayer->baseMaxLife++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_maxManaBase)
 {
-	MyPlayer->_pMaxManaBase++;
+	MyPlayer->baseMaxMana++;
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_pregenItemFlags)
 {
 	size_t count = 0;
-	for (Item &item : MyPlayer->InvList) {
+	for (Item &item : MyPlayer->inventorySlot) {
 		if (item.isEmpty())
 			continue;
 		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
@@ -1319,7 +1319,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_pregenItemFlags)
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_usefulItemFlags)
 {
 	size_t count = 0;
-	for (Item &item : MyPlayer->InvList) {
+	for (Item &item : MyPlayer->inventorySlot) {
 		if (item.isEmpty())
 			continue;
 		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
@@ -1339,7 +1339,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_usefulItemFlags)
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_townItemFlags)
 {
 	size_t count = 0;
-	for (Item &item : MyPlayer->InvList) {
+	for (Item &item : MyPlayer->inventorySlot) {
 		if (item.isEmpty())
 			continue;
 		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
@@ -1360,7 +1360,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_townItemLevel)
 {
 	size_t boyCount = 0;
 	size_t otherCount = 0;
-	for (Item &item : MyPlayer->InvBody) {
+	for (Item &item : MyPlayer->bodySlot) {
 		if (item.isEmpty())
 			continue;
 		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
@@ -1385,7 +1385,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_townItemLevel)
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_uniqueMonsterItemLevel)
 {
 	size_t count = 0;
-	for (Item &item : MyPlayer->InvList) {
+	for (Item &item : MyPlayer->inventorySlot) {
 		if (item.isEmpty())
 			continue;
 		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
@@ -1406,7 +1406,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_uniqueMonsterItemLevel)
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_monsterItemLevel)
 {
 	size_t count = 0;
-	for (Item &item : MyPlayer->InvBody) {
+	for (Item &item : MyPlayer->bodySlot) {
 		if (item.isEmpty())
 			continue;
 		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -16,8 +16,8 @@ int RunBlockTest(int frames, ItemSpecialEffect flags)
 {
 	Player &player = Players[0];
 
-	player._pHFrames = frames;
-	player._pIFlags = flags;
+	player.numRecoveryFrames = frames;
+	player.flags = flags;
 	// StartPlrHit compares damage (a 6 bit fixed point value) to character level to determine if the player shrugs off the hit.
 	// We don't initialise player so this comparison can't be relied on, instead we use forcehit to ensure the player enters hit mode
 	StartPlrHit(player, 0, true);
@@ -25,9 +25,9 @@ int RunBlockTest(int frames, ItemSpecialEffect flags)
 	int i = 1;
 	for (; i < 100; i++) {
 		TestPlayerDoGotHit(player);
-		if (player._pmode != PM_GOTHIT)
+		if (player.mode != PM_GOTHIT)
 			break;
-		player.AnimInfo.currentFrame++;
+		player.animationInfo.currentFrame++;
 	}
 
 	return i;
@@ -92,91 +92,90 @@ TEST(Player, PM_DoGotHit)
 
 static void AssertPlayer(Player &player)
 {
-	ASSERT_EQ(CountU8(player._pSplLvl, 64), 0);
-	ASSERT_EQ(Count8(player.InvGrid, InventoryGridCells), 1);
-	ASSERT_EQ(CountItems(player.InvBody, NUM_INVLOC), 1);
-	ASSERT_EQ(CountItems(player.InvList, InventoryGridCells), 1);
-	ASSERT_EQ(CountItems(player.SpdList, MaxBeltItems), 2);
-	ASSERT_EQ(CountItems(&player.HoldItem, 1), 0);
+	ASSERT_EQ(CountU8(player.spellLevel, 64), 0);
+	ASSERT_EQ(Count8(player.inventoryGrid, InventoryGridCells), 1);
+	ASSERT_EQ(CountItems(player.bodySlot, NUM_INVLOC), 1);
+	ASSERT_EQ(CountItems(player.inventorySlot, InventoryGridCells), 1);
+	ASSERT_EQ(CountItems(player.beltSlot, MaxBeltItems), 2);
+	ASSERT_EQ(CountItems(&player.heldItem, 1), 0);
 
 	ASSERT_EQ(player.position.tile.x, 0);
 	ASSERT_EQ(player.position.tile.y, 0);
 	ASSERT_EQ(player.position.future.x, 0);
 	ASSERT_EQ(player.position.future.y, 0);
-	ASSERT_EQ(player.plrlevel, 0);
-	ASSERT_EQ(player.destAction, 0);
-	ASSERT_STREQ(player._pName, "");
-	ASSERT_EQ(player._pClass, HeroClass::Rogue);
-	ASSERT_EQ(player._pBaseStr, 20);
-	ASSERT_EQ(player._pStrength, 20);
-	ASSERT_EQ(player._pBaseMag, 15);
-	ASSERT_EQ(player._pMagic, 15);
-	ASSERT_EQ(player._pBaseDex, 30);
-	ASSERT_EQ(player._pDexterity, 30);
-	ASSERT_EQ(player._pBaseVit, 20);
-	ASSERT_EQ(player._pVitality, 20);
+	ASSERT_EQ(player.dungeonLevel, 0);
+	ASSERT_EQ(player.destinationAction, 0);
+	ASSERT_STREQ(player.name, "");
+	ASSERT_EQ(player.heroClass, HeroClass::Rogue);
+	ASSERT_EQ(player.baseStrength, 20);
+	ASSERT_EQ(player.strength, 20);
+	ASSERT_EQ(player.baseMagic, 15);
+	ASSERT_EQ(player.magic, 15);
+	ASSERT_EQ(player.baseDexterity, 30);
+	ASSERT_EQ(player.dexterity, 30);
+	ASSERT_EQ(player.baseVitality, 20);
+	ASSERT_EQ(player.vitality, 20);
 	ASSERT_EQ(player.getCharacterLevel(), 1);
-	ASSERT_EQ(player._pStatPts, 0);
-	ASSERT_EQ(player._pExperience, 0);
-	ASSERT_EQ(player._pGold, 100);
-	ASSERT_EQ(player._pMaxHPBase, 2880);
-	ASSERT_EQ(player._pHPBase, 2880);
+	ASSERT_EQ(player.statPoints, 0);
+	ASSERT_EQ(player.experience, 0);
+	ASSERT_EQ(player.gold, 100);
+	ASSERT_EQ(player.baseMaxLife, 2880);
+	ASSERT_EQ(player.baseLife, 2880);
 	ASSERT_EQ(player.getBaseToBlock(), 20);
-	ASSERT_EQ(player._pMaxManaBase, 1440);
-	ASSERT_EQ(player._pManaBase, 1440);
-	ASSERT_EQ(player._pMemSpells, 0);
-	ASSERT_EQ(player._pNumInv, 1);
-	ASSERT_EQ(player.wReflections, 0);
-	ASSERT_EQ(player.pTownWarps, 0);
-	ASSERT_EQ(player.pDungMsgs, 0);
-	ASSERT_EQ(player.pDungMsgs2, 0);
-	ASSERT_EQ(player.pLvlLoad, 0);
-	ASSERT_EQ(player.pDiabloKillLevel, 0);
-	ASSERT_EQ(player.pManaShield, 0);
-	ASSERT_EQ(player.pDamAcFlags, ItemSpecialEffectHf::None);
+	ASSERT_EQ(player.baseMaxMana, 1440);
+	ASSERT_EQ(player.baseMana, 1440);
+	ASSERT_EQ(player.learnedSpells, 0);
+	ASSERT_EQ(player.numInventoryItems, 1);
+	ASSERT_EQ(player.reflections, 0);
+	ASSERT_EQ(player.townWarps, 0);
+	ASSERT_EQ(player.dungeonMessages, 0);
+	ASSERT_EQ(player.dungeonMessages2, 0);
+	ASSERT_EQ(player.levelLoading, 0);
+	ASSERT_EQ(player.difficultyCompletion, 0);
+	ASSERT_EQ(player.hasManaShield, 0);
+	ASSERT_EQ(player.hellfireFlags, ItemSpecialEffectHf::None);
 
-	ASSERT_EQ(player._pmode, 0);
-	ASSERT_EQ(Count8(player.walkpath, MaxPathLength), 0);
+	ASSERT_EQ(player.mode, 0);
+	ASSERT_EQ(Count8(player.walkPath, MaxPathLength), 0);
 	ASSERT_EQ(player.queuedSpell.spellId, SpellID::Null);
 	ASSERT_EQ(player.queuedSpell.spellType, SpellType::Skill);
 	ASSERT_EQ(player.queuedSpell.spellFrom, 0);
 	ASSERT_EQ(player.inventorySpell, SpellID::Null);
-	ASSERT_EQ(player._pRSpell, SpellID::TrapDisarm);
-	ASSERT_EQ(player._pRSplType, SpellType::Skill);
-	ASSERT_EQ(player._pSBkSpell, SpellID::Null);
-	ASSERT_EQ(player._pAblSpells, 134217728);
-	ASSERT_EQ(player._pScrlSpells, 0);
-	ASSERT_EQ(player._pSpellFlags, SpellFlag::None);
-	ASSERT_EQ(player._pBlockFlag, 0);
-	ASSERT_EQ(player._pLightRad, 10);
-	ASSERT_EQ(player._pDamageMod, 0);
-	ASSERT_EQ(player._pHitPoints, 2880);
-	ASSERT_EQ(player._pMaxHP, 2880);
-	ASSERT_EQ(player._pMana, 1440);
-	ASSERT_EQ(player._pMaxMana, 1440);
+	ASSERT_EQ(player.selectedSpell, SpellID::TrapDisarm);
+	ASSERT_EQ(player.selectedSpellType, SpellType::Skill);
+	ASSERT_EQ(player.skills, 134217728);
+	ASSERT_EQ(player.scrollSpells, 0);
+	ASSERT_EQ(player.spellFlags, SpellFlag::None);
+	ASSERT_EQ(player.hasBlockFlag, 0);
+	ASSERT_EQ(player.lightRadius, 10);
+	ASSERT_EQ(player.damageModifier, 0);
+	ASSERT_EQ(player.life, 2880);
+	ASSERT_EQ(player.maxLife, 2880);
+	ASSERT_EQ(player.mana, 1440);
+	ASSERT_EQ(player.maxMana, 1440);
 	ASSERT_EQ(player.getNextExperienceThreshold(), 2000);
-	ASSERT_EQ(player._pMagResist, 0);
-	ASSERT_EQ(player._pFireResist, 0);
-	ASSERT_EQ(player._pLghtResist, 0);
-	ASSERT_EQ(CountBool(player._pLvlVisited, NUMLEVELS), 0);
-	ASSERT_EQ(CountBool(player._pSLvlVisited, NUMLEVELS), 0);
+	ASSERT_EQ(player.resistMagic, 0);
+	ASSERT_EQ(player.resistFire, 0);
+	ASSERT_EQ(player.resistLightning, 0);
+	ASSERT_EQ(CountBool(player.isLevelVisted, NUMLEVELS), 0);
+	ASSERT_EQ(CountBool(player.isSetLevelVisted, NUMLEVELS), 0);
 	// This test case uses a Rogue, starting loadout is a short bow with damage 1-4
-	ASSERT_EQ(player._pIMinDam, 1);
-	ASSERT_EQ(player._pIMaxDam, 4);
-	ASSERT_EQ(player._pIAC, 0);
-	ASSERT_EQ(player._pIBonusDam, 0);
-	ASSERT_EQ(player._pIBonusToHit, 0);
-	ASSERT_EQ(player._pIBonusAC, 0);
-	ASSERT_EQ(player._pIBonusDamMod, 0);
-	ASSERT_EQ(player._pISpells, 0);
-	ASSERT_EQ(player._pIFlags, ItemSpecialEffect::None);
-	ASSERT_EQ(player._pIGetHit, 0);
-	ASSERT_EQ(player._pISplLvlAdd, 0);
-	ASSERT_EQ(player._pIEnAc, 0);
-	ASSERT_EQ(player._pIFMinDam, 0);
-	ASSERT_EQ(player._pIFMaxDam, 0);
-	ASSERT_EQ(player._pILMinDam, 0);
-	ASSERT_EQ(player._pILMaxDam, 0);
+	ASSERT_EQ(player.minDamage, 1);
+	ASSERT_EQ(player.maxDamage, 4);
+	ASSERT_EQ(player.armorClass, 0);
+	ASSERT_EQ(player.bonusDamagePercent, 0);
+	ASSERT_EQ(player.bonusToHit, 0);
+	ASSERT_EQ(player.bonusArmorClass, 0);
+	ASSERT_EQ(player.bonusDamage, 0);
+	ASSERT_EQ(player.staffSpells, 0);
+	ASSERT_EQ(player.flags, ItemSpecialEffect::None);
+	ASSERT_EQ(player.damageFromEnemies, 0);
+	ASSERT_EQ(player.bonusSpellLevel, 0);
+	ASSERT_EQ(player.armorPierce, 0);
+	ASSERT_EQ(player.minFireDamage, 0);
+	ASSERT_EQ(player.maxFireDamage, 0);
+	ASSERT_EQ(player.minLightningDamage, 0);
+	ASSERT_EQ(player.maxLightningDamage, 0);
 }
 
 TEST(Player, CreatePlayer)

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -46,19 +46,19 @@ void SwapLE(PlayerPack &player)
 	player.pManaBase = SDL_SwapLE32(player.pManaBase);
 	player.pMaxManaBase = SDL_SwapLE32(player.pMaxManaBase);
 	player.pMemSpells = SDL_SwapLE64(player.pMemSpells);
-	for (ItemPack &item : player.InvBody) {
+	for (ItemPack &item : player.bodySlot) {
 		SwapLE(item);
 	}
-	for (ItemPack &item : player.InvList) {
+	for (ItemPack &item : player.inventorySlot) {
 		SwapLE(item);
 	}
-	for (ItemPack &item : player.SpdList) {
+	for (ItemPack &item : player.beltSlot) {
 		SwapLE(item);
 	}
-	player.wReflections = SDL_SwapLE16(player.wReflections);
-	player.pDiabloKillLevel = SDL_SwapLE32(player.pDiabloKillLevel);
+	player.reflections = SDL_SwapLE16(player.reflections);
+	player.difficultyCompletion = SDL_SwapLE32(player.difficultyCompletion);
 	player.pDifficulty = SDL_SwapLE32(player.pDifficulty);
-	player.pDamAcFlags = SDL_SwapLE32(player.pDamAcFlags);
+	player.hellfireFlags = SDL_SwapLE32(player.hellfireFlags);
 }
 
 void PackItemUnique(ItemPack *id, int idx)
@@ -177,23 +177,23 @@ int PrepareInvSlot(PlayerPack *pPack, int pos, int size, int start = 0)
 		ret = 0;
 	++ret;
 	if (size == 0) {
-		pPack->InvGrid[pos] = ret;
+		pPack->inventoryGrid[pos] = ret;
 	} else if (size == 1) {
-		pPack->InvGrid[pos] = ret;
-		pPack->InvGrid[pos - 10] = -ret;
-		pPack->InvGrid[pos - 20] = -ret;
+		pPack->inventoryGrid[pos] = ret;
+		pPack->inventoryGrid[pos - 10] = -ret;
+		pPack->inventoryGrid[pos - 20] = -ret;
 	} else if (size == 2) {
-		pPack->InvGrid[pos] = ret;
-		pPack->InvGrid[pos + 1] = -ret;
-		pPack->InvGrid[pos - 10] = -ret;
-		pPack->InvGrid[pos - 10 + 1] = -ret;
-		pPack->InvGrid[pos - 20] = -ret;
-		pPack->InvGrid[pos - 20 + 1] = -ret;
+		pPack->inventoryGrid[pos] = ret;
+		pPack->inventoryGrid[pos + 1] = -ret;
+		pPack->inventoryGrid[pos - 10] = -ret;
+		pPack->inventoryGrid[pos - 10 + 1] = -ret;
+		pPack->inventoryGrid[pos - 20] = -ret;
+		pPack->inventoryGrid[pos - 20 + 1] = -ret;
 	} else if (size == 3) {
-		pPack->InvGrid[pos] = ret;
-		pPack->InvGrid[pos + 1] = -ret;
-		pPack->InvGrid[pos - 10] = -ret;
-		pPack->InvGrid[pos - 10 + 1] = -ret;
+		pPack->inventoryGrid[pos] = ret;
+		pPack->inventoryGrid[pos + 1] = -ret;
+		pPack->inventoryGrid[pos - 10] = -ret;
+		pPack->inventoryGrid[pos - 10 + 1] = -ret;
 	} else {
 		abort();
 	}
@@ -203,10 +203,10 @@ int PrepareInvSlot(PlayerPack *pPack, int pos, int size, int start = 0)
 void PackPlayerTest(PlayerPack *pPack)
 {
 	memset(pPack, 0, 0x4F2);
-	pPack->destAction = -1;
-	pPack->destParam1 = 0;
-	pPack->destParam2 = 0;
-	pPack->plrlevel = 0;
+	pPack->destinationAction = -1;
+	pPack->destinationParam1 = 0;
+	pPack->destinationParam2 = 0;
+	pPack->dungeonLevel = 0;
 	pPack->pExperience = 1583495809;
 	pPack->pLevel = 50;
 	pPack->px = 75;
@@ -215,13 +215,13 @@ void PackPlayerTest(PlayerPack *pPack)
 	pPack->targy = 68;
 	pPack->pGold = 0;
 	pPack->pStatPts = 0;
-	pPack->pDiabloKillLevel = 3;
+	pPack->difficultyCompletion = 3;
 	for (auto i = 0; i < 40; i++)
-		pPack->InvList[i].idx = -1;
+		pPack->inventorySlot[i].idx = -1;
 	for (auto i = 0; i < 7; i++)
-		pPack->InvBody[i].idx = -1;
+		pPack->bodySlot[i].idx = -1;
 	for (auto i = 0; i < MaxBeltItems; i++)
-		PackItemFullRejuv(pPack->SpdList + i, i);
+		PackItemFullRejuv(pPack->beltSlot + i, i);
 	for (auto i = 1; i < 37; i++) {
 		if (SpellDatVanilla[i] != -1) {
 			pPack->pMemSpells |= 1ULL << (i - 1);
@@ -229,7 +229,7 @@ void PackPlayerTest(PlayerPack *pPack)
 		}
 	}
 	for (auto i = 0; i < 7; i++)
-		pPack->InvBody[i].idx = -1;
+		pPack->bodySlot[i].idx = -1;
 	strcpy(pPack->pName, "TestPlayer");
 	pPack->pClass = static_cast<uint8_t>(HeroClass::Rogue);
 	pPack->pBaseStr = 20 + 35;
@@ -241,123 +241,122 @@ void PackPlayerTest(PlayerPack *pPack)
 	pPack->pManaBase = (15 << 6) + (15 << 5) + 48 * 128 + (55 << 6);
 	pPack->pMaxManaBase = pPack->pManaBase;
 
-	PackItemUnique(pPack->InvBody + INVLOC_HEAD, 52);
-	PackItemRing1(pPack->InvBody + INVLOC_RING_LEFT);
-	PackItemRing2(pPack->InvBody + INVLOC_RING_RIGHT);
-	PackItemAmulet(pPack->InvBody + INVLOC_AMULET);
-	PackItemArmor(pPack->InvBody + INVLOC_CHEST);
-	PackItemBow(pPack->InvBody + INVLOC_HAND_LEFT);
+	PackItemUnique(pPack->bodySlot + INVLOC_HEAD, 52);
+	PackItemRing1(pPack->bodySlot + INVLOC_RING_LEFT);
+	PackItemRing2(pPack->bodySlot + INVLOC_RING_RIGHT);
+	PackItemAmulet(pPack->bodySlot + INVLOC_AMULET);
+	PackItemArmor(pPack->bodySlot + INVLOC_CHEST);
+	PackItemBow(pPack->bodySlot + INVLOC_HAND_LEFT);
 
-	PackItemStaff(pPack->InvList + PrepareInvSlot(pPack, 28, 2, 1));
-	PackItemSword(pPack->InvList + PrepareInvSlot(pPack, 20, 1));
+	PackItemStaff(pPack->inventorySlot + PrepareInvSlot(pPack, 28, 2, 1));
+	PackItemSword(pPack->inventorySlot + PrepareInvSlot(pPack, 20, 1));
 
-	pPack->_pNumInv = 2;
+	pPack->numInventoryItems = 2;
 
 	SwapLE(*pPack);
 }
 
 void AssertPlayer(Player &player)
 {
-	ASSERT_EQ(CountU8(player._pSplLvl, 64), 23);
-	ASSERT_EQ(Count8(player.InvGrid, InventoryGridCells), 9);
-	ASSERT_EQ(CountItems(player.InvBody, NUM_INVLOC), 6);
-	ASSERT_EQ(CountItems(player.InvList, InventoryGridCells), 2);
-	ASSERT_EQ(CountItems(player.SpdList, MaxBeltItems), 8);
-	ASSERT_EQ(CountItems(&player.HoldItem, 1), 0);
+	ASSERT_EQ(CountU8(player.spellLevel, 64), 23);
+	ASSERT_EQ(Count8(player.inventoryGrid, InventoryGridCells), 9);
+	ASSERT_EQ(CountItems(player.bodySlot, NUM_INVLOC), 6);
+	ASSERT_EQ(CountItems(player.inventorySlot, InventoryGridCells), 2);
+	ASSERT_EQ(CountItems(player.beltSlot, MaxBeltItems), 8);
+	ASSERT_EQ(CountItems(&player.heldItem, 1), 0);
 
 	ASSERT_EQ(player.position.tile.x, 75);
 	ASSERT_EQ(player.position.tile.y, 68);
 	ASSERT_EQ(player.position.future.x, 75);
 	ASSERT_EQ(player.position.future.y, 68);
-	ASSERT_EQ(player.plrlevel, 0);
-	ASSERT_EQ(player.destAction, -1);
-	ASSERT_STREQ(player._pName, "TestPlayer");
-	ASSERT_EQ(player._pClass, HeroClass::Rogue);
-	ASSERT_EQ(player._pBaseStr, 55);
-	ASSERT_EQ(player._pStrength, 124);
-	ASSERT_EQ(player._pBaseMag, 70);
-	ASSERT_EQ(player._pMagic, 80);
-	ASSERT_EQ(player._pBaseDex, 250);
-	ASSERT_EQ(player._pDexterity, 281);
-	ASSERT_EQ(player._pBaseVit, 80);
-	ASSERT_EQ(player._pVitality, 90);
+	ASSERT_EQ(player.dungeonLevel, 0);
+	ASSERT_EQ(player.destinationAction, -1);
+	ASSERT_STREQ(player.name, "TestPlayer");
+	ASSERT_EQ(player.heroClass, HeroClass::Rogue);
+	ASSERT_EQ(player.baseStrength, 55);
+	ASSERT_EQ(player.strength, 124);
+	ASSERT_EQ(player.baseMagic, 70);
+	ASSERT_EQ(player.magic, 80);
+	ASSERT_EQ(player.baseDexterity, 250);
+	ASSERT_EQ(player.dexterity, 281);
+	ASSERT_EQ(player.baseVitality, 80);
+	ASSERT_EQ(player.vitality, 90);
 	ASSERT_EQ(player.getCharacterLevel(), 50);
-	ASSERT_EQ(player._pStatPts, 0);
-	ASSERT_EQ(player._pExperience, 1583495809);
-	ASSERT_EQ(player._pGold, 0);
-	ASSERT_EQ(player._pMaxHPBase, 12864);
-	ASSERT_EQ(player._pHPBase, 12864);
+	ASSERT_EQ(player.statPoints, 0);
+	ASSERT_EQ(player.experience, 1583495809);
+	ASSERT_EQ(player.gold, 0);
+	ASSERT_EQ(player.baseMaxLife, 12864);
+	ASSERT_EQ(player.baseLife, 12864);
 	ASSERT_EQ(player.getBaseToBlock(), 20);
-	ASSERT_EQ(player._pMaxManaBase, 11104);
-	ASSERT_EQ(player._pManaBase, 11104);
-	ASSERT_EQ(player._pMemSpells, 66309357295);
-	ASSERT_EQ(player._pNumInv, 2);
-	ASSERT_EQ(player.wReflections, 0);
-	ASSERT_EQ(player.pTownWarps, 0);
-	ASSERT_EQ(player.pDungMsgs, 0);
-	ASSERT_EQ(player.pDungMsgs2, 0);
-	ASSERT_EQ(player.pLvlLoad, 0);
-	ASSERT_EQ(player.pDiabloKillLevel, 3);
-	ASSERT_EQ(player.pManaShield, 0);
-	ASSERT_EQ(player.pDamAcFlags, ItemSpecialEffectHf::None);
+	ASSERT_EQ(player.baseMaxMana, 11104);
+	ASSERT_EQ(player.baseMana, 11104);
+	ASSERT_EQ(player.learnedSpells, 66309357295);
+	ASSERT_EQ(player.numInventoryItems, 2);
+	ASSERT_EQ(player.reflections, 0);
+	ASSERT_EQ(player.townWarps, 0);
+	ASSERT_EQ(player.dungeonMessages, 0);
+	ASSERT_EQ(player.dungeonMessages2, 0);
+	ASSERT_EQ(player.levelLoading, 0);
+	ASSERT_EQ(player.difficultyCompletion, 3);
+	ASSERT_EQ(player.hasManaShield, 0);
+	ASSERT_EQ(player.hellfireFlags, ItemSpecialEffectHf::None);
 
-	ASSERT_EQ(player._pmode, 0);
-	ASSERT_EQ(Count8(player.walkpath, MaxPathLength), 25);
-	ASSERT_EQ(player._pgfxnum, 36);
-	ASSERT_EQ(player.AnimInfo.ticksPerFrame, 4);
-	ASSERT_EQ(player.AnimInfo.tickCounterOfCurrentFrame, 1);
-	ASSERT_EQ(player.AnimInfo.numberOfFrames, 20);
-	ASSERT_EQ(player.AnimInfo.currentFrame, 0);
+	ASSERT_EQ(player.mode, 0);
+	ASSERT_EQ(Count8(player.walkPath, MaxPathLength), 25);
+	ASSERT_EQ(player.graphic, 36);
+	ASSERT_EQ(player.animationInfo.ticksPerFrame, 4);
+	ASSERT_EQ(player.animationInfo.tickCounterOfCurrentFrame, 1);
+	ASSERT_EQ(player.animationInfo.numberOfFrames, 20);
+	ASSERT_EQ(player.animationInfo.currentFrame, 0);
 	ASSERT_EQ(player.queuedSpell.spellId, SpellID::Invalid);
 	ASSERT_EQ(player.queuedSpell.spellType, SpellType::Invalid);
 	ASSERT_EQ(player.queuedSpell.spellFrom, 0);
 	ASSERT_EQ(player.inventorySpell, SpellID::Null);
-	ASSERT_EQ(player._pRSpell, SpellID::Invalid);
-	ASSERT_EQ(player._pRSplType, SpellType::Invalid);
-	ASSERT_EQ(player._pSBkSpell, SpellID::Invalid);
-	ASSERT_EQ(player._pAblSpells, 134217728);
-	ASSERT_EQ(player._pScrlSpells, 0);
-	ASSERT_EQ(player._pSpellFlags, SpellFlag::None);
+	ASSERT_EQ(player.selectedSpell, SpellID::Invalid);
+	ASSERT_EQ(player.selectedSpellType, SpellType::Invalid);
+	ASSERT_EQ(player.skills, 134217728);
+	ASSERT_EQ(player.scrollSpells, 0);
+	ASSERT_EQ(player.spellFlags, SpellFlag::None);
 	ASSERT_TRUE(player.UsesRangedWeapon());
-	ASSERT_EQ(player._pBlockFlag, 0);
-	ASSERT_EQ(player._pLightRad, 11);
-	ASSERT_EQ(player._pDamageMod, 101);
-	ASSERT_EQ(player._pHitPoints, 16640);
-	ASSERT_EQ(player._pMaxHP, 16640);
-	ASSERT_EQ(player._pMana, 14624);
-	ASSERT_EQ(player._pMaxMana, 14624);
+	ASSERT_EQ(player.hasBlockFlag, 0);
+	ASSERT_EQ(player.lightRadius, 11);
+	ASSERT_EQ(player.damageModifier, 101);
+	ASSERT_EQ(player.life, 16640);
+	ASSERT_EQ(player.maxLife, 16640);
+	ASSERT_EQ(player.mana, 14624);
+	ASSERT_EQ(player.maxMana, 14624);
 	ASSERT_EQ(player.getNextExperienceThreshold(), 1583495809);
-	ASSERT_EQ(player._pMagResist, 75);
-	ASSERT_EQ(player._pFireResist, 16);
-	ASSERT_EQ(player._pLghtResist, 75);
-	ASSERT_EQ(CountBool(player._pLvlVisited, NUMLEVELS), 0);
-	ASSERT_EQ(CountBool(player._pSLvlVisited, NUMLEVELS), 0);
-	ASSERT_EQ(player._pNFrames, 20);
-	ASSERT_EQ(player._pWFrames, 8);
-	ASSERT_EQ(player._pAFrames, 0);
-	ASSERT_EQ(player._pAFNum, 0);
-	ASSERT_EQ(player._pSFrames, 16);
-	ASSERT_EQ(player._pSFNum, 12);
-	ASSERT_EQ(player._pHFrames, 0);
-	ASSERT_EQ(player._pDFrames, 20);
-	ASSERT_EQ(player._pBFrames, 0);
-	ASSERT_EQ(player._pIMinDam, 1);
-	ASSERT_EQ(player._pIMaxDam, 14);
-	ASSERT_EQ(player._pIAC, 115);
-	ASSERT_EQ(player._pIBonusDam, 0);
-	ASSERT_EQ(player._pIBonusToHit, 0);
-	ASSERT_EQ(player._pIBonusAC, 0);
-	ASSERT_EQ(player._pIBonusDamMod, 0);
-	ASSERT_EQ(player._pISpells, 0);
-	ASSERT_EQ(player._pIFlags, ItemSpecialEffect::None);
-	ASSERT_EQ(player._pIGetHit, 0);
-	ASSERT_EQ(player._pISplLvlAdd, 0);
-	ASSERT_EQ(player._pIEnAc, 0);
-	ASSERT_EQ(player._pIFMinDam, 0);
-	ASSERT_EQ(player._pIFMaxDam, 0);
-	ASSERT_EQ(player._pILMinDam, 0);
-	ASSERT_EQ(player._pILMaxDam, 0);
-	ASSERT_EQ(player.pOriginalCathedral, 0);
+	ASSERT_EQ(player.resistMagic, 75);
+	ASSERT_EQ(player.resistFire, 16);
+	ASSERT_EQ(player.resistLightning, 75);
+	ASSERT_EQ(CountBool(player.isLevelVisted, NUMLEVELS), 0);
+	ASSERT_EQ(CountBool(player.isSetLevelVisted, NUMLEVELS), 0);
+	ASSERT_EQ(player.numIdleFrames, 20);
+	ASSERT_EQ(player.numWalkFrames, 8);
+	ASSERT_EQ(player.numAttackFrames, 0);
+	ASSERT_EQ(player.attackActionFrame, 0);
+	ASSERT_EQ(player.numSpellFrames, 16);
+	ASSERT_EQ(player.spellActionFrame, 12);
+	ASSERT_EQ(player.numRecoveryFrames, 0);
+	ASSERT_EQ(player.numDeathFrames, 20);
+	ASSERT_EQ(player.numBlockFrames, 0);
+	ASSERT_EQ(player.minDamage, 1);
+	ASSERT_EQ(player.maxDamage, 14);
+	ASSERT_EQ(player.armorClass, 115);
+	ASSERT_EQ(player.bonusDamagePercent, 0);
+	ASSERT_EQ(player.bonusToHit, 0);
+	ASSERT_EQ(player.bonusArmorClass, 0);
+	ASSERT_EQ(player.bonusDamage, 0);
+	ASSERT_EQ(player.staffSpells, 0);
+	ASSERT_EQ(player.flags, ItemSpecialEffect::None);
+	ASSERT_EQ(player.damageFromEnemies, 0);
+	ASSERT_EQ(player.bonusSpellLevel, 0);
+	ASSERT_EQ(player.armorPierce, 0);
+	ASSERT_EQ(player.minFireDamage, 0);
+	ASSERT_EQ(player.maxFireDamage, 0);
+	ASSERT_EQ(player.minLightningDamage, 0);
+	ASSERT_EQ(player.maxLightningDamage, 0);
+	ASSERT_EQ(player.originalCathedral, 0);
 }
 
 TEST(Writehero, pfile_write_hero)


### PR DESCRIPTION
Renames most variables that are a part of the `Player` struct. No logic changes. Comments were added for cross reference with older code/devilution. Brief comment blocks were made consistent across the board (Which is why there are more additions than removals).