### PR TITLE
Add gameplay options to hide item and gold stash from the player

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1064,6 +1064,8 @@ GameplayOptions::GameplayOptions()
     , showItemLabels("Show Item Labels", OptionEntryFlags::None, N_("Show Item Labels"), N_("Show labels for items on the ground when enabled."), false)
     , autoRefillBelt("Auto Refill Belt", OptionEntryFlags::None, N_("Auto Refill Belt"), N_("Refill belt from inventory when belt item is consumed."), false)
     , disableCripplingShrines("Disable Crippling Shrines", OptionEntryFlags::None, N_("Disable Crippling Shrines"), N_("When enabled Cauldrons, Fascinating Shrines, Goat Shrines, Ornate Shrines, Sacred Shrines and Murphy's Shrines are not able to be clicked on and labeled as disabled."), false)
+	, useItemStorage("Enable item storage", OptionEntryFlags::None, N_("Enable item storage"), N_("Gillian will store items and gold for you. Disabling this option will also disable gold in the stash from being visible to stores."), true)
+	, sharedGoldStash("Stashed gold is usable", OptionEntryFlags::None, N_("Stashed gold is usable"), N_("Gold stored in the item stash is visible to stores and usable without withdrawing it."), true)
     , quickCast("Quick Cast", OptionEntryFlags::None, N_("Quick Cast"), N_("Spell hotkeys instantly cast the spell, rather than switching the readied spell."), false)
     , numHealPotionPickup("Heal Potion Pickup", OptionEntryFlags::None, N_("Heal Potion Pickup"), N_("Number of Healing potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
     , numFullHealPotionPickup("Full Heal Potion Pickup", OptionEntryFlags::None, N_("Full Heal Potion Pickup"), N_("Number of Full Healing potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
@@ -1096,6 +1098,8 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&testBard,
 		&testBarbarian,
 		&experienceBar,
+		&useItemStorage,
+		&sharedGoldStash,
 		&showItemGraphicsInStores,
 		&showHealthValues,
 		&showManaValues,

--- a/Source/options.h
+++ b/Source/options.h
@@ -546,6 +546,10 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryBoolean experienceBar;
 	/** @brief Show item graphics to the left of item descriptions in store menus. */
 	OptionEntryBoolean showItemGraphicsInStores;
+	/** @brief Gold from the stash will be visible to all stores. */
+	OptionEntryBoolean sharedGoldStash;
+	/** @brief Gillian will show the option to use the item stash. */
+	OptionEntryBoolean useItemStorage;
 	/** @brief Display current/max health values on health globe. */
 	OptionEntryBoolean showHealthValues;
 	/** @brief Display current/max mana values on mana globe. */

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -398,7 +398,7 @@ void ScrollSmithBuy(int idx)
 
 uint32_t TotalPlayerGold()
 {
-	return MyPlayer->_pGold + Stash.gold;
+	return (!*sgOptions.Gameplay.useItemStorage || !*sgOptions.Gameplay.sharedGoldStash) ? MyPlayer->_pGold : MyPlayer->_pGold + Stash.gold;
 }
 
 // TODO: Change `_iIvalue` to be unsigned instead of passing `int` here.
@@ -1261,7 +1261,8 @@ void StartBarmaid()
 	AddSText(0, 2, _("Gillian"), UiFlags::ColorWhitegold | UiFlags::AlignCenter, false);
 	AddSText(0, 9, _("Would you like to:"), UiFlags::ColorWhitegold | UiFlags::AlignCenter, false);
 	AddSText(0, 12, _("Talk to Gillian"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
-	AddSText(0, 14, _("Access Storage"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
+	if (*sgOptions.Gameplay.useItemStorage)
+		AddSText(0, 14, _("Access Storage"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
 	AddSText(0, 18, _("Say goodbye"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
 	AddSLine(5);
 	CurrentItemIndex = 20;


### PR DESCRIPTION
This is mostly to address discussion in #7462, because of certain devices that run DevilutionX (such as devices running Batocera) don't have easy access to a file manager to disable or move the `stash.sv` file to prevent the stash and/or gold from being shared between different saves. This has been brought up a couple of times by different users.

These new gameplay options don't disable the item stash offered by Gillian, but rather hide it from the player. Two new options are added in the Gameplay Options menu:

- **Enable item storage:** This option will allow the player to access Gillian's item storage. Comes enabled by default to keep it consistent with current behavior. Disabling this option will hide the storage from her dialog options. Disabling this option will also hide the gold stored in the item stash from being visible to other stores in town.
- **Stashed gold is usable:** This option will allow gold stored in Gillian's stash to be directly usable in stores without the need to be present in the player's storage. Comes enabled by default, to keep it consistent with current behavior. Disabling this option will only make it so stores in town require gold be withdrawn from the stash to be usable.