### PR TITLE
Divorce town seed from game seed

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -795,6 +795,8 @@ bool NetInit(bool bSinglePlayer)
 		DungeonSeeds[i] = gameGenerator.next();
 		LevelSeeds[i] = std::nullopt;
 	}
+	// explicitly randomize the town seed to divorce shops from the game seed
+	DungeonSeeds[0] = GenerateSeed();
 	PublicGame = DvlNet_IsPublicGame();
 
 	Player &myPlayer = *MyPlayer;


### PR DESCRIPTION
#7030 removed the logic that combines the town seed with `SDL_GetTicks()` because the `GenerateSeed()` function that uses the xoshiro generator was applied to town seed rotation in `SaveLevel()` and `DeltaLeaveSync()`. However, the initial town seed is still dependent on the game seed, meaning players who join the same Multiplayer game session will have the same initial set of shops. This PR further applies the xoshiro generator to the initial town seed to fix that blind spot.