### PR TITLE
Prevent PlaceUniqueMonster() loop from finding random location for quest monsters with a set position

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -333,101 +333,87 @@ size_t GetMonsterTypeIndex(_monster_id type)
 	return LevelMonsterTypeCount;
 }
 
-void PlaceUniqueMonst(UniqueMonsterType uniqindex, size_t minionType, int bosspacksize)
+Point GetUniqueMonstPosition(UniqueMonsterType uniqindex)
 {
-	Monster &monster = Monsters[ActiveMonsterCount];
-	const auto &uniqueMonsterData = UniqueMonstersData[static_cast<size_t>(uniqindex)];
-
-	Point position;
-	bool hasPredefinedPosition = true;
+	if (setlevel) {
+		switch (uniqindex) {
+		case UniqueMonsterType::Lazarus:
+			return { 32, 46 };
+		case UniqueMonsterType::RedVex:
+			return { 40, 45 };
+		case UniqueMonsterType::BlackJade:
+			return { 38, 49 };
+		case UniqueMonsterType::SkeletonKing:
+			return { 35, 47 };
+		default:
+			break;
+		}
+	}
 
 	switch (uniqindex) {
 	case UniqueMonsterType::SnotSpill:
-		position = SetPiece.position.megaToWorld() + Displacement { 8, 12 };
-		break;
+		return SetPiece.position.megaToWorld() + Displacement { 8, 12 };
 	case UniqueMonsterType::WarlordOfBlood:
-		position = SetPiece.position.megaToWorld() + Displacement { 6, 7 };
-		break;
+		return SetPiece.position.megaToWorld() + Displacement { 6, 7 };
 	case UniqueMonsterType::Zhar:
 		for (int i = 0; i < themeCount; i++) {
 			if (i == zharlib) {
-				position = themeLoc[i].room.position.megaToWorld() + Displacement { 4, 4 };
-				break;
+				return themeLoc[i].room.position.megaToWorld() + Displacement { 4, 4 };
 			}
 		}
 		break;
 	case UniqueMonsterType::Lazarus:
-		if (setlevel) {
-			position = { 32, 46 };
-		} else {
-			position = SetPiece.position.megaToWorld() + Displacement { 3, 6 };
-		}
-		break;
+		return SetPiece.position.megaToWorld() + Displacement { 3, 6 };
 	case UniqueMonsterType::RedVex:
-		if (setlevel) {
-			position = { 40, 45 };
-		} else {
-			position = SetPiece.position.megaToWorld() + Displacement { 5, 3 };
-		}
-		break;
+		return SetPiece.position.megaToWorld() + Displacement { 5, 3 };
 	case UniqueMonsterType::BlackJade:
-		if (setlevel) {
-			position = { 38, 49 };
-		} else {
-			position = SetPiece.position.megaToWorld() + Displacement { 5, 9 };
-		}
-		break;
-	case UniqueMonsterType::SkeletonKing:
-		if (setlevel) {
-			position = { 35, 47 };
-		}
-		break;
+		return SetPiece.position.megaToWorld() + Displacement { 5, 9 };
 	case UniqueMonsterType::Butcher:
-		position = SetPiece.position.megaToWorld() + Displacement { 4, 4 };
-		break;
+		return SetPiece.position.megaToWorld() + Displacement { 4, 4 };
 	case UniqueMonsterType::NaKrul:
 		if (UberRow == 0 || UberCol == 0) {
 			UberDiabloMonsterIndex = -1;
-			return;
+			break;
 		}
-		position = { UberRow - 2, UberCol };
 		UberDiabloMonsterIndex = static_cast<int>(ActiveMonsterCount);
-		break;
+		return { UberRow - 2, UberCol };
 	default:
-		hasPredefinedPosition = false;
 		break;
 	}
 
-	if (!hasPredefinedPosition) {
-		int count = 0;
-		while (true) {
-			position = Point { GenerateRnd(80), GenerateRnd(80) } + Displacement { 16, 16 };
-			int count2 = 0;
-			for (int x = position.x - 3; x < position.x + 3; x++) {
-				for (int y = position.y - 3; y < position.y + 3; y++) {
-					if (InDungeonBounds({ x, y }) && CanPlaceMonster({ x, y })) {
-						count2++;
-					}
+	Point position;
+	int count = 0;
+	do {
+		Point position = Point { GenerateRnd(80), GenerateRnd(80) } + Displacement { 16, 16 };
+		int count2 = 0;
+		for (int x = position.x - 3; x < position.x + 3; x++) {
+			for (int y = position.y - 3; y < position.y + 3; y++) {
+				if (InDungeonBounds({ x, y }) && CanPlaceMonster({ x, y })) {
+					count2++;
 				}
-			}
-
-			if (count2 < 9) {
-				count++;
-				if (count < 1000) {
-					continue;
-				}
-			}
-
-			if (CanPlaceMonster(position)) {
-				break;
 			}
 		}
-	}
 
+		if (count2 < 9) {
+			count++;
+			if (count < 1000) {
+				continue;
+			}
+		}
+	} while (!CanPlaceMonster(position));
+
+	return position;
+}
+
+void PlaceUniqueMonst(UniqueMonsterType uniqindex, size_t minionType, int bosspacksize)
+{
+	const auto &uniqueMonsterData = UniqueMonstersData[static_cast<size_t>(uniqindex)];
 	const size_t typeIndex = GetMonsterTypeIndex(uniqueMonsterData.mtype);
+	const Point position = GetUniqueMonstPosition(uniqindex);
 	PlaceMonster(ActiveMonsterCount, typeIndex, position);
-	ActiveMonsterCount++;
 
+	Monster &monster = Monsters[ActiveMonsterCount];
+	ActiveMonsterCount++;
 	PrepareUniqueMonst(monster, uniqindex, minionType, bosspacksize, uniqueMonsterData);
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -338,81 +338,92 @@ void PlaceUniqueMonst(UniqueMonsterType uniqindex, size_t minionType, int bosspa
 	Monster &monster = Monsters[ActiveMonsterCount];
 	const auto &uniqueMonsterData = UniqueMonstersData[static_cast<size_t>(uniqindex)];
 
-	int count = 0;
 	Point position;
-	while (true) {
-		position = Point { GenerateRnd(80), GenerateRnd(80) } + Displacement { 16, 16 };
-		int count2 = 0;
-		for (int x = position.x - 3; x < position.x + 3; x++) {
-			for (int y = position.y - 3; y < position.y + 3; y++) {
-				if (InDungeonBounds({ x, y }) && CanPlaceMonster({ x, y })) {
-					count2++;
-				}
-			}
-		}
+	bool hasPredefinedPosition = true;
 
-		if (count2 < 9) {
-			count++;
-			if (count < 1000) {
-				continue;
-			}
-		}
-
-		if (CanPlaceMonster(position)) {
-			break;
-		}
-	}
-
-	if (uniqindex == UniqueMonsterType::SnotSpill) {
+	switch (uniqindex) {
+	case UniqueMonsterType::SnotSpill:
 		position = SetPiece.position.megaToWorld() + Displacement { 8, 12 };
-	}
-	if (uniqindex == UniqueMonsterType::WarlordOfBlood) {
+		break;
+	case UniqueMonsterType::WarlordOfBlood:
 		position = SetPiece.position.megaToWorld() + Displacement { 6, 7 };
-	}
-	if (uniqindex == UniqueMonsterType::Zhar) {
+		break;
+	case UniqueMonsterType::Zhar:
 		for (int i = 0; i < themeCount; i++) {
 			if (i == zharlib) {
 				position = themeLoc[i].room.position.megaToWorld() + Displacement { 4, 4 };
 				break;
 			}
 		}
-	}
-	if (setlevel) {
-		if (uniqindex == UniqueMonsterType::Lazarus) {
+		break;
+	case UniqueMonsterType::Lazarus:
+		if (setlevel) {
 			position = { 32, 46 };
-		}
-		if (uniqindex == UniqueMonsterType::RedVex) {
-			position = { 40, 45 };
-		}
-		if (uniqindex == UniqueMonsterType::BlackJade) {
-			position = { 38, 49 };
-		}
-		if (uniqindex == UniqueMonsterType::SkeletonKing) {
-			position = { 35, 47 };
-		}
-	} else {
-		if (uniqindex == UniqueMonsterType::Lazarus) {
+		} else {
 			position = SetPiece.position.megaToWorld() + Displacement { 3, 6 };
 		}
-		if (uniqindex == UniqueMonsterType::RedVex) {
+		break;
+	case UniqueMonsterType::RedVex:
+		if (setlevel) {
+			position = { 40, 45 };
+		} else {
 			position = SetPiece.position.megaToWorld() + Displacement { 5, 3 };
 		}
-		if (uniqindex == UniqueMonsterType::BlackJade) {
+		break;
+	case UniqueMonsterType::BlackJade:
+		if (setlevel) {
+			position = { 38, 49 };
+		} else {
 			position = SetPiece.position.megaToWorld() + Displacement { 5, 9 };
 		}
-	}
-	if (uniqindex == UniqueMonsterType::Butcher) {
+		break;
+	case UniqueMonsterType::SkeletonKing:
+		if (setlevel) {
+			position = { 35, 47 };
+		}
+		break;
+	case UniqueMonsterType::Butcher:
 		position = SetPiece.position.megaToWorld() + Displacement { 4, 4 };
-	}
-
-	if (uniqindex == UniqueMonsterType::NaKrul) {
+		break;
+	case UniqueMonsterType::NaKrul:
 		if (UberRow == 0 || UberCol == 0) {
 			UberDiabloMonsterIndex = -1;
 			return;
 		}
 		position = { UberRow - 2, UberCol };
 		UberDiabloMonsterIndex = static_cast<int>(ActiveMonsterCount);
+		break;
+	default:
+		hasPredefinedPosition = false;
+		break;
 	}
+
+	if (!hasPredefinedPosition) {
+		int count = 0;
+		while (true) {
+			position = Point { GenerateRnd(80), GenerateRnd(80) } + Displacement { 16, 16 };
+			int count2 = 0;
+			for (int x = position.x - 3; x < position.x + 3; x++) {
+				for (int y = position.y - 3; y < position.y + 3; y++) {
+					if (InDungeonBounds({ x, y }) && CanPlaceMonster({ x, y })) {
+						count2++;
+					}
+				}
+			}
+
+			if (count2 < 9) {
+				count++;
+				if (count < 1000) {
+					continue;
+				}
+			}
+
+			if (CanPlaceMonster(position)) {
+				break;
+			}
+		}
+	}
+
 	const size_t typeIndex = GetMonsterTypeIndex(uniqueMonsterData.mtype);
 	PlaceMonster(ActiveMonsterCount, typeIndex, position);
 	ActiveMonsterCount++;


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/issues/7463

`PlaceUniqueMonst()` is a function that does what the name suggests, with logic as follows:
1. Find a random valid location to place the unique monster, assigning the chosen valid location to `position`
2. If the monster is a quest unique monster, overwrite `position` with a set location
3. Complete setting up the unique monster data and place it in the map

While this may not be *the* fix for the linked issue report, this does change the order of operations, to prevent running the loop to find a spawn location for monsters that already have a predefined location. Since these quest monsters have a very specific location, typically involving set pieces or set levels, their spawning conditions are predetermined to be valid, and we don't need to run the checks like we do with randomly placed unique monsters. As a result, the infinite loop problem will no longer occur with Lazarus and his minion uniques.

An explanation for the infinite loop where every map tile is considered "Solid" and causes spawning condition checks to fail can be found here: https://github.com/diasurgical/devilutionX/issues/7463#issuecomment-2398606310

The proper solution can be found here: https://github.com/diasurgical/devilutionX/pull/7465