### PR TITLE
Test paths fixes

### DIFF
--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -59,7 +59,7 @@ enum class MouseActionType : uint8_t {
 };
 
 extern uint32_t DungeonSeeds[NUMLEVELS];
-extern std::optional<uint32_t> LevelSeeds[NUMLEVELS];
+extern DVL_API_FOR_TEST std::optional<uint32_t> LevelSeeds[NUMLEVELS];
 extern Point MousePosition;
 extern DVL_API_FOR_TEST bool gbRunGame;
 extern bool gbRunGameResult;

--- a/test/drlg_l1_test.cpp
+++ b/test/drlg_l1_test.cpp
@@ -205,7 +205,6 @@ TEST(Drlg_l1, CreateL5Dungeon_crypt_1_2122696790)
 {
 	LoadExpectedLevelData("hellfire/21-2122696790.dun");
 
-	paths::SetAssetsPath(paths::BasePath() + "/assets");
 	TestInitGame();
 
 	TestCreateDungeon(21, 2122696790, ENTRY_TWARPDN);
@@ -244,7 +243,6 @@ TEST(Drlg_l1, CreateL5Dungeon_crypt_4_1324803725)
 {
 	LoadExpectedLevelData("hellfire/24-1324803725.dun");
 
-	paths::SetAssetsPath(paths::BasePath() + "/assets");
 	TestInitGame();
 
 	TestCreateDungeon(24, 1324803725, ENTRY_MAIN);

--- a/test/drlg_test.hpp
+++ b/test/drlg_test.hpp
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <gtest/gtest.h>
+
 #include "engine/load_file.hpp"
 #include "levels/themes.h"
 #include "multi.h"
@@ -40,14 +42,10 @@ std::unique_ptr<uint16_t[]> DunData;
 
 void LoadExpectedLevelData(const char *fixture)
 {
-	std::string dunPath = "test/fixtures/";
-
-	paths::SetPrefPath(paths::BasePath());
-	paths::SetAssetsPath(paths::BasePath() + "/" + dunPath);
-
-	dunPath.append(fixture);
-	DunData = LoadFileInMem<uint16_t>(dunPath.c_str());
-	ASSERT_NE(DunData, nullptr) << "Unable to load test fixture " << dunPath;
+	// Set look up path to the location to load set pieces from later:
+	paths::SetPrefPath(paths::BasePath() + "test/fixtures/");
+	DunData = LoadFileInMem<uint16_t>(fixture);
+	ASSERT_NE(DunData, nullptr) << "Unable to load test fixture " << fixture;
 	ASSERT_EQ(WorldTileSize(DMAXX, DMAXY), GetDunSize(DunData.get()));
 }
 
@@ -65,6 +63,7 @@ void TestInitGame(bool fullQuests = true, bool originalCathedral = true)
 
 void TestCreateDungeon(int level, uint32_t seed, lvl_entry entry)
 {
+	LevelSeeds[level] = std::nullopt;
 	currlevel = level;
 	leveltype = GetLevelType(level);
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -2,6 +2,7 @@
 
 #include "diablo.h"
 #include "options.h"
+#include "utils/paths.h"
 
 int main(int argc, char **argv)
 {
@@ -11,6 +12,11 @@ int main(int argc, char **argv)
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	// Disable hardware cursor while testing.
 	devilution::sgOptions.Graphics.hardwareCursor.SetValue(false);
+#endif
+
+#ifdef __APPLE__
+	devilution::paths::SetAssetsPath(
+	    devilution::paths::BasePath() + "devilutionx.app/Contents/Resources/");
 #endif
 
 	testing::InitGoogleTest(&argc, argv);

--- a/test/timedemo_test.cpp
+++ b/test/timedemo_test.cpp
@@ -33,15 +33,17 @@ void RunTimedemo(std::string timedemoFolderName)
 	    <= -1) {
 		ErrSdl();
 	}
-	std::string unitTestFolderCompletePath = paths::BasePath() + "/test/fixtures/timedemo/" + timedemoFolderName;
-	paths::SetPrefPath(unitTestFolderCompletePath);
-	paths::SetConfigPath(unitTestFolderCompletePath);
+
 	LoadCoreArchives();
 	LoadGameArchives();
 
 	// The tests need spawn.mpq or diabdat.mpq
 	// Please provide them so that the tests can run successfully
 	ASSERT_TRUE(HaveSpawn() || HaveDiabdat());
+
+	std::string unitTestFolderCompletePath = paths::BasePath() + "test/fixtures/timedemo/" + timedemoFolderName;
+	paths::SetPrefPath(unitTestFolderCompletePath);
+	paths::SetConfigPath(unitTestFolderCompletePath);
 
 	InitKeymapActions();
 	LoadOptions();

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -369,8 +369,9 @@ TEST(Writehero, pfile_write_hero)
 	// Please provide them so that the tests can run successfully
 	ASSERT_TRUE(HaveSpawn() || HaveDiabdat());
 
-	paths::SetPrefPath(".");
-	std::remove("multi_0.sv");
+	const std::string savePath = paths::BasePath() + "multi_0.sv";
+	paths::SetPrefPath(paths::BasePath());
+	RemoveFile(savePath.c_str());
 
 	gbVanilla = true;
 	gbIsHellfire = false;
@@ -397,11 +398,10 @@ TEST(Writehero, pfile_write_hero)
 	AssertPlayer(Players[0]);
 	pfile_write_hero();
 
-	const char *path = "multi_0.sv";
 	uintmax_t fileSize;
-	ASSERT_TRUE(GetFileSize(path, &fileSize));
+	ASSERT_TRUE(GetFileSize(savePath.c_str(), &fileSize));
 	size_t size = static_cast<size_t>(fileSize);
-	FILE *f = std::fopen(path, "rb");
+	FILE *f = OpenFile(savePath.c_str(), "rb");
 	ASSERT_TRUE(f != nullptr);
 	std::unique_ptr<char[]> data { new char[size] };
 	ASSERT_EQ(std::fread(data.get(), size, 1, f), 1);


### PR DESCRIPTION
1. Load assets from the bundle on Mac.
2. In timedemo_test, load MPQs before overriding pref path, so that they can also be loaded from the user/system location.
3. Fix various double directory separators ("build//assets" etc).

Also fixes running drlg test directly (e.g. `build/drlg_l1_test`, as opposed to via ctest) -- the latter runs an individual process for each test but in the former we weren't resetting `LevelSeeds` so when running multiple tests from the same process the later tests were failing.