### PR TITLE
Extract logic from CheckInvCut/AutoPlaceItemInInventory

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -473,7 +473,7 @@ std::string TextCmdArenaPot(const std::string_view parameter)
 		GenerateNewSeed(item);
 		item.updateRequiredStatsCacheForPlayer(myPlayer);
 
-		if (!AutoPlaceItemInBelt(myPlayer, item, true, true) && !AutoPlaceItemInInventory(myPlayer, item, true, true)) {
+		if (!AutoPlaceItemInBelt(myPlayer, item, true, true) && !AutoPlaceItemInInventory(myPlayer, item, true)) {
 			break; // inventory is full
 		}
 	}

--- a/Source/engine/point.hpp
+++ b/Source/engine/point.hpp
@@ -42,6 +42,13 @@ struct PointOf {
 	}
 
 	template <typename PointCoordT>
+	DVL_ALWAYS_INLINE explicit constexpr PointOf(DisplacementOf<PointCoordT> other)
+	    : x(other.deltaX)
+	    , y(other.deltaY)
+	{
+	}
+
+	template <typename PointCoordT>
 	DVL_ALWAYS_INLINE constexpr bool operator==(const PointOf<PointCoordT> &other) const
 	{
 		return x == other.x && y == other.y;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -603,13 +603,11 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 	}
 }
 
-namespace {
 inv_body_loc MapSlotToInvBodyLoc(inv_xy_slot slot)
 {
 	assert(slot <= SLOTXY_CHEST);
 	return static_cast<inv_body_loc>(slot);
 }
-} // namespace
 
 void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool dropItem)
 {

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -142,15 +142,21 @@ bool AutoEquip(Player &player, const Item &item, bool persistItem = true, bool s
 
 /**
  * @brief Checks whether the given item can be placed on the specified player's inventory.
- * If 'persistItem' is 'True', the item is also placed in the inventory.
  * @param player The player whose inventory will be checked.
  * @param item The item to be checked.
- * @param persistItem Pass 'True' to actually place the item in the inventory. The default is 'False'.
- * @param sendNetworkMessage Set to true if you want a network message to be generated if the item is persisted.
- * Should only be set if a local player is placing an item in a play session (not when creating a new game)
  * @return 'True' in case the item can be placed on the player's inventory and 'False' otherwise.
  */
-bool AutoPlaceItemInInventory(Player &player, const Item &item, bool persistItem = false, bool sendNetworkMessage = false);
+bool CanFitItemInInventory(const Player &player, const Item &item);
+
+/**
+ * @brief Attempts to place the given item in the specified player's inventory.
+ * @param player The player whose inventory will be used.
+ * @param item The item to be placed.
+ * @param sendNetworkMessage Set to true if you want a network message to be generated if the item is persisted.
+ * Should only be set if a local player is placing an item in a play session (not when creating a new game)
+ * @return 'True' if the item was placed on the player's inventory and 'False' otherwise.
+ */
+bool AutoPlaceItemInInventory(Player &player, const Item &item, bool sendNetworkMessage = false);
 
 /**
  * @brief Checks whether the given item can be placed on the specified player's belt. Returns 'True' when the item can be placed

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2967,7 +2967,7 @@ void CreateStartingItem(Player &player, _item_indexes itemData)
 	InitializeItem(item, itemData);
 	GenerateNewSeed(item);
 	item.updateRequiredStatsCacheForPlayer(player);
-	AutoEquip(player, item) || AutoPlaceItemInBelt(player, item, true) || AutoPlaceItemInInventory(player, item, true);
+	AutoEquip(player, item) || AutoPlaceItemInBelt(player, item, true) || AutoPlaceItemInInventory(player, item);
 }
 } // namespace
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2729,7 +2729,7 @@ void StripTopGold(Player &player)
 		return;
 	if (AutoEquip(player, player.HoldItem, false))
 		return;
-	if (AutoPlaceItemInInventory(player, player.HoldItem))
+	if (CanFitItemInInventory(player, player.HoldItem))
 		return;
 	if (AutoPlaceItemInBelt(player, player.HoldItem))
 		return;

--- a/Source/qol/autopickup.cpp
+++ b/Source/qol/autopickup.cpp
@@ -47,7 +47,7 @@ bool DoPickup(Item item)
 		return true;
 
 	if (item._itype == ItemType::Misc
-	    && (AutoPlaceItemInInventory(*MyPlayer, item) || AutoPlaceItemInBelt(*MyPlayer, item))) {
+	    && (CanFitItemInInventory(*MyPlayer, item) || AutoPlaceItemInBelt(*MyPlayer, item))) {
 		switch (item._iMiscId) {
 		case IMISC_HEAL:
 			return *sgOptions.Gameplay.numHealPotionPickup > NumMiscItemsInInv(item._iMiscId);

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -293,7 +293,7 @@ void TransferItemToInventory(Player &player, uint16_t itemId)
 		return;
 	}
 
-	if (!AutoPlaceItemInInventory(player, item, true)) {
+	if (!AutoPlaceItemInInventory(player, item)) {
 		player.SaySpecific(HeroSpeech::IHaveNoRoom);
 		return;
 	}

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -345,7 +345,11 @@ bool StoreAutoPlace(Item &item, bool persistItem)
 		return true;
 	}
 
-	return AutoPlaceItemInInventory(player, item, persistItem, true);
+	if (persistItem) {
+		return AutoPlaceItemInInventory(player, item, true);
+	}
+
+	return CanFitItemInInventory(player, item);
 }
 
 void ScrollVendorStore(Item *itemData, int storeLimit, int idx, int selling = true)


### PR DESCRIPTION
Cleanups that I found useful when prepping for in-place swapping.

This shouldn't change any behaviour but I haven't tested further than making sure shift-clicking equipped items still worked.