### PR TITLE
Silence warnings in compilers without [[noreturn]]

### DIFF
--- a/CMake/platforms/android.cmake
+++ b/CMake/platforms/android.cmake
@@ -29,3 +29,10 @@ set(UBSAN OFF)
 
 # Disable in-game options to exit the game.
 set(NOEXIT ON)
+
+# NDK C++ compiler does not support [[noreturn]], leading to lots of warnings like this:
+#
+#   warning: non-void function does not return a value in all control paths
+#
+# Silence them.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-return-type")

--- a/CMake/platforms/xbox_nxdk.cmake
+++ b/CMake/platforms/xbox_nxdk.cmake
@@ -20,3 +20,10 @@ set(CMAKE_THREAD_LIBS_INIT "-lpthread")
 set(CMAKE_HAVE_THREADS_LIBRARY 1)
 set(CMAKE_USE_WIN32_THREADS_INIT 0)
 set(CMAKE_USE_PTHREADS_INIT 1)
+
+# nxdk C++ compiler does not support [[noreturn]], leading to lots of warnings like this:
+#
+#   warning: non-void function does not return a value in all control paths
+#
+# Silence them.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-return-type")


### PR DESCRIPTION
Thanks @nelchael for bringing this to our attention in #7527