### PR TITLE
Add a `StaticVector` pretty-printer for GDB

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,1 @@
+source tools/gdb/pretty_printers/utils/static_vector_pp.py

--- a/tools/gdb/pretty_printers/utils/static_vector_pp.py
+++ b/tools/gdb/pretty_printers/utils/static_vector_pp.py
@@ -1,0 +1,35 @@
+import gdb
+
+
+class StaticVectorPrinter(gdb.ValuePrinter):
+    def __init__(self, val):
+        self._val = val
+
+    def to_string(self):
+        return f"{self._val.type} of length {self.num_children()}"
+
+    def display_hint(self):
+        return "array"
+
+    def children(self):
+        return map(lambda i: self.child(i), range(self.num_children()))
+
+    def num_children(self):
+        return int(self._val["size_"])
+
+    def child(self, n):
+        return (f"[{n}]", self._elements()[n])
+
+    def _elements(self):
+        return self._val["data_"].reinterpret_cast(self._element_type().pointer())
+
+    def _element_type(self):
+        return self._val.type.template_argument(0)
+
+
+def StaticVectorPrinter_fn(val):
+    if str(val.type).startswith("devilution::StaticVector<"):
+        return StaticVectorPrinter(val)
+
+
+gdb.pretty_printers.append(StaticVectorPrinter_fn)


### PR DESCRIPTION
Previously, printing a `StaticVector` in gdb printer the size and the raw bytes of `data_`.

Example of using this pretty-printer:

```
$ gdb -iex 'add-autoload-safe-path .' build/devilutionx
(gdb) b Source/engine/load_file.hpp:126
(gdb) run
(gdb) p files
$1 = devilution::StaticVector<devilution::AssetRef, 6> of length 5 = {{archive = 0x55555c8d7460 <devilution::diabdat_mpq>, fileNumber = 1420,
    filename = "monsters\\zombie\\zombien.cl2", directHandle = 0x0}, {archive = 0x55555c8d7460 <devilution::diabdat_mpq>, fileNumber = 1421,
    filename = "monsters\\zombie\\zombiew.cl2", directHandle = 0x0}, {archive = 0x55555c8d7460 <devilution::diabdat_mpq>, fileNumber = 1422,
    filename = "monsters\\zombie\\zombiea.cl2", directHandle = 0x0}, {archive = 0x55555c8d7460 <devilution::diabdat_mpq>, fileNumber = 1423,
    filename = "monsters\\zombie\\zombieh.cl2", directHandle = 0x0}, {archive = 0x55555c8d7460 <devilution::diabdat_mpq>, fileNumber = 1424,
    filename = "monsters\\zombie\\zombied.cl2", directHandle = 0x0}}
```

The pretty-printer implements the full array printer protocol, so it even works in IDEs.

For VS Code and CMake, add the following to your `.vscode/settings.json`:

```
"cmake.debugConfig": {
	"setupCommands": [
		{
			"description": "Enable pretty-printing for gdb",
			"text": "-enable-pretty-printing",
			"ignoreFailures": true
		},
		{
			"description": "Load StaticVector pretty-printer"
			"text": "source ${workspaceFolder}/tools/gdb/pretty_printers/utils/static_vector_pp.py",
			"ignoreFailures": false
		}
	]
}
```

To get this:
![Screenshot from 2024-08-14 20-24-06](https://github.com/user-attachments/assets/c8ba8447-97c1-4efd-a4d8-f5e9285f7a31)
![Screenshot from 2024-08-14 20-25-00](https://github.com/user-attachments/assets/873195ff-5f6d-4f53-b754-519b21624883)

