### PR TITLE
Don't apply dungeon item validation to town items

### DIFF
--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -11,6 +11,7 @@
 #include "items.h"
 #include "monstdat.h"
 #include "player.h"
+#include "spells.h"
 
 namespace devilution {
 
@@ -137,6 +138,22 @@ bool IsDungeonItemValid(uint16_t iCreateInfo, uint32_t dwBuff)
 	return level <= (diabloMaxDungeonLevel * 2);
 }
 
+bool IsHellfireSpellBookValid(const Item &spellBook)
+{
+	// Hellfire uses the spell book level when generating items via CreateSpellBook()
+	int spellBookLevel = GetSpellBookLevel(spellBook._iSpell);
+
+	// CreateSpellBook() adds 1 to the spell level for ilvl
+	spellBookLevel++;
+
+	if (spellBookLevel >= 1 && (spellBook._iCreateInfo & CF_LEVEL) == spellBookLevel * 2) {
+		// The ilvl matches the result for a spell book drop, so we confirm the item is legitimate
+		return true;
+	}
+
+	return IsDungeonItemValid(spellBook._iCreateInfo, spellBook.dwBuff);
+}
+
 bool IsItemValid(const Player &player, const Item &item)
 {
 	if (!gbIsMultiplayer)
@@ -144,19 +161,14 @@ bool IsItemValid(const Player &player, const Item &item)
 
 	if (item.IDidx != IDI_GOLD && !IsCreationFlagComboValid(item._iCreateInfo))
 		return false;
+	if ((item._iCreateInfo & CF_TOWN) != 0)
+		return IsTownItemValid(item._iCreateInfo, player) && IsShopPriceValid(item);
+	if ((item._iCreateInfo & CF_USEFUL) == CF_UPER15)
+		return IsUniqueMonsterItemValid(item._iCreateInfo, item.dwBuff);
+	if ((item.dwBuff & CF_HELLFIRE) != 0 && AllItemsList[item.IDidx].iMiscId == IMISC_BOOK)
+		return IsHellfireSpellBookValid(item);
 
-	if ((item._iCreateInfo & CF_TOWN) != 0) {
-		if (!IsTownItemValid(item._iCreateInfo, player) || !IsShopPriceValid(item))
-			return false;
-	} else if ((item._iCreateInfo & CF_USEFUL) == CF_UPER15) {
-		if (!IsUniqueMonsterItemValid(item._iCreateInfo, item.dwBuff))
-			return false;
-	}
-
-	if (!IsDungeonItemValid(item._iCreateInfo, item.dwBuff))
-		return false;
-
-	return true;
+	return IsDungeonItemValid(item._iCreateInfo, item.dwBuff);
 }
 
 } // namespace devilution


### PR DESCRIPTION
This PR fixes up the logic in `IsItemValid()` based on the validation logic located in `UnPackNetItem()`.

https://github.com/diasurgical/devilutionX/blob/a12b5368c381cf1c910e77c506345995a149e717/Source/pack.cpp#L443-L457

Prior to this fix, items bought from Wirt by a clvl 50 character would always be unusable, despite `Net Validation` indicating success.

![image](https://github.com/user-attachments/assets/7d5adda5-b7ee-4d64-9f9e-fb9446d30033)