### PR TITLE
Improve moving to the inventory/body using a gamepad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,6 +262,8 @@ _pkginfo.txt
 *.[Cc]ache
 # but keep track of directories ending in .cache
 !*.[Cc]ache/
+# except for a top-level .cache directory (clangd uses /.cache/clangd for temporary files)
+/.cache/
 
 # Others
 ClientBin/
@@ -435,7 +437,7 @@ DerivedData/
 
 # End of https://www.gitignore.io/api/xcode
 
-# Don't accidently commit the diabdat.mpq
+# Don't accidently commit the diabdat.mpq or any other MPQ files
 *.mpq
 
 ### Nintendo Switch ###
@@ -443,9 +445,6 @@ exefs/main
 /out/isenseconfig/CPI-Debug
 
 /docs/html/
-
-# MPQ files
-*.mpq
 
 # ddraw wrapper configuration file
 ddraw_settings.ini

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -744,15 +744,22 @@ void ResetInvCursorPosition()
 {
 	Point mousePos {};
 	if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_INV_LAST) {
-		int8_t itemInvId = GetItemIdOnSlot(Slot);
-		if (itemInvId != 0) {
-			mousePos = GetSlotCoord(FindFirstSlotOnItem(itemInvId));
-			Size itemSize = GetItemSizeOnSlot(Slot);
-			mousePos.x += ((itemSize.width - 1) * InventorySlotSizeInPixels.width) / 2;
-			mousePos.y += ((itemSize.height - 1) * InventorySlotSizeInPixels.height) / 2;
+		auto slot = Slot;
+		Size itemSize = { 1, 1 };
+
+		if (MyPlayer->HoldItem.isEmpty()) {
+			int8_t itemInvId = GetItemIdOnSlot(Slot);
+			if (itemInvId != 0) {
+				slot = FindFirstSlotOnItem(itemInvId);
+				itemSize = GetItemSizeOnSlot(Slot);
+			}
 		} else {
-			mousePos = GetSlotCoord(Slot);
+			itemSize = GetInventorySize(MyPlayer->HoldItem);
 		}
+
+		mousePos = GetSlotCoord(slot);
+		mousePos.x += ((itemSize.width - 1) * InventorySlotSizeInPixels.width) / 2;
+		mousePos.y += ((itemSize.height - 1) * InventorySlotSizeInPixels.height) / 2;
 	} else if (Slot >= SLOTXY_BELT_FIRST && Slot <= SLOTXY_BELT_LAST) {
 		mousePos = GetSlotCoord(Slot);
 	} else {
@@ -1198,7 +1205,7 @@ void StashMove(AxisDirection dir)
 			Point rightPanelCoord = { GetRightPanel().position.x, stashSlotCoord.y };
 			Slot = FindClosestInventorySlot(rightPanelCoord, holdItem, [](Point mousePos, int slot) {
 				Point slotPos = GetSlotCoord(slot);
-				// Exagerrate the vertical difference so that moving from the top 6 rows of the
+				// Exaggerate the vertical difference so that moving from the top 6 rows of the
 				//  stash is more likely to land on a body slot. The value 3 was found by trial and
 				//  error, this allows moving from the top row of the stash to the head while
 				//  empty-handed while 4 causes the amulet to be preferenced (due to less vertical

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1106,9 +1106,9 @@ void StashMove(AxisDirection dir)
 	Item &holdItem = MyPlayer->HoldItem;
 	Size itemSize = holdItem.isEmpty() ? Size { 1, 1 } : GetInventorySize(holdItem);
 
-	// Jump from belt to stash
-	if (BeltReturnsToStash && Slot >= SLOTXY_BELT_FIRST && Slot <= SLOTXY_BELT_LAST) {
-		if (dir.y == AxisDirectionY_UP) {
+	if (dir.y == AxisDirectionY_UP) {
+		// Check if we need to jump from belt to stash
+		if (BeltReturnsToStash && Slot >= SLOTXY_BELT_FIRST && Slot <= SLOTXY_BELT_LAST) {
 			int beltSlot = Slot - SLOTXY_BELT_FIRST;
 			InvalidateInventorySlot();
 			ActiveStashSlot = { 2 + beltSlot, 10 - itemSize.height };
@@ -1116,30 +1116,21 @@ void StashMove(AxisDirection dir)
 		}
 	}
 
-	// Jump from general inventory to stash
-	if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_INV_LAST) {
+	if (dir.x == AxisDirectionX_LEFT) {
+		// Check if we need to jump from general inventory to stash
 		int firstSlot = Slot;
-		if (MyPlayer->HoldItem.isEmpty()) {
-			int8_t itemId = GetItemIdOnSlot(Slot);
-			if (itemId != 0) {
-				firstSlot = FindFirstSlotOnItem(itemId);
+		if (Slot >= SLOTXY_INV_FIRST && Slot <= SLOTXY_INV_LAST) {
+			if (MyPlayer->HoldItem.isEmpty()) {
+				int8_t itemId = GetItemIdOnSlot(Slot);
+				if (itemId != 0) {
+					firstSlot = FindFirstSlotOnItem(itemId);
+				}
 			}
 		}
-		if (IsAnyOf(firstSlot, SLOTXY_INV_ROW1_FIRST, SLOTXY_INV_ROW2_FIRST, SLOTXY_INV_ROW3_FIRST, SLOTXY_INV_ROW4_FIRST)) {
-			if (dir.x == AxisDirectionX_LEFT) {
-				Point slotCoord = GetSlotCoord(Slot);
-				InvalidateInventorySlot();
-				ActiveStashSlot = FindClosestStashSlot(slotCoord) - Displacement { itemSize.width - 1, 0 };
-				dir.x = AxisDirectionX_NONE;
-			}
-		}
-	}
 
-	bool isHeadSlot = SLOTXY_HEAD == Slot;
-	bool isLeftHandSlot = SLOTXY_HAND_LEFT == Slot;
-	bool isLeftRingSlot = Slot == SLOTXY_RING_LEFT;
-	if (isHeadSlot || isLeftHandSlot || isLeftRingSlot) {
-		if (dir.x == AxisDirectionX_LEFT) {
+		// If we're in the leftmost column (or hovering over an item on the left side of the inventory) or
+		//  left side of the body and we're moving left we need to move into the closest stash column
+		if (IsAnyOf(firstSlot, SLOTXY_HEAD, SLOTXY_HAND_LEFT, SLOTXY_RING_LEFT, SLOTXY_INV_ROW1_FIRST, SLOTXY_INV_ROW2_FIRST, SLOTXY_INV_ROW3_FIRST, SLOTXY_INV_ROW4_FIRST)) {
 			Point slotCoord = GetSlotCoord(Slot);
 			InvalidateInventorySlot();
 			ActiveStashSlot = FindClosestStashSlot(slotCoord) - Displacement { itemSize.width - 1, 0 };

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1145,7 +1145,6 @@ void StashMove(AxisDirection dir)
 
 	if (dir.x == AxisDirectionX_LEFT) {
 		if (ActiveStashSlot.x > 0) {
-
 			const StashStruct::StashCell itemIdAtActiveStashSlot = Stash.GetItemIdAtPosition(ActiveStashSlot);
 			ActiveStashSlot.x--;
 			if (holdItem.isEmpty() && itemIdAtActiveStashSlot != StashStruct::EmptyCell) {
@@ -1155,8 +1154,11 @@ void StashMove(AxisDirection dir)
 			}
 		}
 	} else if (dir.x == AxisDirectionX_RIGHT) {
-		if (ActiveStashSlot.x < 10 - itemSize.width) {
-
+		// If we're empty-handed and trying to move right while hovering over an item we may not
+		//  have a free stash column to move to. If the item we're hovering over occupies the last
+		//  column then we want to jump to the inventory instead of just moving one column over.
+		Size itemUnderCursorSize = holdItem.isEmpty() ? GetItemSizeOnSlot(ActiveStashSlot) : itemSize;
+		if (ActiveStashSlot.x < 10 - itemUnderCursorSize.width) {
 			const StashStruct::StashCell itemIdAtActiveStashSlot = Stash.GetItemIdAtPosition(ActiveStashSlot);
 			ActiveStashSlot.x++;
 			if (holdItem.isEmpty() && itemIdAtActiveStashSlot != StashStruct::EmptyCell) {
@@ -1174,7 +1176,6 @@ void StashMove(AxisDirection dir)
 	}
 	if (dir.y == AxisDirectionY_UP) {
 		if (ActiveStashSlot.y > 0) {
-
 			const StashStruct::StashCell itemIdAtActiveStashSlot = Stash.GetItemIdAtPosition(ActiveStashSlot);
 			ActiveStashSlot.y--;
 			if (holdItem.isEmpty() && itemIdAtActiveStashSlot != StashStruct::EmptyCell) {
@@ -1185,7 +1186,6 @@ void StashMove(AxisDirection dir)
 		}
 	} else if (dir.y == AxisDirectionY_DOWN) {
 		if (ActiveStashSlot.y < 10 - itemSize.height) {
-
 			const StashStruct::StashCell itemIdAtActiveStashSlot = Stash.GetItemIdAtPosition(ActiveStashSlot);
 			ActiveStashSlot.y++;
 			if (holdItem.isEmpty() && itemIdAtActiveStashSlot != StashStruct::EmptyCell) {


### PR DESCRIPTION
Builds on #7551 to fix the second and third point in #4270. Doesn't fully address that issue as moving into the inventory while holding an item still leaves the cursor overlapping the top edge of the inventory.