### PR TITLE
Minor improvements / fixes extracted from #7191

### DIFF
--- a/Source/engine/clx_sprite.hpp
+++ b/Source/engine/clx_sprite.hpp
@@ -89,14 +89,10 @@ public:
 
 private:
 	// For OptionalClxSprite.
-	constexpr ClxSprite()
-	    : data_(nullptr)
-	    , pixel_data_size_(0)
-	{
-	}
+	constexpr ClxSprite() = default;
 
-	const uint8_t *data_;
-	uint32_t pixel_data_size_;
+	const uint8_t *data_ = nullptr;
+	uint32_t pixel_data_size_ = 0;
 
 	friend class OptionalClxSprite;
 };
@@ -139,7 +135,7 @@ public:
 	}
 
 	/** @brief The offset to the next sprite sheet, or file size if this is the last sprite sheet. */
-	[[nodiscard]] constexpr uint32_t nextSpriteSheetOffsetOrFileSize() const
+	[[nodiscard]] constexpr uint32_t dataSize() const
 	{
 		return LoadLE32(&data_[4 + numSprites() * 4]);
 	}
@@ -154,12 +150,9 @@ public:
 
 private:
 	// For OptionalClxSpriteList.
-	constexpr ClxSpriteList()
-	    : data_(nullptr)
-	{
-	}
+	constexpr ClxSpriteList() = default;
 
-	const uint8_t *data_;
+	const uint8_t *data_ = nullptr;
 
 	friend class OptionalClxSpriteList;
 };
@@ -264,16 +257,17 @@ public:
 	[[nodiscard]] constexpr ClxSpriteSheetIterator begin() const;
 	[[nodiscard]] constexpr ClxSpriteSheetIterator end() const;
 
-private:
-	// For OptionalClxSpriteSheet.
-	constexpr ClxSpriteSheet()
-	    : data_(nullptr)
-	    , num_lists_(0)
+	[[nodiscard]] size_t dataSize() const
 	{
+		return static_cast<size_t>(&data_[sheetOffset(num_lists_ - 1)] + (*this)[num_lists_ - 1].dataSize() - &data_[0]);
 	}
 
-	const uint8_t *data_;
-	uint16_t num_lists_;
+private:
+	// For OptionalClxSpriteSheet.
+	constexpr ClxSpriteSheet() = default;
+
+	const uint8_t *data_ = nullptr;
+	uint16_t num_lists_ = 0;
 
 	friend class OptionalClxSpriteSheet;
 };
@@ -367,6 +361,11 @@ public:
 		return ClxSpriteList { *this }.numSprites();
 	}
 
+	[[nodiscard]] size_t dataSize() const
+	{
+		return ClxSpriteList { *this }.dataSize();
+	}
+
 private:
 	// For OptionalOwnedClxSpriteList.
 	OwnedClxSpriteList() = default;
@@ -385,9 +384,9 @@ inline ClxSpriteList::ClxSpriteList(const OwnedClxSpriteList &owned)
 
 inline OwnedClxSpriteList ClxSpriteList::clone() const
 {
-	const size_t dataSize = nextSpriteSheetOffsetOrFileSize();
-	std::unique_ptr<uint8_t[]> data { new uint8_t[dataSize] };
-	memcpy(data.get(), data_, dataSize);
+	const size_t size = dataSize();
+	std::unique_ptr<uint8_t[]> data { new uint8_t[size] };
+	memcpy(data.get(), data_, size);
 	return OwnedClxSpriteList { std::move(data) };
 }
 
@@ -422,16 +421,17 @@ public:
 		return ClxSpriteSheet { *this }.end();
 	}
 
-private:
-	// For OptionalOwnedClxSpriteList.
-	OwnedClxSpriteSheet()
-	    : data_(nullptr)
-	    , num_lists_(0)
+	[[nodiscard]] size_t dataSize() const
 	{
+		return ClxSpriteSheet { *this }.dataSize();
 	}
 
+private:
+	// For OptionalOwnedClxSpriteList.
+	OwnedClxSpriteSheet() = default;
+
 	std::unique_ptr<uint8_t[]> data_;
