### PR TITLE
Don't send spell level in spell casting network message

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2682,17 +2682,16 @@ bool TryIconCurs()
 	if (pcurs == CURSOR_TELEPORT) {
 		const SpellID spellID = myPlayer.inventorySpell;
 		const SpellType spellType = SpellType::Scroll;
-		const int spellLevel = myPlayer.GetSpellLevel(spellID);
 		const int spellFrom = myPlayer.spellFrom;
 		if (IsWallSpell(spellID)) {
 			Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
-			NetSendCmdLocParam5(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellLevel, spellFrom);
+			NetSendCmdLocParam4(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellFrom);
 		} else if (pcursmonst != -1) {
-			NetSendCmdParam5(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+			NetSendCmdParam4(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);
 		} else if (PlayerUnderCursor != nullptr && !myPlayer.friendlyMode) {
-			NetSendCmdParam5(true, CMD_SPELLPID, PlayerUnderCursor->getId(), static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+			NetSendCmdParam4(true, CMD_SPELLPID, PlayerUnderCursor->getId(), static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);
 		} else {
-			NetSendCmdLocParam4(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+			NetSendCmdLocParam3(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);
 		}
 		NewCursor(CURSOR_HAND);
 		return true;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4265,7 +4265,7 @@ void UseItem(Player &player, item_misc_id mid, SpellID spellID, int spellFrom)
 				target = player.position.future + Displacement(player._pdir);
 			// Use CMD_SPELLXY because it's the same behavior as normal casting
 			assert(IsValidSpellFrom(spellFrom));
-			NetSendCmdLocParam4(true, CMD_SPELLXY, target, static_cast<int8_t>(spellID), static_cast<uint8_t>(SpellType::Scroll), spellLevel, static_cast<uint16_t>(spellFrom));
+			NetSendCmdLocParam3(true, CMD_SPELLXY, target, static_cast<int8_t>(spellID), static_cast<uint8_t>(SpellType::Scroll), static_cast<uint16_t>(spellFrom));
 		}
 		break;
 	case IMISC_BOOK: {

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1481,7 +1481,7 @@ bool InitNewSpell(Player &player, uint16_t wParamSpellID, uint16_t wParamSpellTy
 
 size_t OnSpellWall(const TCmd *pCmd, Player &player)
 {
-	const auto &message = *reinterpret_cast<const TCmdLocParam5 *>(pCmd);
+	const auto &message = *reinterpret_cast<const TCmdLocParam4 *>(pCmd);
 	const Point position { message.x, message.y };
 
 	if (gbBufferMsgs == 1)
@@ -1494,7 +1494,7 @@ size_t OnSpellWall(const TCmd *pCmd, Player &player)
 	if (wParamDirection > static_cast<uint16_t>(Direction::SouthEast))
 		return sizeof(message);
 
-	if (!InitNewSpell(player, message.wParam1, message.wParam2, message.wParam5))
+	if (!InitNewSpell(player, message.wParam1, message.wParam2, message.wParam4))
 		return sizeof(message);
 
 	ClrPlrPath(player);
@@ -1502,14 +1502,14 @@ size_t OnSpellWall(const TCmd *pCmd, Player &player)
 	player.destParam1 = position.x;
 	player.destParam2 = position.y;
 	player.destParam3 = wParamDirection;
-	player.destParam4 = SDL_SwapLE16(message.wParam4); // Spell Level
+	player.destParam4 = player.GetSpellLevel(player.queuedSpell.spellId);
 
 	return sizeof(message);
 }
 
 size_t OnSpellTile(const TCmd *pCmd, Player &player)
 {
-	const auto &message = *reinterpret_cast<const TCmdLocParam4 *>(pCmd);
+	const auto &message = *reinterpret_cast<const TCmdLocParam3 *>(pCmd);
 	const Point position { message.x, message.y };
 
 	if (gbBufferMsgs == 1)
@@ -1519,14 +1519,14 @@ size_t OnSpellTile(const TCmd *pCmd, Player &player)
 	if (!InDungeonBounds(position))
 		return sizeof(message);
 
-	if (!InitNewSpell(player, message.wParam1, message.wParam2, message.wParam4))
+	if (!InitNewSpell(player, message.wParam1, message.wParam2, message.wParam3))
 		return sizeof(message);
 
 	ClrPlrPath(player);
 	player.destAction = ACTION_SPELL;
 	player.destParam1 = position.x;
 	player.destParam2 = position.y;
-	player.destParam3 = SDL_SwapLE16(message.wParam3); // Spell Level
+	player.destParam3 = player.GetSpellLevel(player.queuedSpell.spellId);
 
 	return sizeof(message);
 }
@@ -1608,7 +1608,7 @@ size_t OnRangedAttackPlayer(const TCmd *pCmd, Player &player)
 
 size_t OnSpellMonster(const TCmd *pCmd, Player &player)
 {
-	const auto &message = *reinterpret_cast<const TCmdParam5 *>(pCmd);
+	const auto &message = *reinterpret_cast<const TCmdParam4 *>(pCmd);
 
 	if (gbBufferMsgs == 1)
 		return sizeof(message);
@@ -1618,20 +1618,20 @@ size_t OnSpellMonster(const TCmd *pCmd, Player &player)
 	if (monsterIdx >= MaxMonsters)
 		return sizeof(message);
 
-	if (!InitNewSpell(player, message.wParam2, message.wParam3, message.wParam5))
+	if (!InitNewSpell(player, message.wParam2, message.wParam3, message.wParam4))
 		return sizeof(message);
 
 	ClrPlrPath(player);
 	player.destAction = ACTION_SPELLMON;
 	player.destParam1 = monsterIdx;
-	player.destParam2 = SDL_SwapLE16(message.wParam4); // Spell Level
+	player.destParam2 = player.GetSpellLevel(player.queuedSpell.spellId);
 
 	return sizeof(message);
 }
 
 size_t OnSpellPlayer(const TCmd *pCmd, Player &player)
 {
-	const auto &message = *reinterpret_cast<const TCmdParam5 *>(pCmd);
+	const auto &message = *reinterpret_cast<const TCmdParam4 *>(pCmd);
 
 	if (gbBufferMsgs == 1)
 		return sizeof(message);
@@ -1641,13 +1641,13 @@ size_t OnSpellPlayer(const TCmd *pCmd, Player &player)
 	if (playerIdx >= Players.size())
 		return sizeof(message);
 
-	if (!InitNewSpell(player, message.wParam2, message.wParam3, message.wParam5))
+	if (!InitNewSpell(player, message.wParam2, message.wParam3, message.wParam4))
 		return sizeof(message);
 
 	ClrPlrPath(player);
 	player.destAction = ACTION_SPELLPLR;
 	player.destParam1 = playerIdx;
-	player.destParam2 = SDL_SwapLE16(message.wParam4); // Spell Level
+	player.destParam2 = player.GetSpellLevel(player.queuedSpell.spellId);
 
 	return sizeof(message);
 }
@@ -2953,29 +2953,6 @@ void NetSendCmdLocParam4(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 	MyPlayer->UpdatePreviewCelSprite(bCmd, position, wParam1, wParam3);
 }
 
-void NetSendCmdLocParam5(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4, uint16_t wParam5)
-{
-	if (WasPlayerCmdAlreadyRequested(bCmd, position, wParam1, wParam2, wParam3, wParam4, wParam5))
-		return;
-
-	TCmdLocParam5 cmd;
-
-	cmd.bCmd = bCmd;
-	cmd.x = position.x;
-	cmd.y = position.y;
-	cmd.wParam1 = SDL_SwapLE16(wParam1);
-	cmd.wParam2 = SDL_SwapLE16(wParam2);
-	cmd.wParam3 = SDL_SwapLE16(wParam3);
-	cmd.wParam4 = SDL_SwapLE16(wParam4);
-	cmd.wParam5 = SDL_SwapLE16(wParam5);
-	if (bHiPri)
-		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
-	else
-		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
-
-	MyPlayer->UpdatePreviewCelSprite(bCmd, position, wParam1, wParam3);
-}
-
 void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, uint16_t wParam1)
 {
 	if (WasPlayerCmdAlreadyRequested(bCmd, {}, wParam1))
@@ -3006,19 +2983,18 @@ void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wPar
 		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
-void NetSendCmdParam5(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4, uint16_t wParam5)
+void NetSendCmdParam4(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4)
 {
 	if (WasPlayerCmdAlreadyRequested(bCmd, {}, wParam1, wParam2, wParam3, wParam4))
 		return;
 
-	TCmdParam5 cmd;
+	TCmdParam4 cmd;
 
 	cmd.bCmd = bCmd;
 	cmd.wParam1 = SDL_SwapLE16(wParam1);
 	cmd.wParam2 = SDL_SwapLE16(wParam2);
 	cmd.wParam3 = SDL_SwapLE16(wParam3);
 	cmd.wParam4 = SDL_SwapLE16(wParam4);
-	cmd.wParam5 = SDL_SwapLE16(wParam5);
 	if (bHiPri)
 		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 	else

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -499,13 +499,12 @@ struct TCmdParam2 {
 	uint16_t wParam2;
 };
 
-struct TCmdParam5 {
+struct TCmdParam4 {
 	_cmd_id bCmd;
 	uint16_t wParam1;
 	uint16_t wParam2;
 	uint16_t wParam3;
 	uint16_t wParam4;
-	uint16_t wParam5;
 };
 
 struct TCmdGolem {
@@ -758,10 +757,9 @@ void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wPa
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2);
 void NetSendCmdLocParam3(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3);
 void NetSendCmdLocParam4(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4);
-void NetSendCmdLocParam5(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4, uint16_t wParam5);
 void NetSendCmdParam1(bool bHiPri, _cmd_id bCmd, uint16_t wParam1);
 void NetSendCmdParam2(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2);
-void NetSendCmdParam5(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4, uint16_t wParam5);
+void NetSendCmdParam4(bool bHiPri, _cmd_id bCmd, uint16_t wParam1, uint16_t wParam2, uint16_t wParam3, uint16_t wParam4);
 void NetSendCmdQuest(bool bHiPri, const Quest &quest);
 void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, const Player &player, uint8_t ii);
 void NetSendCmdPItem(bool bHiPri, _cmd_id bCmd, Point position, const Item &item);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1241,22 +1241,18 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 		case ACTION_SPELL:
 			d = GetDirection(player.position.tile, { player.destParam1, player.destParam2 });
 			StartSpell(player, d, player.destParam1, player.destParam2);
-			player.executedSpell.spellLevel = player.destParam3;
 			break;
 		case ACTION_SPELLWALL:
 			StartSpell(player, static_cast<Direction>(player.destParam3), player.destParam1, player.destParam2);
 			player.tempDirection = static_cast<Direction>(player.destParam3);
-			player.executedSpell.spellLevel = player.destParam4;
 			break;
 		case ACTION_SPELLMON:
 			d = GetDirection(player.position.tile, monster->position.future);
 			StartSpell(player, d, monster->position.future.x, monster->position.future.y);
-			player.executedSpell.spellLevel = player.destParam2;
 			break;
 		case ACTION_SPELLPLR:
 			d = GetDirection(player.position.tile, target->position.future);
 			StartSpell(player, d, target->position.future.x, target->position.future.y);
-			player.executedSpell.spellLevel = player.destParam2;
 			break;
 		case ACTION_OPERATE:
 			if (IsPlayerAdjacentToObject(player, *object)) {
@@ -3151,18 +3147,17 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 		return;
 	}
 
-	const int spellLevel = myPlayer.GetSpellLevel(spellID);
 	const int spellFrom = 0;
 	if (IsWallSpell(spellID)) {
 		LastMouseButtonAction = MouseActionType::Spell;
 		Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
-		NetSendCmdLocParam5(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellLevel, spellFrom);
+		NetSendCmdLocParam4(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellFrom);
 	} else if (pcursmonst != -1 && !isShiftHeld) {
 		LastMouseButtonAction = MouseActionType::SpellMonsterTarget;
-		NetSendCmdParam5(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+		NetSendCmdParam4(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);
 	} else if (PlayerUnderCursor != nullptr && !isShiftHeld && !myPlayer.friendlyMode) {
 		LastMouseButtonAction = MouseActionType::SpellPlayerTarget;
-		NetSendCmdParam5(true, CMD_SPELLPID, PlayerUnderCursor->getId(), static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+		NetSendCmdParam4(true, CMD_SPELLPID, PlayerUnderCursor->getId(), static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);
 	} else {
 		Point targetedTile = cursPosition;
 		if (spellID == SpellID::Teleport && myPlayer.executedSpell.spellId == SpellID::Teleport) {
@@ -3175,7 +3170,7 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 			}
 		}
 		LastMouseButtonAction = MouseActionType::Spell;
-		NetSendCmdLocParam4(true, CMD_SPELLXY, targetedTile, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+		NetSendCmdLocParam3(true, CMD_SPELLXY, targetedTile, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);
 	}
 }
 


### PR DESCRIPTION
This fixes an inconsistency in `CheckNewPath()`. When casting a spell from a standing animation, the spell would use the spell level that was included in the network message. When casting a queued spell immediately after executing another spell, the spell would use the spell level stored in the `Player` struct.

We sync spell levels with the `CMD_CHANGE_SPELL_LEVEL` command, and the game _never_ casts a spell at a different spell level than what is stored in the `Player` struct. There is no real benefit to including the spell level in the spell casting network messages. All it does is allow a hacker to pass whatever spell level they want, as long as they do it from a standing animation.