### PR TITLE
Do not assume 10-byte header for CL2 data

### DIFF
--- a/Source/utils/cl2_to_clx.cpp
+++ b/Source/utils/cl2_to_clx.cpp
@@ -64,7 +64,7 @@ uint16_t Cl2ToClx(const uint8_t *data, size_t size,
 			unsigned transparentRunWidth = 0;
 			int_fast16_t xOffset = 0;
 			size_t frameHeight = 0;
-			const uint8_t *src = frameBegin + FrameHeaderSize;
+			const uint8_t *src = frameBegin + LoadLE16(frameBegin);
 			while (src != frameEnd) {
 				auto remainingWidth = static_cast<int_fast16_t>(frameWidth) - xOffset;
 				while (remainingWidth > 0) {


### PR DESCRIPTION
CL2 graphics taller than 160 pixels may allocate more than 10 bytes for the header. Although there are no such graphics in the data that ships with the game, I don't feel there's any particularly good reason not to make our decoder compatible with D1GT in this regard.