### PR TITLE
Remove CheckCheatStats()

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2522,10 +2522,10 @@ void CalcPlrPrimaryStats(Player &player, int strength, int &magic, int dexterity
 		vitality -= 2 * playerLevel;
 	}
 
-	player._pStrength = std::max(0, strength + player._pBaseStr);
-	player._pMagic = std::max(0, magic + player._pBaseMag);
-	player._pDexterity = std::max(0, dexterity + player._pBaseDex);
-	player._pVitality = std::max(0, vitality + player._pBaseVit);
+	player._pStrength = std::clamp(strength + player._pBaseStr, 0, 750);
+	player._pMagic = std::clamp(magic + player._pBaseMag, 0, 750);
+	player._pDexterity = std::clamp(dexterity + player._pBaseDex, 0, 750);
+	player._pVitality = std::clamp(vitality + player._pBaseVit, 0, 750);
 }
 
 void CalcPlrLightRadius(Player &player, int lrad)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1458,33 +1458,6 @@ void ValidatePlayer()
 	myPlayer._pInfraFlag = false;
 }
 
-void CheckCheatStats(Player &player)
-{
-	if (player._pStrength > 750) {
-		player._pStrength = 750;
-	}
-
-	if (player._pDexterity > 750) {
-		player._pDexterity = 750;
-	}
-
-	if (player._pMagic > 750) {
-		player._pMagic = 750;
-	}
-
-	if (player._pVitality > 750) {
-		player._pVitality = 750;
-	}
-
-	if (player._pHitPoints > 128000) {
-		player._pHitPoints = 128000;
-	}
-
-	if (player._pMana > 128000) {
-		player._pMana = 128000;
-	}
-}
-
 HeroClass GetPlayerSpriteClass(HeroClass cls)
 {
 	if (cls == HeroClass::Bard && !gbBard)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2947,8 +2947,6 @@ void ProcessPlayers()
 	for (size_t pnum = 0; pnum < Players.size(); pnum++) {
 		Player &player = Players[pnum];
 		if (player.plractive && player.isOnActiveLevel() && (&player == MyPlayer || !player._pLvlChanging)) {
-			CheckCheatStats(player);
-
 			if (!PlrDeathModeOK(player) && (player._pHitPoints >> 6) <= 0) {
 				SyncPlrKill(player, DeathReason::Unknown);
 			}


### PR DESCRIPTION
This function is an unnecessary burden for the game to keep checking every frame if the current stats are valid. Instead we should clamp them when there's an item change.

This won't prevent players from cheating via memory editing their stats to the degree `CheckCheatStats()` would, however we have validation code for this sort of cheating to prevent cheaters from playing with others.

Life and Mana clamp exists in https://github.com/diasurgical/devilutionX/pull/5777