-	uint16_t num_lists_;
+	uint16_t num_lists_ = 0;
 
 	friend class ClxSpriteSheet; // for implicit conversion.
 	friend class OptionalOwnedClxSpriteSheet;
@@ -489,16 +489,17 @@ public:
 		return num_lists_ != 0;
 	}
 
-private:
-	const uint8_t *data_;
-	uint16_t num_lists_;
-
-	// For OptionalClxSpriteListOrSheet.
-	constexpr ClxSpriteListOrSheet()
-	    : data_(nullptr)
-	    , num_lists_(0)
+	[[nodiscard]] size_t dataSize() const
 	{
+		return isSheet() ? sheet().dataSize() : list().dataSize();
 	}
+
+private:
+	// For OptionalClxSpriteListOrSheet.
+	constexpr ClxSpriteListOrSheet() = default;
+
+	const uint8_t *data_ = nullptr;
+	uint16_t num_lists_ = 0;
 
 	friend class OptionalClxSpriteListOrSheet;
 };
@@ -563,16 +564,19 @@ public:
 		return num_lists_ != 0;
 	}
 
-private:
-	std::unique_ptr<uint8_t[]> data_;
-	uint16_t num_lists_;
+	[[nodiscard]] uint16_t numLists() const { return num_lists_; }
 
-	// For OptionalOwnedClxSpriteListOrSheet.
-	OwnedClxSpriteListOrSheet()
-	    : data_(nullptr)
-	    , num_lists_(0)
+	[[nodiscard]] size_t dataSize() const
 	{
+		return ClxSpriteListOrSheet { *this }.dataSize();
 	}
+
+private:
+	// For OptionalOwnedClxSpriteListOrSheet.
+	OwnedClxSpriteListOrSheet() = default;
+
+	std::unique_ptr<uint8_t[]> data_;
+	uint16_t num_lists_ = 0;
 
 	friend class ClxSpriteListOrSheet;
 	friend class OptionalOwnedClxSpriteListOrSheet;

--- a/Source/utils/intrusive_optional.hpp
+++ b/Source/utils/intrusive_optional.hpp
@@ -30,7 +30,10 @@ public:                                                                         
 	}                                                                                             \
                                                                                                   \
 	template <class U = VALUE_CLASS>                                                              \
-	CONSTEXPR OPTIONAL_CLASS &operator=(VALUE_CLASS &&value)                                      \
+	CONSTEXPR std::enable_if_t<                                                                   \
+	    !std::is_same_v<OPTIONAL_CLASS, std::remove_cv_t<std::remove_reference_t<U>>>,            \
+	    OPTIONAL_CLASS> &                                                                         \
+	operator=(U &&value) noexcept                                                                 \
 	{                                                                                             \
 		value_ = std::forward<U>(value);                                                          \
 		return *this;                                                                             \
@@ -66,9 +69,14 @@ public:                                                                         
 		return &value_;                                                                           \
 	}                                                                                             \
                                                                                                   \
-	CONSTEXPR operator bool() const                                                               \
+	[[nodiscard]] CONSTEXPR bool has_value() const                                                \
 	{                                                                                             \
 		return value_.FIELD != NULL_VALUE;                                                        \
+	}                                                                                             \
+                                                                                                  \
+	CONSTEXPR operator bool() const                                                               \
+	{                                                                                             \
+		return has_value();                                                                       \
 	}                                                                                             \
                                                                                                   \
 private:                                                                                          \

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -14,6 +14,7 @@
 #include "utils/file_util.h"
 #include "utils/log.hpp"
 #include "utils/paths.h"
+#include "utils/string_view_hash.hpp"
 
 #ifdef USE_SDL1
 #include "utils/sdl2_to_1_2_backports.h"
@@ -37,23 +38,7 @@ std::unique_ptr<char[]> translationValues;
 
 using TranslationRef = uint32_t;
 
