### PR TITLE
Fix Phasing Desync

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1754,29 +1754,12 @@ void AddPhasing(Missile &missile, AddMissileParameter &parameter)
 		return;
 	}
 
-	std::array<Point, 4 * 9> targets;
-
-	int count = 0;
-	for (int y = -6; y <= 6; y++) {
-		for (int x = -6; x <= 6; x++) {
-			if ((x >= -3 && x <= 3) || (y >= -3 && y <= 3))
-				continue; // Skip center
-
-			Point target = missile.position.start + Displacement { x, y };
-			if (!PosOkPlayer(player, target))
-				continue;
-
-			targets[count] = target;
-			count++;
-		}
-	}
-
-	if (count == 0) {
+	if (parameter.dst == player.position.tile) { // Target is the player location; Spell failed.
 		missile._miDelFlag = true;
 		return;
 	}
 
-	missile.position.tile = targets[std::max<int32_t>(GenerateRnd(count), 0)];
+	missile.position.tile = parameter.dst; // Target is the valid destination calculated in CheckPhasingTarget().
 }
 
 void AddFirebolt(Missile &missile, AddMissileParameter &parameter)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1759,7 +1759,7 @@ void AddPhasing(Missile &missile, AddMissileParameter &parameter)
 		return;
 	}
 
-	missile.position.tile = parameter.dst; // Target is the valid destination calculated in CheckPhasingTarget().
+	missile.position.tile = parameter.dst; // Target is a valid destination calculated in CheckPhasingTarget() by the caster.
 }
 
 void AddFirebolt(Missile &missile, AddMissileParameter &parameter)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3112,10 +3112,35 @@ void CalcPlrStaff(Player &player)
 /*
  * @brief Get a target location for the Phasing spell.
  */
-static Point CheckPhasingTarget(Player &myPlayer)
+static Point CheckPhasingTarget(const Player &myPlayer)
 {
+	/*
+	 * Grid representation for the Phasing spell
+	 * The '[P]' marks the player position.
+	 * The '[ ]' marks the tiles that are skipped.
+	 * The '[x]' marks the valid tiles that can be targeted.
+	 *
+	 *  -6 -5 -4 -3 -2 -1  0  1  2  3  4  5  6
+	 *  ---------------------------------------
+	 *  [x][x][x][x][x][x][x][x][x][x][x][x][x]  // -6
+	 *  [x][x][x][x][x][x][x][x][x][x][x][x][x]  // -5
+	 *  [x][x][x][x][x][x][x][x][x][x][x][x][x]  // -4
+	 *  [x][x][x][ ][ ][ ][ ][ ][ ][ ][x][x][x]  // -3
+	 *  [x][x][x][ ][ ][ ][ ][ ][ ][ ][x][x][x]  // -2
+	 *  [x][x][x][ ][ ][ ][ ][ ][ ][ ][x][x][x]  // -1
+	 *  [x][x][x][ ][ ][ ][P][ ][ ][ ][x][x][x]  //  0
+	 *  [x][x][x][ ][ ][ ][ ][ ][ ][ ][x][x][x]  //  1
+	 *  [x][x][x][ ][ ][ ][ ][ ][ ][ ][x][x][x]  //  2
+	 *  [x][x][x][ ][ ][ ][ ][ ][ ][ ][x][x][x]  //  3
+	 *  [x][x][x][x][x][x][x][x][x][x][x][x][x]  //  4
+	 *  [x][x][x][x][x][x][x][x][x][x][x][x][x]  //  5
+	 *  [x][x][x][x][x][x][x][x][x][x][x][x][x]  //  6
+	 */
+
 	std::vector<Point> targets;
 	targets.reserve(36);
+
+	const WorldTilePosition position = myPlayer.position.tile;
 
 	for (int y = -6; y <= 6; y++) {
 		for (int x = -6; x <= 6; x++) {
@@ -3123,7 +3148,7 @@ static Point CheckPhasingTarget(Player &myPlayer)
 				continue; // Skip center
 			}
 
-			Point target = myPlayer.position.tile + Displacement { x, y };
+			Point target = position + Displacement { x, y };
 			if (PosOkPlayer(myPlayer, target)) {
 				targets.push_back(target);
 			}
@@ -3131,7 +3156,7 @@ static Point CheckPhasingTarget(Player &myPlayer)
 	}
 
 	if (targets.empty()) {
-		return myPlayer.position.tile; // No valid targets. No position change will be recognized in the missile function to make spell fail.
+		return position; // No valid targets. No position change will be recognized in the missile function to make spell fail.
 	}
 
 	return targets[std::max<int32_t>(GenerateRnd(targets.size()), 0)];

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3109,6 +3109,34 @@ void CalcPlrStaff(Player &player)
 	}
 }
 
