### PR TITLE
Fix tile incorrectly marked as solid next to crypt stairs down

### DIFF
--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -486,6 +486,7 @@ tl::expected<void, std::string> LoadLevelSOLData()
 		break;
 	case DTYPE_CRYPT:
 		RETURN_IF_ERROR(LoadFileInMemWithStatus("nlevels\\l5data\\l5.sol", SOLData));
+		SOLData[142] = TileProperties::None; // Tile is incorrectly marked as being solid
 		break;
 	default:
 		return tl::make_unexpected("LoadLevelSOLData");


### PR DESCRIPTION
This resolves #7576