### PR TITLE
Fix infinite loop in unique item randomization

### DIFF
--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -645,10 +645,10 @@ struct UniqueItem {
 	ItemPower powers[6];
 };
 
-extern std::vector<ItemData> AllItemsList;
+extern DVL_API_FOR_TEST std::vector<ItemData> AllItemsList;
 extern std::vector<PLStruct> ItemPrefixes;
 extern std::vector<PLStruct> ItemSuffixes;
-extern std::vector<UniqueItem> UniqueItems;
+extern DVL_API_FOR_TEST std::vector<UniqueItem> UniqueItems;
 
 void LoadItemData();
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -481,7 +481,7 @@ extern uint8_t ActiveItemCount;
 extern int8_t dItem[MAXDUNX][MAXDUNY];
 extern bool ShowUniqueItemInfoBox;
 extern CornerStoneStruct CornerStone;
-extern bool UniqueItemFlags[128];
+extern DVL_API_FOR_TEST bool UniqueItemFlags[128];
 
 uint8_t GetOutlineColor(const Item &item, bool checkReq);
 bool IsItemAvailable(int i);

--- a/Source/items.h
+++ b/Source/items.h
@@ -513,6 +513,9 @@ Point GetSuperItemLoc(Point position);
 void GetItemAttrs(Item &item, _item_indexes itemData, int lvl);
 void SetupItem(Item &item);
 Item *SpawnUnique(_unique_items uid, Point position, std::optional<int> level = std::nullopt, bool sendmsg = true, bool exactPosition = false);
+void GetSuperItemSpace(Point position, int8_t inum);
+_item_indexes RndItemForMonsterLevel(int8_t monsterLevel);
+void SetupAllItems(const Player &player, Item &item, _item_indexes idx, uint32_t iseed, int lvl, int uper, bool onlygood, bool pregen, int uidOffset = 0, bool forceNotUnique = false);
 void TryRandomUniqueItem(Item &item, _item_indexes idx, int8_t mLevel, int uper, bool onlygood, bool pregen);
 void SpawnItem(Monster &monster, Point position, bool sendmsg, bool spawn = false);
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta);
@@ -572,10 +575,6 @@ bool ApplyOilToItem(Item &item, Player &player);
  */
 void UpdateHellfireFlag(Item &item, const char *identifiedItemName);
 
-#ifdef _DEBUG
-std::string DebugSpawnItem(std::string itemName);
-std::string DebugSpawnUniqueItem(std::string itemName);
-#endif
 /* data */
 
 extern int MaxGold;

--- a/Source/lua/modules/dev/items.cpp
+++ b/Source/lua/modules/dev/items.cpp
@@ -1,15 +1,18 @@
 #ifdef _DEBUG
 #include "lua/modules/dev/items.hpp"
 
+#include <random>
 #include <string>
 
 #include <sol/sol.hpp>
 
 #include "cursor.h"
+#include "engine/random.hpp"
 #include "items.h"
 #include "lua/metadoc.hpp"
 #include "pack.h"
 #include "player.h"
+#include "utils/str_case.hpp"
 #include "utils/str_cat.hpp"
 
 namespace devilution {
@@ -56,6 +59,137 @@ std::string DebugCmdItemInfo()
 		    "\nNet Validation: ", netPackValidation);
 	}
 	return StrCat("Num items: ", ActiveItemCount);
