### PR TITLE
Add dun_render_benchmark

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2855,6 +2855,7 @@ void LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	}
 	SetRndSeed(DungeonSeeds[currlevel]);
 	IncProgress();
+	LoadTrns();
 	MakeLightTable();
 	LoadLvlGFX();
 	SetDungeonMicros();

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -167,7 +167,7 @@ extern WorldTileRectangle SetPiece;
 extern OptionalOwnedClxSpriteList pSpecialCels;
 /** Specifies the tile definitions of the active dungeon type; (e.g. levels/l1data/l1.til). */
 extern DVL_API_FOR_TEST std::unique_ptr<MegaTile[]> pMegaTiles;
-extern std::unique_ptr<std::byte[]> pDungeonCels;
+extern DVL_API_FOR_TEST std::unique_ptr<std::byte[]> pDungeonCels;
 /**
  * List tile properties
  */
@@ -194,7 +194,7 @@ extern std::array<bool, 256> TransList;
 /** Contains the piece IDs of each tile on the map. */
 extern DVL_API_FOR_TEST uint16_t dPiece[MAXDUNX][MAXDUNY];
 /** Map of micros that comprises a full tile for any given dungeon piece. */
-extern MICROS DPieceMicros[MAXTILES];
+extern DVL_API_FOR_TEST MICROS DPieceMicros[MAXTILES];
 /** Specifies the transparency at each coordinate of the map. */
 extern DVL_API_FOR_TEST int8_t dTransVal[MAXDUNX][MAXDUNY];
 /** Current realtime lighting. Per tile. */

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -260,6 +260,13 @@ void DoVision(Point position, uint8_t radius, MapExplorationType doAutomap, bool
 	}
 }
 
+void LoadTrns()
+{
+	LoadFileInMem("plrgfx\\infra.trn", InfravisionTable);
+	LoadFileInMem("plrgfx\\stone.trn", StoneTable);
+	LoadFileInMem("gendata\\pause.trn", PauseTable);
+}
+
 void MakeLightTable()
 {
 	// Generate 16 gradually darker translation tables for doing lighting
@@ -318,10 +325,6 @@ void MakeLightTable()
 	// Verify that fully lit and fully dark light table optimizations are correctly enabled/disabled (nullptr = disabled)
 	assert((FullyLitLightTable != nullptr) == (LightTables[0][0] == 0 && std::adjacent_find(LightTables[0].begin(), LightTables[0].end() - 1, [](auto x, auto y) { return (x + 1) != y; }) == LightTables[0].end() - 1));
 	assert((FullyDarkLightTable != nullptr) == (std::all_of(LightTables[LightsMax].begin(), LightTables[LightsMax].end(), [](auto x) { return x == 0; })));
-
-	LoadFileInMem("plrgfx\\infra.trn", InfravisionTable);
-	LoadFileInMem("plrgfx\\stone.trn", StoneTable);
-	LoadFileInMem("gendata\\pause.trn", PauseTable);
 
 	// Generate light falloffs ranges
 	const float maxDarkness = 15;

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -48,11 +48,11 @@ extern Light Lights[MAXLIGHTS];
 extern std::array<uint8_t, MAXLIGHTS> ActiveLights;
 extern int ActiveLightCount;
 constexpr char LightsMax = 15;
-extern std::array<std::array<uint8_t, 256>, NumLightingLevels> LightTables;
+extern DVL_API_FOR_TEST std::array<std::array<uint8_t, 256>, NumLightingLevels> LightTables;
 /** @brief Contains a pointer to a light table that is fully lit (no color mapping is required). Can be null in hell. */
-extern uint8_t *FullyLitLightTable;
+extern DVL_API_FOR_TEST uint8_t *FullyLitLightTable;
 /** @brief Contains a pointer to a light table that is fully dark (every color result to 0/black). Can be null in hellfire levels. */
-extern uint8_t *FullyDarkLightTable;
+extern DVL_API_FOR_TEST uint8_t *FullyDarkLightTable;
 extern std::array<uint8_t, 256> InfravisionTable;
 extern std::array<uint8_t, 256> StoneTable;
 extern std::array<uint8_t, 256> PauseTable;
@@ -65,6 +65,7 @@ void DoUnLight(Point position, uint8_t radius);
 void DoLighting(Point position, uint8_t radius, DisplacementOf<int8_t> offset);
 void DoUnVision(Point position, uint8_t radius);
 void DoVision(Point position, uint8_t radius, MapExplorationType doAutomap, bool visible);
+void LoadTrns();
 void MakeLightTable();
 #ifdef _DEBUG
 void ToggleLighting();

--- a/Source/mpq/mpq_reader.cpp
+++ b/Source/mpq/mpq_reader.cpp
@@ -40,6 +40,7 @@ MpqArchive &MpqArchive::operator=(MpqArchive &&other) noexcept
 	if (archive_ != nullptr)
 		libmpq__archive_close(archive_);
 	archive_ = other.archive_;
+	other.archive_ = nullptr;
 	tmp_buf_ = std::move(other.tmp_buf_);
 	return *this;
 }

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -32,3 +32,34 @@ tools/linux_reduced_cpu_variance_run.sh build-reld/clx_render_benchmark
 See `tools/build_and_run_benchmark.py --help` for more information.
 
 You can also [profile](profiling-linux.md) your benchmarks.
