### PR TITLE
Update ASIO to fix error messages on Windows

### DIFF
--- a/3rdParty/asio/CMakeLists.txt
+++ b/3rdParty/asio/CMakeLists.txt
@@ -2,8 +2,8 @@ include(functions/FetchContent_MakeAvailableExcludeFromAll)
 
 include(FetchContent)
 FetchContent_Declare(asio
-    URL https://github.com/diasurgical/asio/archive/bd1c839ef741b14365e77964bdd5a78994c05934.tar.gz
-    URL_HASH MD5=e3b470abdfe4d95e9472239902cf7a65
+    URL https://github.com/diasurgical/asio/archive/4bcf552fcea3e1ae555dde2ab33bc9fa6770da4d.tar.gz
+    URL_HASH MD5=7ffee993fc21b1115abf485958d03ac8
 )
 FetchContent_MakeAvailableExcludeFromAll(asio)
 


### PR DESCRIPTION
Discord user cucamorais reported that his error messages were being cut off so he couldn't troubleshoot TCP port forwarding.

![image](https://github.com/user-attachments/assets/e8b9f2fb-aeb2-4148-b4e0-c2a29e187b5c)

This PR updates ASIO to pull in the fix.

See https://github.com/diasurgical/asio/pull/9 for more details.