### PR TITLE
dun_render: Unroll triangle loops

### DIFF
--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -14,8 +14,8 @@
 
 #include <SDL_endian.h>
 
-#include <algorithm>
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 
 #include "engine/render/blit_impl.hpp"
@@ -473,16 +473,53 @@ DVL_ALWAYS_INLINE std::size_t CalculateTriangleSourceSkipUpperBottom(int_fast16_
 }
 
 template <LightType Light, bool Transparent>
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleLower(uint8_t *DVL_RESTRICT &dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
+{
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 0 * dstLineOffset, src + 0, 2, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 1 * dstLineOffset, src + 2, 4, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 2 * dstLineOffset, src + 6, 6, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 3 * dstLineOffset, src + 12, 8, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 4 * dstLineOffset, src + 20, 10, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 5 * dstLineOffset, src + 30, 12, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 6 * dstLineOffset, src + 42, 14, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 7 * dstLineOffset, src + 56, 16, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 8 * dstLineOffset, src + 72, 18, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 9 * dstLineOffset, src + 90, 20, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 10 * dstLineOffset, src + 110, 22, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 11 * dstLineOffset, src + 132, 24, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 12 * dstLineOffset, src + 156, 26, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 13 * dstLineOffset, src + 182, 28, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 14 * dstLineOffset, src + 210, 30, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 15 * dstLineOffset, src + 240, 32, tbl);
+	src += 272;
+	dst -= 16 * dstLineOffset;
+}
+
+template <LightType Light, bool Transparent>
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper(uint8_t *DVL_RESTRICT dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+{
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 0 * dstLineOffset, src + 0, 30, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 1 * dstLineOffset, src + 30, 28, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 2 * dstLineOffset, src + 58, 26, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 3 * dstLineOffset, src + 84, 24, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 4 * dstLineOffset, src + 108, 22, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 5 * dstLineOffset, src + 130, 20, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 6 * dstLineOffset, src + 150, 18, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 7 * dstLineOffset, src + 168, 16, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 8 * dstLineOffset, src + 184, 14, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 9 * dstLineOffset, src + 198, 12, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 10 * dstLineOffset, src + 210, 10, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 11 * dstLineOffset, src + 220, 8, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 12 * dstLineOffset, src + 228, 6, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 13 * dstLineOffset, src + 234, 4, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 14 * dstLineOffset, src + 238, 2, tbl);
+}
+
+template <LightType Light, bool Transparent>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLower(uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
 {
 	dst += XStep * (LowerHeight - 1);
-	unsigned width = XStep;
-	for (unsigned i = 0; i < LowerHeight; ++i) {
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl);
-		src += width;
-		dst -= dstPitch + XStep;
-		width += XStep;
-	}
+	RenderTriangleLower<Light, Transparent>(dst, dstPitch + XStep, src, tbl);
 }
 
 template <LightType Light, bool Transparent>
@@ -533,13 +570,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleFull(uint8_t *DVL_RES
 {
 	RenderLeftTriangleLower<Light, Transparent>(dst, dstPitch, src, tbl);
 	dst += 2 * XStep;
-	unsigned width = Width - XStep;
-	for (unsigned i = 0; i < TriangleUpperHeight; ++i) {
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl);
-		src += width;
-		dst -= dstPitch - XStep;
-		width -= XStep;
-	}
+	RenderTriangleUpper<Light, Transparent>(dst, dstPitch - XStep, src, tbl);
 }
 
 template <LightType Light, bool Transparent>
@@ -612,13 +643,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangle(uint8_t *DVL_RESTRIC
 template <LightType Light, bool Transparent>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleLower(uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
 {
-	unsigned width = XStep;
-	for (unsigned i = 0; i < LowerHeight; ++i) {
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl);
-		src += width;
-		dst -= dstPitch;
-		width += XStep;
-	}
+	RenderTriangleLower<Light, Transparent>(dst, dstPitch, src, tbl);
 }
 
 template <LightType Light, bool Transparent>
@@ -664,13 +689,7 @@ template <LightType Light, bool Transparent>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
 {
 	RenderRightTriangleLower<Light, Transparent>(dst, dstPitch, src, tbl);
-	unsigned width = Width - XStep;
-	for (unsigned i = 0; i < TriangleUpperHeight; ++i) {
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl);
-		src += width;
-		dst -= dstPitch;
-		width -= XStep;
-	}
+	RenderTriangleUpper<Light, Transparent>(dst, dstPitch, src, tbl);
 }
 
 template <LightType Light, bool Transparent>