+
+
+## Comparing benchmark runs
+
+You can use [compare.py from Google Benchmark](https://github.com/google/benchmark/blob/main/docs/tools.md) to compare 2 benchmarks.
+
+First, install the tool:
+
+```bash
+git clone git@github.com:google/benchmark.git ~/google-benchmark
+cd ~/google-benchmark/tools
+pip3 install -r requirements.txt
+cd -
+```
+
+Then, build the 2 binaries that you'd like to compare. For example:
+
+```bash
+BASELINE=master
+BENCHMARK=dun_render_benchmark
+
+git checkout "$BASELINE"
+tools/build_and_run_benchmark.py -B "build-reld-${BASELINE}" --no-run "$BENCHMARK"
+git checkout -
+
+tools/build_and_run_benchmark.py --no-run "$BENCHMARK"
+
+tools/linux_reduced_cpu_variance_run.sh ~/google-benchmark/tools/compare.py -a benchmarks \
+  "build-reld-${BASELINE}/${BENCHMARK}" "build-reld/${BENCHMARK}" \
+  --benchmark_repetitions=10
+```

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,7 +48,8 @@ set(standalone_tests
 )
 set(benchmarks
   clx_render_benchmark
-  crawl_benchmark)
+  crawl_benchmark
+  dun_render_benchmark)
 
 include(Fixtures.cmake)
 
