### PR TITLE
Async loading

### DIFF
--- a/Source/DiabloUI/dialogs.cpp
+++ b/Source/DiabloUI/dialogs.cpp
@@ -62,6 +62,9 @@ bool Init(std::string_view caption, std::string_view text, bool error, bool rend
 				LogError("{}", SDL_GetError());
 		}
 	}
+	if (!IsHardwareCursor() && !ArtCursor) {
+		ArtCursor = LoadPcx("ui_art\\cursor", /*transparentColor=*/0);
+	}
 	LoadDialogButtonGraphics();
 
 	OptionalClxSprite dialogSprite = LoadDialogSprite(!caption.empty(), error);

--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -44,13 +44,18 @@ void FreeDlg()
 	SNetDestroy();
 }
 
+[[noreturn]] void DisplayFatalErrorAndExit(std::string_view title, std::string_view body)
+{
+	FreeDlg();
+	UiErrorOkDialog(title, body);
+	diablo_quit(1);
+}
+
 } // namespace
 
 void app_fatal(std::string_view str)
 {
-	FreeDlg();
-	UiErrorOkDialog(_("Error"), str);
-	diablo_quit(1);
+	DisplayFatalErrorAndExit(_("Error"), str);
 }
 
 #ifdef _DEBUG
@@ -62,32 +67,27 @@ void assert_fail(int nLineNo, const char *pszFile, const char *pszFail)
 
 void ErrDlg(const char *title, std::string_view error, std::string_view logFilePath, int logLineNr)
 {
-	FreeDlg();
-
-	std::string text = fmt::format(fmt::runtime(_(/* TRANSLATORS: Error message that displays relevant information for bug report */ "{:s}\n\nThe error occurred at: {:s} line {:d}")), error, logFilePath, logLineNr);
-
-	UiErrorOkDialog(title, text);
-	diablo_quit(1);
+	DisplayFatalErrorAndExit(
+	    title,
+	    fmt::format(fmt::runtime(_(/* TRANSLATORS: Error message that displays relevant information for bug report */ "{:s}\n\nThe error occurred at: {:s} line {:d}")),
+	        error, logFilePath, logLineNr));
 }
 
 void InsertCDDlg(std::string_view archiveName)
 {
-	std::string text = fmt::format(
-	    fmt::runtime(_("Unable to open main data archive ({:s}).\n"
-	                   "\n"
-	                   "Make sure that it is in the game folder.")),
-	    archiveName);
-
-	UiErrorOkDialog(_("Data File Error"), text);
-	diablo_quit(1);
+	DisplayFatalErrorAndExit(_("Data File Error"),
+	    fmt::format(fmt::runtime(_("Unable to open main data archive ({:s}).\n"
+	                               "\n"
+	                               "Make sure that it is in the game folder.")),
+	        archiveName));
 }
 
 void DirErrorDlg(std::string_view error)
 {
-	std::string text = fmt::format(fmt::runtime(_(/* TRANSLATORS: Error when Program is not allowed to write data */ "Unable to write to location:\n{:s}")), error);
-
-	UiErrorOkDialog(_("Read-Only Directory Error"), text);
-	diablo_quit(1);
+	DisplayFatalErrorAndExit(
+	    _("Read-Only Directory Error"),
+	    fmt::format(fmt::runtime(_(/* TRANSLATORS: Error when Program is not allowed to write data */ "Unable to write to location:\n{:s}")),
+	        error));
 }
 
 } // namespace devilution

--- a/Source/control.h
+++ b/Source/control.h
@@ -8,9 +8,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <string_view>
 
 #include <SDL.h>
+#include <expected.hpp>
 
 #ifdef USE_SDL1
 #include "utils/sdl2_to_1_2_backports.h"
@@ -127,7 +129,7 @@ void DrawFlaskValues(const Surface &out, Point pos, int currValue, int maxValue)
  */
 void UpdateLifeManaPercent();
 
