### PR TITLE
Do not apply item validation to Single Player games

### DIFF
--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -139,6 +139,9 @@ bool IsDungeonItemValid(uint16_t iCreateInfo, uint32_t dwBuff)
 
 bool IsItemValid(const Player &player, const Item &item)
 {
+	if (!gbIsMultiplayer)
+		return true;
+
 	if (item.IDidx != IDI_GOLD && !IsCreationFlagComboValid(item._iCreateInfo))
 		return false;
 


### PR DESCRIPTION
#7506 introduced calls to item validation into `Player::CanUseItem()` and `CalcSelfItems()` which are functions shared between Single Player and Multiplayer games. The item validation should probably not be applied to Single Player at all because data errors introduced by bugs in vanilla can make their way into DevilutionX via the item data stored in Single Player savegames. Those data errors can cause items to appear invalid when they actually aren't.

Note that the steps to reproduce described in #7561 will no longer work after incorporating this fix.