### PR TITLE
Remove special case when auto-placing 2x2 items

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1297,18 +1297,10 @@ bool AutoPlaceItemInInventory(Player &player, const Item &item, bool persistItem
 	}
 
 	if (itemSize.height == 2) {
-		for (int x = 10 - itemSize.width; x >= 0; x -= itemSize.width) {
+		for (int x = 10 - itemSize.width; x >= 0; x--) {
 			for (int y = 0; y < 3; y++) {
 				if (AutoPlaceItemInInventorySlot(player, 10 * y + x, item, persistItem, sendNetworkMessage))
 					return true;
-			}
-		}
-		if (itemSize.width == 2) {
-			for (int x = 7; x >= 0; x -= 2) {
-				for (int y = 0; y < 3; y++) {
-					if (AutoPlaceItemInInventorySlot(player, 10 * y + x, item, persistItem, sendNetworkMessage))
-						return true;
-				}
 			}
 		}
 		return false;


### PR DESCRIPTION
With this change 2x2 items are placed from the right in a similar fashion to 2x3 items (the search progresses across the inventory one column at a time instead of checking even columns then odd columns).

Relates to #7028 