### PR TITLE
Screenshotting: Use `SDL_RWops` throughout

### DIFF
--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -34,7 +34,7 @@
 namespace devilution {
 namespace {
 
-FILE *CaptureFile(std::string *dstPath)
+SDL_RWops *CaptureFile(std::string *dstPath)
 {
 	const char *ext =
 #if DEVILUTIONX_SCREENSHOT_FORMAT == DEVILUTIONX_SCREENSHOT_FORMAT_PCX
@@ -54,7 +54,7 @@ FILE *CaptureFile(std::string *dstPath)
 		i++;
 		*dstPath = StrCat(paths::PrefPath(), filename, "-", i, ext);
 	}
-	return OpenFile(dstPath->c_str(), "wb");
+	return SDL_RWFromFile(dstPath->c_str(), "wb");
 }
 
 /**
@@ -79,9 +79,10 @@ void CaptureScreen()
 	std::string fileName;
 	const uint32_t startTime = SDL_GetTicks();
 
-	FILE *outStream = CaptureFile(&fileName);
+	SDL_RWops *outStream = CaptureFile(&fileName);
 	if (outStream == nullptr) {
-		LogError("Failed to open {} for writing: {}", fileName, std::strerror(errno));
+		LogError("Failed to open {} for writing: {}", fileName, SDL_GetError());
+		SDL_ClearError();
 		return;
 	}
 	DrawAndBlit();

--- a/Source/utils/surface_to_pcx.hpp
+++ b/Source/utils/surface_to_pcx.hpp
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <string>
 
+#include <SDL.h>
 #include <expected.hpp>
 
 #include "engine/surface.hpp"
@@ -8,6 +9,6 @@
 namespace devilution {
 
 tl::expected<void, std::string>
-WriteSurfaceToFilePcx(const Surface &buf, FILE *outStream);
+WriteSurfaceToFilePcx(const Surface &buf, SDL_RWops *outStream);
 
 } // namespace devilution

--- a/Source/utils/surface_to_png.cpp
+++ b/Source/utils/surface_to_png.cpp
@@ -13,10 +13,9 @@ namespace devilution {
 extern "C" int IMG_SavePNG_RW(SDL_Surface *surface, SDL_RWops *dst, int freedst);
 
 tl::expected<void, std::string>
-WriteSurfaceToFilePng(const Surface &buf, FILE *outStream)
+WriteSurfaceToFilePng(const Surface &buf, SDL_RWops *dst)
 {
-	SDL_RWops *rwops = SDL_RWFromFP(outStream, /*autoclose=*/SDL_TRUE);
-	if (rwops == nullptr || IMG_SavePNG_RW(buf.surface, rwops, /*freedst=*/1) != 0) {
+	if (IMG_SavePNG_RW(buf.surface, dst, /*freedst=*/1) != 0) {
 		tl::expected<void, std::string> result = tl::make_unexpected(std::string(SDL_GetError()));
 		SDL_ClearError();
 		return result;

--- a/Source/utils/surface_to_png.hpp
+++ b/Source/utils/surface_to_png.hpp
@@ -1,13 +1,19 @@
 #include <cstdio>
 #include <string>
 
+#include <SDL.h>
 #include <expected.hpp>
 
 #include "engine/surface.hpp"
 
 namespace devilution {
 
+/**
+ * @brief Writes the given surface to `dst` as PNG.
+ *
+ * Takes ownership of `dst` and closes it when done.
+ */
 tl::expected<void, std::string>
-WriteSurfaceToFilePng(const Surface &buf, FILE *outStream);
+WriteSurfaceToFilePng(const Surface &buf, SDL_RWops *dst);
 
 } // namespace devilution


### PR DESCRIPTION
Turns out `SDL_RWFromFP` isn't implemented in SDL for mingw.

Follow-up to #7176