### PR TITLE
Remove CalcPlrStaff()

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1969,7 +1969,7 @@ void ConsumeStaffCharge(Player &player)
 		return;
 
 	staff._iCharges--;
-	CalcPlrStaff(player);
+	CalcPlrInv(player, false);
 }
 
 bool CanUseStaff(Player &player, SpellID spellId)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2892,7 +2892,6 @@ void CalcPlrInv(Player &player, bool loadgfx)
 			item.updateRequiredStatsCacheForPlayer(player);
 		}
 		player.CalcScrolls();
-		CalcPlrStaff(player);
 		if (IsStashOpen) {
 			// If stash is open, ensure the items are displayed correctly
 			Stash.RefreshItemStatFlags();

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3059,16 +3059,6 @@ void MakePlrPath(Player &player, Point targetPosition, bool endspace)
 	player.walkpath[path] = WALK_NONE;
 }
 
-void CalcPlrStaff(Player &player)
-{
-	player._pISpells = 0;
-	if (!player.InvBody[INVLOC_HAND_LEFT].isEmpty()
-	    && player.InvBody[INVLOC_HAND_LEFT]._iStatFlag
-	    && player.InvBody[INVLOC_HAND_LEFT]._iCharges > 0) {
-		player._pISpells |= GetSpellBitmask(player.InvBody[INVLOC_HAND_LEFT]._iSpell);
-	}
-}
-
 void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 {
 	bool addflag = false;

--- a/Source/player.h
+++ b/Source/player.h
@@ -967,7 +967,6 @@ void ProcessPlayers();
 void ClrPlrPath(Player &player);
 bool PosOkPlayer(const Player &player, Point position);
 void MakePlrPath(Player &player, Point targetPosition, bool endspace);
-void CalcPlrStaff(Player &player);
 void CheckPlrSpell(bool isShiftHeld, SpellID spellID = MyPlayer->_pRSpell, SpellType spellType = MyPlayer->_pRSplType);
 void SyncPlrAnim(Player &player);
 void SyncInitPlrPos(Player &player);


### PR DESCRIPTION
This function is duplicate logic of the `CalcPlrItemVals()` logic for staves, which creates the potential for bugs.

`CalcPlrInv()`:
`CalcPlrItemVals()` iterates each equipped item, and accumulates the spell from each item, then writes the bitmask to the Player struct variable that holds staff spells.

`CalcPlrStaff` is then called if player is `myPlayer`, and checks the left hand specifically with some conditions to see if it should add the spell from the staff to the Player struct variable. `CalcPlrStaff()` is also utilized to check if the player should continue having the staff spell after consuming a charge. This PR bypasses the need for that by directly calling `CalcPlrInv()` when consuming a charge, so we consistently call `CalcPlrInv()` any time there is an update in any form to the player's equipped items. This also keeps the logic in one place to avoid discrepancies.