### PR TITLE
Move Game Mode to own category

### DIFF
--- a/Source/DiabloUI/selstart.cpp
+++ b/Source/DiabloUI/selstart.cpp
@@ -18,7 +18,7 @@ std::vector<std::unique_ptr<UiItemBase>> vecDialog;
 void ItemSelected(size_t value)
 {
 	auto option = static_cast<StartUpGameMode>(vecDialogItems[value]->m_value);
-	sgOptions.StartUp.gameMode.SetValue(option);
+	sgOptions.GameMode.gameMode.SetValue(option);
 	SaveOptions();
 	endMenu = true;
 }

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1174,9 +1174,9 @@ void ApplicationInit()
 
 void DiabloInit()
 {
-	if (forceSpawn || *sgOptions.StartUp.shareware)
+	if (forceSpawn || *sgOptions.GameMode.shareware)
 		gbIsSpawn = true;
-	if (forceDiablo || *sgOptions.StartUp.gameMode == StartUpGameMode::Diablo)
+	if (forceDiablo || *sgOptions.GameMode.gameMode == StartUpGameMode::Diablo)
 		gbIsHellfire = false;
 	if (forceHellfire)
 		gbIsHellfire = true;
@@ -1197,7 +1197,7 @@ void DiabloInit()
 	UiInitialize();
 	was_ui_init = true;
 
-	if (gbIsHellfire && !forceHellfire && *sgOptions.StartUp.gameMode == StartUpGameMode::Ask) {
+	if (gbIsHellfire && !forceHellfire && *sgOptions.GameMode.gameMode == StartUpGameMode::Ask) {
 		UiSelStartUpGameOption();
 		if (!gbIsHellfire) {
 			// Reinitialize the UI Elements because we changed the game

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -317,13 +317,13 @@ void OptionLanguageCodeChanged()
 
 void OptionGameModeChanged()
 {
-	gbIsHellfire = *sgOptions.StartUp.gameMode == StartUpGameMode::Hellfire;
+	gbIsHellfire = *sgOptions.GameMode.gameMode == StartUpGameMode::Hellfire;
 	discord_manager::UpdateMenu(true);
 }
 
 void OptionSharewareChanged()
 {
-	gbIsSpawn = *sgOptions.StartUp.shareware;
+	gbIsSpawn = *sgOptions.GameMode.shareware;
 }
 
 void OptionAudioChanged()
@@ -565,8 +565,8 @@ std::string_view OptionCategoryBase::GetDescription() const
 	return _(description);
 }
 
-StartUpOptions::StartUpOptions()
-    : OptionCategoryBase("StartUp", N_("Start Up"), N_("Start Up Settings"))
+GameModeOptions::GameModeOptions()
+    : OptionCategoryBase("GameMode", N_("Game Mode"), N_("Game Mode Settings"))
     , gameMode("Game", OptionEntryFlags::NeedHellfireMpq | OptionEntryFlags::RecreateUI, N_("Game Mode"), N_("Play Diablo or Hellfire."), StartUpGameMode::Ask,
           {
               { StartUpGameMode::Diablo, N_("Diablo") },
@@ -574,6 +574,21 @@ StartUpOptions::StartUpOptions()
               { StartUpGameMode::Hellfire, N_("Hellfire") },
           })
     , shareware("Shareware", OptionEntryFlags::NeedDiabloMpq | OptionEntryFlags::RecreateUI, N_("Restrict to Shareware"), N_("Makes the game compatible with the demo. Enables multiplayer with friends who don't own a full copy of Diablo."), false)
+
+{
+	gameMode.SetValueChangedCallback(OptionGameModeChanged);
+	shareware.SetValueChangedCallback(OptionSharewareChanged);
+}
+std::vector<OptionEntryBase *> GameModeOptions::GetEntries()
+{
+	return {
+		&gameMode,
+		&shareware,
+	};
+}
+
+StartUpOptions::StartUpOptions()
+    : OptionCategoryBase("StartUp", N_("Start Up"), N_("Start Up Settings"))
     , diabloIntro("Diablo Intro", OptionEntryFlags::OnlyDiablo, N_("Intro"), N_("Shown Intro cinematic."), StartUpIntro::Once,
           {
               { StartUpIntro::Off, N_("OFF") },
@@ -593,14 +608,10 @@ StartUpOptions::StartUpOptions()
               { StartUpSplash::None, N_("None") },
           })
 {
-	gameMode.SetValueChangedCallback(OptionGameModeChanged);
-	shareware.SetValueChangedCallback(OptionSharewareChanged);
 }
 std::vector<OptionEntryBase *> StartUpOptions::GetEntries()
 {
 	return {
-		&gameMode,
-		&shareware,
 		&diabloIntro,
 		&hellfireIntro,
 		&splash,

--- a/Source/options.h
+++ b/Source/options.h
@@ -411,12 +411,18 @@ protected:
 	const char *description;
 };
 
-struct StartUpOptions : OptionCategoryBase {
-	StartUpOptions();
+struct GameModeOptions : OptionCategoryBase {
+	GameModeOptions();
 	std::vector<OptionEntryBase *> GetEntries() override;
 
 	OptionEntryEnum<StartUpGameMode> gameMode;
 	OptionEntryBoolean shareware;
+};
+
+struct StartUpOptions : OptionCategoryBase {
+	StartUpOptions();
+	std::vector<OptionEntryBase *> GetEntries() override;
+
 	/** @brief Play game intro video on diablo startup. */
 	OptionEntryEnum<StartUpIntro> diabloIntro;
 	/** @brief Play game intro video on hellfire startup. */
@@ -790,6 +796,7 @@ private:
 };
 
 struct Options {
+	GameModeOptions GameMode;
 	StartUpOptions StartUp;
 	DiabloOptions Diablo;
 	HellfireOptions Hellfire;
@@ -807,6 +814,7 @@ struct Options {
 	{
 		return {
 			&Language,
+			&GameMode,
 			&StartUp,
 			&Graphics,
 			&Audio,


### PR DESCRIPTION
Over time, many users have been confused as to how to switch between Diablo and Hellfire. This simplifies it.

![image](https://github.com/user-attachments/assets/58e77bc0-e347-451c-93eb-ae9c86e14435)

![image](https://github.com/user-attachments/assets/4d7189d1-a941-486f-9785-b8d34026b028)
