### PR TITLE
display affix rolls/tier

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1801,6 +1801,13 @@ void InitKeymapActions()
 	    nullptr,
 	    IsGameRunning);
 	sgOptions.Keymapper.AddAction(
+	    "Show Affix Data",
+	    N_("Show affix data"),
+	    N_("Shows detailed affix data while held."),
+	    SDLK_LCTRL,
+	    [] { showDetailedAffixData = true; },
+	    [] { showDetailedAffixData = false; });
+	sgOptions.Keymapper.AddAction(
 	    "CycleAutomapType",
 	    N_("Cycle map type"),
 	    N_("Opaque -> Transparent -> Minimap -> None"),

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -633,6 +633,8 @@ struct PLStruct {
 	int minVal;
 	int maxVal;
 	int multVal;
+	uint8_t currentTier;
+	uint8_t maxTier;
 };
 
 struct UniqueItem {
@@ -649,6 +651,9 @@ extern std::vector<ItemData> AllItemsList;
 extern std::vector<PLStruct> ItemPrefixes;
 extern std::vector<PLStruct> ItemSuffixes;
 extern std::vector<UniqueItem> UniqueItems;
+
+extern std::unordered_map<uint32_t, std::pair<const PLStruct *, const PLStruct *>> affixDataCache;
+extern bool showDetailedAffixData;
 
 void LoadItemData();
 


### PR DESCRIPTION
![devxitemtier](https://github.com/user-attachments/assets/c0e04144-30c0-4de5-9053-6d106b92b3cc)

current issues:
- obsidian ring shows 4/5 tier despite obsidian being top tier on rings because a higher tier exists for weapons/shields etc.
- showing high durability stats is kind of meaningless
- probably more