### PR TITLE
Target enemies based on walk progress

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1554,7 +1554,7 @@ size_t OnAttackMonster(const TCmd *pCmd, Player &player)
 	const uint16_t monsterIdx = SDL_SwapLE16(message.wParam1);
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && monsterIdx < MaxMonsters) {
-		Point position = Monsters[monsterIdx].position.future;
+		Point position = GetTargetMonsterPosition(Monsters[monsterIdx], player);
 		if (player.position.tile.WalkingDistance(position) > 1)
 			MakePlrPath(player, position, false);
 		player.destAction = ACTION_ATTACKMON;
@@ -1570,7 +1570,7 @@ size_t OnAttackPlayer(const TCmd *pCmd, Player &player)
 	const uint16_t playerIdx = SDL_SwapLE16(message.wParam1);
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && playerIdx < Players.size()) {
-		MakePlrPath(player, Players[playerIdx].position.future, false);
+		MakePlrPath(player, GetTargetPlayerPosition(Players[playerIdx], player), false);
 		player.destAction = ACTION_ATTACKPLR;
 		player.destParam1 = playerIdx;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1110,6 +1110,13 @@ void TryDisarm(const Player &player, Object &object)
 	}
 }
 
+bool IsPlayerNextToTarget(Player &player, const WorldTilePosition &target)
+{
+	int x = std::abs(player.position.tile.x - target.x);
+	int y = std::abs(player.position.tile.y - target.y);
+	return x <= 1 && y <= 1;
+}
+
 void CheckNewPath(Player &player, bool pmWillBeCalled)
 {
 	int x = 0;
@@ -1161,23 +1168,21 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 	}
 
 	Direction d;