-void InitMainPanel();
+tl::expected<void, std::string> InitMainPanel();
 void DrawMainPanel(const Surface &out);
 
 /**

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -90,7 +90,7 @@ VirtualGamepadButtonType GetStandButtonType(bool isPressed)
 	return isPressed ? GAMEPAD_STANDDOWN : GAMEPAD_STAND;
 }
 
-void LoadButtonArt(ButtonTexture *buttonArt, SDL_Renderer *renderer)
+void LoadButtonArt(ButtonTexture *buttonArt)
 {
 	constexpr unsigned Sprites = 13;
 	constexpr unsigned Frames = 2;
@@ -100,14 +100,9 @@ void LoadButtonArt(ButtonTexture *buttonArt, SDL_Renderer *renderer)
 
 	buttonArt->numSprites = Sprites;
 	buttonArt->numFrames = Frames;
-
-	if (renderer != nullptr) {
-		buttonArt->texture.reset(SDL_CreateTextureFromSurface(renderer, buttonArt->surface.get()));
-		buttonArt->surface = nullptr;
-	}
 }
 
-void LoadPotionArt(ButtonTexture *potionArt, SDL_Renderer *renderer)
+void LoadPotionArt(ButtonTexture *potionArt)
 {
 	item_cursor_graphic potionGraphics[] {
 		ICURS_POTION_OF_HEALING,
@@ -149,12 +144,7 @@ void LoadPotionArt(ButtonTexture *potionArt, SDL_Renderer *renderer)
 
 	potionArt->numFrames = sizeof(potionGraphics);
 
-	if (renderer == nullptr) {
-		potionArt->surface.reset(SDL_ConvertSurfaceFormat(surface.get(), SDL_PIXELFORMAT_ARGB8888, 0));
-	} else {
-		potionArt->texture.reset(SDL_CreateTextureFromSurface(renderer, surface.get()));
-		potionArt->surface = nullptr;
-	}
+	potionArt->surface.reset(SDL_ConvertSurfaceFormat(surface.get(), SDL_PIXELFORMAT_ARGB8888, 0));
 }
 
 bool InteractsWithCharButton(Point point)
@@ -223,39 +213,24 @@ void RenderVirtualGamepad(SDL_Surface *surface)
 	Renderer.Render(renderFunction);
 }
 
-void VirtualGamepadRenderer::LoadArt(SDL_Renderer *renderer)
+void VirtualGamepadRenderer::LoadArt()
 {
-	menuPanelRenderer.LoadArt(renderer);
-	directionPadRenderer.LoadArt(renderer);
-	LoadButtonArt(&buttonArt, renderer);
-	LoadPotionArt(&potionArt, renderer);
+	menuPanelRenderer.LoadArt();
+	directionPadRenderer.LoadArt();
+	LoadButtonArt(&buttonArt);
+	LoadPotionArt(&potionArt);
 }
 
-void VirtualMenuPanelRenderer::LoadArt(SDL_Renderer *renderer)
+void VirtualMenuPanelRenderer::LoadArt()
 {
 	menuArt.surface.reset(LoadPNG("ui_art\\menu.png"));
 	menuArtLevelUp.surface.reset(LoadPNG("ui_art\\menu-levelup.png"));
-
-	if (renderer != nullptr) {
-		menuArt.texture.reset(SDL_CreateTextureFromSurface(renderer, menuArt.surface.get()));
-		menuArt.surface = nullptr;
-		menuArtLevelUp.texture.reset(SDL_CreateTextureFromSurface(renderer, menuArtLevelUp.surface.get()));
-		menuArtLevelUp.surface = nullptr;
-	}
 }
 
-void VirtualDirectionPadRenderer::LoadArt(SDL_Renderer *renderer)
+void VirtualDirectionPadRenderer::LoadArt()
 {
 	padArt.surface.reset(LoadPNG("ui_art\\directions.png"));
 	knobArt.surface.reset(LoadPNG("ui_art\\directions2.png"));
-
-	if (renderer != nullptr) {
-		padArt.texture.reset(SDL_CreateTextureFromSurface(renderer, padArt.surface.get()));
-		padArt.surface = nullptr;
-
-		knobArt.texture.reset(SDL_CreateTextureFromSurface(renderer, knobArt.surface.get()));
-		knobArt.surface = nullptr;
-	}
 }
 
 void VirtualGamepadRenderer::Render(RenderFunction renderFunction)
@@ -516,30 +491,98 @@ void VirtualGamepadRenderer::UnloadArt()
 {
 	menuPanelRenderer.UnloadArt();
 	directionPadRenderer.UnloadArt();
-	buttonArt.clear();
-	potionArt.clear();
+	buttonArt.clearSurface();
+	potionArt.clearSurface();
 }
 
 void VirtualMenuPanelRenderer::UnloadArt()
 {
-	menuArt.clear();
-	menuArtLevelUp.clear();
+	menuArt.clearSurface();
+	menuArtLevelUp.clearSurface();
 }
 
 void VirtualDirectionPadRenderer::UnloadArt()
 {
-	padArt.clear();
-	knobArt.clear();
+	padArt.clearSurface();
+	knobArt.clearSurface();
 }
 
-void InitVirtualGamepadGFX(SDL_Renderer *renderer)
+void InitVirtualGamepadGFX()
 {
-	Renderer.LoadArt(renderer);
+	Renderer.LoadArt();
 }
 
 void FreeVirtualGamepadGFX()
 {
 	Renderer.UnloadArt();
+}
+
+void VirtualGamepadRenderer::createTextures(SDL_Renderer &renderer)
+{
+	menuPanelRenderer.createTextures(renderer);
+	directionPadRenderer.createTextures(renderer);
+	if (buttonArt.surface != nullptr) {
+		buttonArt.texture.reset(SDL_CreateTextureFromSurface(&renderer, buttonArt.surface.get()));
+		buttonArt.surface = nullptr;
+	}
+	if (potionArt.surface != nullptr) {
+		potionArt.texture.reset(SDL_CreateTextureFromSurface(&renderer, potionArt.surface.get()));
+		potionArt.surface = nullptr;
+	}
+}
+
+void VirtualMenuPanelRenderer::createTextures(SDL_Renderer &renderer)
+{
+	if (menuArt.surface != nullptr) {
+		menuArt.texture.reset(SDL_CreateTextureFromSurface(&renderer, menuArt.surface.get()));
+		menuArt.surface = nullptr;
+	}
+	if (menuArtLevelUp.surface != nullptr) {
+		menuArtLevelUp.texture.reset(SDL_CreateTextureFromSurface(&renderer, menuArtLevelUp.surface.get()));
+		menuArtLevelUp.surface = nullptr;
+	}
+}
+
+void VirtualDirectionPadRenderer::createTextures(SDL_Renderer &renderer)
+{
+	if (padArt.surface != nullptr) {
+		padArt.texture.reset(SDL_CreateTextureFromSurface(&renderer, padArt.surface.get()));
+		padArt.surface = nullptr;
+	}
+	if (knobArt.surface != nullptr) {
+		knobArt.texture.reset(SDL_CreateTextureFromSurface(&renderer, knobArt.surface.get()));
+		knobArt.surface = nullptr;
+	}
+}
+
+void VirtualGamepadRenderer::destroyTextures()
+{
+	menuPanelRenderer.destroyTextures();
+	directionPadRenderer.destroyTextures();
+	buttonArt.destroyTexture();
+	potionArt.destroyTexture();
+}
+
+void VirtualMenuPanelRenderer::destroyTextures()
+{
+	menuArt.destroyTexture();
+	menuArtLevelUp.destroyTexture();
+}
+
+void VirtualDirectionPadRenderer::destroyTextures()
+{
+	padArt.destroyTexture();
+	knobArt.destroyTexture();
+}
+
+void InitVirtualGamepadTextures(SDL_Renderer &renderer)
+{
+	Renderer.createTextures(renderer);
+}
+
+void FreeVirtualGamepadTextures()
+{
+	Renderer.destroyTextures();
 }
 
 } // namespace devilution

--- a/Source/controls/touch/renderers.h
+++ b/Source/controls/touch/renderers.h
@@ -61,11 +61,15 @@ struct ButtonTexture {
 
 	Size size() const;
 
-	void clear()
+	void clearSurface()
 	{
 		surface = nullptr;
-		texture = nullptr;
 		numFrames = 1;
+	}
+
+	void destroyTexture()
+	{
+		texture = nullptr;
 	}
 };
 
@@ -78,7 +82,23 @@ public:
 	{
 	}
 
-	void LoadArt(SDL_Renderer *renderer);
+	void LoadArt();
+
+	/**
+	 * @brief Converts surfaces to textures.
+	 *
+	 * Must be called from the main thread.
+	 *
+	 * Per https://wiki.libsdl.org/SDL3/CategoryRender:
+	 * > These functions must be called from the main thread. See this bug for details: https://github.com/libsdl-org/SDL/issues/986
+	 */
+	void createTextures(SDL_Renderer &renderer);
+
+	/**
+	 * @brief Must be called from the main thread.
+	 */
+	void destroyTextures();
+
 	void Render(RenderFunction renderFunction);
 	void UnloadArt();
 
@@ -95,7 +115,23 @@ public:
 	{
 	}
 
-	void LoadArt(SDL_Renderer *renderer);
+	void LoadArt();
+
+	/**
+	 * @brief Converts surfaces to textures.
+	 *
+	 * Must be called from the main thread.
+	 *
+	 * Per https://wiki.libsdl.org/SDL3/CategoryRender:
+	 * > These functions must be called from the main thread. See this bug for details: https://github.com/libsdl-org/SDL/issues/986
+	 */
+	void createTextures(SDL_Renderer &renderer);
+
+	/**
+	 * @brief Must be called from the main thread.
+	 */
+	void destroyTextures();
+
 	void Render(RenderFunction renderFunction);
 	void UnloadArt();
 
@@ -213,7 +249,23 @@ public:
 	{
 	}
 
-	void LoadArt(SDL_Renderer *renderer);
+	void LoadArt();
+
+	/**
+	 * @brief Converts surfaces to textures.
+	 *
+	 * Must be called from the main thread.
+	 *
+	 * Per https://wiki.libsdl.org/SDL3/CategoryRender:
+	 * > These functions must be called from the main thread. See this bug for details: https://github.com/libsdl-org/SDL/issues/986
+	 */
+	void createTextures(SDL_Renderer &renderer);
+
+	/**
+	 * @brief Must be called from the main thread.
+	 */
+	void destroyTextures();
+
 	void Render(RenderFunction renderFunction);
 	void UnloadArt();
 
@@ -234,7 +286,22 @@ private:
 	ButtonTexture potionArt;
 };
 
