### PR TITLE
Fix RenderClxOutline OOB Draw

### DIFF
--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -144,7 +144,7 @@ bool SetHardwareCursorFromSprite(int pcurs)
 	constexpr std::uint8_t TransparentColor = 1;
 	SDL_FillRect(out.surface, nullptr, TransparentColor);
 	SDL_SetColorKey(out.surface, 1, TransparentColor);
-	DrawSoftwareCursor(out, { outlineWidth, size.height - outlineWidth }, pcurs);
+	DrawSoftwareCursor(out, { outlineWidth, size.height - outlineWidth - 1 }, pcurs);
 
 	const bool result = SetHardwareCursorFromSurface(
 	    out.surface, isItem ? HotpointPosition::Center : HotpointPosition::TopLeft);


### PR DESCRIPTION
Credit to @StephenCWills

>Maybe we're not drawing the item CEL in the right spot. Actually.. that might be exactly what the problem is.
If the graphic is 84 pixels tall, and you draw it with the top-left corner at (0,0), then you'd expect it to place pixels between y-coordinates 0 and 83 inclusive.
But CELs draw from the bottom-left. So drawing at (1,85) suggests you assume it won't be including y-coordinate 85, but that doesn't make sense. It would probably then occupy y-coordinates between 2 and 85, not 1 and 84.

