### PR TITLE
Update Amiga build configs

### DIFF
--- a/.github/workflows/amiga-m68k.yml
+++ b/.github/workflows/amiga-m68k.yml
@@ -40,9 +40,10 @@ jobs:
             -S . \
             -B build \
             -G Ninja \
-            -D M68K_COMMON="-s -fbbb=- -ffast-math -O2" \
-            -D M68K_CPU=68040 \
-            -D M68K_FPU=hard
+            -DCMAKE_BUILD_TYPE=Release \
+            -DM68K_COMMON="-s -fbbb=- -ffast-math" \
+            -DM68K_CPU=68040 \
+            -DM68K_FPU=hard
 
       - name: Build DevilutionX
         run: cmake --build build

--- a/CMake/platforms/amiga.cmake
+++ b/CMake/platforms/amiga.cmake
@@ -14,6 +14,10 @@ set(DEVILUTIONX_SYSTEM_ZLIB OFF)
 # As this build uses an older compiler, there are lots of them.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")
 
+# Lower the optimization level to O2 because there are issues with O3.
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
+
 # `fseeko` fails to link on Amiga.
 add_definitions(-Dfseeko=fseek)
 

--- a/Packaging/amiga/Dockerfile
+++ b/Packaging/amiga/Dockerfile
@@ -1,11 +1,13 @@
-FROM amigadev/crosstools:m68k-amigaos
+FROM amigadev/crosstools:m68k-amigaos-gcc10
 
 RUN apt-get install --no-install-recommends -y smpq
 RUN mkdir /devilutionx-deps-build
 COPY Packaging/amiga/prep.sh /devilutionx-deps-build/prep.sh
 RUN cd /devilutionx-deps-build && ./prep.sh
 
-CMD PKG_CONFIG_PATH=/opt/m68k-amigaos/usr/lib/pkgconfig/:/opt/m68k-amigaos/usr/share/pkgconfig/ \
-		cmake -S. -Bbuild-amiga -DCMAKE_BUILD_TYPE=Release -DCPACK=ON -DM68K_CPU=68040 -DM68K_FPU=hard \
-		-DM68K_COMMON="-s -ffast-math -O3 -noixemul -D__BIG_ENDIAN__ -D__AMIGA__ -fpermissive" && \
+CMD cmake -S. -Bbuild-amiga -DCPACK=ON \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DM68K_CPU=68040 \
+		-DM68K_FPU=hard \
+		-DM68K_COMMON="-s -fbbb=- -ffast-math" && \
 	cmake --build build-amiga -j $(nproc)


### PR DESCRIPTION
1. Updates the Dockerfile to the same image and flags as the CI.
2. Sets `-O2` as the default CMake Release flag rather than passing it in a custom way.

This fixes building by following the instructions in building.md.

/cc @arczi84