@@ -88,6 +89,7 @@ target_link_libraries(codec_test PRIVATE libdevilutionx_codec app_fatal_for_test
 target_link_libraries(clx_render_benchmark PRIVATE libdevilutionx_so)
 target_link_libraries(crawl_test PRIVATE libdevilutionx_crawl)
 target_link_libraries(crawl_benchmark PRIVATE libdevilutionx_crawl)
+target_link_libraries(dun_render_benchmark PRIVATE libdevilutionx_so)
 target_link_libraries(file_util_test PRIVATE libdevilutionx_file_util app_fatal_for_testing)
 target_link_libraries(format_int_test PRIVATE libdevilutionx_format_int language_for_testing)
 target_link_libraries(parse_int_test PRIVATE libdevilutionx_parse_int)

--- a/test/dun_render_benchmark.cpp
+++ b/test/dun_render_benchmark.cpp
@@ -1,0 +1,116 @@
+#include <cstddef>
+#include <span>
+
+#include <ankerl/unordered_dense.h>
+#include <benchmark/benchmark.h>
+
+#include "diablo.h"
+#include "engine/clx_sprite.hpp"
+#include "engine/displacement.hpp"
+#include "engine/load_file.hpp"
+#include "engine/render/dun_render.hpp"
+#include "engine/surface.hpp"
+#include "init.h"
+#include "levels/dun_tile.hpp"
+#include "levels/gendung.h"
+#include "lighting.h"
+#include "options.h"
+#include "utils/log.hpp"
+#include "utils/sdl_wrap.h"
+
+namespace devilution {
+namespace {
+
+SDLSurfaceUniquePtr SdlSurface;
+ankerl::unordered_dense::map<TileType, std::vector<LevelCelBlock>> Tiles;
+
+void InitOnce()
+{
+	[[maybe_unused]] static const bool GlobalInitDone = []() {
+		LoadCoreArchives();
+		LoadGameArchives();
+		if (!HaveSpawn() && !HaveDiabdat()) {
+			LogError("This benchmark needs spawn.mpq or diabdat.mpq");
+			exit(1);
+		}
+
+		leveltype = DTYPE_CATHEDRAL;
+		pDungeonCels = LoadFileInMem("levels\\l1data\\l1.cel");
+		SetDungeonMicros();
+		MakeLightTable();
+
+		SdlSurface = SDLWrap::CreateRGBSurfaceWithFormat(
+		    /*flags=*/0, /*width=*/640, /*height=*/480, /*depth=*/8, SDL_PIXELFORMAT_INDEX8);
+		if (SdlSurface == nullptr) {
+			LogError("Failed to create SDL Surface: {}", SDL_GetError());
+			exit(1);
+		}
+
+		for (size_t i = 0; i < 700; ++i) {
+			for (size_t j = 0; j < 10; ++j) {
+				if (const LevelCelBlock levelCelBlock = DPieceMicros[i].mt[j]; levelCelBlock.hasValue()) {
+					Tiles[levelCelBlock.type()].push_back(levelCelBlock);
+				}
+			}
+		}
+		return true;
+	}();
+}
+
+void RunForTileMaskLight(benchmark::State &state, TileType tileType, MaskType maskType, const uint8_t *lightTable)
+{
+	Surface out = Surface(SdlSurface.get());
+	size_t numItemsProcessed = 0;
+	const std::span<const LevelCelBlock> tiles = Tiles[tileType];
+	for (auto _ : state) {
+		for (const LevelCelBlock &levelCelBlock : tiles) {
+			RenderTile(out, Point { 320, 240 }, levelCelBlock, maskType, lightTable);
+			uint8_t color = out[Point { 310, 200 }];
+			benchmark::DoNotOptimize(color);
+		}
+		numItemsProcessed += tiles.size();
+	}
+	state.SetItemsProcessed(numItemsProcessed);
+}
+
+using GetLightTableFn = const uint8_t *();
+
+const uint8_t *FullyLit() { return FullyLitLightTable; }
+const uint8_t *FullyDark() { return FullyDarkLightTable; }
+const uint8_t *PartiallyLit() { return LightTables[5].data(); }
+
+template <TileType TileT, MaskType MaskT, GetLightTableFn GetLightTableFnT>
+void Render(benchmark::State &state)
+{
+	InitOnce();
+	RunForTileMaskLight(state, TileT, MaskT, GetLightTableFnT());
+}
+
+// Define aliases in order to have shorter benchmark names.
+constexpr auto LeftTriangle = TileType::LeftTriangle;
+constexpr auto RightTriangle = TileType::RightTriangle;
+constexpr auto TransparentSquare = TileType::TransparentSquare;
+constexpr auto Square = TileType::Square;
+constexpr auto LeftTrapezoid = TileType::LeftTrapezoid;
+constexpr auto RightTrapezoid = TileType::RightTrapezoid;
+constexpr auto Transparent = MaskType::Transparent;
+constexpr auto Solid = MaskType::Solid;
+
+#define DEFINE_FOR_TILE_AND_MASK_TYPE(TILE_TYPE, MASK_TYPE)      \
+	BENCHMARK_TEMPLATE(Render, TILE_TYPE, MASK_TYPE, FullyLit);  \
+	BENCHMARK_TEMPLATE(Render, TILE_TYPE, MASK_TYPE, FullyDark); \
+	BENCHMARK_TEMPLATE(Render, TILE_TYPE, MASK_TYPE, PartiallyLit);
+
+#define DEFINE_FOR_TILE_TYPE(TILE_TYPE)             \
+	DEFINE_FOR_TILE_AND_MASK_TYPE(TILE_TYPE, Solid) \
+	DEFINE_FOR_TILE_AND_MASK_TYPE(TILE_TYPE, Transparent)
+
+DEFINE_FOR_TILE_TYPE(LeftTriangle)
+DEFINE_FOR_TILE_TYPE(RightTriangle)
+DEFINE_FOR_TILE_TYPE(TransparentSquare)
+DEFINE_FOR_TILE_TYPE(Square)
+DEFINE_FOR_TILE_TYPE(LeftTrapezoid)
+DEFINE_FOR_TILE_TYPE(RightTrapezoid)
+
+} // namespace
+} // namespace devilution

--- a/tools/build_and_run_benchmark.py
+++ b/tools/build_and_run_benchmark.py
@@ -71,6 +71,7 @@ def main():
         nargs="*",
         help="arguments passed to the benchmark binary",
     )
+    parser.add_argument("--run", action=argparse.BooleanOptionalAction, default=True, help="If false, only builds the target")
     args = parser.parse_args()
     build = args.build
     if not build:
@@ -81,9 +82,10 @@ def main():
     try:
         maybe_create_build_dir(build, configure_args)
         build_target(build, args.target)
-        run_benchmark(build, args.target, args.benchmark_args, args.gperf)
-        if args.gperf:
-            run_pprof(build, args.target, args.port)
+        if args.run:
+            run_benchmark(build, args.target, args.benchmark_args, args.gperf)
+            if args.gperf:
+                run_pprof(build, args.target, args.port)
     except subprocess.CalledProcessError as e:
         print("Error:", e.cmd[0], "failed", file=sys.stderr)
         return e.returncode


### PR DESCRIPTION
Results from a single run (a bit noisy) on my machine:

```
tools/build_and_run_benchmark.py dun_render_benchmark
```

