### PR TITLE
Remove stash gold sharing

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -396,15 +396,10 @@ void ScrollSmithBuy(int idx)
 	ScrollVendorStore(SmithItems, static_cast<int>(std::size(SmithItems)), idx);
 }
 
-uint32_t TotalPlayerGold()
-{
-	return MyPlayer->_pGold + Stash.gold;
-}
-
 // TODO: Change `_iIvalue` to be unsigned instead of passing `int` here.
 bool PlayerCanAfford(int price)
 {
-	return TotalPlayerGold() >= static_cast<uint32_t>(price);
+	return MyPlayer->_pGold >= static_cast<uint32_t>(price);
 }
 
 void StartSmithBuy()
@@ -2404,7 +2399,7 @@ void DrawSText(const Surface &out)
 	}
 
 	if (RenderGold) {
-		PrintSString(out, 28, 1, fmt::format(fmt::runtime(_("Your gold: {:s}")), FormatInteger(TotalPlayerGold())).c_str(), UiFlags::ColorWhitegold | UiFlags::AlignRight);
+		PrintSString(out, 28, 1, fmt::format(fmt::runtime(_("Your gold: {:s}")), FormatInteger(MyPlayer->_pGold)).c_str(), UiFlags::ColorWhitegold | UiFlags::AlignRight);
 	}
 
 	if (HasScrollbar)


### PR DESCRIPTION
Prevents utilizing stash gold while at towner stores.

**Justification:**
- Players may want to utilize stash with some characters, but not others (purist playthroughs, ironman, etc.)
- Players not on Linux/PC may have difficulty moving around files to prevent some characters from utilizing stash gold
- Utilizing stash gold may feel a bit "immersion breaking", as they are summoning their wealth through the veil (I don't feel as strongly about this argument as the others)
- Players may generally just want a degree of separation between their characters
- This change places more usefulness on the Auric Amulet
- This change places more usefulness on the general stash feature of withdrawing gold, making the game feel more interactive in the sense of town interactions
- While the immediate reaction may be negative due to players generally never being in favor of being inconvenienced, the impact of quite a change is low, and players are still at a much greater convenience than when they played Diablo prior to a stash being introduced (In fact, stash mods for vanilla did not even have this feature)
- Stash gold sharing may make a better candidate for a Lua mod going forward, as this feature proves to be annoying as much as it is beneficial, and adding more special cases and toggles doesn't seem like the right step forward.