+
 	if (player.walkpath[0] != WALK_NONE) {
 		if (player._pmode == PM_STAND) {
 			if (&player == MyPlayer) {
 				if (player.destAction == ACTION_ATTACKMON || player.destAction == ACTION_ATTACKPLR) {
-					if (player.destAction == ACTION_ATTACKMON) {
-						auto monsterPosition = GetTargetMonsterPosition(*monster, player);
-						x = std::abs(player.position.future.x - monsterPosition.x);
-						y = std::abs(player.position.future.y - monsterPosition.y);
-						d = GetDirection(player.position.future, monsterPosition);
-					} else {
-						auto targetPosition = GetTargetPlayerPosition(*target, player);
-						x = std::abs(player.position.future.x - targetPosition.x);
-						y = std::abs(player.position.future.y - targetPosition.y);
-						d = GetDirection(player.position.future, targetPosition);
-					}
+					WorldTilePosition targetPosition;
 
-					if (x <= 1 && y <= 1) {
+					if (player.destAction == ACTION_ATTACKMON)
+						targetPosition = GetTargetMonsterPosition(*monster, player);
+					else
+						targetPosition = GetTargetPlayerPosition(*target, player);
+
+					d = GetDirection(player.position.future, targetPosition);
+
+					if (IsPlayerNextToTarget(player, targetPosition)) {
 						ClrPlrPath(player);
 						if (player.destAction == ACTION_ATTACKMON && monster->talkMsg != TEXT_NONE && monster->talkMsg != TEXT_VILE14) {
 							TalktoMonster(player, *monster);
@@ -1242,9 +1247,8 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			break;
 		case ACTION_ATTACKMON:
 			auto monsterPosition = GetTargetMonsterPosition(*monster, player);
-			x = std::abs(player.position.tile.x - monsterPosition.x);
-			y = std::abs(player.position.tile.y - monsterPosition.y);
-			if (x <= 1 && y <= 1) {
+
+			if (IsPlayerNextToTarget(player, monsterPosition)) {
 				d = GetDirection(player.position.future, monsterPosition);
 				if (monster->talkMsg != TEXT_NONE && monster->talkMsg != TEXT_VILE14) {
 					TalktoMonster(player, *monster);
@@ -1254,10 +1258,9 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			}
 			break;
 		case ACTION_ATTACKPLR:
-			x = std::abs(player.position.tile.x - target->position.future.x);
-			y = std::abs(player.position.tile.y - target->position.future.y);
-			if (x <= 1 && y <= 1) {
-				d = GetDirection(player.position.future, target->position.future);
+			auto targetPosition = GetTargetPlayerPosition(*target, player);
+			if (IsPlayerNextToTarget(player, targetPosition)) {
+				d = GetDirection(player.position.future, targetPosition);
 				StartAttack(player, d, pmWillBeCalled);
 			}
 			break;
@@ -1364,18 +1367,17 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			StartAttack(player, d, pmWillBeCalled);
 			player.destAction = ACTION_NONE;
 		} else if (player.destAction == ACTION_ATTACKMON) {
-			x = std::abs(player.position.tile.x - monster->position.future.x);
-			y = std::abs(player.position.tile.y - monster->position.future.y);
-			if (x <= 1 && y <= 1) {
-				d = GetDirection(player.position.future, monster->position.future);
+			auto monsterPosition = GetTargetMonsterPosition(*monster, player);
+			if (IsPlayerNextToTarget(player, monsterPosition)) {
+				d = GetDirection(player.position.future, monsterPosition);
 				StartAttack(player, d, pmWillBeCalled);
 			}
 			player.destAction = ACTION_NONE;
 		} else if (player.destAction == ACTION_ATTACKPLR) {
-			x = std::abs(player.position.tile.x - target->position.future.x);
-			y = std::abs(player.position.tile.y - target->position.future.y);
-			if (x <= 1 && y <= 1) {
-				d = GetDirection(player.position.future, target->position.future);
+			auto targetPosition = GetTargetPlayerPosition(*target, player);
+
+			if (IsPlayerNextToTarget(player, targetPosition)) {
+				d = GetDirection(player.position.future, targetPosition);
 				StartAttack(player, d, pmWillBeCalled);
 			}
 			player.destAction = ACTION_NONE;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1161,20 +1161,20 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 	}
 
 	Direction d;
-	if (player.walkpath[0] != WALK_NONE) { // player is currently walking
-		if (player._pmode == PM_STAND) {   // player is currently standing
+	if (player.walkpath[0] != WALK_NONE) {
+		if (player._pmode == PM_STAND) {
 			if (&player == MyPlayer) {
 				if (player.destAction == ACTION_ATTACKMON || player.destAction == ACTION_ATTACKPLR) {
 					if (player.destAction == ACTION_ATTACKMON) {
 						auto monsterPosition = GetTargetMonsterPosition(*monster, player);
-						x = std::abs(player.position.tile.x - monsterPosition.x);
-						y = std::abs(player.position.tile.y - monsterPosition.y);
-						d = GetDirection(player.position.tile, monsterPosition);
+						x = std::abs(player.position.future.x - monsterPosition.x);
+						y = std::abs(player.position.future.y - monsterPosition.y);
+						d = GetDirection(player.position.future, monsterPosition);
 					} else {
 						auto targetPosition = GetTargetPlayerPosition(*target, player);
-						x = std::abs(player.position.tile.x - targetPosition.x);
-						y = std::abs(player.position.tile.y - targetPosition.y);
-						d = GetDirection(player.position.tile, targetPosition);
+						x = std::abs(player.position.future.x - targetPosition.x);
+						y = std::abs(player.position.future.y - targetPosition.y);
+						d = GetDirection(player.position.future, targetPosition);
 					}
 
 					if (x <= 1 && y <= 1) {
@@ -1879,13 +1879,13 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 	switch (cmdId) {
 	case _cmd_id::CMD_RATTACKID: {
 		Monster &monster = Monsters[wParam1];
-		dir = GetDirection(position.tile, GetTargetMonsterPosition(monster, *this));
+		dir = GetDirection(position.future, GetTargetMonsterPosition(monster, *this));
 		graphic = player_graphic::Attack;
 		break;
 	}
 	case _cmd_id::CMD_SPELLID: {
 		Monster &monster = Monsters[wParam1];
-		dir = GetDirection(position.tile, GetTargetMonsterPosition(monster, *this));
+		dir = GetDirection(position.future, GetTargetMonsterPosition(monster, *this));
 		graphic = GetPlayerGraphicForSpell(static_cast<SpellID>(wParam2));
 		break;
 	}
@@ -1894,20 +1894,20 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 		point = GetTargetMonsterPosition(monster, *this);
 		minimalWalkDistance = 2;
 		if (!CanTalkToMonst(monster)) {
-			dir = GetDirection(position.tile, point);
+			dir = GetDirection(position.future, point);
 			graphic = player_graphic::Attack;
 		}
 		break;
 	}
 	case _cmd_id::CMD_RATTACKPID: {
 		Player &targetPlayer = Players[wParam1];
-		dir = GetDirection(position.tile, GetTargetPlayerPosition(targetPlayer, *this));
+		dir = GetDirection(position.future, GetTargetPlayerPosition(targetPlayer, *this));
 		graphic = player_graphic::Attack;
 		break;
 	}
 	case _cmd_id::CMD_SPELLPID: {
 		Player &targetPlayer = Players[wParam1];
-		dir = GetDirection(position.tile, GetTargetPlayerPosition(targetPlayer, *this));
+		dir = GetDirection(position.future, GetTargetPlayerPosition(targetPlayer, *this));
 		graphic = GetPlayerGraphicForSpell(static_cast<SpellID>(wParam2));
 		break;
 	}
@@ -1915,7 +1915,7 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 		Player &targetPlayer = Players[wParam1];
 		point = GetTargetPlayerPosition(targetPlayer, *this);
 		minimalWalkDistance = 2;
-		dir = GetDirection(position.tile, point);
+		dir = GetDirection(position.future, point);
 		graphic = player_graphic::Attack;
 		break;
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1245,9 +1245,8 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			d = GetDirection(player.position.tile, { player.destParam1, player.destParam2 });
 			StartAttack(player, d, pmWillBeCalled);
 			break;
-		case ACTION_ATTACKMON:
+		case ACTION_ATTACKMON: {
 			auto monsterPosition = GetTargetMonsterPosition(*monster, player);
-
 			if (IsPlayerNextToTarget(player, monsterPosition)) {
 				d = GetDirection(player.position.future, monsterPosition);
 				if (monster->talkMsg != TEXT_NONE && monster->talkMsg != TEXT_VILE14) {
@@ -1256,14 +1255,14 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 					StartAttack(player, d, pmWillBeCalled);
 				}
 			}
-			break;
-		case ACTION_ATTACKPLR:
+		} break;
+		case ACTION_ATTACKPLR: {
 			auto targetPosition = GetTargetPlayerPosition(*target, player);
 			if (IsPlayerNextToTarget(player, targetPosition)) {
 				d = GetDirection(player.position.future, targetPosition);
 				StartAttack(player, d, pmWillBeCalled);
 			}
-			break;
+		} break;
 		case ACTION_RATTACK:
 			d = GetDirection(player.position.tile, { player.destParam1, player.destParam2 });
 			StartRangeAttack(player, d, player.destParam1, player.destParam2, pmWillBeCalled);
@@ -1328,9 +1327,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			break;
 		case ACTION_PICKUPITEM:
 			if (&player == MyPlayer) {
-				x = std::abs(player.position.tile.x - item->position.x);
-				y = std::abs(player.position.tile.y - item->position.y);
-				if (x <= 1 && y <= 1 && pcurs == CURSOR_HAND && !item->_iRequest) {
+				if (IsPlayerNextToTarget(player, item->position) && pcurs == CURSOR_HAND && !item->_iRequest) {
 					NetSendCmdGItem(true, CMD_REQUESTGITEM, player, targetId);
 					item->_iRequest = true;
 				}
@@ -1338,9 +1335,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 			break;
 		case ACTION_PICKUPAITEM:
 			if (&player == MyPlayer) {
-				x = std::abs(player.position.tile.x - item->position.x);
-				y = std::abs(player.position.tile.y - item->position.y);
-				if (x <= 1 && y <= 1 && pcurs == CURSOR_HAND) {
+				if (IsPlayerNextToTarget(player, item->position) && pcurs == CURSOR_HAND) {
 					NetSendCmdGItem(true, CMD_REQUESTAGITEM, player, targetId);
 				}
 			}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -65,7 +65,7 @@ WorldTilePosition GetTargetMonsterPosition(const Monster &monster, const Player 
 
 	if (monster.isWalking()) {
 		auto progress = monster.animInfo.getAnimationProgress();
-		if (progress <= 64) {
+		if (progress <= AnimationInfo::baseValueFraction / 2) {
 			targetPosition = monster.position.tile;
 		}
 	}
@@ -82,7 +82,7 @@ WorldTilePosition GetTargetPlayerPosition(const Player &targetPlayer, const Play
 
 	if (targetPlayer.isWalking()) {
 		auto progress = targetPlayer.AnimInfo.getAnimationProgress();
-		if (progress <= 64) {
+		if (progress <= AnimationInfo::baseValueFraction / 2) {
 			targetPosition = targetPlayer.position.tile;
 		}
 	}

--- a/Source/player.h
+++ b/Source/player.h
@@ -917,6 +917,9 @@ inline bool IsInspectingPlayer()
 }
 extern bool MyPlayerIsDead;
 
+WorldTilePosition GetTargetMonsterPosition(const Monster &monster, const Player &player);
+WorldTilePosition GetTargetPlayerPosition(const Player &targetPlayer, const Player &player);
+
 Player *PlayerAtPosition(Point position, bool ignoreMovingPlayers = false);
 
 void LoadPlrGFX(Player &player, player_graphic graphic);


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/pull/7473

When using melee, players target the tile that the enemy is "most inside" by tracking walk progress. Previously, only the future tile was tracked. This caused a problem where while a melee player could technically hit an escaping enemy, the player instead chose to pursue the target because the future tile was more than a tile away from the player. This targeting behavior also caused hitting stone cursed monsters that were in a walking animation to face a strange direction. This change does not affect spell or ranged targeting.