### PR TITLE
Fix PS4 workflow

### DIFF
--- a/.github/workflows/PS4.yml
+++ b/.github/workflows/PS4.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   ps4:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -32,12 +32,18 @@ jobs:
         fetch-depth: 0
 
     - name: Create Build Environment
-      run: >
-        sudo apt-get update &&
-        sudo apt-get install -y wget cmake git gettext smpq &&
-        wget https://github.com/PacBrew/pacbrew-pacman/releases/download/v1.1/pacbrew-pacman-1.1.deb &&
-        sudo dpkg -i pacbrew-pacman-1.1.deb && sudo pacbrew-pacman -Sy &&
-        sudo pacbrew-pacman --noconfirm -S ps4-openorbis ps4-openorbis-portlibs &&
+      run: |
+        sudo apt-get update && \
+        sudo apt-get install -y pacman-package-manager wget cmake git gettext smpq && \
+        sudo tee -a /etc/pacman.conf > /dev/null <<TEXT
+        [pacbrew]
+        SigLevel = Optional TrustAll
+        Server = https://pacman.mydedibox.fr/pacbrew/packages/
+        TEXT
+    - name: Setup pacman packages
+      run: |
+        sudo pacman --noconfirm -Sy && \
+        sudo pacman --noconfirm -S ps4-openorbis ps4-openorbis-portlibs && \
         echo "#include <endian.h>" | sudo tee /opt/pacbrew/ps4/openorbis/include/sys/endian.h
 
     - name: Build


### PR DESCRIPTION
Switches from `pacbrew-pacman` to vanilla pacman that is now an Ubuntu package (`pacman-package-manager`) starting from Ubuntu 24.04.

pacbrew-pacman from https://github.com/PacBrew/pacbrew-pacman/releases is 2 years old and has the repo URL that no longer works. With the vanilla pacman, we simply add pacbrew as a repo source with the correct URL.

Refs https://github.com/PacBrew/pacbrew-packages/issues/6

@Cpasjuste does this look right to you?