-struct StringHash {
-	using is_avalanching = void;
-
-	[[nodiscard]] uint64_t operator()(const char *str) const noexcept
-	{
-		return ankerl::unordered_dense::hash<std::string_view> {}(str);
-	}
-};
-
-struct StringEq {
-	bool operator()(const char *lhs, const char *rhs) const noexcept
-	{
-		return std::string_view(lhs) == std::string_view(rhs);
-	}
-};
-
-std::vector<ankerl::unordered_dense::map<const char *, TranslationRef, StringHash, StringEq>> translation = { {}, {} };
+std::vector<ankerl::unordered_dense::map<const char *, TranslationRef, StringViewHash, StringViewEquals>> translation = { {}, {} };
 
 constexpr uint32_t TranslationRefOffsetBits = 19;
 constexpr uint32_t TranslationRefSizeBits = 32 - TranslationRefOffsetBits; // 13

--- a/Source/utils/string_view_hash.hpp
+++ b/Source/utils/string_view_hash.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include <ankerl/unordered_dense.h>
+
+namespace devilution {
+
+// A hash functor that enables heterogenous lookup for `unordered_set/map`.
+struct StringViewHash {
+	using is_transparent = void;
+	using is_avalanching = void;
+
+	[[nodiscard]] uint64_t operator()(std::string_view str) const noexcept
+	{
+		return ankerl::unordered_dense::hash<std::string_view> {}(str);
+	}
+
+	[[nodiscard]] uint64_t operator()(const char *str) const noexcept
+	{
+		return (*this)(std::string_view { str });
+	}
+
+	[[nodiscard]] uint64_t operator()(const std::string &str) const noexcept
+	{
+		return (*this)(std::string_view { str });
+	}
+};
+
+// Usually we'd use `std::equal_to<>` instead but the latter
+// does not link on the libcxx that comes with Xbox NXDK as of Aug 2024,
+struct StringViewEquals {
+	using is_transparent = void;
+
+	[[nodiscard]] bool operator()(std::string_view a, std::string_view b) const { return a == b; }
+	[[nodiscard]] bool operator()(std::string_view a, const std::string &b) const { return a == b; }
+	[[nodiscard]] bool operator()(const std::string &a, std::string_view &b) const { return a == b; }
+	[[nodiscard]] bool operator()(const char *a, const std::string &b) const { return a == b; }
+	[[nodiscard]] bool operator()(const std::string &a, const char *b) const { return a == b; }
+	[[nodiscard]] bool operator()(std::string_view a, const char *b) const { return a == b; }
+	[[nodiscard]] bool operator()(const char *a, std::string_view b) const { return a == b; }
+	[[nodiscard]] bool operator()(const char *a, const char *b) const { return std::string_view { a } == b; }
+};
+
+} // namespace devilution

--- a/uwp-project/devilutionx.vcxproj
+++ b/uwp-project/devilutionx.vcxproj
@@ -79,7 +79,7 @@
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
-      <AdditionalIncludeDirectories>..\Source;..\build\SDL\include;..\build\_deps\sdl_audiolib-src\include;..\build\_deps\sdl_audiolib-build;..\3rdParty\tl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\Source;..\build\SDL\include;..\build\_deps\sdl_audiolib-src\include;..\build\_deps\sdl_audiolib-build;..\build\_deps\unordered_dense-src\include;..\3rdParty\tl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <PreprocessorDefinitions>_DEBUG;__UWP__=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -102,7 +102,7 @@
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <PreprocessorDefinitions>NDEBUG;__UWP__=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\Source;..\build\SDL\include;..\build\_deps\sdl_audiolib-src\include;..\build\_deps\sdl_audiolib-build;..\3rdParty\tl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\Source;..\build\SDL\include;..\build\_deps\sdl_audiolib-src\include;..\build\_deps\sdl_audiolib-build;..\build\_deps\unordered_dense-src\include;..\3rdParty\tl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>


### PR DESCRIPTION
1. Adds `dataSize()` to all the CLX sprite classes.
2. Brings intrusive optional closer to `std::optional`.
3. Adds the `unordered_dense` header to the Xbox One build.