### PR TITLE
Fix error in Lua require() function

### DIFF
--- a/Source/lua/lua.cpp
+++ b/Source/lua/lua.cpp
@@ -44,10 +44,10 @@ function requireGen(env, loaded, loadFn)
       local p = loaded[packageName]
       if p == nil then
           local loader = loadFn(packageName)
-          setEnvironment(loader, env)
           if type(loader) == "string" then
             error(loader)
           end
+          setEnvironment(env, loader)
           p = loader(packageName)
           loaded[packageName] = p
       end


### PR DESCRIPTION
**user.lua**:
```lua
require('test')
```

---

**test.lua**:
```lua
print(os.date())
```

---

Error:
```
ERROR: Lua error: stack index 2, expected function, received table: value is not a function and does not have overriden metatable (bad argument into 'void(const sol::basic_environment<sol::basic_reference<0> >&, const sol::basic_function<sol::basic_reference<0>,0>&)')
stack traceback:
	[C]: in function 'base.setEnvironment'
	[string "..."]:7: in global 'require'
	[string "lua\user.lua"]:1: in main chunk
```

This happens because the arguments to `setEnvironment()` are backwards. Furthermore, we shouldn't try to call `setEnvironment()` if `loader` is a string, since it expects a function.