### PR TITLE
Add a CLX rendering benchmark

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ set(standalone_tests
   utf8_test
 )
 set(benchmarks
+  clx_render_benchmark
   crawl_benchmark)
 
 include(Fixtures.cmake)
@@ -84,6 +85,7 @@ add_library(language_for_testing OBJECT language_for_testing.cpp)
 target_sources(language_for_testing INTERFACE $<TARGET_OBJECTS:language_for_testing>)
 
 target_link_libraries(codec_test PRIVATE libdevilutionx_codec app_fatal_for_testing)
+target_link_libraries(clx_render_benchmark PRIVATE libdevilutionx_so)
 target_link_libraries(crawl_test PRIVATE libdevilutionx_crawl)
 target_link_libraries(crawl_benchmark PRIVATE libdevilutionx_crawl)
 target_link_libraries(file_util_test PRIVATE libdevilutionx_file_util app_fatal_for_testing)

--- a/test/clx_render_benchmark.cpp
+++ b/test/clx_render_benchmark.cpp
@@ -1,0 +1,73 @@
+#include <cstddef>
+
+#include <benchmark/benchmark.h>
+
+#include "engine/clx_sprite.hpp"
+#include "engine/displacement.hpp"
+#include "engine/load_clx.hpp"
+#include "engine/render/clx_render.hpp"
+#include "engine/surface.hpp"
+#include "utils/log.hpp"
+#include "utils/sdl_wrap.h"
+
+namespace devilution {
+namespace {
+
+void BM_RenderSmallClx(benchmark::State &state)
+{
+	SDLSurfaceUniquePtr sdl_surface = SDLWrap::CreateRGBSurfaceWithFormat(
+	    /*flags=*/0, /*width=*/640, /*height=*/480, /*depth=*/8, SDL_PIXELFORMAT_INDEX8);
+	if (sdl_surface == nullptr) {
+		LogError("Failed to create SDL Surface: {}", SDL_GetError());
+		exit(1);
+	}
+	Surface out = Surface(sdl_surface.get());
+	OwnedClxSpriteList sprites = LoadClx("data\\resistance.clx");
+
+	const size_t numSprites = sprites.numSprites();
+	const size_t dataSize = sprites.dataSize();
+	size_t numBytesProcessed = 0;
+	size_t numItemsProcessed = 0;
+	for (auto _ : state) {
+		for (size_t i = 0; i < numSprites; ++i) {
+			RenderClxSprite(out, sprites[i], Point { static_cast<int>(i * 100), static_cast<int>(i * 60) });
+		}
+		uint8_t color = out[Point { 120, 120 }];
+		benchmark::DoNotOptimize(color);
+		numItemsProcessed += numSprites;
+		numBytesProcessed += dataSize;
+	}
+	state.SetBytesProcessed(numBytesProcessed);
+	state.SetItemsProcessed(numItemsProcessed);
+}
+
+void BM_RenderLargeClx(benchmark::State &state)
+{
+	SDLSurfaceUniquePtr sdl_surface = SDLWrap::CreateRGBSurfaceWithFormat(
+	    /*flags=*/0, /*width=*/640, /*height=*/480, /*depth=*/8, SDL_PIXELFORMAT_INDEX8);
+	if (sdl_surface == nullptr) {
+		LogError("Failed to create SDL Surface: {}", SDL_GetError());
+		exit(1);
+	}
+	Surface out = Surface(sdl_surface.get());
+	OwnedClxSpriteList sprites = LoadClx("ui_art\\dvl_lrpopup.clx");
+
+	const size_t dataSize = sprites.dataSize();
+	size_t numBytesProcessed = 0;
+	size_t numItemsProcessed = 0;
+	for (auto _ : state) {
+		RenderClxSprite(out, sprites[0], Point { 100, 100 });
+		uint8_t color = out[Point { 120, 120 }];
+		benchmark::DoNotOptimize(color);
+		numBytesProcessed += dataSize;
+		++numItemsProcessed;
+	}
+	state.SetBytesProcessed(numBytesProcessed);
+	state.SetItemsProcessed(numItemsProcessed);
+}
+
+BENCHMARK(BM_RenderSmallClx);
+BENCHMARK(BM_RenderLargeClx);
+
+} // namespace
+} // namespace devilution


### PR DESCRIPTION
```
----------------------------------------------------------------------------
Benchmark                  Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------
BM_RenderSmallClx        868 ns          866 ns       802315 bytes_per_second=2.04538Gi/s items_per_second=6.92446M/s
BM_RenderLargeClx     128208 ns       128032 ns         5434 bytes_per_second=716.703Mi/s items_per_second=7.81057k/s
```