```
Render<LeftTriangle, Solid, FullyLit>                     19699 ns        19698 ns        35517 items_per_second=15.0775M/s
Render<LeftTriangle, Solid, FullyDark>                    20876 ns        20872 ns        34207 items_per_second=14.2298M/s
Render<LeftTriangle, Solid, PartiallyLit>                103195 ns       103163 ns         6784 items_per_second=2.87894M/s
Render<LeftTriangle, Transparent, FullyLit>              104028 ns       104004 ns         6727 items_per_second=2.85567M/s
Render<LeftTriangle, Transparent, FullyDark>             105041 ns       105018 ns         6666 items_per_second=2.82808M/s
Render<LeftTriangle, Transparent, PartiallyLit>          106628 ns       106622 ns         6468 items_per_second=2.78553M/s
Render<RightTriangle, Solid, FullyLit>                    19079 ns        19076 ns        35953 items_per_second=16.198M/s
Render<RightTriangle, Solid, FullyDark>                   22906 ns        22902 ns        30518 items_per_second=13.4922M/s
Render<RightTriangle, Solid, PartiallyLit>               107537 ns       107477 ns         6499 items_per_second=2.87504M/s
Render<RightTriangle, Transparent, FullyLit>             109076 ns       109050 ns         6428 items_per_second=2.83357M/s
Render<RightTriangle, Transparent, FullyDark>            108203 ns       108180 ns         6485 items_per_second=2.85636M/s
Render<RightTriangle, Transparent, PartiallyLit>         117863 ns       117817 ns         5929 items_per_second=2.62271M/s
Render<TransparentSquare, Solid, FullyLit>               174985 ns       174970 ns         3998 items_per_second=3.68635M/s
Render<TransparentSquare, Solid, FullyDark>              166255 ns       166220 ns         4211 items_per_second=3.8804M/s
Render<TransparentSquare, Solid, PartiallyLit>           275303 ns       275243 ns         2543 items_per_second=2.34338M/s
Render<TransparentSquare, Transparent, FullyLit>         251113 ns       251055 ns         2784 items_per_second=2.56915M/s
Render<TransparentSquare, Transparent, FullyDark>        251473 ns       251452 ns         2780 items_per_second=2.5651M/s
Render<TransparentSquare, Transparent, PartiallyLit>     258953 ns       258930 ns         2709 items_per_second=2.49102M/s
Render<Square, Solid, FullyLit>                           10138 ns        10136 ns        69089 items_per_second=32.557M/s
Render<Square, Solid, FullyDark>                           7107 ns         7106 ns        98532 items_per_second=46.4416M/s
Render<Square, Solid, PartiallyLit>                      214649 ns       214617 ns         3322 items_per_second=1.53763M/s
Render<Square, Transparent, FullyLit>                    208696 ns       208669 ns         3354 items_per_second=1.58145M/s
Render<Square, Transparent, FullyDark>                   208138 ns       208110 ns         3364 items_per_second=1.5857M/s
Render<Square, Transparent, PartiallyLit>                231270 ns       231246 ns         3024 items_per_second=1.42705M/s
Render<LeftTrapezoid, Solid, FullyLit>                     5612 ns         5611 ns       124764 items_per_second=18.8919M/s
Render<LeftTrapezoid, Solid, FullyDark>                    5363 ns         5362 ns       138590 items_per_second=19.7685M/s
Render<LeftTrapezoid, Solid, PartiallyLit>                53817 ns        53809 ns        13004 items_per_second=1.96993M/s
Render<LeftTrapezoid, Transparent, FullyLit>              54047 ns        54039 ns        12712 items_per_second=1.96154M/s
Render<LeftTrapezoid, Transparent, FullyDark>             53736 ns        53730 ns        13033 items_per_second=1.97281M/s
Render<LeftTrapezoid, Transparent, PartiallyLit>          57232 ns        57226 ns        12226 items_per_second=1.85231M/s
Render<RightTrapezoid, Solid, FullyLit>                    4944 ns         4943 ns       141304 items_per_second=21.0385M/s
Render<RightTrapezoid, Solid, FullyDark>                   4576 ns         4576 ns       153025 items_per_second=22.729M/s
Render<RightTrapezoid, Solid, PartiallyLit>               51946 ns        51937 ns        13455 items_per_second=2.00241M/s
Render<RightTrapezoid, Transparent, FullyLit>             52531 ns        52523 ns        13201 items_per_second=1.98009M/s
Render<RightTrapezoid, Transparent, FullyDark>            52146 ns        52143 ns        13431 items_per_second=1.99453M/s
Render<RightTrapezoid, Transparent, PartiallyLit>         55647 ns        55641 ns        12581 items_per_second=1.86912M/s
```