### PR TITLE
Dedupe/tidy up CheckInvCut

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -730,12 +730,10 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 	}
 
 	if (r >= SLOTXY_INV_FIRST && r <= SLOTXY_INV_LAST) {
-		int ig = r - SLOTXY_INV_FIRST;
-		int8_t ii = player.InvGrid[ig];
-		if (ii != 0) {
-			int iv = (ii < 0) ? -ii : ii;
-
-			holdItem = player.InvList[iv - 1];
+		unsigned ig = r - SLOTXY_INV_FIRST;
+		int iv = std::abs(player.InvGrid[ig]) - 1;
+		if (iv >= 0) {
+			holdItem = player.InvList[iv];
 			if (automaticMove) {
 				if (CanBePlacedOnBelt(player, holdItem)) {
 					automaticallyMoved = AutoPlaceItemInBelt(player, holdItem, true, &player == MyPlayer);
@@ -819,7 +817,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 			}
 
 			if (!automaticMove || automaticallyMoved) {
-				player.RemoveInvItem(iv - 1, false);
+				player.RemoveInvItem(iv, false);
 			}
 		}
 	}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -756,20 +756,18 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 						invloc = INVLOC_AMULET;
 						break;
 					case ILOC_ONEHAND:
-						// User is attempting to move a weapon (left hand)
-						if (holdItem._iClass == player.InvBody[INVLOC_HAND_LEFT]._iClass
-						    && player.GetItemLocation(holdItem) == player.GetItemLocation(player.InvBody[INVLOC_HAND_LEFT])) {
+						if (!player.InvBody[INVLOC_HAND_LEFT].isEmpty()
+						    && (holdItem._iClass == player.InvBody[INVLOC_HAND_LEFT]._iClass
+						        || player.GetItemLocation(player.InvBody[INVLOC_HAND_LEFT]) == ILOC_TWOHAND)) {
+							// The left hand is not empty and we're either trying to equip the same type of item or
+							// it's holding a two handed weapon, so it must be unequipped
 							invloc = INVLOC_HAND_LEFT;
-						}
-						// User is attempting to move a shield (right hand)
-						if (holdItem._iClass == player.InvBody[INVLOC_HAND_RIGHT]._iClass
-						    && player.GetItemLocation(holdItem) == player.GetItemLocation(player.InvBody[INVLOC_HAND_RIGHT])) {
+						} else if (!player.InvBody[INVLOC_HAND_RIGHT].isEmpty() && holdItem._iClass == player.InvBody[INVLOC_HAND_RIGHT]._iClass) {
+							// The right hand is not empty and we're trying to equip the same type of item, so we need
+							// to unequip that item
 							invloc = INVLOC_HAND_RIGHT;
 						}
-						// A two-hand item can always be replaced with a one-hand item
-						if (player.GetItemLocation(player.InvBody[INVLOC_HAND_LEFT]) == ILOC_TWOHAND) {
-							invloc = INVLOC_HAND_LEFT;
-						}
+						// otherwise one hand is empty so we can let the auto-equip code put the target item into that hand.
 						break;
 					case ILOC_TWOHAND:
 						// Moving a two-hand item from inventory to InvBody requires emptying both hands.

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -759,13 +759,13 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 						break;
 					case ILOC_ONEHAND:
 						// User is attempting to move a weapon (left hand)
-						if (player.InvList[iv - 1]._iClass == player.InvBody[INVLOC_HAND_LEFT]._iClass
-						    && player.GetItemLocation(player.InvList[iv - 1]) == player.GetItemLocation(player.InvBody[INVLOC_HAND_LEFT])) {
+						if (holdItem._iClass == player.InvBody[INVLOC_HAND_LEFT]._iClass
+						    && player.GetItemLocation(holdItem) == player.GetItemLocation(player.InvBody[INVLOC_HAND_LEFT])) {
 							invloc = INVLOC_HAND_LEFT;
 						}
 						// User is attempting to move a shield (right hand)
-						if (player.InvList[iv - 1]._iClass == player.InvBody[INVLOC_HAND_RIGHT]._iClass
-						    && player.GetItemLocation(player.InvList[iv - 1]) == player.GetItemLocation(player.InvBody[INVLOC_HAND_RIGHT])) {
+						if (holdItem._iClass == player.InvBody[INVLOC_HAND_RIGHT]._iClass
+						    && player.GetItemLocation(holdItem) == player.GetItemLocation(player.InvBody[INVLOC_HAND_RIGHT])) {
 							invloc = INVLOC_HAND_RIGHT;
 						}
 						// A two-hand item can always be replaced with a one-hand item
@@ -808,14 +808,12 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 					}
 					// Empty the identified InvBody slot (invloc) and hand over to AutoEquip
 					if (invloc != NUM_INVLOC) {
-						holdItem = player.InvBody[invloc];
-						if (player.InvBody[invloc]._itype != ItemType::None) {
-							if (AutoPlaceItemInInventory(player, holdItem, true)) {
+						if (!player.InvBody[invloc].isEmpty()) {
+							if (AutoPlaceItemInInventory(player, player.InvBody[invloc], true)) {
 								player.InvBody[invloc].clear();
 							}
 						}
 					}
-					holdItem = player.InvList[iv - 1];
 					automaticallyMoved = automaticallyEquipped = AutoEquip(player, holdItem, true, &player == MyPlayer);
 				}
 			}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -603,6 +603,14 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 	}
 }
 
+namespace {
+inv_body_loc MapSlotToInvBodyLoc(inv_xy_slot slot)
+{
+	assert(slot <= SLOTXY_CHEST);
+	return static_cast<inv_body_loc>(slot);
+}
+} // namespace
+
 void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool dropItem)
 {
 	if (player._pmode > PM_WALK_SIDEWAYS) {
@@ -638,94 +646,18 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 	bool automaticallyEquipped = false;
 	bool automaticallyUnequip = false;
 
-	Item &headItem = player.InvBody[INVLOC_HEAD];
-	if (r == SLOTXY_HEAD && !headItem.isEmpty()) {
-		holdItem = headItem;
-		if (automaticMove) {
-			automaticallyUnequip = true;
-			automaticallyMoved = automaticallyEquipped = AutoPlaceItemInInventory(player, holdItem, true);
-		}
+	if (r >= SLOTXY_HEAD && r <= SLOTXY_CHEST) {
+		inv_body_loc invloc = MapSlotToInvBodyLoc(static_cast<inv_xy_slot>(r));
+		if (!player.InvBody[invloc].isEmpty()) {
+			holdItem = player.InvBody[invloc];
+			if (automaticMove) {
+				automaticallyUnequip = true;
+				automaticallyMoved = automaticallyEquipped = AutoPlaceItemInInventory(player, holdItem, true);
+			}
 
-		if (!automaticMove || automaticallyMoved) {
-			RemoveEquipment(player, INVLOC_HEAD, false);
-		}
-	}
-
-	Item &leftRingItem = player.InvBody[INVLOC_RING_LEFT];
-	if (r == SLOTXY_RING_LEFT && !leftRingItem.isEmpty()) {
-		holdItem = leftRingItem;
-		if (automaticMove) {
-			automaticallyUnequip = true;
-			automaticallyMoved = automaticallyEquipped = AutoPlaceItemInInventory(player, holdItem, true);
-		}
-
-		if (!automaticMove || automaticallyMoved) {
-			RemoveEquipment(player, INVLOC_RING_LEFT, false);
-		}
-	}
-
-	Item &rightRingItem = player.InvBody[INVLOC_RING_RIGHT];
-	if (r == SLOTXY_RING_RIGHT && !rightRingItem.isEmpty()) {
-		holdItem = rightRingItem;
-		if (automaticMove) {
-			automaticallyUnequip = true;
-			automaticallyMoved = automaticallyEquipped = AutoPlaceItemInInventory(player, holdItem, true);
-		}
-
-		if (!automaticMove || automaticallyMoved) {
-			RemoveEquipment(player, INVLOC_RING_RIGHT, false);
-		}
-	}
-
-	Item &amuletItem = player.InvBody[INVLOC_AMULET];
-	if (r == SLOTXY_AMULET && !amuletItem.isEmpty()) {
-		holdItem = amuletItem;
-		if (automaticMove) {
-			automaticallyUnequip = true;
-			automaticallyMoved = automaticallyEquipped = AutoPlaceItemInInventory(player, holdItem, true);
-		}
-
-		if (!automaticMove || automaticallyMoved) {
-			RemoveEquipment(player, INVLOC_AMULET, false);
-		}
-	}
-
-	Item &leftHandItem = player.InvBody[INVLOC_HAND_LEFT];
-	if (r == SLOTXY_HAND_LEFT && !leftHandItem.isEmpty()) {
-		holdItem = leftHandItem;
-		if (automaticMove) {
-			automaticallyUnequip = true;
-			automaticallyMoved = automaticallyEquipped = AutoPlaceItemInInventory(player, holdItem, true);
-		}
-
-		if (!automaticMove || automaticallyMoved) {
-			RemoveEquipment(player, INVLOC_HAND_LEFT, false);
-		}
-	}
-
-	Item &rightHandItem = player.InvBody[INVLOC_HAND_RIGHT];
-	if (r == SLOTXY_HAND_RIGHT && !rightHandItem.isEmpty()) {
-		holdItem = rightHandItem;
-		if (automaticMove) {
-			automaticallyUnequip = true;
-			automaticallyMoved = automaticallyEquipped = AutoPlaceItemInInventory(player, holdItem, true);
-		}
-
-		if (!automaticMove || automaticallyMoved) {
-			RemoveEquipment(player, INVLOC_HAND_RIGHT, false);
-		}
-	}
-
-	Item &chestItem = player.InvBody[INVLOC_CHEST];
-	if (r == SLOTXY_CHEST && !chestItem.isEmpty()) {
-		holdItem = chestItem;
-		if (automaticMove) {
-			automaticallyUnequip = true;
-			automaticallyMoved = automaticallyEquipped = AutoPlaceItemInInventory(player, holdItem, true);
-		}
-
-		if (!automaticMove || automaticallyMoved) {
-			RemoveEquipment(player, INVLOC_CHEST, false);
+			if (!automaticMove || automaticallyMoved) {
+				RemoveEquipment(player, invloc, false);
+			}
 		}
 	}
 


### PR DESCRIPTION
Trying to unpick the code to the point I can safely allow shift-clicking to do an in-place swap when equipping (by actually removing the item from the inventory when it gets moved to `holdItem`)