### PR TITLE
miyoo_mini/setup_toolchain.sh: Install smpq

### DIFF
--- a/Packaging/miyoo_mini/setup_toolchain.sh
+++ b/Packaging/miyoo_mini/setup_toolchain.sh
@@ -41,6 +41,7 @@ install_dependencies() {
 		make \
 		rsync \
 		scons \
+  		smpq \
 		tree \
 		unzip \
 		wget \


### PR DESCRIPTION
Looks like the 1.5.3 release build failed because smpq was missing (https://github.com/diasurgical/devilutionX/actions/runs/10645902045)