### PR TITLE
Show accurate armor/dmg

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1793,6 +1793,13 @@ void InitKeymapActions()
 	    nullptr,
 	    [] { ToggleItemLabelHighlight(); });
 	sgOptions.Keymapper.AddAction(
+	    "Show Base Stats",
+	    N_("Show item base stats"),
+	    N_("Shows item base armor/damage without including bonuses"),
+	    SDLK_LCTRL,
+	    [] { showItemBaseStats = true; },
+	    [] { showItemBaseStats = false; });
+	sgOptions.Keymapper.AddAction(
 	    "Toggle Automap",
 	    N_("Toggle automap"),
 	    N_("Toggles if automap is displayed."),

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1916,11 +1916,7 @@ int8_t CheckInvHLight()
 	} else {
 		InfoColor = pi->getTextColor();
 		InfoString = pi->getName();
-		if (pi->_iIdentified) {
-			PrintItemDetails(*pi);
-		} else {
-			PrintItemDur(*pi);
-		}
+		PrintItemDetails(*pi);
 	}
 
 	return rv;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4117,56 +4117,22 @@ void PrintItemDetails(const Item &item)
 	if (item._iMiscId == IMISC_STAFF && item._iMaxCharges != 0) {
 		AddInfoBoxString(fmt::format(fmt::runtime(_("Charges: {:d}/{:d}")), item._iCharges, item._iMaxCharges));
 	}
