### PR TITLE
Return anything from non-void function.

### DIFF
--- a/Source/utils/log.hpp
+++ b/Source/utils/log.hpp
@@ -58,6 +58,7 @@ std::string format(std::string_view fmt, Args &&...args)
 		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "%s", error.c_str());
 		app_fatal(error);
 #endif
+		return std::string("");
 	}
 }
 


### PR DESCRIPTION
Android and Xbox compilation logs a warning that non-`void` function in some code paths doesn't return anything, this is correct as the last invocation in the catch is `app_fatal`. To prevent this warning I'm adding a `return` statement that will not be actually executed but will silence the compiler warnings.

[Android warning](https://github.com/diasurgical/devilutionX/actions/runs/11767662351/job/32776597807#step:6:140):

```
C/C++: In file included from /home/runner/work/devilutionX/devilutionX/Source/capture.cpp:30:
C/C++: /home/runner/work/devilutionX/devilutionX/Source/utils/log.hpp:62:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
C/C++: }
C/C++: ^
C/C++: /home/runner/work/devilutionX/devilutionX/Source/utils/log.hpp:160:21: note: in instantiation of function template specialization 'devilution::detail::format<std::string &, const char *>' requested here
C/C++:         auto str = detail::format(fmt, std::forward<Args>(args)...);
C/C++:                            ^
C/C++: /home/runner/work/devilutionX/devilutionX/Source/utils/log.hpp:167:2: note: in instantiation of function template specialization 'devilution::LogError<std::string &, const char *>' requested here
C/C++:         LogError(defaultCategory, fmt, std::forward<Args>(args)...);
C/C++:         ^
C/C++: /home/runner/work/devilutionX/devilutionX/Source/capture.cpp:84:3: note: in instantiation of function template specialization 'devilution::LogError<std::string &, const char *>' requested here
C/C++:                 LogError("Failed to open {} for writing: {}", fileName, SDL_GetError());
C/C++:                 ^
```

With this change the [Android build log](https://github.com/diasurgical/devilutionX/actions/runs/11767925967/job/32777164948#step:6:1136) is readable again -- down from ~21500 lines to ~1100.