### PR TITLE
storm_svid: use DISPLAY_TEXTURE_FORMAT also for SVidPlayEnd

### DIFF
--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -400,7 +400,7 @@ void SVidPlayEnd()
 
 #ifndef USE_SDL1
 	if (renderer != nullptr) {
-		texture = SDLWrap::CreateTexture(renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, gnScreenWidth, gnScreenHeight);
+		texture = SDLWrap::CreateTexture(renderer, DEVILUTIONX_DISPLAY_TEXTURE_FORMAT, SDL_TEXTUREACCESS_STREAMING, gnScreenWidth, gnScreenHeight);
 		if (renderer != nullptr && SDL_RenderSetLogicalSize(renderer, gnScreenWidth, gnScreenHeight) <= -1) {
 			ErrSdl();
 		}


### PR DESCRIPTION
I'm testing it on platform which operates on RGB565 soly (sdl-directfb) and without this patch we get incorrect menu graphics. Moreover if you not define correct DISPLAY_TEXTURE_FORMAT before compiling, then SDL_HINT_RENDER_SCALE_QUALITY have no effect for DirectFB and the default value is picked by render for all scaling options.

BTW: Compiled via `1.5` branch because our older gcc 9.4.0 doesn't support `std::span`, so I've small request to cherry-pick this and c2ad6da733de93f817bc7a66d0c0eb49a5540ed4 commit to stable branch 🙏 