### PR TITLE
Revise Teleport Target

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3123,6 +3123,26 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 		return;
 	}
 
+	Point targetedTile = cursPosition;
+
+	if (spellID == SpellID::Teleport) {
+		// Check if the player is attempting to queue Teleport onto a tile that is currently being targeted with Teleport, or a nearby tile
+		if (IsAnyOf(cursPosition, myPlayer.position.temp,
+		        myPlayer.position.temp + Direction::North,
+		        myPlayer.position.temp + Direction::NorthEast,
+		        myPlayer.position.temp + Direction::East,
+		        myPlayer.position.temp + Direction::SouthEast,
+		        myPlayer.position.temp + Direction::South,
+		        myPlayer.position.temp + Direction::SouthWest,
+		        myPlayer.position.temp + Direction::West,
+		        myPlayer.position.temp + Direction::NorthWest)) {
+			// Get the relative displacement from the player's current position to the cursor position
+			WorldTileDisplacement relativeMove = cursPosition - static_cast<Point>(myPlayer.position.tile);
+			// Target the tile the relative distance away from the player's targeted Teleport tile
+			targetedTile = myPlayer.position.temp + relativeMove;
+		}
+	}
+
 	if (!addflag) {
 		if (spellType == SpellType::Spell) {
 			switch (spellcheck) {
@@ -3155,7 +3175,7 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 		NetSendCmdParam5(true, CMD_SPELLPID, PlayerUnderCursor->getId(), static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	} else {
 		LastMouseButtonAction = MouseActionType::Spell;
-		NetSendCmdLocParam4(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
+		NetSendCmdLocParam4(true, CMD_SPELLXY, targetedTile, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	}
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3123,18 +3123,6 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 		return;
 	}
 
-	Point targetedTile = cursPosition;
-
-	if (spellID == SpellID::Teleport && myPlayer.executedSpell.spellId == SpellID::Teleport) {
-		// Check if the player is attempting to queue Teleport onto a tile that is currently being targeted with Teleport, or a nearby tile
-		if (cursPosition.WalkingDistance(myPlayer.position.temp) <= 1) {
-			// Get the relative displacement from the player's current position to the cursor position
-			WorldTileDisplacement relativeMove = cursPosition - static_cast<Point>(myPlayer.position.tile);
-			// Target the tile the relative distance away from the player's targeted Teleport tile
-			targetedTile = myPlayer.position.temp + relativeMove;
-		}
-	}
-
 	if (!addflag) {
 		if (spellType == SpellType::Spell) {
 			switch (spellcheck) {
@@ -3166,6 +3154,16 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 		LastMouseButtonAction = MouseActionType::SpellPlayerTarget;
 		NetSendCmdParam5(true, CMD_SPELLPID, PlayerUnderCursor->getId(), static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	} else {
+		Point targetedTile = cursPosition;
+		if (spellID == SpellID::Teleport && myPlayer.executedSpell.spellId == SpellID::Teleport) {
+			// Check if the player is attempting to queue Teleport onto a tile that is currently being targeted with Teleport, or a nearby tile
+			if (cursPosition.WalkingDistance(myPlayer.position.temp) <= 1) {
+				// Get the relative displacement from the player's current position to the cursor position
+				WorldTileDisplacement relativeMove = cursPosition - static_cast<Point>(myPlayer.position.tile);
+				// Target the tile the relative distance away from the player's targeted Teleport tile
+				targetedTile = myPlayer.position.temp + relativeMove;
+			}
+		}
 		LastMouseButtonAction = MouseActionType::Spell;
 		NetSendCmdLocParam4(true, CMD_SPELLXY, targetedTile, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellLevel, spellFrom);
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3125,7 +3125,7 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 
 	Point targetedTile = cursPosition;
 
-	if (spellID == SpellID::Teleport) {
+	if (spellID == SpellID::Teleport && myPlayer.executedSpell.spellId == SpellID::Teleport) {
 		// Check if the player is attempting to queue Teleport onto a tile that is currently being targeted with Teleport, or a nearby tile
 		if (IsAnyOf(cursPosition, myPlayer.position.temp,
 		        myPlayer.position.temp + Direction::North,

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3127,15 +3127,7 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 
 	if (spellID == SpellID::Teleport && myPlayer.executedSpell.spellId == SpellID::Teleport) {
 		// Check if the player is attempting to queue Teleport onto a tile that is currently being targeted with Teleport, or a nearby tile
-		if (IsAnyOf(cursPosition, myPlayer.position.temp,
-		        myPlayer.position.temp + Direction::North,
-		        myPlayer.position.temp + Direction::NorthEast,
-		        myPlayer.position.temp + Direction::East,
-		        myPlayer.position.temp + Direction::SouthEast,
-		        myPlayer.position.temp + Direction::South,
-		        myPlayer.position.temp + Direction::SouthWest,
-		        myPlayer.position.temp + Direction::West,
-		        myPlayer.position.temp + Direction::NorthWest)) {
+		if (cursPosition.WalkingDistance(myPlayer.position.temp) <= 1) {
 			// Get the relative displacement from the player's current position to the cursor position
 			WorldTileDisplacement relativeMove = cursPosition - static_cast<Point>(myPlayer.position.tile);
 			// Target the tile the relative distance away from the player's targeted Teleport tile


### PR DESCRIPTION
Currently, if the player holds right click with Teleport selected, this causes the game to select a tile as the Teleport target, and then select the same tile as the queued Teleport target, resulting in the player casting every other Teleport with no movement.

This PR does the following:

If the player is casting Teleport and the new target tile is the same as the currently targeted tile (or any nearby tile) by the currently executed Teleport spell, get the relative distance between the player and the new target tile, and add that to the currently executed tile, then Teleport the player there instead.

This allows the player to keep the mouse still and continuously queue Teleport to move in a direction. However, this does not work consistently if the player is moving the mouse around while doing this, since the player will end up zigzagging, as the queued tile can end up being different enough at this point from the executed tile. This isn't a new problem, but an existing potential annoyance due to spells targeting fixed positions rather than relative positions. The only way around that is to completely move Teleport to a relative target system, however doing so can end up being incredibly disruptive to gameplay and I don't believe it should be done.

This fix is effectively the same as simply not letting the game queue a Teleport if the queued tile is the same as the executed tile, however doing that end up adding 1 frame to every cast animation, since the chained Teleports are no longer actually chained, but fresh casts. Instead, we preemptively get the new position to Teleport the player to, in order to maintain the queueing and not slow the player's casting down.

Before:

https://github.com/user-attachments/assets/b473a1bf-6450-42f2-b356-4112e1892063





After:



https://github.com/user-attachments/assets/b4d53bbe-aaa2-457a-83c3-1eeeb1e46be2

