### PR TITLE
Allow auto-equipping items when the inventory item frees space for the equipped item

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -837,20 +837,25 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 							// the left hand), invloc isn't used there.
 							invloc = INVLOC_HAND_RIGHT;
 						} else {
-							// Both hands are holding items, we must unequip the right hand item and check that there's
-							// space for the left before trying to auto-equip
-							if (!AutoPlaceItemInInventory(player, player.InvBody[INVLOC_HAND_RIGHT])) {
-								// No space to move right hand item to inventory, abort.
-								break;
+							// Both hands are holding items, we must unequip one of the items and check that there's
+							// space for the other before trying to auto-equip
+							inv_body_loc mainHand = INVLOC_HAND_LEFT;
+							inv_body_loc offHand = INVLOC_HAND_RIGHT;
+							if (!AutoPlaceItemInInventory(player, player.InvBody[offHand])) {
+								// No space to move right hand item to inventory, can we move the left instead?
+								std::swap(mainHand, offHand);
+								if (!AutoPlaceItemInInventory(player, player.InvBody[offHand])) {
+									break;
+								}
 							}
-							if (!CouldFitItemInInventory(player, player.InvBody[INVLOC_HAND_LEFT], iv)) {
-								// No space for left item. Move back right item to right hand and abort.
-								player.InvBody[INVLOC_HAND_RIGHT] = player.InvList[player._pNumInv - 1];
+							if (!CouldFitItemInInventory(player, player.InvBody[mainHand], iv)) {
+								// No space for the main hand item. Move the other item back to the off hand and abort.
+								player.InvBody[offHand] = player.InvList[player._pNumInv - 1];
 								player.RemoveInvItem(player._pNumInv - 1, false);
 								break;
 							}
-							RemoveEquipment(player, INVLOC_HAND_RIGHT, false);
-							invloc = INVLOC_HAND_LEFT;
+							RemoveEquipment(player, offHand, false);
+							invloc = mainHand;
 						}
 						break;
 					default:


### PR DESCRIPTION
New behaviour:
https://github.com/user-attachments/assets/3b7ab495-59f9-4315-a986-18a8b876c40d

Main thing of note is the item that used to be equipped will fill the gap left by the item being equipped if it fits.

Commit 2324108386c74758f20745a932768a2917a12bb5 is some prep that made it easier to reason about the steps required, I tried to keep the same behaviour/sound feedback. What I was attempting to show at about 10 seconds into this clip was trying to equip the short sword when there's no room to remove the two-handed sword would play the "I have no room" speech but the screen recording didn't capture sound :(

This builds on #7494, I've split them to hopefully make things easier to review.