### PR TITLE
Lua mod INI file configuration

### DIFF
--- a/Source/lua/lua.hpp
+++ b/Source/lua/lua.hpp
@@ -8,6 +8,7 @@
 namespace devilution {
 
 void LuaInitialize();
+void LuaReloadActiveMods();
 void LuaShutdown();
 void LuaEvent(std::string_view name);
 sol::state &GetLuaState();

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1787,6 +1787,52 @@ bool PadmapperOptions::CanDeferToMovementHandler(const Action &action) const
 	    ControllerButton_BUTTON_DPAD_RIGHT);
 }
 
+ModOptions::ModOptions()
+    : OptionCategoryBase("Mods", N_("Mods"), N_("Mod Settings"))
+{
+}
+
+std::vector<std::string_view> ModOptions::GetActiveModList()
+{
+	std::vector<std::string_view> modList;
+	for (auto &modEntry : GetModEntries()) {
+		if (*modEntry.enabled)
+			modList.emplace_back(modEntry.name);
+	}
+	return modList;
+}
+
+std::vector<std::string_view> ModOptions::GetModList()
+{
+	std::vector<std::string_view> modList;
+	for (auto &modEntry : GetModEntries()) {
+		modList.emplace_back(modEntry.name);
+	}
+	return modList;
+}
+
+std::vector<OptionEntryBase *> ModOptions::GetEntries()
+{
+	std::vector<OptionEntryBase *> optionEntries;
+	for (auto &modEntry : GetModEntries()) {
+		optionEntries.emplace_back(&modEntry.enabled);
+	}
+	return optionEntries;
+}
+
+std::vector<ModOptions::ModEntry> &ModOptions::GetModEntries()
+{
+	if (modEntries)
+		return *modEntries;
+
+	std::vector<std::string> modNames = ini->getKeys(name);
+	std::vector<ModOptions::ModEntry> &newModEntries = modEntries.emplace();
+	for (auto &modName : modNames) {
+		newModEntries.emplace_back(modName);
+	}
+	return newModEntries;
+}
+
 namespace {
 #ifdef DEVILUTIONX_RESAMPLER_SPEEX
 constexpr char ResamplerSpeex[] = "Speex";

--- a/Source/options.h
+++ b/Source/options.h
@@ -803,6 +803,28 @@ private:
 	bool CanDeferToMovementHandler(const Action &action) const;
 };
 
+struct ModOptions : OptionCategoryBase {
+	ModOptions();
+	std::vector<std::string_view> GetActiveModList();
+	std::vector<std::string_view> GetModList();
+	std::vector<OptionEntryBase *> GetEntries() override;
+
+private:
+	struct ModEntry {
+		ModEntry(std::string_view name)
+		    : name(name)
+		    , enabled(this->name, OptionEntryFlags::None, this->name.c_str(), "", false)
+		{
+		}
+
+		std::string name;
+		OptionEntryBoolean enabled;
+	};
+
+	std::vector<ModEntry> &GetModEntries();
+	std::optional<std::vector<ModEntry>> modEntries;
+};
+
 struct Options {
 	GameModeOptions GameMode;
 	StartUpOptions StartUp;
@@ -817,6 +839,7 @@ struct Options {
 	LanguageOptions Language;
 	KeymapperOptions Keymapper;
 	PadmapperOptions Padmapper;
+	ModOptions Mods;
 
 	[[nodiscard]] std::vector<OptionCategoryBase *> GetCategories()
 	{
@@ -834,6 +857,7 @@ struct Options {
 			&Chat,
 			&Keymapper,
 			&Padmapper,
+			&Mods,
 		};
 	}
 };

--- a/Source/utils/ini.hpp
+++ b/Source/utils/ini.hpp
@@ -54,6 +54,9 @@ public:
 	static tl::expected<Ini, std::string> parse(std::string_view buffer);
 	[[nodiscard]] std::string serialize() const;
 
+	/** @return all the keys associated with this section in the ini */
+	[[nodiscard]] std::vector<std::string> getKeys(std::string_view section) const;
+
 	/** @return all the values associated with this section and key in the ini */
 	[[nodiscard]] std::span<const Value> get(std::string_view section, std::string_view key) const;
 

--- a/assets/lua/devilutionx/events.lua
+++ b/assets/lua/devilutionx/events.lua
@@ -40,9 +40,9 @@ local function CreateEvent()
 end
 
 local events = {
-  ---Called early on game boot.
-  GameBoot = CreateEvent(),
-  __doc_GameBoot = "Called early on game boot.",
+  ---Called after all mods have been loaded.
+  LoadModsComplete = CreateEvent(),
+  __doc_LoadModsComplete = "Called after all mods have been loaded.",
 
   ---Called every time a new game is started.
   GameStart = CreateEvent(),


### PR DESCRIPTION
Reads a list of mods from `diablo.ini` and loads `init.lua` scripts based on that list.

---

Example:
```ini
[Mods]
clockmod=1
helloworld=0
scwmod=1
```

The INI configuration above will attempt to execute the following scripts from assets.

* `lua/mods/clockmod/init.lua`
* `lua/mods/scwmod/init.lua`

The value that comes after the name of the mod is simply an "enabled" flag to indicate whether the mod should be loaded. Hence why it does not attempt to load `lua/mods/helloworld/init.lua`.

---

Notes:
* The `devilutionx.events` script was moved to the `LuaReloadActiveMods()` function in preparation for adding a `Settings` menu page to enable/disable mods.
* The `GameBoot` event was replaced with `LoadModsComplete` for the same reason. It's no longer "Game Boot" if the mods were reloaded by enabling/disabling them in the `Settings` menu.
* The mod scripts will be executed in the same order they appear in the INI, giving the user some basic control over the order of precedence of installed mods.