### PR TITLE
Fix bounds check in RenderClxOutline()

### DIFF
--- a/Source/engine/render/clx_render.cpp
+++ b/Source/engine/render/clx_render.cpp
@@ -405,8 +405,8 @@ void RenderClxOutline(const Surface &out, Point position, ClxSprite sprite, uint
 	UpdateOutlinePixelsCache<SkipColorIndexZero>(sprite);
 	--position.x;
 	position.y -= sprite.height();
-	if (position.x >= 0 && position.x + sprite.width() < out.w()
-	    && position.y >= 0 && position.y + sprite.height() < out.h()) {
+	if (position.x >= 0 && position.x + sprite.width() + 2 < out.w()
+	    && position.y >= 0 && position.y + sprite.height() + 2 < out.h()) {
 		for (const auto &[x, y] : OutlinePixelsCache.outlinePixels) {
 			*out.at(position.x + x, position.y + y) = color;
 		}


### PR DESCRIPTION
Follow-up to #7429 

I noticed yesterday that the bounds check here wasn't including the extra space around the sprite in which the outline would be rendered. That's part of the reason we encountered an OOB instead of falling through to the `else` clause which would have done the bounds check inside the `for` loop.