+}
+
+std::mt19937 BetterRng;
+std::string DebugSpawnItem(std::string itemName)
+{
+	if (ActiveItemCount >= MAXITEMS) return "No space to generate the item!";
+
+	const int max_time = 3000;
+	const int max_iter = 1000000;
+
+	AsciiStrToLower(itemName);
+
+	Item testItem;
+
+	uint32_t begin = SDL_GetTicks();
+	int i = 0;
+	for (;; i++) {
+		// using a better rng here to seed the item to prevent getting stuck repeating same values using old one
+		std::uniform_int_distribution<int32_t> dist(0, INT_MAX);
+		SetRndSeed(dist(BetterRng));
+		if (SDL_GetTicks() - begin > max_time)
+			return StrCat("Item not found in ", max_time / 1000, " seconds!");
+
+		if (i > max_iter)
+			return StrCat("Item not found in ", max_iter, " tries!");
+
+		const int8_t monsterLevel = dist(BetterRng) % CF_LEVEL + 1;
+		_item_indexes idx = RndItemForMonsterLevel(monsterLevel);
+		if (IsAnyOf(idx, IDI_NONE, IDI_GOLD))
+			continue;
+
+		testItem = {};
+		SetupAllItems(*MyPlayer, testItem, idx, AdvanceRndSeed(), monsterLevel, 1, false, false);
+		TryRandomUniqueItem(testItem, idx, monsterLevel, 1, false, false);
+		SetupItem(testItem);
+
+		std::string tmp = AsciiStrToLower(testItem._iIName);
+		if (tmp.find(itemName) != std::string::npos)
+			break;
+	}
+
+	int ii = AllocateItem();
+	auto &item = Items[ii];
+	item = testItem.pop();
+	item._iIdentified = true;
+	Point pos = MyPlayer->position.tile;
+	GetSuperItemSpace(pos, ii);
+	NetSendCmdPItem(false, CMD_SPAWNITEM, item.position, item);
+	return StrCat("Item generated successfully - iterations: ", i);
+}
+
+std::string DebugSpawnUniqueItem(std::string itemName)
+{
+	if (ActiveItemCount >= MAXITEMS) return "No space to generate the item!";
+
+	AsciiStrToLower(itemName);
+	UniqueItem uniqueItem;
+	bool foundUnique = false;
+	int uniqueIndex = 0;
+	for (int j = 0, n = static_cast<int>(UniqueItems.size()); j < n; ++j) {
+		if (!IsUniqueAvailable(j))
+			break;
+
+		const std::string tmp = AsciiStrToLower(std::string_view(UniqueItems[j].UIName));
+		if (tmp.find(itemName) != std::string::npos) {
+			itemName = tmp;
+			uniqueItem = UniqueItems[j];
+			uniqueIndex = j;
+			foundUnique = true;
+			break;
+		}
+	}
+	if (!foundUnique) return "No unique item found!";
+
+	_item_indexes uniqueBaseIndex = IDI_GOLD;
+	for (std::underlying_type_t<_item_indexes> j = IDI_GOLD; j <= IDI_LAST; j++) {
+		if (!IsItemAvailable(j))
+			continue;
+		if (AllItemsList[j].iItemId == uniqueItem.UIItemId) {
+			uniqueBaseIndex = static_cast<_item_indexes>(j);
+			break;
+		}
+	}
+
+	if (uniqueBaseIndex == IDI_GOLD) return "Base item not available!";
+
+	auto &baseItemData = AllItemsList[static_cast<size_t>(uniqueBaseIndex)];
+
+	Item testItem;
+
+	int i = 0;
+	for (uint32_t begin = SDL_GetTicks();; i++) {
+		constexpr int max_time = 3000;
+		if (SDL_GetTicks() - begin > max_time)
+			return StrCat("Item not found in ", max_time / 1000, " seconds!");
+
+		constexpr int max_iter = 1000000;
+		if (i > max_iter)
+			return StrCat("Item not found in ", max_iter, " tries!");
+
+		testItem = {};
+		testItem._iMiscId = baseItemData.iMiscId;
+		std::uniform_int_distribution<int32_t> dist(0, INT_MAX);
+		SetRndSeed(dist(BetterRng));
+		for (auto &flag : UniqueItemFlags)
+			flag = true;
+		UniqueItemFlags[uniqueIndex] = false;
+		SetupAllItems(*MyPlayer, testItem, uniqueBaseIndex, testItem._iMiscId == IMISC_UNIQUE ? uniqueIndex : AdvanceRndSeed(), uniqueItem.UIMinLvl, 1, false, false);
+		TryRandomUniqueItem(testItem, uniqueBaseIndex, uniqueItem.UIMinLvl, 1, false, false);
+		SetupItem(testItem);
+		for (auto &flag : UniqueItemFlags)
+			flag = false;
+
+		if (testItem._iMagical != ITEM_QUALITY_UNIQUE)
+			continue;
+
+		const std::string tmp = AsciiStrToLower(testItem._iIName);
+		if (tmp.find(itemName) != std::string::npos)
+			break;
+		return "Impossible to generate!";
+	}
+
+	int ii = AllocateItem();
+	auto &item = Items[ii];
+	item = testItem.pop();
+	Point pos = MyPlayer->position.tile;
+	GetSuperItemSpace(pos, ii);
+	item._iIdentified = true;
+	NetSendCmdPItem(false, CMD_SPAWNITEM, item.position, item);
+
+	return StrCat("Item generated successfully - iterations: ", i);
 }
 
 } // namespace

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(tests
   drlg_l4_test
   effects_test
   inv_test
+  items_test
   math_test
   missiles_test
   pack_test

--- a/test/items_test.cpp
+++ b/test/items_test.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+#include <random>
+
+#include "engine/random.hpp"
+#include "items.h"
+#include "player.h"
+#include "spells.h"
+#include "utils/str_cat.hpp"
+
+namespace devilution {
+namespace {
+
+class ItemsTest : public ::testing::Test {
+public:
+	void SetUp() override
+	{
+		Players.resize(1);
+		MyPlayer = &Players[0];
+		for (auto &flag : UniqueItemFlags)
+			flag = false;
+	}
+
+	static void SetUpTestSuite()
+	{
+		LoadItemData();
+		LoadSpellData();
+		gbIsSpawn = false;
+		gbIsMultiplayer = false; // to also test UniqueItemFlags
+	}
+};
+
+void GenerateAllUniques(bool hellfire, const size_t expectedUniques)
+{
+	gbIsHellfire = hellfire;
+
+	std::mt19937 betterRng;
+	std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());
+
+	// Get seed for test run from time. If a test run fails, remember the seed and hardcode it here.
+	uint32_t testRunSeed = static_cast<uint32_t>(time(nullptr));
+	betterRng.seed(testRunSeed);
+
+	std::set<int> foundUniques;
+
+	constexpr int max_iterations = 1000000;
+	int iteration = 0;
+
+	for (int uniqueIndex = 0, n = static_cast<int>(UniqueItems.size()); uniqueIndex < n; ++uniqueIndex) {
+
+		if (!IsUniqueAvailable(uniqueIndex))
+			continue;
+
+		if (foundUniques.contains(uniqueIndex))
+			continue;
+
+		auto &uniqueItem = UniqueItems[uniqueIndex];
+
+		_item_indexes uniqueBaseIndex = IDI_GOLD;
+		for (std::underlying_type_t<_item_indexes> j = IDI_GOLD; j <= IDI_LAST; j++) {
+			if (!IsItemAvailable(j))
+				continue;
+			if (AllItemsList[j].iItemId != uniqueItem.UIItemId)
+				continue;
+			if (AllItemsList[j].iRnd != IDROP_NEVER)
+				uniqueBaseIndex = static_cast<_item_indexes>(j);
+			break;
+		}
+
+		if (uniqueBaseIndex == IDI_GOLD)
+			continue; // Unique not dropable (Quest-Unique)
+
+		auto &baseItemData = AllItemsList[static_cast<size_t>(uniqueBaseIndex)];
+
+		while (true) {
+			iteration += 1;
+
+			if (iteration > max_iterations)
+				FAIL() << StrCat("Item ", uniqueItem.UIName, " not found in ", max_iterations, " tries with test run seed ", testRunSeed);
+
+			Item testItem = {};
+			testItem._iMiscId = baseItemData.iMiscId;
+			std::uniform_int_distribution<int32_t> dist(0, INT_MAX);
+			SetRndSeed(dist(betterRng));
+
+			int targetLvl = uniqueItem.UIMinLvl;
+			int uper = 1;
+			if (uniqueItem.UIMinLvl - 4 > 0) {
+				uper = 15;
+				targetLvl = uniqueItem.UIMinLvl - 4;
+			}
+
+			SetupAllItems(*MyPlayer, testItem, uniqueBaseIndex, AdvanceRndSeed(), targetLvl, uper, true, false);
+			TryRandomUniqueItem(testItem, uniqueBaseIndex, targetLvl, uper, true, false);
+			SetupItem(testItem);
+
+			if (testItem._iMagical != ITEM_QUALITY_UNIQUE)
+				continue;
+
+			foundUniques.insert(testItem._iUid);
+
+			if (testItem._iUid == uniqueIndex)
+				break;
+		}
+	}
+
+	EXPECT_EQ(foundUniques.size(), expectedUniques) << StrCat("test run seed ", testRunSeed);
+}
+
+TEST_F(ItemsTest, AllDiabloUniquesCanDrop)
+{
+	GenerateAllUniques(false, 79);
+}
+
+TEST_F(ItemsTest, AllHellfireUniquesCanDrop)
+{
+	GenerateAllUniques(true, 99);
+}
+
+} // namespace
+} // namespace devilution