+/*
+ * @brief Get a target location for the Phasing spell.
+ */
+static Point CheckPhasingTarget(Player &myPlayer)
+{
+	std::vector<Point> targets;
+	targets.reserve(36);
+
+	for (int y = -6; y <= 6; y++) {
+		for (int x = -6; x <= 6; x++) {
+			if ((x >= -3 && x <= 3) || (y >= -3 && y <= 3)) {
+				continue; // Skip center
+			}
+
+			Point target = myPlayer.position.tile + Displacement { x, y };
+			if (PosOkPlayer(myPlayer, target)) {
+				targets.push_back(target);
+			}
+		}
+	}
+
+	if (targets.empty()) {
+		return myPlayer.position.tile; // No valid targets. No position change will be recognized in the missile function to make spell fail.
+	}
+
+	return targets[std::max<int32_t>(GenerateRnd(targets.size()), 0)];
+}
+
 void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 {
 	bool addflag = false;
@@ -3183,19 +3211,27 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 
 	const int spellLevel = myPlayer.GetSpellLevel(spellID);
 	const int spellFrom = 0;
+	const bool isPhasing = (spellID == SpellID::Phasing);
+	const bool targetMonster = (pcursmonst != -1) && !isShiftHeld && !isPhasing;
+	const bool targetPlayer = (PlayerUnderCursor != nullptr) && !isShiftHeld && !myPlayer.friendlyMode && !isPhasing;
+
+	LastMouseButtonAction = MouseActionType::Spell;
+
 	if (IsWallSpell(spellID)) {
-		LastMouseButtonAction = MouseActionType::Spell;
 		Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
 		NetSendCmdLocParam5(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellLevel, spellFrom);
-	} else if (pcursmonst != -1 && !isShiftHeld) {
+	} else if (targetMonster) {
 		LastMouseButtonAction = MouseActionType::SpellMonsterTarget;
 		NetSendCmdParam5(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
-	} else if (PlayerUnderCursor != nullptr && !isShiftHeld && !myPlayer.friendlyMode) {
+	} else if (targetPlayer) {
 		LastMouseButtonAction = MouseActionType::SpellPlayerTarget;
 		NetSendCmdParam5(true, CMD_SPELLPID, PlayerUnderCursor->getId(), static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	} else {
-		LastMouseButtonAction = MouseActionType::Spell;
-		NetSendCmdLocParam4(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+		Point targetPosition = cursPosition;
+		if (isPhasing) {
+			targetPosition = CheckPhasingTarget(myPlayer); // Override target position with Phasing target position.
+		}
+		NetSendCmdLocParam4(true, CMD_SPELLXY, targetPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	}
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3119,7 +3119,7 @@ static Point CheckPhasingTarget(Player &myPlayer)
 
 	for (int y = -6; y <= 6; y++) {
 		for (int x = -6; x <= 6; x++) {
-			if ((x >= -3 && x <= 3) || (y >= -3 && y <= 3)) {
+			if (std::abs(x) <= 3 && std::abs(y) <= 3) {
 				continue; // Skip center
 			}
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3252,11 +3252,7 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 		LastMouseButtonAction = MouseActionType::SpellPlayerTarget;
 		NetSendCmdParam5(true, CMD_SPELLPID, PlayerUnderCursor->getId(), static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	} else {
-		Point targetPosition = cursPosition;
-		if (isPhasing) {
-			targetPosition = CheckPhasingTarget(myPlayer); // Override target position with Phasing target position.
-		}
-		NetSendCmdLocParam4(true, CMD_SPELLXY, targetPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+		NetSendCmdLocParam4(true, CMD_SPELLXY, isPhasing ? CheckPhasingTarget(myPlayer) : cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	}
 }
 


### PR DESCRIPTION
Phasing relies on RNG to pick a destination. Since RNG state isn't properly synced between clients, this means that all clients run RNG to decide the Phasing location for any player, which can result in different outcomes, then the game needs to correct the position of the player who cast Phasing. 

This fix removes the RNG calculation that occurs on each client when the spell executes. Instead of calculating the target position at this point in time, the caster calculates the position and sends the calculated target position with the packet information for casting the Phasing spell, with the new position syncing properly for all clients.