### PR TITLE
Clear unique item flags in LoadGameLevel()

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2884,6 +2884,7 @@ void LoadGameLevelFirstFlagEntry()
 	qtextflag = false;
 	if (!HeadlessMode) {
 		InitInv();
+		ClearUniqueItemFlags();
 		InitQuestText();
 		InitInfoBoxGfx();
 		InitHelp();

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2413,6 +2413,11 @@ bool IsUniqueAvailable(int i)
 	return gbIsHellfire || i <= 89;
 }
 
+void ClearUniqueItemFlags()
+{
+	memset(UniqueItemFlags, 0, sizeof(UniqueItemFlags));
+}
+
 void InitItemGFX()
 {
 	char arglist[64];
@@ -2422,7 +2427,6 @@ void InitItemGFX()
 		*BufCopy(arglist, "items\\", ItemDropNames[i]) = '\0';
 		itemanims[i] = LoadCel(arglist, ItemAnimWidth);
 	}
-	memset(UniqueItemFlags, 0, sizeof(UniqueItemFlags));
 }
 
 void InitItems()

--- a/Source/items.h
+++ b/Source/items.h
@@ -487,6 +487,7 @@ extern DVL_API_FOR_TEST bool UniqueItemFlags[128];
 uint8_t GetOutlineColor(const Item &item, bool checkReq);
 bool IsItemAvailable(int i);
 bool IsUniqueAvailable(int i);
+void ClearUniqueItemFlags();
 void InitItemGFX();
 void InitItems();
 void CalcPlrItemVals(Player &player, bool Loadgfx);


### PR DESCRIPTION
Vanilla called `InitItemGFX()` in `LoadGameLevel()` when `firstflag == true`.
https://github.com/diasurgical/devilution/blob/bbda8dd586c65b03028ec75c52f8ea8627eb9ff5/Source/diablo.cpp#L1845

In DevilutionX, this call to `InitItemGFX()` was moved to game client startup, and also when changing various settings.

Startup:
https://github.com/diasurgical/devilutionX/blob/d8dde8d2b119dfbc7973384aa598bd9e9de2c864/Source/diablo.cpp#L1217-L1218

Changing settings:
https://github.com/diasurgical/devilutionX/blob/d8dde8d2b119dfbc7973384aa598bd9e9de2c864/Source/DiabloUI/settingsmenu.cpp#L211-L214

This function had side effects with regard to the unique item drop table. This PR simply moves those side effects to its own function and invokes it in the same place vanilla does.