### PR TITLE
Fix Teleport Desync

### DIFF
--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -409,6 +409,8 @@ Object *ObjectUnderCursor;
 const Player *PlayerUnderCursor;
 /** Current highlighted tile position */
 Point cursPosition;
+/** Current absolute tile position */
+Point cursPositionAbs;
 /** Previously highlighted monster */
 int pcurstemp;
 /** Index of current cursor image */
@@ -725,6 +727,8 @@ void CheckCursMove()
 	my = std::clamp(my, 0, MAXDUNY - 1);
 
 	const Point currentTile { mx, my };
+
+	cursPositionAbs = currentTile;
 
 	// While holding the button down we should retain target (but potentially lose it if it dies, goes out of view, etc)
 	if ((sgbMouseDown != CLICK_NONE || ControllerActionHeld != GameActionType_NONE) && IsNoneOf(LastMouseButtonAction, MouseActionType::None, MouseActionType::Attack, MouseActionType::Spell)) {

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -592,6 +592,7 @@ void InitLevelCursor()
 {
 	NewCursor(CURSOR_HAND);
 	cursPosition = ViewPosition;
+	cursPositionAbs = ViewPosition;
 	pcurstemp = -1;
 	pcursmonst = -1;
 	ObjectUnderCursor = nullptr;

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -42,6 +42,7 @@ extern Object *ObjectUnderCursor;
 struct Player; // Defined in player.h
 extern const Player *PlayerUnderCursor;
 extern Point cursPosition;
+extern Point cursPositionAbs;
 extern DVL_API_FOR_TEST int pcurs;
 
 void InitCursor();

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3183,14 +3183,15 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 
 	const int spellLevel = myPlayer.GetSpellLevel(spellID);
 	const int spellFrom = 0;
+	const bool isTeleport = spellID == SpellID::Teleport;
 	if (IsWallSpell(spellID)) {
 		LastMouseButtonAction = MouseActionType::Spell;
 		Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
 		NetSendCmdLocParam5(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellLevel, spellFrom);
-	} else if (pcursmonst != -1 && !isShiftHeld) {
+	} else if (pcursmonst != -1 && !isShiftHeld && !isTeleport) {
 		LastMouseButtonAction = MouseActionType::SpellMonsterTarget;
 		NetSendCmdParam5(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
-	} else if (PlayerUnderCursor != nullptr && !isShiftHeld && !myPlayer.friendlyMode) {
+	} else if (PlayerUnderCursor != nullptr && !isShiftHeld && !myPlayer.friendlyMode && !isTeleport) {
 		LastMouseButtonAction = MouseActionType::SpellPlayerTarget;
 		NetSendCmdParam5(true, CMD_SPELLPID, PlayerUnderCursor->getId(), static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	} else {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3196,7 +3196,7 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 		NetSendCmdParam5(true, CMD_SPELLPID, PlayerUnderCursor->getId(), static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	} else {
 		LastMouseButtonAction = MouseActionType::Spell;
-		NetSendCmdLocParam4(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+		NetSendCmdLocParam4(true, CMD_SPELLXY, isTeleport ? cursPositionAbs : cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	}
 }
 


### PR DESCRIPTION
Since all non-wall spells can be cast with three modes (lock onto monster, lock onto player, lock onto tile), this creates a predicament with the one spell that changes player position. If the player casting Teleport casts locked onto a non-tile target, if that target's position is not synced between all clients at the time the casting animation completes, the Teleporting player will land next to the target and have a desynced position on all other clients until the game is able to correct it. This can result in a "warping" effect where the Teleported player is snapped to a new location after the correction occurs.

Regardless if desync is a factor or not, I get the impression that Teleport locking onto entities is just a result of how spells work, rather than intent, given that *any* spell being cast with an entity selected will lock the destination to that entity. It seems more intuitive to me that the Teleport spell would send you to the position your mouse is over, rather than locking on to something. This seems quite absurd behavior when for example, you cast a Teleport on a Teleporting player and their Teleport completes first and your Teleport is redirected to wherever this player lands.