### PR TITLE
Revert changes to price validation logic in cfac786

### DIFF
--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -58,11 +58,15 @@ bool IsTownItemValid(uint16_t iCreateInfo, const Player &player)
 
 bool IsShopPriceValid(const Item &item)
 {
-	const int boyPriceLimit = gbIsHellfire ? MaxBoyValueHf : MaxBoyValue;
-	if ((item._iCreateInfo & CF_BOY) != 0 && item._iIvalue > boyPriceLimit)
+	const int boyPriceLimit = MaxBoyValue;
+	if (!gbIsHellfire && (item._iCreateInfo & CF_BOY) != 0 && item._iIvalue > boyPriceLimit)
 		return false;
 
-	const uint16_t smithOrWitch = CF_SMITH | CF_SMITHPREMIUM | CF_WITCH;
+	const int premiumPriceLimit = MaxVendorValue;
+	if (!gbIsHellfire && (item._iCreateInfo & CF_SMITHPREMIUM) != 0 && item._iIvalue > premiumPriceLimit)
+		return false;
+
+	const uint16_t smithOrWitch = CF_SMITH | CF_WITCH;
 	const int smithAndWitchPriceLimit = gbIsHellfire ? MaxVendorValueHf : MaxVendorValue;
 	if ((item._iCreateInfo & smithOrWitch) != 0 && item._iIvalue > smithAndWitchPriceLimit)
 		return false;


### PR DESCRIPTION
We can't validate price on Wirt's items or Griswold's premium items in Hellfire because shop manipulation can drive these vendors to sell items above their price limit.

![image](https://github.com/user-attachments/assets/e0712289-2d41-446a-9925-2ae9fef99b14)