### PR TITLE
Fix Unique Item generation infinite loop

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3345,7 +3345,7 @@ void TryRandomUniqueItem(Item &item, _item_indexes idx, int8_t mLevel, int uper,
 
 	// Amount to decrease the final uid by in CheckUnique() to get the desired unique.
 	const auto uidOffset = static_cast<int>(std::count_if(UniqueItems.begin() + uid + 1, UniqueItems.end(), [&uniqueItem](UniqueItem &potentialMatch) {
-		return uniqueItem.UIItemId == potentialMatch.UIItemId && uniqueItem.UIMinLvl == potentialMatch.UIMinLvl;
+		return uniqueItem.UIItemId == potentialMatch.UIItemId && uniqueItem.UIMinLvl >= potentialMatch.UIMinLvl;
 	}));
 
 	Point itemPos = item.position;


### PR DESCRIPTION
Problem: Unique Item generation uses vanilla generation, then uses a new function to use RNG to select a different Unique Item. If it's different from the one vanilla generation already picked, we force generate items until the newly created Unique Item matches our desired Unique. It does this by force generating items using the minimum level of the desired Unique, since that puts it last in the list, which ensures reverse compatibility. However, Hellfire added several Unique Items that have matching Base Items to a few of the Diablo Uniques, which completely broke the system of relying on the last valid Unique Item in the list having the highest qlvl. This fixes `uidOffset` calculation to further adjust the offset when there are matching Unique Items that come after our desired Unique Item but have a lower minimum level. The Unique Items that were causing an infinite loop prior to this fix will drop in DevilutionX, but will morph if moved back to vanilla Hellfire, but will return to their correct Unique if brought back to DevilutionX, just like the other "impossible" items as referenced in Jarulf's Guide.