### PR DESCRIPTION
I tried to create some debug items for testing (with `dev.items.spawn`) and sometimes I encountered an infinite loop in `TryRandomUniqueItem`.

After some debugging I found out that it is trying to generate one of the following unqiues
- The Grandfather
- Schaefer's Hammer
- Amulet of Warding

The problem can be reproduced with debug lua commands `dev.items.spawnUnique` command and one of the above uniques.

The cause was that the `uid` offset was not always calculated correctly. There are two reasons why this can happen
1. The valid uniques in `CheckUnique` and `TryRandomUniqueItem` can be different because the check against `UIMinLvl` is different (`CheckUnique` calculates it with `GetItemBLevel` and `TryRandomUniqueItem` has a custom implementation). So the calculated offset can be different or the desired unique can't be generated by `CheckUnique`.
2. When calculating the offset the check against `UIMinLvl` is == and not >= as in `CheckUnique`.

All this can only happen for some specific uniques or item levels, so the problem is not so easy to get in normal gameplay.

This PR
- fixes the offset calculation by
  - generating the item level the same way as `SetupAllItems` does 
  - reuse the logic for getting valid uniques from `CheckUnique`
- simplifies item generation (we can reuse the same seed and set the required offset)
- doesn't affect existing items, because the logic in `CheckUnique` remains the same