### PR TITLE
Cleanup panel code (Part 1)

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -947,7 +947,7 @@ void DrawCtrlBtns(const Surface &out)
 			DrawPanelBox(out, MakeSdlRect(PanelButtonRect[i].position.x, PanelButtonRect[i].position.y + SdlRectYAdjustment, PanelButtonRect[i].size.width, PanelButtonRect[i].size.height + 1), mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y });
 		} else {
 			Point position = mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y };
-			RenderClxSprite(out, (*pPanelButtons)[i], position); // FIXME
+			RenderClxSprite(out, (*pPanelButtons)[i], position);
 			RenderClxSprite(out, (*PanelButtonDown)[i], position + Displacement { 4, 0 });
 		}
 	}

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -145,11 +145,9 @@ int beltItems = 8;
 Size BeltSize { (INV_SLOT_SIZE_PX + 1) * beltItems, INV_SLOT_SIZE_PX };
 Rectangle BeltRect { { 205, 5 }, BeltSize };
 
-constexpr Size SpellButtonSize { 56, 56 };
-Rectangle SpellButtonRect { { 565, 64 }, SpellButtonSize };
+Rectangle SpellButtonRect { { 565, 64 }, { 56, 56 } };
 
-constexpr Size FlaskTopSize = { 60, 13 };
-Rectangle FlaskTopRect = { { 13, 3 }, FlaskTopSize };
+Rectangle FlaskTopRect = { { 13, 3 }, { 60, 13 } };
 constexpr Size FlaskBottomSize = { 84, 69 };
 Rectangle FlaskBottomRect = { { 0, 16 }, FlaskBottomSize };
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -183,6 +183,7 @@ char TalkMessage[MAX_SEND_STR_LEN];
 bool TalkButtonsDown[3];
 int sgbPlrTalkTbl;
 bool WhisperList[MAX_PLRS];
+int PanelPaddingHeight = 16;
 
 TextInputCursorState ChatCursor;
 std::optional<TextInputState> ChatInputState;
