### PR TITLE
[1.5] events: ignore ALT modifier if using Keyboard-as-Controller

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -8,6 +8,7 @@
 #include "DiabloUI/dialogs.h"
 #include "DiabloUI/scrollbar.h"
 #include "controls/controller.h"
+#include "controls/devices/kbcontroller.h"
 #include "controls/input.h"
 #include "controls/menu_controls.h"
 #include "controls/plrctrls.h"
@@ -463,6 +464,7 @@ void UiHandleEvents(SDL_Event *event)
 		return;
 	}
 
+#if HAS_KBCTRL == 0
 	if (event->type == SDL_KEYDOWN && event->key.keysym.sym == SDLK_RETURN) {
 		const Uint8 *state = SDLC_GetKeyState();
 		if (state[SDLC_KEYSTATE_LALT] != 0 || state[SDLC_KEYSTATE_RALT] != 0) {
@@ -473,6 +475,7 @@ void UiHandleEvents(SDL_Event *event)
 			return;
 		}
 	}
+#endif
 
 	if (event->type == SDL_QUIT)
 		diablo_quit(0);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -19,6 +19,7 @@
 #include "debug.h"
 #endif
 #include "DiabloUI/diabloui.h"
+#include "controls/devices/kbcontroller.h"
 #include "controls/plrctrls.h"
 #include "controls/remap_keyboard.h"
 #include "diablo.h"
@@ -488,10 +489,13 @@ void PressKey(SDL_Keycode vkey, uint16_t modState)
 		}
 		sgOptions.Keymapper.KeyPressed(vkey);
 		if (vkey == SDLK_RETURN || vkey == SDLK_KP_ENTER) {
+#if HAS_KBCTRL == 0
 			if ((modState & KMOD_ALT) != 0) {
 				sgOptions.Graphics.fullscreen.SetValue(!IsFullScreen());
 				SaveOptions();
-			} else {
+			} else
+#endif
+			{
 				control_type_message();
 			}
 		}
@@ -523,10 +527,12 @@ void PressKey(SDL_Keycode vkey, uint16_t modState)
 	sgOptions.Keymapper.KeyPressed(vkey);
 
 	if (PauseMode == 2) {
+#if HAS_KBCTRL == 0
 		if ((vkey == SDLK_RETURN || vkey == SDLK_KP_ENTER) && (modState & KMOD_ALT) != 0) {
 			sgOptions.Graphics.fullscreen.SetValue(!IsFullScreen());
 			SaveOptions();
 		}
+#endif
 		return;
 	}
 
@@ -562,8 +568,10 @@ void PressKey(SDL_Keycode vkey, uint16_t modState)
 	case SDLK_RETURN:
 	case SDLK_KP_ENTER:
 		if ((modState & KMOD_ALT) != 0) {
+#if HAS_KBCTRL == 0
 			sgOptions.Graphics.fullscreen.SetValue(!IsFullScreen());
 			SaveOptions();
+#endif
 		} else if (stextflag != TalkID::None) {
 			StoreEnter();
 		} else if (QuestLogIsOpen) {


### PR DESCRIPTION
When using HAS_KBCTRL flag, fullscreen hotkey should be avoided IMO (end-user don't expect them to happen on gamepad as well). Generally I wouldn't mind leaving it as it was, but there is weird event happening in DialogUI when only left alone LALT is pressed and game switches between Fullscreen/Windowed mode, so there may be smth more to look in [PressKey()](https://github.com/diasurgical/devilutionX/blob/72d8a56d1be4880a75e00a4a9e4974d3c005ccdb/Source/diablo.cpp#L564).

@AJenbo, compiling it for old OE Miyoo devices with F1C100S (ARMv5, 32MB of RAM). I must congratulate for ppl working on this project, cuz the code is very portable even for such obscure platform with little resources 👍 .