### PR TITLE
Rename Player struct variables: _pExperience

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -456,7 +456,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player.setCharacterLevel(file.NextLE<uint8_t>());
 	file.Skip<uint8_t>(); // Skip _pMaxLevel - unused
 	file.Skip(2);         // Alignment
-	player._pExperience = file.NextLE<uint32_t>();
+	player.experiencePoints = file.NextLE<uint32_t>();
 	file.Skip<uint32_t>(); // Skip _pMaxExp - unused
 	file.Skip<uint32_t>(); // Skip _pNextExper, we retrieve it when needed based on _pLevel
 	player._pArmorClass = file.NextLE<int8_t>();
@@ -1280,7 +1280,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<uint8_t>(player.getCharacterLevel());
 	file.Skip<uint8_t>(); // skip _pMaxLevel, this value is uninitialised in most cases in Diablo/Hellfire so there's no point setting it.
 	file.Skip(2);         // Alignment
-	file.WriteLE<uint32_t>(player._pExperience);
+	file.WriteLE<uint32_t>(player.experiencePoints);
 	file.Skip<uint32_t>();                                       // Skip _pMaxExp
 	file.WriteLE<uint32_t>(player.getNextExperienceThreshold()); // set _pNextExper for backwards compatibility
 	file.WriteLE<int8_t>(player._pArmorClass);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2285,7 +2285,7 @@ size_t OnCheatExperience(const TCmd *pCmd, Player &player) // NOLINT(misc-unused
 	if (gbBufferMsgs == 1)
 		SendPacket(player, pCmd, sizeof(*pCmd));
 	else if (!player.isMaxCharacterLevel()) {
-		player._pExperience = player.getNextExperienceThreshold();
+		player.experiencePoints = player.getNextExperienceThreshold();
 		if (*sgOptions.Gameplay.experienceBar) {
 			RedrawEverything();
 		}

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2835,13 +2835,13 @@ void OperateShrineGlowing(Player &player)
 		return;
 
 	// Add 0-5 points to Magic (0.1% of the players XP)
-	ModifyPlrMag(player, static_cast<int>(std::min<uint32_t>(player._pExperience / 1000, 5)));
+	ModifyPlrMag(player, static_cast<int>(std::min<uint32_t>(player.experiencePoints / 1000, 5)));
 
 	// Take 5% of the players experience to offset the bonus, unless they're very low level in which case take all their experience.
-	if (player._pExperience > 5000)
-		player._pExperience = static_cast<uint32_t>(player._pExperience * 0.95);
+	if (player.experiencePoints > 5000)
+		player.experiencePoints = static_cast<uint32_t>(player.experiencePoints * 0.95);
 	else
-		player._pExperience = 0;
+		player.experiencePoints = 0;
 
 	CheckStats(player);
 	RedrawEverything();

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -267,7 +267,7 @@ void PackPlayer(PlayerPack &packed, const Player &player)
 	packed.pBaseVit = player._pBaseVit;
 	packed.pLevel = player.getCharacterLevel();
 	packed.pStatPts = player._pStatPts;
-	packed.pExperience = SDL_SwapLE32(player._pExperience);
+	packed.pExperience = SDL_SwapLE32(player.experiencePoints);
 	packed.pGold = SDL_SwapLE32(player._pGold);
 	packed.pHPBase = SDL_SwapLE32(player._pHPBase);
 	packed.pMaxHPBase = SDL_SwapLE32(player._pMaxHPBase);
@@ -327,7 +327,7 @@ void PackNetPlayer(PlayerNetPack &packed, const Player &player)
 	packed.pBaseVit = player._pBaseVit;
 	packed.pLevel = player.getCharacterLevel();
 	packed.pStatPts = player._pStatPts;
-	packed.pExperience = SDL_SwapLE32(player._pExperience);
+	packed.pExperience = SDL_SwapLE32(player.experiencePoints);
 	packed.pHPBase = SDL_SwapLE32(player._pHPBase);
 	packed.pMaxHPBase = SDL_SwapLE32(player._pMaxHPBase);
 	packed.pManaBase = SDL_SwapLE32(player._pManaBase);
@@ -475,7 +475,7 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 	player._pVitality = player._pBaseVit;
 	player._pStatPts = packed.pStatPts;
 
-	player._pExperience = SDL_SwapLE32(packed.pExperience);
+	player.experiencePoints = SDL_SwapLE32(packed.pExperience);
 	player._pGold = SDL_SwapLE32(packed.pGold);
 	if ((int)(player._pHPBase & 0xFFFFFFC0) < 64)
 		player._pHPBase = 64;
@@ -610,7 +610,7 @@ bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 	player._pVitality = player._pBaseVit;
 	player._pStatPts = packed.pStatPts;
 
-	player._pExperience = SDL_SwapLE32(packed.pExperience);
+	player.experiencePoints = SDL_SwapLE32(packed.pExperience);
 	player._pMaxManaBase = baseManaMax;
 	player._pManaBase = baseMana;
 	player._pMemSpells = SDL_SwapLE64(packed.pMemSpells);

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -129,8 +129,8 @@ PanelEntry panelEntries[] = {
 	    []() { return StyledText { UiFlags::ColorWhite, StrCat(InspectPlayer->getCharacterLevel()) }; } },
 	{ N_("Experience"), { TopRightLabelX, 52 }, 99, 91,
 	    []() {
-	        int spacing = ((InspectPlayer->_pExperience >= 1000000000) ? 0 : 1);
-	        return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->_pExperience), spacing };
+	        int spacing = ((InspectPlayer->experiencePoints >= 1000000000) ? 0 : 1);
+	        return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->experiencePoints), spacing };
 	    } },
 	{ N_("Next level"), { TopRightLabelX, 80 }, 99, 198,
 	    []() {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1422,8 +1422,8 @@ void ValidatePlayer()
 	// Player::setCharacterLevel ensures that the player level is within the expected range in case someone has edited their character level in memory
 	myPlayer.setCharacterLevel(myPlayer.getCharacterLevel());
 	// This lets us catch cases where someone is editing experience directly through memory modification and reset their experience back to the expected cap.
-	if (myPlayer._pExperience > myPlayer.getNextExperienceThreshold()) {
-		myPlayer._pExperience = myPlayer.getNextExperienceThreshold();
+	if (myPlayer.experiencePoints > myPlayer.getNextExperienceThreshold()) {
+		myPlayer.experiencePoints = myPlayer.getNextExperienceThreshold();
 		if (*sgOptions.Gameplay.experienceBar) {
 			RedrawEverything();
 		}
@@ -2296,7 +2296,7 @@ void CreatePlayer(Player &player, HeroClass c)
 	player._pManaBase = player._pMana;
 	player._pMaxManaBase = player._pMana;
 
-	player._pExperience = 0;
+	player.experiencePoints = 0;
 	player._pArmorClass = 0;
 	player._pLightRad = 10;
 	player._pInfraFlag = false;
@@ -2410,14 +2410,14 @@ void Player::_addExperience(uint32_t experience, int levelDelta)
 	const uint32_t maxExperience = GetNextExperienceThresholdForLevel(getMaxCharacterLevel());
 
 	// ensure we only add enough experience to reach the max experience cap so we don't overflow
-	_pExperience += std::min(clampedExp, maxExperience - _pExperience);
+	experiencePoints += std::min(clampedExp, maxExperience - experiencePoints);
 
 	if (*sgOptions.Gameplay.experienceBar) {
 		RedrawEverything();
 	}
 
 	// Increase player level if applicable
-	while (!isMaxCharacterLevel() && _pExperience >= getNextExperienceThreshold()) {
+	while (!isMaxCharacterLevel() && experiencePoints >= getNextExperienceThreshold()) {
 		// NextPlrLevel increments character level which changes the next experience threshold
 		NextPlrLevel(*this);
 	}

--- a/Source/player.h
+++ b/Source/player.h
@@ -259,7 +259,7 @@ struct Player {
 	int _pIFMaxDam;
 	int _pILMinDam;
 	int _pILMaxDam;
-	uint32_t _pExperience;
+	uint32_t experiencePoints; // _pExperience
 	PLR_MODE _pmode;
 	int8_t walkpath[MaxPathLength];
 	bool plractive;

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -86,10 +86,10 @@ void DrawXPBar(const Surface &out)
 	const uint8_t charLevel = player.getCharacterLevel();
 
 	const uint64_t prevXp = GetNextExperienceThresholdForLevel(charLevel - 1);
-	if (player._pExperience < prevXp)
+	if (player.experiencePoints < prevXp)
 		return;
 
-	uint64_t prevXpDelta1 = player._pExperience - prevXp;
+	uint64_t prevXpDelta1 = player.experiencePoints - prevXp;
 	uint64_t prevXpDelta = GetNextExperienceThresholdForLevel(charLevel) - prevXp;
 	uint64_t fullBar = BarWidth * prevXpDelta1 / prevXpDelta;
 
@@ -128,7 +128,7 @@ bool CheckXPBarInfo()
 		// Show a maximum level indicator for max level players.
 		InfoColor = UiFlags::ColorWhitegold;
 
-		AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player._pExperience)));
+		AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player.experiencePoints)));
 		AddPanelString(_("Maximum Level"));
 
 		return true;
