### PR TITLE
Hide Upscale option in Settings menu

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -58,12 +58,6 @@ namespace devilution {
 
 namespace {
 
-#if defined(__ANDROID__) || defined(__APPLE__)
-constexpr OptionEntryFlags OnlyIfNoImplicitRenderer = OptionEntryFlags::Invisible;
-#else
-constexpr OptionEntryFlags OnlyIfNoImplicitRenderer = OptionEntryFlags::None;
-#endif
-
 #if defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
 constexpr OptionEntryFlags OnlyIfSupportsWindowed = OptionEntryFlags::Invisible;
 #else
@@ -953,7 +947,7 @@ GraphicsOptions::GraphicsOptions()
     , fitToScreen("Fit to Screen", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::RecreateUI, N_("Fit to Screen"), N_("Automatically adjust the game window to your current desktop screen aspect ratio and resolution."), true)
 #endif
 #ifndef USE_SDL1
-    , upscale("Upscale", OnlyIfNoImplicitRenderer | OptionEntryFlags::CantChangeInGame | OptionEntryFlags::RecreateUI, N_("Upscale"), N_("Enables image scaling from the game resolution to your monitor resolution. Prevents changing the monitor resolution and allows window resizing."),
+    , upscale("Upscale", OptionEntryFlags::Invisible | OptionEntryFlags::CantChangeInGame | OptionEntryFlags::RecreateUI, N_("Upscale"), N_("Enables image scaling from the game resolution to your monitor resolution. Prevents changing the monitor resolution and allows window resizing."),
 #ifdef NXDK
           false
 #else
@@ -1000,7 +994,6 @@ GraphicsOptions::GraphicsOptions()
 	fitToScreen.SetValueChangedCallback(ResizeWindowAndUpdateResolutionOptions);
 #endif
 #ifndef USE_SDL1
-	upscale.SetValueChangedCallback(ResizeWindowAndUpdateResolutionOptions);
 	scaleQuality.SetValueChangedCallback(ReinitializeTexture);
 	integerScaling.SetValueChangedCallback(ReinitializeIntegerScale);
 	vSync.SetValueChangedCallback(ReinitializeRenderer);

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -110,12 +110,10 @@ void FreeRenderer()
 {
 #if defined(_WIN32) && !defined(NXDK)
 	bool wasD3D9 = false;
-	bool wasD3D11 = false;
 	if (renderer != nullptr) {
 		SDL_RendererInfo previousRendererInfo;
 		SDL_GetRendererInfo(renderer, &previousRendererInfo);
 		wasD3D9 = (std::string_view(previousRendererInfo.name) == "direct3d");
-		wasD3D11 = (std::string_view(previousRendererInfo.name) == "direct3d11");
 	}
 #endif
 
@@ -126,8 +124,7 @@ void FreeRenderer()
 
 #if defined(_WIN32) && !defined(NXDK)
 	// On Windows 11 the directx9 VSYNC timer doesn't get recreated properly, see https://github.com/libsdl-org/SDL/issues/5099
-	// Furthermore, the direct3d11 driver "poisons" the window so it can't be used by another renderer
-	if ((wasD3D9 && *sgOptions.Graphics.upscale && *sgOptions.Graphics.vSync) || (wasD3D11 && !*sgOptions.Graphics.upscale)) {
+	if (wasD3D9 && *sgOptions.Graphics.upscale && *sgOptions.Graphics.vSync) {
 		std::string title = SDL_GetWindowTitle(ghMainWnd);
 		Uint32 flags = SDL_GetWindowFlags(ghMainWnd);
 		Rectangle dimensions;


### PR DESCRIPTION
This is perhaps the easiest option to address the ever-increasing number of platforms that crash when toggling this setting. SDL just doesn't want us to do it.

This resolves #4421
This resolves #5168
This resolves #6387