### PR TITLE
Remove Adria Refill

### DIFF
--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -117,7 +117,6 @@ struct {
 	bool autoElixirPickup = false;
 	bool autoOilPickup = false;
 	bool autoPickupInTown = false;
-	bool adriaRefillsMana = false;
 	bool autoEquipWeapons = false;
 	bool autoEquipArmor = false;
 	bool autoEquipHelms = false;
@@ -156,7 +155,6 @@ void ReadSettings(FILE *in, uint8_t version) // NOLINT(readability-identifier-le
 		DemoSettings.autoElixirPickup = ReadByte(in) != 0;
 		DemoSettings.autoOilPickup = ReadByte(in) != 0;
 		DemoSettings.autoPickupInTown = ReadByte(in) != 0;
-		DemoSettings.adriaRefillsMana = ReadByte(in) != 0;
 		DemoSettings.autoEquipWeapons = ReadByte(in) != 0;
 		DemoSettings.autoEquipArmor = ReadByte(in) != 0;
 		DemoSettings.autoEquipHelms = ReadByte(in) != 0;
@@ -185,7 +183,6 @@ void ReadSettings(FILE *in, uint8_t version) // NOLINT(readability-identifier-le
 	         { _("Auto Elixir Pickup"), DemoSettings.autoGoldPickup },
 	         { _("Auto Oil Pickup"), DemoSettings.autoOilPickup },
 	         { _("Auto Pickup in Town"), DemoSettings.autoPickupInTown },
-	         { _("Adria Refills Mana"), DemoSettings.adriaRefillsMana },
 	         { _("Auto Equip Weapons"), DemoSettings.autoEquipWeapons },
 	         { _("Auto Equip Armor"), DemoSettings.autoEquipArmor },
 	         { _("Auto Equip Helms"), DemoSettings.autoEquipHelms },
@@ -220,7 +217,6 @@ void WriteSettings(FILE *out)
 	WriteByte(out, static_cast<uint8_t>(*sgOptions.Gameplay.autoElixirPickup));
 	WriteByte(out, static_cast<uint8_t>(*sgOptions.Gameplay.autoOilPickup));
 	WriteByte(out, static_cast<uint8_t>(*sgOptions.Gameplay.autoPickupInTown));
-	WriteByte(out, static_cast<uint8_t>(*sgOptions.Gameplay.adriaRefillsMana));
 	WriteByte(out, static_cast<uint8_t>(*sgOptions.Gameplay.autoEquipWeapons));
 	WriteByte(out, static_cast<uint8_t>(*sgOptions.Gameplay.autoEquipArmor));
 	WriteByte(out, static_cast<uint8_t>(*sgOptions.Gameplay.autoEquipHelms));
@@ -607,7 +603,6 @@ void OverrideOptions()
 	sgOptions.Gameplay.autoElixirPickup.SetValue(DemoSettings.autoElixirPickup);
 	sgOptions.Gameplay.autoOilPickup.SetValue(DemoSettings.autoOilPickup);
 	sgOptions.Gameplay.autoPickupInTown.SetValue(DemoSettings.autoPickupInTown);
-	sgOptions.Gameplay.adriaRefillsMana.SetValue(DemoSettings.adriaRefillsMana);
 	sgOptions.Gameplay.autoEquipWeapons.SetValue(DemoSettings.autoEquipWeapons);
 	sgOptions.Gameplay.autoEquipArmor.SetValue(DemoSettings.autoEquipArmor);
 	sgOptions.Gameplay.autoEquipHelms.SetValue(DemoSettings.autoEquipHelms);

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1060,7 +1060,6 @@ GameplayOptions::GameplayOptions()
     , autoElixirPickup("Auto Elixir Pickup", OptionEntryFlags::None, N_("Auto Elixir Pickup"), N_("Elixirs are automatically collected when in close proximity to the player."), false)
     , autoOilPickup("Auto Oil Pickup", OptionEntryFlags::OnlyHellfire, N_("Auto Oil Pickup"), N_("Oils are automatically collected when in close proximity to the player."), false)
     , autoPickupInTown("Auto Pickup in Town", OptionEntryFlags::None, N_("Auto Pickup in Town"), N_("Automatically pickup items in town."), false)
-    , adriaRefillsMana("Adria Refills Mana", OptionEntryFlags::None, N_("Adria Refills Mana"), N_("Adria will refill your mana when you visit her shop."), false)
     , autoEquipWeapons("Auto Equip Weapons", OptionEntryFlags::None, N_("Auto Equip Weapons"), N_("Weapons will be automatically equipped on pickup or purchase if enabled."), true)
     , autoEquipArmor("Auto Equip Armor", OptionEntryFlags::None, N_("Auto Equip Armor"), N_("Armor will be automatically equipped on pickup or purchase if enabled."), false)
     , autoEquipHelms("Auto Equip Helms", OptionEntryFlags::None, N_("Auto Equip Helms"), N_("Helms will be automatically equipped on pickup or purchase if enabled."), false)
@@ -1127,7 +1126,6 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&numFullRejuPotionPickup,
 		&autoPickupInTown,
 		&disableCripplingShrines,
-		&adriaRefillsMana,
 		&grabInput,
 		&pauseOnFocusLoss,
 	};

--- a/Source/options.h
+++ b/Source/options.h
@@ -560,8 +560,6 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryBoolean autoOilPickup;
 	/** @brief Enable or Disable auto-pickup in town */
 	OptionEntryBoolean autoPickupInTown;
-	/** @brief Recover mana when talking to Adria. */
-	OptionEntryBoolean adriaRefillsMana;
 	/** @brief Automatically attempt to equip weapon-type items when picking them up. */
 	OptionEntryBoolean autoEquipWeapons;
 	/** @brief Automatically attempt to equip armor-type items when picking them up. */

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -656,24 +656,8 @@ void StartSmithRepair()
 	AddItemListBackButton();
 }
 
-void FillManaPlayer()
-{
-	if (!*sgOptions.Gameplay.adriaRefillsMana)
-		return;
-
-	Player &myPlayer = *MyPlayer;
-
-	if (myPlayer._pMana != myPlayer._pMaxMana) {
-		PlaySFX(SfxID::CastHealing);
-	}
-	myPlayer._pMana = myPlayer._pMaxMana;
-	myPlayer._pManaBase = myPlayer._pMaxManaBase;
-	RedrawComponent(PanelDrawComponent::Mana);
-}
-
 void StartWitch()
 {
-	FillManaPlayer();
 	IsTextFullSize = false;
 	HasScrollbar = false;
 	AddSText(0, 2, _("Witch's shack"), UiFlags::ColorWhitegold | UiFlags::AlignCenter, false);


### PR DESCRIPTION
This removes the QOL option to have Adria refill your Mana when speaking to her.

**Rationale:** This QOL option has a direct impact on game balance with a greater emphasis on very early game progress. Despite being quite convenient and a cool feature on it's own, this offers a resource to the player for free when it would normally cost the player 150 gold pieces. Pepin's Auto Life refill doesn't impact game balance because the feature for restoring life already exists; it's just made to be automatic rather than requiring the extra click. I believe Adria's refill could be comparable to if Cain identified the first item for free, or Wirt showed his item for free, which would all be methods of saving the player gold for things in town that normally cost gold pieces.