-	if (item._iPrePower != -1) {
-		AddInfoBoxString(PrintItemPower(item._iPrePower, item));
-	}
-	if (item._iSufPower != -1) {
-		AddInfoBoxString(PrintItemPower(item._iSufPower, item));
-	}
-	if (item._iMagical == ITEM_QUALITY_UNIQUE) {
-		AddInfoBoxString(_("unique item"));
-		ShowUniqueItemInfoBox = true;
-		curruitem = item;
-	}
-	PrintItemInfo(item);
-}
-
-void PrintItemDur(const Item &item)
-{
-	if (HeadlessMode)
-		return;
-
-	if (item._iClass == ICLASS_WEAPON) {
-		if (item._iMinDam == item._iMaxDam) {
-			if (item._iMaxDur == DUR_INDESTRUCTIBLE)
-				AddInfoBoxString(fmt::format(fmt::runtime(_("damage: {:d}  Indestructible")), item._iMinDam));
-			else
-				AddInfoBoxString(fmt::format(fmt::runtime(_("damage: {:d}  Dur: {:d}/{:d}")), item._iMinDam, item._iDurability, item._iMaxDur));
-		} else {
-			if (item._iMaxDur == DUR_INDESTRUCTIBLE)
-				AddInfoBoxString(fmt::format(fmt::runtime(_("damage: {:d}-{:d}  Indestructible")), item._iMinDam, item._iMaxDam));
-			else
-				AddInfoBoxString(fmt::format(fmt::runtime(_("damage: {:d}-{:d}  Dur: {:d}/{:d}")), item._iMinDam, item._iMaxDam, item._iDurability, item._iMaxDur));
+	if (item._iIdentified) {
+		if (item._iPrePower != -1) {
+			AddInfoBoxString(PrintItemPower(item._iPrePower, item));
 		}
-		if (item._iMiscId == IMISC_STAFF && item._iMaxCharges > 0) {
-			AddInfoBoxString(fmt::format(fmt::runtime(_("Charges: {:d}/{:d}")), item._iCharges, item._iMaxCharges));
+		if (item._iSufPower != -1) {
+			AddInfoBoxString(PrintItemPower(item._iSufPower, item));
 		}
-		if (item._iMagical != ITEM_QUALITY_NORMAL)
-			AddInfoBoxString(_("Not Identified"));
-	}
-	if (item._iClass == ICLASS_ARMOR) {
-		if (item._iMaxDur == DUR_INDESTRUCTIBLE)
-			AddInfoBoxString(fmt::format(fmt::runtime(_("armor: {:d}  Indestructible")), item._iAC));
-		else
-			AddInfoBoxString(fmt::format(fmt::runtime(_("armor: {:d}  Dur: {:d}/{:d}")), item._iAC, item._iDurability, item._iMaxDur));
-		if (item._iMagical != ITEM_QUALITY_NORMAL)
-			AddInfoBoxString(_("Not Identified"));
-		if (item._iMiscId == IMISC_STAFF && item._iMaxCharges > 0) {
-			AddInfoBoxString(fmt::format(fmt::runtime(_("Charges: {:d}/{:d}")), item._iCharges, item._iMaxCharges));
+		if (item._iMagical == ITEM_QUALITY_UNIQUE) {
+			AddInfoBoxString(_("unique item"));
+			ShowUniqueItemInfoBox = true;
+			curruitem = item;
 		}
-	}
-	if (IsAnyOf(item._itype, ItemType::Ring, ItemType::Amulet))
+	} else {
 		AddInfoBoxString(_("Not Identified"));
+	}
+
 	PrintItemInfo(item);
 }
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4108,20 +4108,22 @@ void PrintItemDetails(const Item &item)
 	if (item._iMiscId == IMISC_STAFF && item._iMaxCharges != 0) {
 		AddInfoBoxString(fmt::format(fmt::runtime(_("Charges: {:d}/{:d}")), item._iCharges, item._iMaxCharges));
 	}
-	if (item._iIdentified) {
-		if (item._iPrePower != -1) {
-			AddInfoBoxString(PrintItemPower(item._iPrePower, item));
+	if (item._iMagical != ITEM_QUALITY_NORMAL) {
+		if (item._iIdentified) {
+			if (item._iPrePower != -1) {
+				AddInfoBoxString(PrintItemPower(item._iPrePower, item));
+			}
+			if (item._iSufPower != -1) {
+				AddInfoBoxString(PrintItemPower(item._iSufPower, item));
+			}
+			if (item._iMagical == ITEM_QUALITY_UNIQUE) {
+				AddInfoBoxString(_("unique item"));
+				ShowUniqueItemInfoBox = true;
+				curruitem = item;
+			}
+		} else {
+			AddInfoBoxString(_("Not Identified"));
 		}
-		if (item._iSufPower != -1) {
-			AddInfoBoxString(PrintItemPower(item._iSufPower, item));
-		}
-		if (item._iMagical == ITEM_QUALITY_UNIQUE) {
-			AddInfoBoxString(_("unique item"));
-			ShowUniqueItemInfoBox = true;
-			curruitem = item;
-		}
-	} else {
-		AddInfoBoxString(_("Not Identified"));
 	}
 
 	PrintItemInfo(item);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -58,6 +58,7 @@ bool ShowUniqueItemInfoBox;
 CornerStoneStruct CornerStone;
 bool UniqueItemFlags[128];
 int MaxGold = GOLD_MAX_LIMIT;
+bool showItemBaseStats = false;
 
 /** Maps from item_cursor_graphic to in-memory item type. */
 int8_t ItemCAnimTbl[] = {
@@ -4110,7 +4111,7 @@ void PrintItemDetails(const Item &item)
 	}
 	if (item._iClass == ICLASS_ARMOR) {
 		int realAC = item._iAC;
-		if (item._iIdentified) {
+		if (!showItemBaseStats && item._iIdentified) {
 			realAC += GetBonusAC(item);
 		}
 		if (item._iMaxDur == DUR_INDESTRUCTIBLE)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4109,10 +4109,14 @@ void PrintItemDetails(const Item &item)
 		}
 	}
 	if (item._iClass == ICLASS_ARMOR) {
+		int realAC = item._iAC;
+		if (item._iIdentified) {
+			realAC += GetBonusAC(item);
+		}
 		if (item._iMaxDur == DUR_INDESTRUCTIBLE)
-			AddInfoBoxString(fmt::format(fmt::runtime(_("armor: {:d}  Indestructible")), item._iAC));
+			AddInfoBoxString(fmt::format(fmt::runtime(_("armor: {:d}  Indestructible")), realAC));
 		else
-			AddInfoBoxString(fmt::format(fmt::runtime(_(/* TRANSLATORS: Dur: is durability */ "armor: {:d}  Dur: {:d}/{:d}")), item._iAC, item._iDurability, item._iMaxDur));
+			AddInfoBoxString(fmt::format(fmt::runtime(_(/* TRANSLATORS: Dur: is durability */ "armor: {:d}  Dur: {:d}/{:d}")), realAC, item._iDurability, item._iMaxDur));
 	}
 	if (item._iMiscId == IMISC_STAFF && item._iMaxCharges != 0) {
 		AddInfoBoxString(fmt::format(fmt::runtime(_("Charges: {:d}/{:d}")), item._iCharges, item._iMaxCharges));

--- a/Source/items.h
+++ b/Source/items.h
@@ -15,6 +15,7 @@
 #include "engine/point.hpp"
 #include "itemdat.h"
 #include "monster.h"
+#include "utils/math.h"
 #include "utils/string_or_view.hpp"
 
 namespace devilution {
@@ -418,6 +419,33 @@ struct Item {
 	[[nodiscard]] bool keyAttributesMatch(uint32_t seed, _item_indexes itemIndex, uint16_t createInfo) const
 	{
 		return _iSeed == seed && IDidx == itemIndex && _iCreateInfo == createInfo;
+	}
+
+	int getBonusAC() const
+	{
+		if (_iPLAC != 0) {
+			int tempAc = _iAC;
+			tempAc *= _iPLAC;
+			tempAc /= 100;
+			if (tempAc == 0)
+				tempAc = math::Sign(_iPLAC);
+			return tempAc;
+		}
+
+		return 0;
+	}
+
+	std::pair<int, int> getFinalDamage(bool baseDamage) const
+	{
+		int minDmg = _iMinDam;
+		int maxDmg = _iMaxDam;
+		if (!baseDamage) {
+			minDmg += minDmg * _iPLDam / 100;
+			maxDmg += maxDmg * _iPLDam / 100;
+			minDmg += _iPLDamMod;
+			maxDmg += _iPLDamMod;
+		}
+		return { minDmg, maxDmg };
 	}
 
 	UiFlags getTextColor() const

--- a/Source/items.h
+++ b/Source/items.h
@@ -544,7 +544,6 @@ bool DoOil(Player &player, int cii);
 [[nodiscard]] StringOrView PrintItemPower(char plidx, const Item &item);
 void DrawUniqueInfo(const Surface &out);
 void PrintItemDetails(const Item &item);
-void PrintItemDur(const Item &item);
 void UseItem(Player &player, item_misc_id Mid, SpellID spellID, int spellFrom);
 bool UseItemOpensHive(const Item &item, Point position);
 bool UseItemOpensGrave(const Item &item, Point position);

--- a/Source/items.h
+++ b/Source/items.h
@@ -483,6 +483,7 @@ extern int8_t dItem[MAXDUNX][MAXDUNY];
 extern bool ShowUniqueItemInfoBox;
 extern CornerStoneStruct CornerStone;
 extern DVL_API_FOR_TEST bool UniqueItemFlags[128];
+extern bool showItemBaseStats;
 
 uint8_t GetOutlineColor(const Item &item, bool checkReq);
 bool IsItemAvailable(int i);

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -447,11 +447,7 @@ uint16_t CheckStashHLight(Point mousePosition)
 
 	InfoColor = item.getTextColor();
 	InfoString = item.getName();
-	if (item._iIdentified) {
-		PrintItemDetails(item);
-	} else {
-		PrintItemDur(item);
-	}
+	PrintItemDetails(item);
 
 	return itemId;
 }

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -308,8 +308,7 @@ void PrintStoreItem(const Item &item, int l, UiFlags flags, bool cursIndent = fa
 		if (item._iClass == ICLASS_WEAPON) {
 			std::pair<int, int> realDamage = item.getFinalDamage(showItemBaseStats || !item._iIdentified);
 			productLine = fmt::format(fmt::runtime(_("Damage: {:d}-{:d}  ")), realDamage.first, realDamage.second);
-		}
-		else if (item._iClass == ICLASS_ARMOR) {
+		} else if (item._iClass == ICLASS_ARMOR) {
 			int realAC = item._iAC;
 			if (!showItemBaseStats && item._iIdentified) {
 				realAC += item.getBonusAC();

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -305,10 +305,17 @@ void PrintStoreItem(const Item &item, int l, UiFlags flags, bool cursIndent = fa
 	}
 
 	if (item._itype != ItemType::Misc) {
-		if (item._iClass == ICLASS_WEAPON)
-			productLine = fmt::format(fmt::runtime(_("Damage: {:d}-{:d}  ")), item._iMinDam, item._iMaxDam);
-		else if (item._iClass == ICLASS_ARMOR)
-			productLine = fmt::format(fmt::runtime(_("Armor: {:d}  ")), item._iAC);
+		if (item._iClass == ICLASS_WEAPON) {
+			std::pair<int, int> realDamage = item.getFinalDamage(showItemBaseStats || !item._iIdentified);
+			productLine = fmt::format(fmt::runtime(_("Damage: {:d}-{:d}  ")), realDamage.first, realDamage.second);
+		}
+		else if (item._iClass == ICLASS_ARMOR) {
+			int realAC = item._iAC;
+			if (!showItemBaseStats && item._iIdentified) {
+				realAC += item.getBonusAC();
+			}
+			productLine = fmt::format(fmt::runtime(_("Armor: {:d}  ")), realAC);
+		}
 		if (item._iMaxDur != DUR_INDESTRUCTIBLE && item._iMaxDur != 0)
 			productLine += fmt::format(fmt::runtime(_("Dur: {:d}/{:d}")), item._iDurability, item._iMaxDur);
 		else


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/fd0e812e-2b00-4720-8511-f94a8695f35a)
![image](https://github.com/user-attachments/assets/984cea36-6a19-4c6e-831b-1f661a9bb1df)

After:
![image](https://github.com/user-attachments/assets/d8e13201-6872-4802-805f-03666f230bc7)
![image](https://github.com/user-attachments/assets/d8b3949d-af77-46bd-bbbb-03c471db9a44)

Added a hotkey for seeing base stats (dunno why but it's there) - left ctrl by default