### PR TITLE
Fix Magic Rock related bugs

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3757,7 +3757,7 @@ void ProcessItems()
 	for (int i = 0; i < ActiveItemCount; i++) {
 		int ii = ActiveItems[i];
 		auto &item = Items[ii];
-		if (!item._iAnimFlag) // Item isn't being dropped, so don't animate frames
+		if (!item._iAnimFlag) 
 			continue;
 		item.AnimInfo.processAnimation();
 		if (item._iCurs == ICURS_MAGIC_ROCK) {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3705,17 +3705,6 @@ void SpawnTheodore(Point position, bool sendmsg)
 	SpawnRewardItem(IDI_THEODORE, position, sendmsg);
 }
 
-static bool IsStandAtPosition(const Point &position)
-{
-	for (int i = 0; i < ActiveObjectCount; i++) {
-		const Object &object = Objects[ActiveObjects[i]];
-		if (object._otype == OBJ_STAND && object.position == position) {
-			return true;
-		}
-	}
-	return false;
-}
-
 void RespawnItem(Item &item, bool flipFlag)
 {
 	int it = ItemCAnimTbl[item._iCurs];

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3757,7 +3757,7 @@ void ProcessItems()
 	for (int i = 0; i < ActiveItemCount; i++) {
 		int ii = ActiveItems[i];
 		auto &item = Items[ii];
-		if (!item._iAnimFlag) 
+		if (!item._iAnimFlag)
 			continue;
 		item.AnimInfo.processAnimation();
 		if (item._iCurs == ICURS_MAGIC_ROCK) {

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3734,10 +3734,11 @@ void RespawnItem(Item &item, bool flipFlag)
 		item.selectionRegion = SelectionRegion::Middle; // Item is selectable at elevated level
 		break;
 	case ICURS_MAGIC_ROCK:
-		if (IsStandAtPosition(item.position)) {
-			item.selectionRegion = SelectionRegion::Middle;              // Item is selectable at elevated level and renders at elevated level
-			item._iPostDraw = true;          // Draw in front of stand
-			item.AnimInfo.currentFrame = 10; // Frame 10 is the start of the elevated frames in the cel
+		Object *stand = FindObjectAtPosition(item.position);
+		if (stand != nullptr && stand->_otype == OBJ_STAND) {
+			item.selectionRegion = SelectionRegion::Middle; // Item is selectable at elevated level and renders at elevated level
+			item._iPostDraw = true;                         // Draw in front of stand
+			item.AnimInfo.currentFrame = 10;                // Frame 10 is the start of the elevated frames in the cel
 		} else {
 			item.selectionRegion = SelectionRegion::Bottom; // Item is selectable at floor level and renders at floor level
 		}
@@ -3772,9 +3773,9 @@ void ProcessItems()
 		item.AnimInfo.processAnimation();
 		if (item._iCurs == ICURS_MAGIC_ROCK) {
 			if (item.selectionRegion == SelectionRegion::Bottom && item.AnimInfo.currentFrame == 10) // Reached end of floor frames + 1, cycle back
-				item.AnimInfo.currentFrame = 0;                          // Beginning of floor frames
+				item.AnimInfo.currentFrame = 0;                                                      // Beginning of floor frames
 			if (item.selectionRegion == SelectionRegion::Middle && item.AnimInfo.currentFrame == 19) // Reached end of elevated frames, cycle back
-				item.AnimInfo.currentFrame = 10;                         // Beginning of elevated frames
+				item.AnimInfo.currentFrame = 10;                                                     // Beginning of elevated frames
 		} else {
 			if (item.AnimInfo.currentFrame == (item.AnimInfo.numberOfFrames - 1) / 2)
 				PlaySfxLoc(ItemDropSnds[ItemCAnimTbl[item._iCurs]], item.position);


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/issues/7304

Bug 1: Magic Rock isn't animated while on the stand
Bug 2: Magic Rock drops to the ground with full inventory upon attempted pickup, rendering behind the stand

Note: We can't cycle back to frame 10 from frame 20 during the elevated frames animation, because `processAnimation` will reset the `currentFrame` to 0 if the `currentFrame` is greater than or equal to the total number of frames (20). This would make the rock appear to be bouncing up and down.

Additionally, I added a enumeration for `_iSelFlag` for disambiguation.


https://github.com/user-attachments/assets/0b66f4b0-bd85-4b3d-9d7b-3e305c1baeb3

