### PR TITLE
Cleanup for weapon explosions

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1974,8 +1974,14 @@ void AddMissileExplosion(Missile &missile, AddMissileParameter &parameter)
 
 void AddWeaponExplosion(Missile &missile, AddMissileParameter &parameter)
 {
-	missile.var2 = parameter.dst.x;
-	if (parameter.dst.x == 1)
+	bool isFireExplosion = parameter.dst.x == 1;
+
+	if (missile._midam > 0) {
+		DamageType damageType = isFireExplosion ? DamageType::Fire : DamageType::Lightning;
+		CheckMissileCol(missile, damageType, missile._midam, missile._midam, false, missile.position.tile, true);
+	}
+
+	if (isFireExplosion)
 		missile.setAnimation(MissileGraphicID::MagmaBallExplosion);
 	else
 		missile.setAnimation(MissileGraphicID::ChargedBolt);
@@ -3520,21 +3526,6 @@ void ProcessWeaponExplosion(Missile &missile)
 
 	missile.duration--;
 	const Player &player = Players[missile._misource];
-	int mind;
-	int maxd;
-	DamageType damageType;
-	if (missile.var2 == 1) {
-		// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
-		mind = player._pIFMinDam;
-		maxd = player._pIFMaxDam;
-		damageType = DamageType::Fire;
-	} else {
-		// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
-		mind = player._pILMinDam;
-		maxd = player._pILMaxDam;
-		damageType = DamageType::Lightning;
-	}
-	CheckMissileCol(missile, damageType, mind, maxd, false, missile.position.tile, false);
 	if (missile.var1 == 0) {
 		missile._mlid = AddLight(missile.position.tile, 9);
 	} else {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -783,15 +783,6 @@ bool DoAttack(Player &player)
 			}
 		}
 
-		if (!gbIsHellfire || !HasAllOf(player._pIFlags, ItemSpecialEffect::FireDamage | ItemSpecialEffect::LightningDamage)) {
-			if (HasAnyOf(player._pIFlags, ItemSpecialEffect::FireDamage)) {
-				AddMissile(position, { 1, 0 }, Direction::South, MissileID::WeaponExplosion, TARGET_MONSTERS, player, 0, 0);
-			}
-			if (HasAnyOf(player._pIFlags, ItemSpecialEffect::LightningDamage)) {
-				AddMissile(position, { 2, 0 }, Direction::South, MissileID::WeaponExplosion, TARGET_MONSTERS, player, 0, 0);
-			}
-		}
-
 		if (monster != nullptr) {
 			didhit = PlrHitMonst(player, *monster);
 		} else if (PlayerAtPosition(position) != nullptr && !player.friendlyMode) {
@@ -802,6 +793,18 @@ bool DoAttack(Player &player)
 				didhit = PlrHitObj(player, *object);
 			}
 		}
+
+		if (!gbIsHellfire || !HasAllOf(player._pIFlags, ItemSpecialEffect::FireDamage | ItemSpecialEffect::LightningDamage)) {
+			if (HasAnyOf(player._pIFlags, ItemSpecialEffect::FireDamage)) {
+				int elementalDamage = didhit ? RandomIntBetween(player._pIFMinDam, player._pIFMaxDam) : 0;
+				AddMissile(position, { 1, 0 }, Direction::South, MissileID::WeaponExplosion, TARGET_MONSTERS, player, elementalDamage, 0);
+			}
+			if (HasAnyOf(player._pIFlags, ItemSpecialEffect::LightningDamage)) {
+				int elementalDamage = didhit ? RandomIntBetween(player._pILMinDam, player._pILMaxDam) : 0;
+				AddMissile(position, { 2, 0 }, Direction::South, MissileID::WeaponExplosion, TARGET_MONSTERS, player, elementalDamage, 0);
+			}
+		}
+
 		if (player.CanCleave()) {
 			// playing as a class/weapon with cleave
 			position = player.position.tile + Right(player._pdir);


### PR DESCRIPTION
With the changes in this PR, weapon explosions only do the collision check once, in `AddWeaponExplosion()`. I set the `dontDeleteOnCollision` flag to prevent the missile from immediately deleting itself. This means the missile animation will always play to completion regardless of whether the elemental damage strikes the target.

I modified `DoAttack()` to use the `didhit` flag to determine whether the missile should attempt to do damage to the target. Just like with elemental arrows, if the physical attack doesn't hit, the elemental attack doesn't hit either. In order to skip the collision check but still play the missile animation, `DoAttack()` simply sets the missile damage to zero if the physical attack missed. `AddWeaponExplosion()` will skip the collision check entirely if it sees that the missile damage is zero.

This resolves #7571