### PR TITLE
Replaces uses of doubles with floats

### DIFF
--- a/Source/controls/touch/gamepad.cpp
+++ b/Source/controls/touch/gamepad.cpp
@@ -12,40 +12,40 @@ VirtualGamepad VirtualGamepadState;
 
 namespace {
 
-constexpr double Pi = 3.141592653589793;
+constexpr float Pi = 3.141592653589793F;
 
-int roundToInt(double value)
+int roundToInt(float value)
 {
 	return static_cast<int>(round(value));
 }
 
-constexpr bool PointsUp(double angle)
+constexpr bool PointsUp(float angle)
 {
-	constexpr double UpAngle = Pi / 2;
-	constexpr double MinAngle = UpAngle - 3 * Pi / 8;
-	constexpr double MaxAngle = UpAngle + 3 * Pi / 8;
+	constexpr float UpAngle = Pi / 2;
+	constexpr float MinAngle = UpAngle - 3 * Pi / 8;
+	constexpr float MaxAngle = UpAngle + 3 * Pi / 8;
 	return MinAngle <= angle && angle <= MaxAngle;
 }
 
-constexpr bool PointsDown(double angle)
+constexpr bool PointsDown(float angle)
 {
-	constexpr double DownAngle = -Pi / 2;
-	constexpr double MinAngle = DownAngle - 3 * Pi / 8;
-	constexpr double MaxAngle = DownAngle + 3 * Pi / 8;
+	constexpr float DownAngle = -Pi / 2;
+	constexpr float MinAngle = DownAngle - 3 * Pi / 8;
+	constexpr float MaxAngle = DownAngle + 3 * Pi / 8;
 	return MinAngle <= angle && angle <= MaxAngle;
 }
 
-constexpr bool PointsLeft(double angle)
+constexpr bool PointsLeft(float angle)
 {
-	constexpr double MaxAngle = Pi - 3 * Pi / 8;
-	constexpr double MinAngle = -Pi + 3 * Pi / 8;
+	constexpr float MaxAngle = Pi - 3 * Pi / 8;
+	constexpr float MinAngle = -Pi + 3 * Pi / 8;
 	return !(MinAngle < angle && angle < MaxAngle);
 }
 
-constexpr bool PointsRight(double angle)
+constexpr bool PointsRight(float angle)
 {
-	constexpr double MinAngle = -3 * Pi / 8;
-	constexpr double MaxAngle = 3 * Pi / 8;
+	constexpr float MinAngle = -3 * Pi / 8;
+	constexpr float MaxAngle = 3 * Pi / 8;
 	return MinAngle <= angle && angle <= MaxAngle;
 }
 
@@ -227,14 +227,14 @@ void VirtualDirectionPad::UpdatePosition(Point touchCoordinates)
 	if (!area.contains(position)) {
 		int x = diff.deltaX;
 		int y = diff.deltaY;
-		double dist = sqrt(x * x + y * y);
+		float dist = sqrt(x * x + y * y);
 		x = roundToInt(x * area.radius / dist);
 		y = roundToInt(y * area.radius / dist);
 		position.x = area.position.x + x;
 		position.y = area.position.y + y;
 	}
 
-	double angle = atan2(-diff.deltaY, diff.deltaX);
+	float angle = atan2(-diff.deltaY, diff.deltaX);
 
 	isUpPressed = PointsUp(angle);
 	isDownPressed = PointsDown(angle);

--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -184,12 +184,12 @@ void palette_update(int first, int ncolor)
 
 void ApplyGamma(std::array<SDL_Color, 256> &dst, const std::array<SDL_Color, 256> &src, int n)
 {
-	double g = *sgOptions.Graphics.gammaCorrection / 100.0;
+	float g = *sgOptions.Graphics.gammaCorrection / 100.0F;
 
 	for (int i = 0; i < n; i++) {
-		dst[i].r = static_cast<Uint8>(pow(src[i].r / 256.0, g) * 256.0);
-		dst[i].g = static_cast<Uint8>(pow(src[i].g / 256.0, g) * 256.0);
-		dst[i].b = static_cast<Uint8>(pow(src[i].b / 256.0, g) * 256.0);
+		dst[i].r = static_cast<Uint8>(pow(src[i].r / 256.0F, g) * 256.0F);
+		dst[i].g = static_cast<Uint8>(pow(src[i].g / 256.0F, g) * 256.0F);
+		dst[i].b = static_cast<Uint8>(pow(src[i].b / 256.0F, g) * 256.0F);
 	}
 	RedrawEverything();
 }

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -832,7 +832,7 @@ void DiabloDeath(Monster &diablo, bool sendmsg)
 		dist = 20;
 	diablo.var3 = ViewPosition.x << 16;
 	diablo.position.temp.x = ViewPosition.y << 16;
-	diablo.position.temp.y = (int)((diablo.var3 - (diablo.position.tile.x << 16)) / (double)dist);
+	diablo.position.temp.y = (int)((diablo.var3 - (diablo.position.tile.x << 16)) / (float)dist);
 	if (!gbIsMultiplayer) {
 		Player &myPlayer = *MyPlayer;
 		myPlayer.pDiabloKillLevel = std::max(myPlayer.pDiabloKillLevel, static_cast<uint8_t>(sgGameInitInfo.nDifficulty + 1));

--- a/Source/utils/sdl2_to_1_2_backports.cpp
+++ b/Source/utils/sdl2_to_1_2_backports.cpp
@@ -341,10 +341,10 @@ int SDL_BlitScaled(SDL_Surface *src, SDL_Rect *srcrect,
 		return SDL_BlitSurface(src, srcrect, dst, dstrect);
 	}
 
-	double src_x0, src_y0, src_x1, src_y1;
-	double dst_x0, dst_y0, dst_x1, dst_y1;
+	float src_x0, src_y0, src_x1, src_y1;
+	float dst_x0, dst_y0, dst_x1, dst_y1;
 	SDL_Rect final_src, final_dst;
-	double scaling_w, scaling_h;
+	float scaling_w, scaling_h;
 	int src_w, src_h;
 	int dst_w, dst_h;
 
@@ -379,8 +379,8 @@ int SDL_BlitScaled(SDL_Surface *src, SDL_Rect *srcrect,
 		return SDL_BlitSurface(src, srcrect, dst, dstrect);
 	}
 
-	scaling_w = (double)dst_w / src_w;
-	scaling_h = (double)dst_h / src_h;
+	scaling_w = (float)dst_w / src_w;
+	scaling_h = (float)dst_h / src_h;
 
 	if (NULL == dstrect) {
 		dst_x0 = 0;


### PR DESCRIPTION
Looks like the KallistiOS Dreamcast SDK disables double support by default: https://github.com/KallistiOS/KallistiOS/blob/495e77fd60d5b09a1ad52a26cd4a7e73cd0d9d51/environ_dreamcast.sh#L16

We don't really need doubles in this code.

The one place where we might have needed them is the SMK video decoder, handled in a separate PR (#7454).

/cc @azihassan I'm not entirely sure but perhaps this will help with https://github.com/azihassan/devilutionX/issues/8