@@ -136,10 +136,10 @@ bool CheckXPBarInfo()
 
 	InfoColor = UiFlags::ColorWhite;
 
-	AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player._pExperience)));
+	AddPanelString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player.experiencePoints)));
 	uint32_t nextExperienceThreshold = player.getNextExperienceThreshold();
 	AddPanelString(fmt::format(fmt::runtime(_("Next Level: {:s}")), FormatInteger(nextExperienceThreshold)));
-	AddPanelString(fmt::format(fmt::runtime(_("{:s} to Level {:d}")), FormatInteger(nextExperienceThreshold - player._pExperience), charLevel + 1));
+	AddPanelString(fmt::format(fmt::runtime(_("{:s} to Level {:d}")), FormatInteger(nextExperienceThreshold - player.experiencePoints), charLevel + 1));
 
 	return true;
 }

--- a/test/fixtures/memory_map/player.txt
+++ b/test/fixtures/memory_map/player.txt
@@ -88,7 +88,7 @@ R 32 _pManaPer
 R 8 _pLevel
 R 8 _pMaxLvl
 R 16 alignment
-R 32 _pExperience
+R 32 experiencePoints
 R 32 _pMaxExp
 R 32 _pNextExper
 R 8 _pArmorClass

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -117,7 +117,7 @@ static void AssertPlayer(Player &player)
 	ASSERT_EQ(player._pVitality, 20);
 	ASSERT_EQ(player.getCharacterLevel(), 1);
 	ASSERT_EQ(player._pStatPts, 0);
-	ASSERT_EQ(player._pExperience, 0);
+	ASSERT_EQ(player.experiencePoints, 0);
 	ASSERT_EQ(player._pGold, 100);
 	ASSERT_EQ(player._pMaxHPBase, 2880);
 	ASSERT_EQ(player._pHPBase, 2880);

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -283,7 +283,7 @@ void AssertPlayer(Player &player)
 	ASSERT_EQ(player._pVitality, 90);
 	ASSERT_EQ(player.getCharacterLevel(), 50);
 	ASSERT_EQ(player._pStatPts, 0);
-	ASSERT_EQ(player._pExperience, 1583495809);
+	ASSERT_EQ(player.experiencePoints, 1583495809);
 	ASSERT_EQ(player._pGold, 0);
 	ASSERT_EQ(player._pMaxHPBase, 12864);
 	ASSERT_EQ(player._pHPBase, 12864);


### PR DESCRIPTION
Chose `experiencePoints` to avoid naming conflict with member functions that also are already using `experience` as a local/passed variable. Could bypass by using `this->` but I think this is adequate to avoid confusion. Let me know.