--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -495,6 +495,19 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleLower(uint8_t *DVL_RESTRI
 	dst -= 16 * dstLineOffset;
 }
 
+template <>
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleLower<LightType::FullyDark, /*Transparent=*/false>(uint8_t *DVL_RESTRICT &dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT &src, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl)
+{
+	unsigned width = XStep;
+	for (unsigned i = 0; i < LowerHeight; ++i) {
+		BlitFillDirect(dst, width, 0);
+		dst -= dstLineOffset;
+		width += XStep;
+	}
+	src += 272;
+	dst -= 16 * dstLineOffset;
+}
+
 template <LightType Light, bool Transparent>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper(uint8_t *DVL_RESTRICT dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
 {
@@ -513,6 +526,17 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper(uint8_t *DVL_RESTRI
 	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 12 * dstLineOffset, src + 228, 6, tbl);
 	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 13 * dstLineOffset, src + 234, 4, tbl);
 	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 14 * dstLineOffset, src + 238, 2, tbl);
+}
+
+template <>
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper<LightType::FullyDark, /*Transparent=*/false>(uint8_t *DVL_RESTRICT dst, ptrdiff_t dstLineOffset, [[maybe_unused]] const uint8_t *DVL_RESTRICT src, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl)
+{
+	unsigned width = XStep;
+	for (unsigned i = 0; i < LowerHeight; ++i) {
+		BlitFillDirect(dst, width, 0);
+		dst -= dstLineOffset;
+		width += XStep;
+	}
 }
 
 template <LightType Light, bool Transparent>


### PR DESCRIPTION
Rather than relying on the compiler to do it, which doesn't always happen, we do it by hand.

Previously, very slightly different versions of the code could result in those loops not being unrolled (such as in the current master).

I've run the benchmark like this:

```bash
BASELINE=dun-benchmark
BENCHMARK=dun_render_benchmark
git checkout "$BASELINE"
tools/build_and_run_benchmark.py -B "build-reld-${BASELINE}" --no-run "$BENCHMARK"

git checkout -
tools/build_and_run_benchmark.py --no-run "$BENCHMARK"

tools/linux_reduced_cpu_variance_run.sh ~/google-benchmark/tools/compare.py -a benchmarks \
  "build-reld-${BASELINE}/${BENCHMARK}" "build-reld/${BENCHMARK}" \
  --benchmark_repetitions=10
```

Benchmark results from the first commit are here: https://gist.github.com/glebm/ea5378365128c4eabb25faa16be03926#file-benchmark-result-md

The `FullyLit` calls are ~55% faster.
The `PartiallyLit` calls are ~40% faster.

The `Solid_FullyDark` version was initially twice as slow, which is surprising. A subsequent commit adds specialized `RenderTriangleUpper` and `RenderTriangleLower` for that combination.

Benchmark results for commit 2: https://gist.github.com/glebm/768bdcd8050029dbf140de477e02cb65

Only the means:

