### PR TITLE
SDL1: Avoid redundant palette update

### DIFF
--- a/Source/utils/sdl_compat.h
+++ b/Source/utils/sdl_compat.h
@@ -75,7 +75,9 @@ inline int SDLC_SetSurfaceAndPaletteColors(SDL_Surface *surface, SDL_Palette *pa
 
 #if SDL1_VIDEO_MODE_BPP == 8
 	// When the video surface is 8bit, we need to set the output palette as well.
-	SDL_SetColors(SDL_GetVideoSurface(), colors, firstcolor, ncolors);
+	SDL_Surface *videoSurface = SDL_GetVideoSurface();
+	SDL_SetColors(videoSurface, colors, firstcolor, ncolors);
+	if (videoSurface == surface) return 0;
 #endif
 	// In SDL1, the surface always has its own distinct palette, so we need to
 	// update it as well.


### PR DESCRIPTION
When the display surface is 8-bit, skips a redundant call to `SDL_SetPalette`.

/cc @azihassan https://github.com/azihassan/devilutionX/issues/14