@@ -864,7 +865,7 @@ void control_update_life_mana()
 void InitControlPan()
 {
 	if (!HeadlessMode) {
-		pBtmBuff.emplace(GetMainPanel().size.width, (GetMainPanel().size.height + 16) * (IsChatAvailable() ? 2 : 1));
+		pBtmBuff.emplace(GetMainPanel().size.width, (GetMainPanel().size.height + PanelPaddingHeight) * (IsChatAvailable() ? 2 : 1));
 		pManaBuff.emplace(88, 88);
 		pLifeBuff.emplace(88, 88);
 
@@ -872,7 +873,7 @@ void InitControlPan()
 		LoadLargeSpellIcons();
 		{
 			const OwnedClxSpriteList sprite = LoadCel("ctrlpan\\panel8", GetMainPanel().size.width);
-			ClxDraw(*pBtmBuff, { 0, (GetMainPanel().size.height + 16) - 1 }, sprite[0]);
+			ClxDraw(*pBtmBuff, { 0, (GetMainPanel().size.height + PanelPaddingHeight) - 1 }, sprite[0]);
 		}
 		{
 			const Point bulbsPosition { 0, 87 };
@@ -887,7 +888,7 @@ void InitControlPan()
 		if (!HeadlessMode) {
 			{
 				const OwnedClxSpriteList sprite = LoadCel("ctrlpan\\talkpanl", GetMainPanel().size.width);
-				ClxDraw(*pBtmBuff, { 0, (GetMainPanel().size.height + 16) * 2 - 1 }, sprite[0]);
+				ClxDraw(*pBtmBuff, { 0, (GetMainPanel().size.height + PanelPaddingHeight) * 2 - 1 }, sprite[0]);
 			}
 			multiButtons = LoadCel("ctrlpan\\p8but2", 33);
 			talkButtons = LoadCel("ctrlpan\\talkbutt", 61);
@@ -936,7 +937,7 @@ void InitControlPan()
 
 void DrawCtrlPan(const Surface &out)
 {
-	DrawPanelBox(out, MakeSdlRect(0, sgbPlrTalkTbl + 16, GetMainPanel().size.width, GetMainPanel().size.height), GetMainPanel().position);
+	DrawPanelBox(out, MakeSdlRect(0, sgbPlrTalkTbl + PanelPaddingHeight, GetMainPanel().size.width, GetMainPanel().size.height), GetMainPanel().position);
 	DrawInfoBox(out);
 }
 
@@ -947,7 +948,7 @@ void DrawCtrlBtns(const Surface &out)
 
 	for (int i = 0; i < 6; i++) {
 		if (!PanelButtons[i]) {
-			DrawPanelBox(out, MakeSdlRect(PanelButtonRect[i].position.x, PanelButtonRect[i].position.y + 16, PanelButtonRect[i].size.width, PanelButtonRect[i].size.height + 1), mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y });
+			DrawPanelBox(out, MakeSdlRect(PanelButtonRect[i].position.x, PanelButtonRect[i].position.y + PanelPaddingHeight, PanelButtonRect[i].size.width, PanelButtonRect[i].size.height + 1), mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y });
 		} else {
 			Point position = mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y };
 			RenderClxSprite(out, (*pPanelButtons)[i], position);
@@ -1218,7 +1219,7 @@ void FreeControlPan()
 
 void DrawInfoBox(const Surface &out)
 {
-	DrawPanelBox(out, { 177, 62, InfoBoxRect.size.width, InfoBoxRect.size.height }, GetMainPanel().position + Displacement { InfoBoxRect.position.x, InfoBoxRect.position.y });
+	DrawPanelBox(out, { InfoBoxRect.position.x, InfoBoxRect.position.y + PanelPaddingHeight, InfoBoxRect.size.width, InfoBoxRect.size.height }, GetMainPanel().position + Displacement { InfoBoxRect.position.x, InfoBoxRect.position.y });
 	if (!panelflag && !trigflag && pcursinvitem == -1 && pcursstashitem == StashStruct::EmptyCell && !spselflag && pcurs != CURSOR_HOURGLASS) {
 		InfoString = StringOrView {};
 		InfoColor = UiFlags::ColorWhite;
@@ -1587,7 +1588,7 @@ void control_type_message()
 	for (bool &talkButtonDown : TalkButtonsDown) {
 		talkButtonDown = false;
 	}
-	sgbPlrTalkTbl = GetMainPanel().size.height + 16;
+	sgbPlrTalkTbl = GetMainPanel().size.height + PanelPaddingHeight;
 	RedrawEverything();
 	TalkSaveIndex = NextTalkSave;
 	SDL_StartTextInput();

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -114,8 +114,6 @@ bool IsRightPanelOpen()
 	return invflag || sbookflag;
 }
 
-constexpr int SdlRectYAdjustment = 16;
-
 constexpr Size IncrementAttributeButtonSize { 41, 22 };
 /** Maps from attribute_id to the rectangle on screen used for attribute increment buttons. */
 Rectangle CharButtonRect[4] = {
@@ -935,7 +933,7 @@ void InitControlPan()
 
 void DrawCtrlPan(const Surface &out)
 {
-	DrawPanelBox(out, MakeSdlRect(0, sgbPlrTalkTbl + SdlRectYAdjustment, GetMainPanel().size.width, GetMainPanel().size.height), GetMainPanel().position);
+	DrawPanelBox(out, MakeSdlRect(0, sgbPlrTalkTbl + 16, GetMainPanel().size.width, GetMainPanel().size.height), GetMainPanel().position);
 	DrawInfoBox(out);
 }
 
@@ -944,7 +942,7 @@ void DrawCtrlBtns(const Surface &out)
 	const Point mainPanelPosition = GetMainPanel().position;
 	for (int i = 0; i < 6; i++) {
 		if (!PanelButtons[i]) {
-			DrawPanelBox(out, MakeSdlRect(PanelButtonRect[i].position.x, PanelButtonRect[i].position.y + SdlRectYAdjustment, PanelButtonRect[i].size.width, PanelButtonRect[i].size.height + 1), mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y });
+			DrawPanelBox(out, MakeSdlRect(PanelButtonRect[i].position.x, PanelButtonRect[i].position.y + 16, PanelButtonRect[i].size.width, PanelButtonRect[i].size.height + 1), mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y });
 		} else {
 			Point position = mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y };
 			RenderClxSprite(out, (*pPanelButtons)[i], position);

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -139,6 +139,9 @@ Rectangle PanelButtonRect[8] = {
 	// clang-format on
 };
 
+constexpr Size LevelButtonSize { 41, 22 };
+Rectangle LevelButtonRect = { { 40, -39 }, LevelButtonSize };
+
 int beltItems = 8;
 Size BeltSize { (INV_SLOT_SIZE_PX + 1) * beltItems, INV_SLOT_SIZE_PX };
 Rectangle BeltRect { { 205, 5 }, BeltSize };
@@ -946,7 +949,7 @@ void DrawCtrlBtns(const Surface &out)
 	const Point mainPanelPosition = GetMainPanel().position;
 	int totalButtons = IsChatAvailable() ? TotalMpButtons : TotalSpButtons;
 
-	for (int i = 0; i < 6; i++) {
+	for (int i = 0; i < TotalSpButtons; i++) {
 		if (!PanelButtons[i]) {
 			DrawPanelBox(out, MakeSdlRect(PanelButtonRect[i].position.x, PanelButtonRect[i].position.y + PanelPaddingHeight, PanelButtonRect[i].size.width, PanelButtonRect[i].size.height + 1), mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y });
 		} else {
@@ -957,11 +960,14 @@ void DrawCtrlBtns(const Surface &out)
 	}
 
 	if (IsChatAvailable()) {
-		ClxDraw(out, mainPanelPosition + Displacement { 87, 122 }, (*multiButtons)[PanelButtons[PanelButtonSendmsg] ? 1 : 0]);
+		RenderClxSprite(out, (*multiButtons)[PanelButtons[PanelButtonSendmsg] ? 1 : 0], mainPanelPosition + Displacement { PanelButtonRect[PanelButtonSendmsg].position.x, PanelButtonRect[PanelButtonSendmsg].position.y });
+
+		Point friendlyButtonPosition = mainPanelPosition + Displacement { PanelButtonRect[PanelButtonFriendly].position.x, PanelButtonRect[PanelButtonFriendly].position.y };
+
 		if (MyPlayer->friendlyMode)
-			ClxDraw(out, mainPanelPosition + Displacement { 527, 122 }, (*multiButtons)[PanelButtons[PanelButtonFriendly] ? 3 : 2]);
+			RenderClxSprite(out, (*multiButtons)[PanelButtons[PanelButtonFriendly] ? 3 : 2], friendlyButtonPosition);
 		else
-			ClxDraw(out, mainPanelPosition + Displacement { 527, 122 }, (*multiButtons)[PanelButtons[PanelButtonFriendly] ? 5 : 4]);
+			RenderClxSprite(out, (*multiButtons)[PanelButtons[PanelButtonFriendly] ? 5 : 4], friendlyButtonPosition);
 	}
 }
 
@@ -1276,14 +1282,22 @@ void CheckLvlBtn()
 	}
 
 	const Point mainPanelPosition = GetMainPanel().position;
-	if (!lvlbtndown && MousePosition.x >= 40 + mainPanelPosition.x && MousePosition.x <= 81 + mainPanelPosition.x && MousePosition.y >= -39 + mainPanelPosition.y && MousePosition.y <= -17 + mainPanelPosition.y)
+	Rectangle button = LevelButtonRect;
+
+	button.position = GetPanelPosition(UiPanels::Main, button.position);
+
+	if (!lvlbtndown && button.contains(MousePosition))
 		lvlbtndown = true;
 }
 
 void ReleaseLvlBtn()
 {
 	const Point mainPanelPosition = GetMainPanel().position;
-	if (MousePosition.x >= 40 + mainPanelPosition.x && MousePosition.x <= 81 + mainPanelPosition.x && MousePosition.y >= -39 + mainPanelPosition.y && MousePosition.y <= -17 + mainPanelPosition.y) {
+	Rectangle button = LevelButtonRect;
+
+	button.position = GetPanelPosition(UiPanels::Main, button.position);
+
+	if (button.contains(MousePosition)) {
 		OpenCharPanel();
 	}
 	lvlbtndown = false;
@@ -1293,7 +1307,7 @@ void DrawLevelUpIcon(const Surface &out)
 {
 	if (IsLevelUpButtonVisible()) {
 		int nCel = lvlbtndown ? 2 : 1;
-		DrawString(out, _("Level Up"), { GetMainPanel().position + Displacement { 0, -62 }, { 120, 0 } },
+		DrawString(out, _("Level Up"), { GetMainPanel().position + Displacement { 0, LevelButtonRect.position.y - 23 }, { 120, 0 } },
 		    { .flags = UiFlags::ColorWhite | UiFlags::AlignCenter | UiFlags::KerningFitSpacing });
 		ClxDraw(out, GetMainPanel().position + Displacement { 40, -17 }, (*pChrButtons)[nCel]);
 	}

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1309,7 +1309,7 @@ void DrawLevelUpIcon(const Surface &out)
 		int nCel = lvlbtndown ? 2 : 1;
 		DrawString(out, _("Level Up"), { GetMainPanel().position + Displacement { 0, LevelButtonRect.position.y - 23 }, { 120, 0 } },
 		    { .flags = UiFlags::ColorWhite | UiFlags::AlignCenter | UiFlags::KerningFitSpacing });
-		ClxDraw(out, GetMainPanel().position + Displacement { 40, -17 }, (*pChrButtons)[nCel]);
+		RenderClxSprite(out, (*pChrButtons)[nCel], GetMainPanel().position + Displacement { LevelButtonRect.position.x, LevelButtonRect.position.y });
 	}
 }
 

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -174,6 +174,8 @@ enum panel_button_id : uint8_t {
 };
 
 bool PanelButtons[PanelButtonLast + 1];
+int TotalSpButtons = 6;
+int TotalMpButtons = 8;
 char TalkSave[8][MAX_SEND_STR_LEN];
 uint8_t TalkSaveIndex;
 uint8_t NextTalkSave;
@@ -941,6 +943,8 @@ void DrawCtrlPan(const Surface &out)
 void DrawCtrlBtns(const Surface &out)
 {
 	const Point mainPanelPosition = GetMainPanel().position;
+	int totalButtons = IsChatAvailable() ? TotalMpButtons : TotalSpButtons;
+
 	for (int i = 0; i < 6; i++) {
 		if (!PanelButtons[i]) {
 			DrawPanelBox(out, MakeSdlRect(PanelButtonRect[i].position.x, PanelButtonRect[i].position.y + 16, PanelButtonRect[i].size.width, PanelButtonRect[i].size.height + 1), mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y });
@@ -972,7 +976,7 @@ void DoPanBtn()
 {
 	const Point mainPanelPosition = GetMainPanel().position;
 
-	int totalButtons = IsChatAvailable() ? 8 : 6;
+	int totalButtons = IsChatAvailable() ? TotalMpButtons : TotalSpButtons;
 
 	for (int i = 0; i < totalButtons; i++) {
 		Rectangle button = PanelButtonRect[i];
@@ -1050,7 +1054,7 @@ void CheckPanelInfo()
 	panelflag = false;
 	InfoString = StringOrView {};
 
-	int totalButtons = IsChatAvailable() ? 8 : 6;
+	int totalButtons = IsChatAvailable() ? TotalMpButtons : TotalSpButtons;
 
 	for (int i = 0; i < totalButtons; i++) {
 		Rectangle button = PanelButtonRect[i];

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -139,8 +139,7 @@ Rectangle PanelButtonRect[8] = {
 	// clang-format on
 };
 
-constexpr Size LevelButtonSize { 41, 22 };
-Rectangle LevelButtonRect = { { 40, -39 }, LevelButtonSize };
+Rectangle LevelButtonRect = { { 40, -39 }, { 41, 22 } };
 
 int beltItems = 8;
 Size BeltSize { (INV_SLOT_SIZE_PX + 1) * beltItems, INV_SLOT_SIZE_PX };

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -948,7 +948,7 @@ void DrawCtrlBtns(const Surface &out)
 		} else {
 			Point position = mainPanelPosition + Displacement { PanelButtonRect[i].position.x, PanelButtonRect[i].position.y };
 			RenderClxSprite(out, (*pPanelButtons)[i], position); // FIXME
-			RenderClxSprite(out, (*PanelButtonDown)[i], position + Displacement { 4, -18 });
+			RenderClxSprite(out, (*PanelButtonDown)[i], position + Displacement { 4, 0 });
 		}
 	}
 

--- a/Source/control.h
+++ b/Source/control.h
@@ -35,9 +35,7 @@ namespace devilution {
 
 constexpr Size SidePanelSize { 320, 352 };
 
-// Info box displacement of the top-left corner relative to GetMainPanel().position.
-constexpr Displacement InfoBoxTopLeft { 177, 46 };
-constexpr Size InfoBoxSize { 288, 64 };
+constexpr Rectangle InfoBoxRect = { { 177, 46 }, { 288, 64 } };
 
 extern bool dropGoldFlag;
 extern TextInputCursorState GoldDropCursor;
@@ -62,7 +60,7 @@ bool IsLeftPanelOpen();
 bool IsRightPanelOpen();
 extern std::optional<OwnedSurface> pBtmBuff;
 extern OptionalOwnedClxSpriteList pGBoxBuff;
-extern SDL_Rect PanBtnPos[8];
+extern Rectangle PanelButtonRect[8];
 
 void CalculatePanelAreas();
 bool IsChatAvailable();
@@ -192,6 +190,6 @@ void OpenGoldDrop(int8_t invIndex, int max);
 void CloseGoldDrop();
 int GetGoldDropMax();
 bool HandleGoldDropTextInputEvent(const SDL_Event &event);
-extern Rectangle ChrBtnsRect[4];
+extern Rectangle CharButtonRect[4];
 
 } // namespace devilution

--- a/Source/control.h
+++ b/Source/control.h
@@ -121,7 +121,7 @@ void DrawFlaskValues(const Surface &out, Point pos, int currValue, int maxValue)
 /**
  * @brief calls on the active player object to update HP/Mana percentage variables
  *
- * This is used to ensure that DrawFlask routines display an accurate representation of the players health/mana
+ * This is used to ensure that DrawFlaskAbovePanel routines display an accurate representation of the players health/mana
  *
  * @see Player::UpdateHitPointPercentage() and Player::UpdateManaPercentage()
  */

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -562,7 +562,7 @@ void AttrIncBtnSnap(AxisDirection dir)
 	int slot = 0;
 	Rectangle button;
 	for (int i = 0; i < 4; i++) {
-		button = ChrBtnsRect[i];
+		button = CharButtonRect[i];
 		button.position = GetPanelPosition(UiPanels::Character, button.position);
 		if (button.contains(MousePosition)) {
 			slot = i;
@@ -579,7 +579,7 @@ void AttrIncBtnSnap(AxisDirection dir)
 	}
 
 	// move cursor to our new location
-	button = ChrBtnsRect[slot];
+	button = CharButtonRect[slot];
 	button.position = GetPanelPosition(UiPanels::Character, button.position);
 	SetCursorPos(button.Center());
 }

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -166,7 +166,7 @@ bool InteractsWithCharButton(Point point)
 		if (myPlayer.GetBaseAttributeValue(attribute) >= myPlayer.GetMaximumAttributeValue(attribute))
 			continue;
 		auto buttonId = static_cast<size_t>(attribute);
-		Rectangle button = ChrBtnsRect[buttonId];
+		Rectangle button = CharButtonRect[buttonId];
 		button.position = GetPanelPosition(UiPanels::Character, button.position);
 		if (button.contains(point)) {
 			return true;

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1332,7 +1332,8 @@ void DrawMain(int dwHgt, bool drawDesc, bool drawHp, bool drawMana, bool drawSba
 				// When chat input is displayed, the belt is hidden and the chat moves up.
 				DoBlitScreen({ mainPanelPosition + Displacement { 171, 6 }, { 298, 116 } });
 			} else {
-				DoBlitScreen({ mainPanelPosition + InfoBoxTopLeft, InfoBoxSize });
+				DoBlitScreen(mainPanelPosition.x + InfoBoxRect.position.x, mainPanelPosition.y + InfoBoxRect.position.y,
+				    InfoBoxRect.size.width, InfoBoxRect.size.height);
 			}
 		}
 		if (drawMana) {

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1332,8 +1332,7 @@ void DrawMain(int dwHgt, bool drawDesc, bool drawHp, bool drawMana, bool drawSba
 				// When chat input is displayed, the belt is hidden and the chat moves up.
 				DoBlitScreen({ mainPanelPosition + Displacement { 171, 6 }, { 298, 116 } });
 			} else {
-				DoBlitScreen(mainPanelPosition.x + InfoBoxRect.position.x, mainPanelPosition.y + InfoBoxRect.position.y,
-				    InfoBoxRect.size.width, InfoBoxRect.size.height);
+				DoBlitScreen({ mainPanelPosition + Displacement { InfoBoxRect.position.x, InfoBoxRect.position.y }, { InfoBoxRect.size } });
 			}
 		}
 		if (drawMana) {

--- a/Source/panels/mainpanel.cpp
+++ b/Source/panels/mainpanel.cpp
@@ -48,7 +48,7 @@ void DrawButtonOnPanel(Point position, std::string_view text, int frame)
 
 void RenderMainButton(const Surface &out, int buttonId, std::string_view text, int frame)
 {
-	Point panelPosition { PanBtnPos[buttonId].x + 4, PanBtnPos[buttonId].y + 17 };
+	Point panelPosition { PanelButtonRect[buttonId].position.x + 4, PanelButtonRect[buttonId].position.y + 17 };
 	DrawButtonOnPanel(panelPosition, text, frame);
 	if (IsChatAvailable())
 		DrawButtonOnPanel(panelPosition + Displacement { 0, GetMainPanel().size.height + 16 }, text, frame);

--- a/Source/panels/mainpanel.cpp
+++ b/Source/panels/mainpanel.cpp
@@ -48,7 +48,7 @@ void DrawButtonOnPanel(Point position, std::string_view text, int frame)
 
 void RenderMainButton(const Surface &out, int buttonId, std::string_view text, int frame)
 {
-	Point panelPosition { PanelButtonRect[buttonId].position.x + 4, PanelButtonRect[buttonId].position.y + 17 };
+	Point panelPosition { PanelButtonRect[buttonId].position + Displacement { 4, 17 } };
 	DrawButtonOnPanel(panelPosition, text, frame);
 	if (IsChatAvailable())
 		DrawButtonOnPanel(panelPosition + Displacement { 0, GetMainPanel().size.height + 16 }, text, frame);

--- a/Source/player.h
+++ b/Source/player.h
@@ -689,7 +689,7 @@ public:
 			// Maximum achievable HP is approximately 1200. Diablo uses fixed point integers where the last 6 bits are
 			// fractional values. This means that we will never overflow HP values normally by doing this multiplication
 			// as the max value is representable in 17 bits and the multiplication result will be at most 23 bits
-			_pHPPer = std::clamp(_pHitPoints * 80 / _pMaxHP, 0, 80); // hp should never be greater than maxHP but just in case
+			_pHPPer = std::clamp(_pHitPoints * 81 / _pMaxHP, 0, 81); // hp should never be greater than maxHP but just in case
 		}
 
 		return _pHPPer;
@@ -700,7 +700,7 @@ public:
 		if (_pMaxMana <= 0) {
 			_pManaPer = 0;
 		} else {
-			_pManaPer = std::clamp(_pMana * 80 / _pMaxMana, 0, 80);
+			_pManaPer = std::clamp(_pMana * 81 / _pMaxMana, 0, 81);
 		}
 
 		return _pManaPer;


### PR DESCRIPTION
Notes:
- HPPer changed from 80 to 81. The globes have 81 rows of pixels that can be filled.
- Buttons had their positions/sizes scattered around as magic numbers, and resulted in some inconsistencies, so this was resolved, which broke the time demo.
- Fixed flasks always showing an empty row of pixels even with full globes.
- Empty flasks above the panel are slightly larger than the filled flasks, resulting in strange visuals when the globe is changing fill level. I modified them to always draw the empty part entirely, and then draw the filled part, if applicable.

All of this should make it entirely easier to mod the control panel without having to play around with magic numbers in many functions.