### PR TITLE
Update optimized transparency lookup when cycling colors

### DIFF
--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -114,6 +114,20 @@ void GenerateBlendedLookupTable(std::array<SDL_Color, 256> &palette, int skipFro
 #endif
 }
 
+#if DEVILUTIONX_PALETTE_TRANSPARENCY_BLACK_16_LUT
+void UpdateTransparencyLookupBlack16(int from, int to)
+{
+	for (int i = from; i <= to; i++) {
+		for (int j = 0; j < 256; j++) {
+			const std::uint16_t index = i | (j << 8);
+			const std::uint16_t reverseIndex = j | (i << 8);
+			paletteTransparencyLookupBlack16[index] = paletteTransparencyLookup[0][i] | (paletteTransparencyLookup[0][j] << 8);
+			paletteTransparencyLookupBlack16[reverseIndex] = paletteTransparencyLookup[0][j] | (paletteTransparencyLookup[0][i] << 8);
+		}
+	}
+}
+#endif
+
 /**
  * @brief Cycle the given range of colors in the palette
  * @param from First color index of the range
@@ -128,6 +142,10 @@ void CycleColors(int from, int to)
 	}
 
 	std::rotate(&paletteTransparencyLookup[from][0], &paletteTransparencyLookup[from + 1][0], &paletteTransparencyLookup[to + 1][0]);
+
+#if DEVILUTIONX_PALETTE_TRANSPARENCY_BLACK_16_LUT
+	UpdateTransparencyLookupBlack16(from, to);
+#endif
 }
 
 /**
@@ -144,6 +162,10 @@ void CycleColorsReverse(int from, int to)
 	}
 
 	std::rotate(&paletteTransparencyLookup[from][0], &paletteTransparencyLookup[to][0], &paletteTransparencyLookup[to + 1][0]);
+
+#if DEVILUTIONX_PALETTE_TRANSPARENCY_BLACK_16_LUT
+	UpdateTransparencyLookupBlack16(from, to);
+#endif
 }
 
 } // namespace
@@ -426,6 +448,10 @@ void palette_update_quest_palette(int n)
 		Uint8 best = FindBestMatchForColor(logical_palette, blendedColor, 1, 31);
 		paletteTransparencyLookup[i][j] = paletteTransparencyLookup[j][i] = best;
 	}
+
+#if DEVILUTIONX_PALETTE_TRANSPARENCY_BLACK_16_LUT
+	UpdateTransparencyLookupBlack16(i, i);
+#endif
 }
 
 } // namespace devilution


### PR DESCRIPTION
This PR fixes an issue reported by Discord user `john`.

![image](https://github.com/user-attachments/assets/232d8d4e-9ec0-4847-b57b-07e5a0da0a5e)

Basically, the additional lookup table introduced by #3413 wasn't being updated when cycling colors. After testing performance, it seems that the time it takes to update the lookup table is negligible so this change doesn't negate the performance gains of the optimization.