### PR TITLE
Check missile source type to determine death reason

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -445,7 +445,7 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 				isPlayerHit = PlayerMHit(*player, &monster, missile._midist, minDamage, maxDamage, missile._mitype, damageType, isDamageShifted, DeathReason::MonsterOrTrap, &blocked);
 			}
 		} else {
-			DeathReason deathReason = (!missile.IsTrap() && (missile._miAnimType == MissileGraphicID::FireWall || missile._miAnimType == MissileGraphicID::Lightning)) ? DeathReason::Player : DeathReason::MonsterOrTrap;
+			DeathReason deathReason = missile.sourceType() == MissileSource::Player ? DeathReason::Player : DeathReason::MonsterOrTrap;
 			isPlayerHit = PlayerMHit(*player, nullptr, missile._midist, minDamage, maxDamage, missile._mitype, damageType, isDamageShifted, deathReason, &blocked);
 		}
 	}


### PR DESCRIPTION
This resolves an issue where Runes could be used to PK another player and have them drop their equipment as if they had been killed by a trap or monster.

---

`TARGET_BOTH` is only used for a handful of missiles:

* Fire Wall
* Lightning Wall
* Ring of Fire
* Runes
* Phasing

For Fire Wall, Lightning Wall, and Ring of Fire, we were already checking `missile.IsTrap()` which is equivalent to `missile.sourceType() == MissileSource::Trap`. Therefore, the behavior after the change should match what we were doing before. Phasing is harmless, so the only real change is that Rune missiles will now also use `DeathReason::Player`.

This logic also just makes more sense compared to the special case for Fire Wall and Lightning Wall.