-void InitVirtualGamepadGFX(SDL_Renderer *renderer);
+void InitVirtualGamepadGFX();
+
+/**
+ * @brief Creates textures for the virtual gamepad.
+ *
+ * Must be called after `InitVirtualGamepadGFX`.
+ * Must be called from the main thread.
+ *
+ * Per https://wiki.libsdl.org/SDL3/CategoryRender:
+ * > These functions must be called from the main thread. See this bug for details: https://github.com/libsdl-org/SDL/issues/986
+ */
+void InitVirtualGamepadTextures(SDL_Renderer &renderer);
+
+/** @brief Must be called from the main thread. */
+void FreeVirtualGamepadTextures();
+
 void RenderVirtualGamepad(SDL_Renderer *renderer);
 void RenderVirtualGamepad(SDL_Surface *surface);
 void FreeVirtualGamepadGFX();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1324,7 +1324,7 @@ void LoadAllGFX()
 {
 	IncProgress();
 #if !defined(USE_SDL1) && !defined(__vita__)
-	InitVirtualGamepadGFX(renderer);
+	InitVirtualGamepadGFX();
 #endif
 	IncProgress();
 	InitObjectGFX();
@@ -3044,7 +3044,7 @@ void LoadGameLevelSetLevel(bool firstflag, lvl_entry lvldir, const Player &myPla
 	IncProgress();
 	if (!HeadlessMode) {
 #if !defined(USE_SDL1) && !defined(__vita__)
-		InitVirtualGamepadGFX(renderer);
+		InitVirtualGamepadGFX();
 #endif
 		InitMissileGFX(gbIsHellfire);
 		IncProgress();
@@ -3101,7 +3101,7 @@ void LoadGameLevelStandardLevel(bool firstflag, lvl_entry lvldir, const Player &
 		IncProgress();
 
 #if !defined(USE_SDL1) && !defined(__vita__)
-		InitVirtualGamepadGFX(renderer);
+		InitVirtualGamepadGFX();
 #endif
 
 		IncProgress();

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -95,7 +95,7 @@ void diablo_focus_pause();
 void diablo_focus_unpause();
 bool PressEscKey();
 void DisableInputEventHandler(const SDL_Event &event, uint16_t modState);
-void LoadGameLevel(bool firstflag, lvl_entry lvldir);
+tl::expected<void, std::string> LoadGameLevel(bool firstflag, lvl_entry lvldir);
 bool IsDiabloAlive(bool playSFX);
 void PrintScreen(SDL_Keycode vkey);
 

--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -233,4 +233,9 @@ tl::expected<AssetData, std::string> LoadAsset(std::string_view path)
 	return AssetData { std::move(data), size };
 }
 
+std::string FailedToOpenFileErrorMessage(std::string_view path, std::string_view error)
+{
+	return fmt::format(fmt::runtime(_("Failed to open file:\n{:s}\n\n{:s}\n\nThe MPQ file(s) might be damaged. Please check the file integrity.")), path, error);
+}
+
 } // namespace devilution

--- a/Source/engine/assets.hpp
+++ b/Source/engine/assets.hpp
@@ -221,9 +221,11 @@ struct AssetHandle {
 };
 #endif
 
+std::string FailedToOpenFileErrorMessage(std::string_view path, std::string_view error);
+
 [[noreturn]] inline void FailedToOpenFileError(std::string_view path, std::string_view error)
 {
-	app_fatal(fmt::format(fmt::runtime(_("Failed to open file:\n{:s}\n\n{:s}\n\nThe MPQ file(s) might be damaged. Please check the file integrity.")), path, error));
+	app_fatal(FailedToOpenFileErrorMessage(path, error));
 }
 
 inline bool ValidatAssetRef(std::string_view path, const AssetRef &ref)

--- a/Source/engine/load_cel.cpp
+++ b/Source/engine/load_cel.cpp
@@ -2,12 +2,17 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 #ifdef DEBUG_CEL_TO_CL2_SIZE
 #include <iostream>
 #endif
 
+#include <expected.hpp>
+
+#include "appfat.h"
 #include "mpq/mpq_common.hpp"
+#include "utils/status_macros.hpp"
 #include "utils/str_cat.hpp"
 
 #ifdef UNPACKED_MPQS
@@ -19,20 +24,27 @@
 
 namespace devilution {
 
-OwnedClxSpriteListOrSheet LoadCelListOrSheet(const char *pszName, PointerOrValue<uint16_t> widthOrWidths)
+tl::expected<OwnedClxSpriteListOrSheet, std::string> LoadCelListOrSheetWithStatus(const char *pszName, PointerOrValue<uint16_t> widthOrWidths)
 {
 	char path[MaxMpqPathSize];
 	*BufCopy(path, pszName, DEVILUTIONX_CEL_EXT) = '\0';
 #ifdef UNPACKED_MPQS
-	return LoadClxListOrSheet(path);
+	return LoadClxListOrSheetWithStatus(path);
 #else
 	size_t size;
-	std::unique_ptr<uint8_t[]> data = LoadFileInMem<uint8_t>(path, &size);
+	ASSIGN_OR_RETURN(std::unique_ptr<uint8_t[]> data, LoadFileInMemWithStatus<uint8_t>(path, &size));
 #ifdef DEBUG_CEL_TO_CL2_SIZE
 	std::cout << path;
 #endif
 	return CelToClx(data.get(), size, widthOrWidths);
 #endif
+}
+
+OwnedClxSpriteListOrSheet LoadCelListOrSheet(const char *pszName, PointerOrValue<uint16_t> widthOrWidths)
+{
+	tl::expected<OwnedClxSpriteListOrSheet, std::string> result = LoadCelListOrSheetWithStatus(pszName, widthOrWidths);
+	if (DVL_PREDICT_FALSE(!result.has_value())) app_fatal(result.error());
+	return std::move(result).value();
 }
 
 } // namespace devilution

--- a/Source/engine/load_cel.hpp
+++ b/Source/engine/load_cel.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+
+#include <expected.hpp>
 
 #include "engine/clx_sprite.hpp"
 #include "utils/pointer_value_union.hpp"
+#include "utils/status_macros.hpp"
 
 #ifdef UNPACKED_MPQS
 #define DEVILUTIONX_CEL_EXT ".clx"
@@ -13,6 +17,8 @@
 
 namespace devilution {
 
+tl::expected<OwnedClxSpriteListOrSheet, std::string> LoadCelListOrSheetWithStatus(const char *pszName, PointerOrValue<uint16_t> widthOrWidths);
+
 OwnedClxSpriteListOrSheet LoadCelListOrSheet(const char *pszName, PointerOrValue<uint16_t> widthOrWidths);
 
 inline OwnedClxSpriteList LoadCel(const char *pszName, uint16_t width)
@@ -20,9 +26,21 @@ inline OwnedClxSpriteList LoadCel(const char *pszName, uint16_t width)
 	return LoadCelListOrSheet(pszName, PointerOrValue<uint16_t> { width }).list();
 }
 
+inline tl::expected<OwnedClxSpriteList, std::string> LoadCelWithStatus(const char *pszName, uint16_t width)
+{
+	ASSIGN_OR_RETURN(OwnedClxSpriteListOrSheet result, LoadCelListOrSheetWithStatus(pszName, PointerOrValue<uint16_t> { width }));
+	return std::move(result).list();
+}
+
 inline OwnedClxSpriteList LoadCel(const char *pszName, const uint16_t *widths)
 {
 	return LoadCelListOrSheet(pszName, PointerOrValue<uint16_t> { widths }).list();
+}
+
+inline tl::expected<OwnedClxSpriteList, std::string> LoadCelWithStatus(const char *pszName, const uint16_t *widths)
+{
+	ASSIGN_OR_RETURN(OwnedClxSpriteListOrSheet result, LoadCelListOrSheetWithStatus(pszName, PointerOrValue<uint16_t> { widths }));
+	return std::move(result).list();
 }
 
 inline OwnedClxSpriteSheet LoadCelSheet(const char *pszName, uint16_t width)

--- a/Source/engine/load_cl2.cpp
+++ b/Source/engine/load_cl2.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "mpq/mpq_common.hpp"
+#include "utils/status_macros.hpp"
 #include "utils/str_cat.hpp"
 
 #ifdef UNPACKED_MPQS
@@ -16,17 +17,24 @@
 
 namespace devilution {
 
-OwnedClxSpriteListOrSheet LoadCl2ListOrSheet(const char *pszName, PointerOrValue<uint16_t> widthOrWidths)
+tl::expected<OwnedClxSpriteListOrSheet, std::string> LoadCl2ListOrSheetWithStatus(const char *pszName, PointerOrValue<uint16_t> widthOrWidths)
 {
 	char path[MaxMpqPathSize];
 	*BufCopy(path, pszName, DEVILUTIONX_CL2_EXT) = '\0';
 #ifdef UNPACKED_MPQS
-	return LoadClxListOrSheet(path);
+	return LoadClxListOrSheetWithStatus(path);
 #else
 	size_t size;
-	std::unique_ptr<uint8_t[]> data = LoadFileInMem<uint8_t>(path, &size);
+	ASSIGN_OR_RETURN(std::unique_ptr<uint8_t[]> data, LoadFileInMemWithStatus<uint8_t>(path, &size));
 	return Cl2ToClx(std::move(data), size, widthOrWidths);
 #endif
+}
+
+OwnedClxSpriteListOrSheet LoadCl2ListOrSheet(const char *pszName, PointerOrValue<uint16_t> widthOrWidths)
+{
+	tl::expected<OwnedClxSpriteListOrSheet, std::string> result = LoadCl2ListOrSheetWithStatus(pszName, widthOrWidths);
+	if (!result.has_value()) app_fatal(result.error());
+	return std::move(result).value();
 }
 
 } // namespace devilution

--- a/Source/engine/load_cl2.hpp
+++ b/Source/engine/load_cl2.hpp
@@ -3,7 +3,9 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <string>
 
+#include <expected.hpp>
 #include <function_ref.hpp>
 
 #include "appfat.h"
@@ -14,6 +16,7 @@
 #include "utils/endian.hpp"
 #include "utils/pointer_value_union.hpp"
 #include "utils/static_vector.hpp"
+#include "utils/status_macros.hpp"
 #include "utils/str_cat.hpp"
 
 #ifdef UNPACKED_MPQS
@@ -24,10 +27,11 @@
 
 namespace devilution {
 
+tl::expected<OwnedClxSpriteListOrSheet, std::string> LoadCl2ListOrSheetWithStatus(const char *pszName, PointerOrValue<uint16_t> widthOrWidths);
 OwnedClxSpriteListOrSheet LoadCl2ListOrSheet(const char *pszName, PointerOrValue<uint16_t> widthOrWidths);
 
 template <size_t MaxCount>
-OwnedClxSpriteSheet LoadMultipleCl2Sheet(tl::function_ref<const char *(size_t)> filenames, size_t count, uint16_t width)
+tl::expected<OwnedClxSpriteSheet, std::string> LoadMultipleCl2Sheet(tl::function_ref<const char *(size_t)> filenames, size_t count, uint16_t width)
 {
 	StaticVector<std::array<char, MaxMpqPathSize>, MaxCount> paths;
 	StaticVector<AssetRef, MaxCount> files;
@@ -68,6 +72,12 @@ OwnedClxSpriteSheet LoadMultipleCl2Sheet(tl::function_ref<const char *(size_t)> 
 #else
 	return Cl2ToClx(std::move(data), accumulatedSize, frameWidth).sheet();
 #endif
+}
+
+inline tl::expected<OwnedClxSpriteList, std::string> LoadCl2WithStatus(const char *pszName, uint16_t width)
+{
+	ASSIGN_OR_RETURN(OwnedClxSpriteListOrSheet result, LoadCl2ListOrSheetWithStatus(pszName, PointerOrValue<uint16_t> { width }));
+	return std::move(result).list();
 }
 
 inline OwnedClxSpriteList LoadCl2(const char *pszName, uint16_t width)

--- a/Source/engine/load_clx.hpp
+++ b/Source/engine/load_clx.hpp
@@ -1,14 +1,27 @@
 #pragma once
 
+#include <string>
+
+#include <expected.hpp>
+
 #include "clx_sprite.hpp"
+#include "utils/status_macros.hpp"
 
 namespace devilution {
 
 OwnedClxSpriteListOrSheet LoadClxListOrSheet(const char *path);
 
+tl::expected<OwnedClxSpriteListOrSheet, std::string> LoadClxListOrSheetWithStatus(const char *path);
+
 inline OwnedClxSpriteList LoadClx(const char *path)
 {
 	return LoadClxListOrSheet(path).list();
+}
+
+inline tl::expected<OwnedClxSpriteList, std::string> LoadClxWithStatus(const char *path)
+{
+	ASSIGN_OR_RETURN(OwnedClxSpriteListOrSheet result, LoadClxListOrSheetWithStatus(path));
+	return std::move(result).list();
 }
 
 inline OwnedClxSpriteSheet LoadClxSheet(const char *path)

--- a/Source/engine/palette.h
+++ b/Source/engine/palette.h
@@ -60,17 +60,17 @@ void ApplyGamma(std::array<SDL_Color, 256> &dst, const std::array<SDL_Color, 256
 void DecreaseGamma();
 int UpdateGamma(int gamma);
 void BlackPalette();
-void SetFadeLevel(int fadeval, bool updateHardwareCursor = true);
+void SetFadeLevel(int fadeval, bool updateHardwareCursor = true, const std::array<SDL_Color, 256> &srcPalette = logical_palette);
 /**
  * @brief Fade screen from black
  * @param fr Steps per 50ms
  */
-void PaletteFadeIn(int fr);
+void PaletteFadeIn(int fr, const std::array<SDL_Color, 256> &srcPalette = orig_palette);
 /**
  * @brief Fade screen to black
  * @param fr Steps per 50ms
  */
-void PaletteFadeOut(int fr);
+void PaletteFadeOut(int fr, const std::array<SDL_Color, 256> &srcPalette = logical_palette);
 void palette_update_caves();
 void palette_update_crypt();
 void palette_update_hive();

--- a/Source/engine/sound.h
+++ b/Source/engine/sound.h
@@ -9,6 +9,8 @@
 #include <memory>
 #include <string>
 
+#include <expected.hpp>
+
 #include "levels/gendung.h"
 #include "utils/attributes.h"
 
@@ -56,6 +58,7 @@ extern _music_id sgnMusicTrack;
 void ClearDuplicateSounds();
 void snd_play_snd(TSnd *pSnd, int lVolume, int lPan);
 std::unique_ptr<TSnd> sound_file_load(const char *path, bool stream = false);
+tl::expected<std::unique_ptr<TSnd>, std::string> SoundFileLoadWithStatus(const char *path, bool stream = false);
 void snd_init();
 void snd_deinit();
 _music_id GetLevelMusic(dungeon_type dungeonType);

--- a/Source/engine/sound_stubs.cpp
+++ b/Source/engine/sound_stubs.cpp
@@ -11,6 +11,7 @@ _music_id sgnMusicTrack = NUM_MUSIC;
 void ClearDuplicateSounds() { }
 void snd_play_snd(TSnd *pSnd, int lVolume, int lPan) { }
 std::unique_ptr<TSnd> sound_file_load(const char *path, bool stream) { return nullptr; }
+tl::expected<std::unique_ptr<TSnd>, std::string> SoundFileLoadWithStatus(const char *path, bool stream) { return nullptr; }
 TSnd::~TSnd() { }
 void snd_init() { }
 void snd_deinit() { }

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -310,7 +310,9 @@ void gamemenu_load_game(bool /*bActivate*/)
 	DeactivateVirtualGamepad();
 	FreeVirtualGamepadTextures();
 #endif
-	LoadGame(false);
+	if (tl::expected<void, std::string> result = LoadGame(false); !result.has_value()) {
+		app_fatal(result.error());
+	}
 #if !defined(USE_SDL1) && !defined(__vita__)
 	if (renderer != nullptr) {
 		InitVirtualGamepadTextures(*renderer);

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -19,6 +19,10 @@
 #include "qol/floatingnumbers.h"
 #include "utils/language.h"
 
+#ifndef USE_SDL1
+#include "controls/touch/renderers.h"
+#endif
+
 namespace devilution {
 
 bool isGameMenuOpen = false;
@@ -302,7 +306,17 @@ void gamemenu_load_game(bool /*bActivate*/)
 	InitDiabloMsg(EMSG_LOADING);
 	RedrawEverything();
 	DrawAndBlit();
+#ifndef USE_SDL1
+	DeactivateVirtualGamepad();
+	FreeVirtualGamepadTextures();
+#endif
 	LoadGame(false);
+#if !defined(USE_SDL1) && !defined(__vita__)
+	if (renderer != nullptr) {
+		InitVirtualGamepadTextures(*renderer);
+	}
+#endif
+	NewCursor(CURSOR_HAND);
 	ClrDiabloMsg();
 	CornerStone.activated = false;
 	PaletteFadeOut(8);

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -28,6 +28,7 @@ enum interface_mode : uint8_t {
 
 	// Asynchronous loading events.
 	WM_PROGRESS,
+	WM_ERROR,
 	WM_DONE,
 
 	WM_FIRST = WM_DIABNEXTLVL,

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -26,8 +26,12 @@ enum interface_mode : uint8_t {
 	WM_DIABNEWGAME,
 	WM_DIABLOADGAME,
 
+	// Asynchronous loading events.
+	WM_PROGRESS,
+	WM_DONE,
+
 	WM_FIRST = WM_DIABNEXTLVL,
-	WM_LAST = WM_DIABLOADGAME,
+	WM_LAST = WM_DONE,
 };
 
 void RegisterCustomEvents();
@@ -59,7 +63,7 @@ enum Cutscenes : uint8_t {
 };
 
 void interface_msg_pump();
-void IncProgress();
+void IncProgress(uint32_t steps = 1);
 void CompleteProgress();
 void ShowProgress(interface_mode uMsg);
 

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -325,7 +325,7 @@ struct Miniset {
 	return HasAnyOf(SOLData[dPiece[coords.x][coords.y]], property);
 }
 
-void LoadLevelSOLData();
+tl::expected<void, std::string> LoadLevelSOLData();
 void SetDungeonMicros();
 void DRLG_InitTrans();
 void DRLG_MRectTrans(WorldTilePosition origin, WorldTilePosition extent);

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -8,6 +8,9 @@
 #include <algorithm>
 #include <cstdint>
 #include <numeric>
+#include <string>
+
+#include <expected.hpp>
 
 #include "automap.h"
 #include "diablo.h"
@@ -15,6 +18,7 @@
 #include "engine/points_in_rectangle_range.hpp"
 #include "player.h"
 #include "utils/attributes.h"
+#include "utils/status_macros.hpp"
 
 namespace devilution {
 
@@ -260,11 +264,11 @@ void DoVision(Point position, uint8_t radius, MapExplorationType doAutomap, bool
 	}
 }
 
-void LoadTrns()
+tl::expected<void, std::string> LoadTrns()
 {
-	LoadFileInMem("plrgfx\\infra.trn", InfravisionTable);
-	LoadFileInMem("plrgfx\\stone.trn", StoneTable);
-	LoadFileInMem("gendata\\pause.trn", PauseTable);
+	RETURN_IF_ERROR(LoadFileInMemWithStatus("plrgfx\\infra.trn", InfravisionTable));
+	RETURN_IF_ERROR(LoadFileInMemWithStatus("plrgfx\\stone.trn", StoneTable));
+	return LoadFileInMemWithStatus("gendata\\pause.trn", PauseTable);
 }
 
 void MakeLightTable()

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -11,6 +11,7 @@
 #include <type_traits>
 #include <vector>
 
+#include <expected.hpp>
 #include <function_ref.hpp>
 
 #include "automap.h"
@@ -65,7 +66,7 @@ void DoUnLight(Point position, uint8_t radius);
 void DoLighting(Point position, uint8_t radius, DisplacementOf<int8_t> offset);
 void DoUnVision(Point position, uint8_t radius);
 void DoVision(Point position, uint8_t radius, MapExplorationType doAutomap, bool visible);
-void LoadTrns();
+tl::expected<void, std::string> LoadTrns();
 void MakeLightTable();
 #ifdef _DEBUG
 void ToggleLighting();

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2552,7 +2552,6 @@ void LoadGame(bool firstflag)
 
 	SetUpMissileAnimationData();
 	RedoMissileFlags();
-	NewCursor(CURSOR_HAND);
 	gbProcessPlayers = IsDiabloAlive(!firstflag);
 
 	if (gbIsHellfireSaveGame != gbIsHellfire) {

--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -7,6 +7,8 @@
 
 #include <cstdint>
 
+#include <expected.hpp>
+
 #include "pfile.h"
 #include "player.h"
 #include "utils/attributes.h"
@@ -34,14 +36,14 @@ void RemoveEmptyInventory(Player &player);
  * @brief Load game state
  * @param firstflag Can be set to false if we are simply reloading the current game
  */
-void LoadGame(bool firstflag);
+tl::expected<void, std::string> LoadGame(bool firstflag);
 void SaveHotkeys(SaveWriter &saveWriter, const Player &player);
 void SaveHeroItems(SaveWriter &saveWriter, Player &player);
 void SaveGameData(SaveWriter &saveWriter);
 void SaveGame();
 void SaveLevel(SaveWriter &saveWriter);
-void LoadLevel();
-void ConvertLevels(SaveWriter &saveWriter);
+tl::expected<void, std::string> LoadLevel();
+tl::expected<void, std::string> ConvertLevels(SaveWriter &saveWriter);
 void LoadStash();
 void SaveStash(SaveWriter &stashWriter);
 

--- a/Source/lua/modules/dev/monsters.cpp
+++ b/Source/lua/modules/dev/monsters.cpp
@@ -58,7 +58,9 @@ std::string DebugCmdSpawnUniqueMonster(std::string name, std::optional<unsigned>
 	if (!found) {
 		if (LevelMonsterTypeCount == MaxLvlMTypes)
 			LevelMonsterTypeCount--; // we are running out of monster types, so override last used monster type
-		id = AddMonsterType(uniqueIndex, PLACE_SCATTER);
+		tl::expected<size_t, std::string> idResult = AddMonsterType(uniqueIndex, PLACE_SCATTER);
+		if (!idResult.has_value()) return std::move(idResult).error();
+		id = idResult.value();
 		CMonster &monsterType = LevelMonsterTypes[id];
 		InitMonsterGFX(monsterType);
 		monsterType.corpseId = 1;
@@ -131,7 +133,9 @@ std::string DebugCmdSpawnMonster(std::string name, std::optional<unsigned> count
 	if (!found) {
 		if (LevelMonsterTypeCount == MaxLvlMTypes)
 			LevelMonsterTypeCount--; // we are running out of monster types, so override last used monster type
-		id = AddMonsterType(static_cast<_monster_id>(mtype), PLACE_SCATTER);
+		tl::expected<size_t, std::string> idResult = AddMonsterType(static_cast<_monster_id>(mtype), PLACE_SCATTER);
+		if (!idResult.has_value()) return std::move(idResult).error();
+		id = idResult.value();
 		CMonster &monsterType = LevelMonsterTypes[id];
 		InitMonsterGFX(monsterType);
 		monsterType.corpseId = 1;

--- a/Source/misdat.h
+++ b/Source/misdat.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <type_traits>
 
+#include <expected.hpp>
+
 #include "effects.h"
 #include "engine/clx_sprite.hpp"
 #include "spelldat.h"
@@ -183,7 +185,7 @@ struct MissileFileData {
 	[[nodiscard]] uint8_t animDelay(uint8_t dir) const;
 	[[nodiscard]] uint8_t animLen(uint8_t dir) const;
 
-	void LoadGFX();
+	tl::expected<void, std::string> LoadGFX();
 
 	void FreeGFX()
 	{
@@ -209,7 +211,7 @@ MissileFileData &GetMissileSpriteData(MissileGraphicID graphicId);
 
 void LoadMissileData();
 
-void InitMissileGFX(bool loadHellfireGraphics = false);
+tl::expected<void, std::string> InitMissileGFX(bool loadHellfireGraphics = false);
 void FreeMissileGFX();
 
 } // namespace devilution

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -10,7 +10,9 @@
 
 #include <array>
 #include <functional>
+#include <string>
 
+#include <expected.hpp>
 #include <function_ref.hpp>
 
 #include "engine.h"
@@ -479,21 +481,21 @@ extern size_t ActiveMonsterCount;
 extern int MonsterKillCounts[NUM_MTYPES];
 extern bool sgbSaveSoundOn;
 
-void PrepareUniqueMonst(Monster &monster, UniqueMonsterType monsterType, size_t miniontype, int bosspacksize, const UniqueMonsterData &uniqueMonsterData);
+tl::expected<void, std::string> PrepareUniqueMonst(Monster &monster, UniqueMonsterType monsterType, size_t miniontype, int bosspacksize, const UniqueMonsterData &uniqueMonsterData);
 void InitLevelMonsters();
-void GetLevelMTypes();
-size_t AddMonsterType(_monster_id type, placeflag placeflag);
-inline size_t AddMonsterType(UniqueMonsterType uniqueType, placeflag placeflag)
+tl::expected<void, std::string> GetLevelMTypes();
+tl::expected<size_t, std::string> AddMonsterType(_monster_id type, placeflag placeflag);
+inline tl::expected<size_t, std::string> AddMonsterType(UniqueMonsterType uniqueType, placeflag placeflag)
 {
 	return AddMonsterType(UniqueMonstersData[static_cast<size_t>(uniqueType)].mtype, placeflag);
 }
-void InitMonsterSND(CMonster &monsterType);
-void InitMonsterGFX(CMonster &monsterType, MonsterSpritesData &&spritesData = {});
-void InitAllMonsterGFX();
+tl::expected<void, std::string> InitMonsterSND(CMonster &monsterType);
+tl::expected<void, std::string> InitMonsterGFX(CMonster &monsterType, MonsterSpritesData &&spritesData = {});
+tl::expected<void, std::string> InitAllMonsterGFX();
 void WeakenNaKrul();
 void InitGolems();
-void InitMonsters();
-void SetMapMonsters(const uint16_t *dunData, Point startPosition);
+tl::expected<void, std::string> InitMonsters();
+tl::expected<void, std::string> SetMapMonsters(const uint16_t *dunData, Point startPosition);
 Monster *AddMonster(Point position, Direction dir, size_t mtype, bool inMap);
 /**
  * @brief Spawns a new monsters (dynamically/not on level load).
@@ -534,7 +536,7 @@ bool DirOK(const Monster &monster, Direction mdir);
 bool PosOkMissile(Point position);
 bool LineClearMissile(Point startPoint, Point endPoint);
 bool LineClear(tl::function_ref<bool(Point)> clear, Point startPoint, Point endPoint);
-void SyncMonsterAnim(Monster &monster);
+tl::expected<void, std::string> SyncMonsterAnim(Monster &monster);
 void M_FallenFear(Point position);
 void PrintMonstHistory(int mt);
 void PrintUniqueHistory();

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -7,9 +7,11 @@
 #include <cmath>
 #include <cstdint>
 #include <ctime>
+#include <string>
 
 #include <algorithm>
 
+#include <expected.hpp>
 #include <fmt/core.h>
 
 #include "DiabloUI/ui_flags.hpp"
@@ -3671,10 +3673,10 @@ bool IsItemBlockingObjectAtPosition(Point position)
 	return false;
 }
 
-void LoadLevelObjects(uint16_t filesWidths[65])
+tl::expected<void, std::string> LoadLevelObjects(uint16_t filesWidths[65])
 {
 	if (HeadlessMode)
-		return;
+		return {};
 
 	for (const ObjectData objectData : AllObjects) {
 		if (leveltype == objectData.olvltype) {
@@ -3690,12 +3692,13 @@ void LoadLevelObjects(uint16_t filesWidths[65])
 		ObjFileList[numobjfiles] = static_cast<object_graphic_id>(i);
 		char filestr[32];
 		*BufCopy(filestr, "objects\\", ObjMasterLoadList[i]) = '\0';
-		pObjCels[numobjfiles] = LoadCel(filestr, filesWidths[i]);
+		ASSIGN_OR_RETURN(pObjCels[numobjfiles], LoadCelWithStatus(filestr, filesWidths[i]));
 		numobjfiles++;
 	}
+	return {};
 }
 
-void InitObjectGFX()
+tl::expected<void, std::string> InitObjectGFX()
 {
 	uint16_t filesWidths[65] = {};
 
@@ -3728,7 +3731,7 @@ void InitObjectGFX()
 		}
 	}
 
-	LoadLevelObjects(filesWidths);
+	return LoadLevelObjects(filesWidths);
 }
 
 void FreeObjectGFX()

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -7,6 +7,9 @@
 
 #include <cmath>
 #include <cstdint>
+#include <string>
+
+#include <expected.hpp>
 
 #include "cursor.h"
 #include "engine/clx_sprite.hpp"
@@ -322,7 +325,7 @@ inline Object &ObjectAtPosition(Point position)
  */
 bool IsItemBlockingObjectAtPosition(Point position);
 
-void InitObjectGFX();
+tl::expected<void, std::string> InitObjectGFX();
 void FreeObjectGFX();
 void AddL1Objs(int x1, int y1, int x2, int y2);
 void AddL2Objs(int x1, int y1, int x2, int y2);

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -966,6 +966,7 @@ GameplayOptions::GameplayOptions()
               { FloatingNumbers::Random, N_("Random Angles") },
               { FloatingNumbers::Vertical, N_("Vertical Only") },
           })
+    , skipLoadingScreenThresholdMs("Skip loading screen threshold, ms", OptionEntryFlags::Invisible, "", "", 0)
 {
 	grabInput.SetValueChangedCallback(OptionGrabInputChanged);
 	experienceBar.SetValueChangedCallback(OptionExperienceBarChanged);
@@ -1012,6 +1013,7 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&adriaRefillsMana,
 		&grabInput,
 		&pauseOnFocusLoss,
+		&skipLoadingScreenThresholdMs,
 	};
 }
 

--- a/Source/options.h
+++ b/Source/options.h
@@ -599,6 +599,13 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryInt<int> numFullRejuPotionPickup;
 	/** @brief Enable floating numbers. */
 	OptionEntryEnum<FloatingNumbers> enableFloatingNumbers;
+
+	/**
+	 * @brief If loading takes less than this value, skips displaying the loading screen.
+	 *
+	 * Advanced option, not displayed in the UI.
+	 */
+	OptionEntryInt<int> skipLoadingScreenThresholdMs;
 };
 
 struct ControllerOptions : OptionCategoryBase {

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <string>
 
+#include <expected.hpp>
 #include <fmt/format.h>
 #include <function_ref.hpp>
 
@@ -20,6 +21,7 @@
 #include "utils/enum_traits.h"
 #include "utils/format_int.hpp"
 #include "utils/language.h"
+#include "utils/status_macros.hpp"
 #include "utils/str_cat.hpp"
 #include "utils/surface_to_clx.hpp"
 
@@ -270,17 +272,17 @@ void DrawStatButtons(const Surface &out)
 
 } // namespace
 
-void LoadCharPanel()
+tl::expected<void, std::string> LoadCharPanel()
 {
-	OptionalOwnedClxSpriteList background = LoadClx("data\\charbg.clx");
+	ASSIGN_OR_RETURN(OptionalOwnedClxSpriteList background, LoadClxWithStatus("data\\charbg.clx"));
 	OwnedSurface out((*background)[0].width(), (*background)[0].height());
 	RenderClxSprite(out, (*background)[0], { 0, 0 });
 	background = std::nullopt;
 
 	{
-		OwnedClxSpriteList boxLeft = LoadClx("data\\boxleftend.clx");
-		OwnedClxSpriteList boxMiddle = LoadClx("data\\boxmiddle.clx");
-		OwnedClxSpriteList boxRight = LoadClx("data\\boxrightend.clx");
+		ASSIGN_OR_RETURN(OwnedClxSpriteList boxLeft, LoadClxWithStatus("data\\boxleftend.clx"));
+		ASSIGN_OR_RETURN(OwnedClxSpriteList boxMiddle, LoadClxWithStatus("data\\boxmiddle.clx"));
+		ASSIGN_OR_RETURN(OwnedClxSpriteList boxRight, LoadClxWithStatus("data\\boxrightend.clx"));
 
 		const bool isSmallFontTall = IsSmallFontTall();
 		const int attributeHeadersY = isSmallFontTall ? 112 : 114;
@@ -298,6 +300,7 @@ void LoadCharPanel()
 	}
 
 	Panel = SurfaceToClx(out);
+	return {};
 }
 
 void FreeCharPanel()

--- a/Source/panels/charpanel.hpp
+++ b/Source/panels/charpanel.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <string>
+
+#include <expected.hpp>
+
 #include "engine/clx_sprite.hpp"
 #include "engine/surface.hpp"
 
@@ -8,7 +12,7 @@ namespace devilution {
 extern OptionalOwnedClxSpriteList pChrButtons;
 
 void DrawChr(const Surface &);
-void LoadCharPanel();
+tl::expected<void, std::string> LoadCharPanel();
 void FreeCharPanel();
 
 } // namespace devilution

--- a/Source/panels/mainpanel.cpp
+++ b/Source/panels/mainpanel.cpp
@@ -2,6 +2,9 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
+
+#include <expected.hpp>
 
 #include "control.h"
 #include "engine/clx_sprite.hpp"
@@ -12,6 +15,7 @@
 #include "utils/language.h"
 #include "utils/sdl_compat.h"
 #include "utils/sdl_geometry.h"
+#include "utils/status_macros.hpp"
 #include "utils/surface_to_clx.hpp"
 
 namespace devilution {
@@ -66,12 +70,12 @@ void RenderMainButton(const Surface &out, int buttonId, std::string_view text, i
 
 } // namespace
 
-void LoadMainPanel()
+tl::expected<void, std::string> LoadMainPanel()
 {
 	std::optional<OwnedSurface> out;
 	constexpr uint16_t NumButtonSprites = 6;
 	{
-		OptionalOwnedClxSpriteList background = LoadClx("data\\panel8bucp.clx");
+		ASSIGN_OR_RETURN(OptionalOwnedClxSpriteList background, LoadClxWithStatus("data\\panel8bucp.clx"));
 		out.emplace((*background)[0].width(), (*background)[0].height() * NumButtonSprites);
 		int y = 0;
 		for (ClxSprite sprite : ClxSpriteList(*background)) {
@@ -134,6 +138,7 @@ void LoadMainPanel()
 	PanelButtonDownGrime = std::nullopt;
 	PanelButtonGrime = std::nullopt;
 	PanelButton = std::nullopt;
+	return {};
 }
 
 void FreeMainPanel()

--- a/Source/panels/mainpanel.hpp
+++ b/Source/panels/mainpanel.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <string>
+
+#include <expected.hpp>
+
 #include "engine/clx_sprite.hpp"
 
 namespace devilution {
@@ -7,7 +11,7 @@ namespace devilution {
 extern OptionalOwnedClxSpriteList PanelButtonDown;
 extern OptionalOwnedClxSpriteList TalkButton;
 
-void LoadMainPanel();
+tl::expected<void, std::string> LoadMainPanel();
 void FreeMainPanel();
 
 } // namespace devilution

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -2,7 +2,9 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 
+#include <expected.hpp>
 #include <fmt/format.h>
 
 #include "control.h"
@@ -20,6 +22,7 @@
 #include "player.h"
 #include "spelldat.h"
 #include "utils/language.h"
+#include "utils/status_macros.hpp"
 
 namespace devilution {
 
@@ -130,11 +133,11 @@ StringOrView GetSpellPowerText(SpellID spell, int spellLevel)
 
 } // namespace
 
-void InitSpellBook()
+tl::expected<void, std::string> InitSpellBook()
 {
-	spellBookBackground = LoadCel("data\\spellbk", static_cast<uint16_t>(SidePanelSize.width));
-	spellBookButtons = LoadCel("data\\spellbkb", SpellBookButtonWidth());
-	LoadSmallSpellIcons();
+	ASSIGN_OR_RETURN(spellBookBackground, LoadCelWithStatus("data\\spellbk", static_cast<uint16_t>(SidePanelSize.width)));
+	ASSIGN_OR_RETURN(spellBookButtons, LoadCelWithStatus("data\\spellbkb", SpellBookButtonWidth()));
+	return LoadSmallSpellIcons();
 }
 
 void FreeSpellBook()

--- a/Source/panels/spell_book.hpp
+++ b/Source/panels/spell_book.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <string>
+
+#include <expected.hpp>
+
 #include "engine/clx_sprite.hpp"
 #include "engine/surface.hpp"
 
 namespace devilution {
 
-void InitSpellBook();
+tl::expected<void, std::string> InitSpellBook();
 void FreeSpellBook();
 void CheckSBook();
 void DrawSpellBook(const Surface &out);

--- a/Source/panels/spell_icons.cpp
+++ b/Source/panels/spell_icons.cpp
@@ -84,24 +84,25 @@ const SpellIcon SpellITbl[] = {
 
 } // namespace
 
-void LoadLargeSpellIcons()
+tl::expected<void, std::string> LoadLargeSpellIcons()
 {
 	if (!gbIsHellfire) {
 #ifdef UNPACKED_MPQS
-		LargeSpellIcons = LoadClx("ctrlpan\\spelicon_fg.clx");
-		LargeSpellIconsBackground = LoadClx("ctrlpan\\spelicon_bg.clx");
+		ASSIGN_OR_RETURN(LargeSpellIcons, LoadClxWithStatus("ctrlpan\\spelicon_fg.clx"));
+		ASSIGN_OR_RETURN(LargeSpellIconsBackground, LoadClxWithStatus("ctrlpan\\spelicon_bg.clx"));
 #else
-		LargeSpellIcons = LoadCel("ctrlpan\\spelicon", SPLICONLENGTH);
+		ASSIGN_OR_RETURN(LargeSpellIcons, LoadCelWithStatus("ctrlpan\\spelicon", SPLICONLENGTH));
 #endif
 	} else {
 #ifdef UNPACKED_MPQS
-		LargeSpellIcons = LoadClx("data\\spelicon_fg.clx");
-		LargeSpellIconsBackground = LoadClx("data\\spelicon_bg.clx");
+		ASSIGN_OR_RETURN(LargeSpellIcons, LoadClxWithStatus("data\\spelicon_fg.clx"));
+		ASSIGN_OR_RETURN(LargeSpellIconsBackground, LoadClxWithStatus("data\\spelicon_bg.clx"));
 #else
-		LargeSpellIcons = LoadCel("data\\spelicon", SPLICONLENGTH);
+		ASSIGN_OR_RETURN(LargeSpellIcons, LoadCelWithStatus("data\\spelicon", SPLICONLENGTH));
 #endif
 	}
 	SetSpellTrans(SpellType::Skill);
+	return {};
 }
 
 void FreeLargeSpellIcons()
@@ -112,14 +113,15 @@ void FreeLargeSpellIcons()
 	LargeSpellIcons = std::nullopt;
 }
 
-void LoadSmallSpellIcons()
+tl::expected<void, std::string> LoadSmallSpellIcons()
 {
 #ifdef UNPACKED_MPQS
-	SmallSpellIcons = LoadClx("data\\spelli2_fg.clx");
-	SmallSpellIconsBackground = LoadClx("data\\spelli2_bg.clx");
+	ASSIGN_OR_RETURN(SmallSpellIcons, LoadClxWithStatus("data\\spelli2_fg.clx"));
+	ASSIGN_OR_RETURN(SmallSpellIconsBackground, LoadClxWithStatus("data\\spelli2_bg.clx"));
 #else
-	SmallSpellIcons = LoadCel("data\\spelli2", 37);
+	ASSIGN_OR_RETURN(SmallSpellIcons, LoadCelWithStatus("data\\spelli2", 37));
 #endif
+	return {};
 }
 
 void FreeSmallSpellIcons()

--- a/Source/panels/spell_icons.hpp
+++ b/Source/panels/spell_icons.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+
+#include <expected.hpp>
 
 #include "engine/clx_sprite.hpp"
 #include "engine/point.hpp"
@@ -106,10 +109,10 @@ void DrawSmallSpellIconBorder(const Surface &out, Point position);
  */
 void SetSpellTrans(SpellType t);
 
-void LoadLargeSpellIcons();
+tl::expected<void, std::string> LoadLargeSpellIcons();
 void FreeLargeSpellIcons();
 
-void LoadSmallSpellIcons();
+tl::expected<void, std::string> LoadSmallSpellIcons();
 void FreeSmallSpellIcons();
 
 } // namespace devilution

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -10,6 +10,7 @@
 #include <string_view>
 
 #include <ankerl/unordered_dense.h>
+#include <expected.hpp>
 #include <fmt/core.h>
 
 #include "codec.h"
@@ -778,10 +779,10 @@ void pfile_save_level()
 	SaveLevel(saveWriter);
 }
 
-void pfile_convert_levels()
+tl::expected<void, std::string> pfile_convert_levels()
 {
 	SaveWriter saveWriter = GetSaveWriter(gSaveNumber);
-	ConvertLevels(saveWriter);
+	return ConvertLevels(saveWriter);
 }
 
 void pfile_remove_temp_files()

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -6,6 +6,9 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
+
+#include <expected.hpp>
 
 #include "DiabloUI/diabloui.h"
 #include "player.h"
@@ -122,7 +125,7 @@ bool pfile_ui_save_create(_uiheroinfo *heroinfo);
 bool pfile_delete_save(_uiheroinfo *heroInfo);
 void pfile_read_player_from_save(uint32_t saveNum, Player &player);
 void pfile_save_level();
-void pfile_convert_levels();
+tl::expected<void, std::string> pfile_convert_levels();
 void pfile_remove_temp_files();
 std::unique_ptr<std::byte[]> pfile_read(const char *pszName, size_t *pdwLen);
 void pfile_update(bool forceSave);

--- a/Source/utils/attributes.h
+++ b/Source/utils/attributes.h
@@ -11,6 +11,12 @@
 #define DVL_HAVE_ATTRIBUTE(x) 0
 #endif
 
+#ifdef __has_builtin
+#define DVL_HAVE_BUILTIN(x) __has_builtin(x)
+#else
+#define DVL_HAVE_BUILTIN(x) 0
+#endif
+
 #if DVL_HAVE_ATTRIBUTE(format) || (defined(__GNUC__) && !defined(__clang__))
 #define DVL_PRINTF_ATTRIBUTE(fmtargnum, firstarg) \
 	__attribute__((__format__(__printf__, fmtargnum, firstarg)))
@@ -109,4 +115,12 @@
 #define DVL_UNREACHABLE() __assume(false)
 #else
 #define DVL_UNREACHABLE()
+#endif
+
+#if DVL_HAVE_BUILTIN(__builtin_expect)
+#define DVL_PREDICT_FALSE(x) (__builtin_expect(false || (x), false))
+#define DVL_PREDICT_TRUE(x) (__builtin_expect(false || (x), true))
+#else
+#define DVL_PREDICT_FALSE(x) (x)
+#define DVL_PREDICT_TRUE(x) (x)
 #endif

--- a/Source/utils/sdl_thread.h
+++ b/Source/utils/sdl_thread.h
@@ -1,11 +1,14 @@
 #pragma once
 
-#include <SDL.h>
 #include <memory>
+
+#include <SDL.h>
+
 #ifdef USE_SDL1
 #include "utils/sdl2_to_1_2_backports.h"
 #endif
 #include "appfat.h"
+#include "utils/attributes.h"
 
 namespace devilution {
 

--- a/Source/utils/status_macros.hpp
+++ b/Source/utils/status_macros.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "utils/attributes.h"
+
+#define RETURN_IF_ERROR(expr)                                         \
+	if (auto result = expr; DVL_PREDICT_FALSE(!result.has_value())) { \
+		return tl::make_unexpected(std::move(result).error());        \
+	}
+
+#define STATUS_MACROS_CONCAT_NAME_INNER(x, y) x##y
+#define STATUS_MACROS_CONCAT_NAME(x, y) STATUS_MACROS_CONCAT_NAME_INNER(x, y)
+
+#define ASSIGN_OR_RETURN_IMPL(result, lhs, rhs)                                                        \
+	auto result = rhs;                            /* NOLINT(bugprone-macro-parentheses): assignment */ \
+	if (DVL_PREDICT_FALSE(!result.has_value())) { /* NOLINT(bugprone-macro-parentheses): assignment */ \
+		return tl::make_unexpected(std::move(result).error());                                         \
+	}                                                                                                  \
+	lhs = std::move(result).value(); /* NOLINT(bugprone-macro-parentheses): assignment */
+
+#define ASSIGN_OR_RETURN(lhs, rhs) \
+	ASSIGN_OR_RETURN_IMPL(         \
+	    STATUS_MACROS_CONCAT_NAME(_result, __COUNTER__), lhs, rhs)

--- a/test/timedemo_test.cpp
+++ b/test/timedemo_test.cpp
@@ -23,6 +23,9 @@ bool Dummy_GetHeroInfo(_uiheroinfo *pInfo)
 
 void RunTimedemo(std::string timedemoFolderName)
 {
+	if (SDL_Init(SDL_INIT_EVENTS) <= -1) {
+		ErrSdl();
+	}
 	std::string unitTestFolderCompletePath = paths::BasePath() + "/test/fixtures/timedemo/" + timedemoFolderName;
 	paths::SetPrefPath(unitTestFolderCompletePath);
 	paths::SetConfigPath(unitTestFolderCompletePath);
@@ -72,6 +75,7 @@ void RunTimedemo(std::string timedemoFolderName)
 	ASSERT_FALSE(gbRunGame);
 	gbRunGame = false;
 	init_cleanup();
+	SDL_Quit();
 }
 
 } // namespace


### PR DESCRIPTION
Does the loading on a separate thread, so we're now loading while fading in and while updating the progress bar (resulting in much faster loads; fade outs still happen only after loading).

I had to separate the virtual gamepad surface and texture (de)initialization code because it was logging error messages, and upon further investigation I learned that per https://wiki.libsdl.org/SDL3/CategoryRender:
> These functions must be called from the main thread. See this bug for details: https://github.com/libsdl-org/SDL/issues/986

I also had to adjust fatal error reporting: `app_fatal` can only be called from the main thread, so during loading we instead propagate a `tl::expected` and send a custom message to the main thread if there is an error. Introduces `RETURN_IF_ERROR` and `ASSIGN_OR_RETURN` macros for more ergonomic status propagation.

I think I found most of the places where we currently call `app_fatal` during load and replaced them with `tl::expected` propagation. If I missed any, we won't see an error dialog for these errors and the loading process will appear to hang with lots of console spam instead.

Also adds an advanced (ini-only) setting to skip showing loading screen on fast loads. This is what it looks like on my machine with the threshold set to 500ms.

https://github.com/user-attachments/assets/37ff60ca-a247-4e06-b7e3-f5b6b8ea3692


