### PR TITLE
Improve `dev.display.path()`

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1653,21 +1653,21 @@ Point Player::GetTargetPosition() const
 	return target;
 }
 
-bool Player::IsPositionInPath(Point pos)
+int Player::GetPositionPathIndex(Point pos)
 {
 	constexpr Displacement DirectionOffset[8] = { { 0, -1 }, { -1, 0 }, { 1, 0 }, { 0, 1 }, { -1, -1 }, { 1, -1 }, { 1, 1 }, { -1, 1 } };
 	Point target = position.future;
+	int i = 0;
 	for (auto step : walkpath) {
-		if (target == pos) {
-			return true;
-		}
+		if (target == pos) return i;
 		if (step == WALK_NONE)
 			break;
 		if (step > 0) {
 			target += DirectionOffset[step - 1];
 		}
+		++i;
 	}
-	return false;
+	return -1;
 }
 
 void Player::Say(HeroSpeech speechId) const

--- a/Source/player.h
+++ b/Source/player.h
@@ -520,9 +520,9 @@ public:
 	Point GetTargetPosition() const;
 
 	/**
-	 * @brief Check if position is in player's path.
+	 * @brief Returns the index of the given position in `walkpath`, or -1 if not found.
 	 */
-	bool IsPositionInPath(Point position);
+	int GetPositionPathIndex(Point position);
 
 	/**
 	 * @brief Says a speech line.


### PR DESCRIPTION
1. Do not draw foliage with the pause trn.
2. Display the number of steps.
3. If the tile is not walkable (allowed for destination tile), display the number of steps in yellow.

![image](https://github.com/user-attachments/assets/e916f6b8-c1d6-49aa-a663-d1280f4ad3d8)
