### PR TITLE
Upgrade vcpkg baseline commit to upgrade SDL to 2.30.10

### DIFF
--- a/.github/workflows/Windows_MSVC_x64.yml
+++ b/.github/workflows/Windows_MSVC_x64.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Restore or setup vcpkg
       uses: lukka/run-vcpkg@v11.5
       with:
-        vcpkgGitCommitId: '813a241fb83adad503a391facaa6aa634631accc'
+        vcpkgGitCommitId: '80d54ff62d528339c626a6fbc3489a7f25956ade'
 
     - name: Fetch test data
       run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
 		"bzip2",
 		"lua"
 	],
-	"builtin-baseline": "813a241fb83adad503a391facaa6aa634631accc",
+	"builtin-baseline": "80d54ff62d528339c626a6fbc3489a7f25956ade",
 	"features": {
 		"sdl1": {
 			"description": "Use SDL1.2 instead of SDL2",


### PR DESCRIPTION
Since all other platforms upgraded too
@AJenbo should this be backported to 1.5?