### PR TITLE
Fix value of items bought from Wirt's shop

### DIFF
--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1708,11 +1708,11 @@ void BoyEnter()
 	StartStore(TalkID::Gossip);
 }
 
-void BoyBuyItem(Item &item)
+void BoyBuyItem(Item &item, int itemPrice)
 {
-	TakePlrsMoney(item._iIvalue);
+	TakePlrsMoney(itemPrice);
 	StoreAutoPlace(item, true);
-	BoyItem.clear();
+	item.clear();
 	OldActiveStore = TalkID::Boy;
 	CalcPlrInv(*MyPlayer, true);
 	OldTextLine = 12;
@@ -1836,7 +1836,7 @@ void ConfirmEnter(Item &item)
 			WitchRechargeItem(item._iIvalue);
 			break;
 		case TalkID::BoyBuy:
-			BoyBuyItem(item);
+			BoyBuyItem(BoyItem, item._iIvalue);
 			break;
 		case TalkID::HealerBuy:
 			HealerBuyItem(item);


### PR DESCRIPTION
The game was already storing the adjusted price of the item in `TempItem` rather than `BoyItem`. All we really need to do is transfer `BoyItem` to the player's inventory instead of `TempItem`.

Note that this does have the very minor effect of diminishing the resale value of Wirt purchases in Diablo while boosting the resale value in Hellfire. That said, you're selling the item back at a loss regardless. Furthermore, even without this change, the resale value of Wirt purchases would go back to normal after regenerating the item anyway.

This resolves #7561