### PR TITLE
dun_render_benchmark: `BM_RenderBlackTile`

### DIFF
--- a/test/dun_render_benchmark.cpp
+++ b/test/dun_render_benchmark.cpp
@@ -112,5 +112,20 @@ DEFINE_FOR_TILE_TYPE(Square)
 DEFINE_FOR_TILE_TYPE(LeftTrapezoid)
 DEFINE_FOR_TILE_TYPE(RightTrapezoid)
 
+void BM_RenderBlackTile(benchmark::State &state)
+{
+	InitOnce();
+	Surface out = Surface(SdlSurface.get());
+	size_t numItemsProcessed = 0;
+	for (auto _ : state) {
+		world_draw_black_tile(out, 320, 240);
+		uint8_t color = out[Point { 310, 200 }];
+		benchmark::DoNotOptimize(color);
+		++numItemsProcessed;
+	}
+	state.SetItemsProcessed(numItemsProcessed);
+}
+BENCHMARK(BM_RenderBlackTile);
+
 } // namespace
 } // namespace devilution


### PR DESCRIPTION
```bash
tools/build_and_run_benchmark.py dun_render_benchmark -- \
  --benchmark_filter='.*BlackTile.*' \
  --benchmark_repetitions=10 \
  --benchmark_display_aggregates_only
```

```
------------------------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------
BM_RenderBlackTile_mean          157 ns          157 ns           10 items_per_second=6.37889M/s
BM_RenderBlackTile_median        157 ns          157 ns           10 items_per_second=6.38348M/s
BM_RenderBlackTile_stddev      0.490 ns        0.487 ns           10 items_per_second=19.8345k/s
BM_RenderBlackTile_cv           0.31 %          0.31 %            10 items_per_second=0.31%
```

I have a very surprising finding in a follow-up PR...