### PR TITLE
Fix Wall Spells on objects

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2437,7 +2437,7 @@ void AddFireWallControl(Missile &missile, AddMissileParameter &parameter)
 {
 	std::optional<Point> spreadPosition = FindClosestValidPosition(
 	    [start = missile.position.start](Point target) {
-		    return start != target && IsTileNotSolid(target) && !IsObjectAtPosition(target) && LineClearMissile(start, target);
+		    return start != target && IsTileNotSolid(target) && !IsItemBlockingObjectAtPosition(target) && LineClearMissile(start, target);
 	    },
 	    parameter.dst, 0, 5);
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2437,7 +2437,7 @@ void AddFireWallControl(Missile &missile, AddMissileParameter &parameter)
 {
 	std::optional<Point> spreadPosition = FindClosestValidPosition(
 	    [start = missile.position.start](Point target) {
-		    return start != target && IsTileNotSolid(target) && LineClearMissile(start, target);
+		    return start != target && !TileHasAny(target, TileProperties::BlockMissile) && LineClearMissile(start, target);
 	    },
 	    parameter.dst, 0, 5);
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2437,7 +2437,7 @@ void AddFireWallControl(Missile &missile, AddMissileParameter &parameter)
 {
 	std::optional<Point> spreadPosition = FindClosestValidPosition(
 	    [start = missile.position.start](Point target) {
-		    return start != target && IsTileNotSolid(target) && !IsItemBlockingObjectAtPosition(target) && LineClearMissile(start, target);
+		    return start != target && IsTileNotSolid(target) && LineClearMissile(start, target);
 	    },
 	    parameter.dst, 0, 5);
 


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/issues/7323

@NiteKat enjoy

Completely removes the check for objects when attempting to find a valid position for Fire Wall/Lightning Wall. Seems rather absurd that objects force walls to move to another position, but the wall will happily grow over objects.

