### PR TITLE
At shutdown, free surfaces and textures allocated for virtual gamepad graphics

### DIFF
--- a/Source/engine/dx.cpp
+++ b/Source/engine/dx.cpp
@@ -114,6 +114,7 @@ void dx_cleanup()
 	RendererTextureSurface = nullptr;
 #ifndef USE_SDL1
 	texture = nullptr;
+	FreeVirtualGamepadTextures();
 	if (*sgOptions.Graphics.upscale)
 		SDL_DestroyRenderer(renderer);
 #endif


### PR DESCRIPTION
Fixes the following error that intermittently occurs when exiting the game while debugging with Visual Studio.

![image](https://github.com/user-attachments/assets/276631a5-3141-408b-9efb-3080ccb1a2f9)