Benchmark                                            |           Time    |        CPU   |   Time Old   |  Time New    |  CPU Old   |   CPU New
-----------------------------------------------------|------------------:|-------------:|-------------:|-------------:|-----------:|---------:
LeftTriangle, Solid, FullyLit                        |        -0.6149    |    -0.6149   |      19647   |      7566    |    19645   |      7565
LeftTriangle, Solid, FullyDark                       |        +0.0758    |    +0.0758   |      20828   |     22407    |    20826   |     22404
LeftTriangle, Solid, PartiallyLit                    |        -0.3864    |    -0.3864   |     102968   |     63176    |   102953   |     63168
LeftTriangle, Transparent, FullyLit                  |        -0.0967    |    -0.0967   |     103958   |     93902    |   103944   |     93890
LeftTriangle, Transparent, FullyDark                 |        -0.3825    |    -0.3825   |     104804   |     64718    |   104792   |     64711
LeftTriangle, Transparent, PartiallyLit              |        +0.0067    |    +0.0067   |     106556   |    107265    |   106544   |    107254
RightTriangle, Solid, FullyLit                       |        -0.5890    |    -0.5890   |      18533   |      7616    |    18531   |      7616
RightTriangle, Solid, FullyDark                      |        -0.0326    |    -0.0326   |      22899   |     22151    |    22896   |     22149
RightTriangle, Solid, PartiallyLit                   |        -0.4104    |    -0.4104   |     107393   |     63315    |   107379   |     63308
RightTriangle, Transparent, FullyLit                 |        -0.1203    |    -0.1203   |     109148   |     96018    |   109133   |     96005
RightTriangle, Transparent, FullyDark                |        -0.3252    |    -0.3252   |     108010   |     72881    |   107998   |     72872
RightTriangle, Transparent, PartiallyLit             |        -0.0189    |    -0.0189   |     111527   |    109421    |   111512   |    109405
TransparentSquare, Solid, FullyLit                   |        -0.0002    |    -0.0002   |     175262   |    175222    |   175239   |    175199
TransparentSquare, Solid, FullyDark                  |        -0.0198    |    -0.0199   |     167571   |    164247    |   167551   |    164224
TransparentSquare, Solid, PartiallyLit               |        -0.3265    |    -0.3266   |     272130   |    183271    |   272091   |    183235
TransparentSquare, Transparent, FullyLit             |        -0.1282    |    -0.1282   |     254365   |    221761    |   254332   |    221730
TransparentSquare, Transparent, FullyDark            |        -0.2193    |    -0.2193   |     252095   |    196821    |   252064   |    196795
TransparentSquare, Transparent, PartiallyLit         |        -0.0678    |    -0.0678   |     258382   |    240858    |   258352   |    240832
Square, Solid, FullyLit                              |        -0.1021    |    -0.1021   |       9941   |      8926    |     9940   |      8925
Square, Solid, FullyDark                             |        -0.0401    |    -0.0401   |       7090   |      6806    |     7089   |      6805
Square, Solid, PartiallyLit                          |        -0.3984    |    -0.3984   |     210560   |    126676    |   210534   |    126659
Square, Transparent, FullyLit                        |        -0.0605    |    -0.0605   |     208520   |    195902    |   208488   |    195875
Square, Transparent, FullyDark                       |        -0.4413    |    -0.4413   |     208168   |    116312    |   208143   |    116298
Square, Transparent, PartiallyLit                    |        -0.0270    |    -0.0270   |     231066   |    224829    |   231034   |    224796
LeftTrapezoid, Solid, FullyLit                       |        -0.5303    |    -0.5303   |       5583   |      2622    |     5582   |      2622
LeftTrapezoid, Solid, FullyDark                      |        -0.2270    |    -0.2270   |       5304   |      4100    |     5304   |      4100
LeftTrapezoid, Solid, PartiallyLit                   |        -0.4018    |    -0.4018   |      53744   |     32152    |    53738   |     32148
LeftTrapezoid, Transparent, FullyLit                 |        -0.0796    |    -0.0796   |      53993   |     49694    |    53987   |     49687
LeftTrapezoid, Transparent, FullyDark                |        -0.4080    |    -0.4080   |      53682   |     31782    |    53675   |     31778
LeftTrapezoid, Transparent, PartiallyLit             |        -0.0140    |    -0.0140   |      57240   |     56440    |    57234   |     56431
RightTrapezoid, Solid, FullyLit                      |        -0.4681    |    -0.4680   |       4939   |      2627    |     4938   |      2627
RightTrapezoid, Solid, FullyDark                     |        -0.0276    |    -0.0276   |       4267   |      4149    |     4266   |      4148
RightTrapezoid, Solid, PartiallyLit                  |        -0.3792    |    -0.3792   |      52004   |     32282    |    51998   |     32278
RightTrapezoid, Transparent, FullyLit                |        -0.0621    |    -0.0621   |      52479   |     49218    |    52472   |     49212
RightTrapezoid, Transparent, FullyDark               |        -0.4268    |    -0.4268   |      52039   |     29826    |    52032   |     29822
RightTrapezoid, Transparent, PartiallyLit            |        -0.0132    |    -0.0132   |      55693   |     54959    |    55686   |     54953
OVERALL_GEOMEAN                                      |        -0.2437    |    -0.2437   |          0   |         0    |        0   |         0