### PR TITLE
Split endian_write from endian

### DIFF
--- a/Source/dvlnet/frame_queue.cpp
+++ b/Source/dvlnet/frame_queue.cpp
@@ -6,6 +6,7 @@
 #include "dvlnet/packet.h"
 #include "utils/attributes.h"
 #include "utils/endian.hpp"
+#include "utils/endian_write.hpp"
 
 namespace devilution {
 namespace net {

--- a/Source/dvlnet/packet.h
+++ b/Source/dvlnet/packet.h
@@ -16,6 +16,7 @@
 #include "appfat.h"
 #include "dvlnet/abstract_net.h"
 #include "utils/attributes.h"
+#include "utils/endian_write.hpp"
 #include "utils/str_cat.hpp"
 #include "utils/stubs.h"
 

--- a/Source/engine/load_cl2.hpp
+++ b/Source/engine/load_cl2.hpp
@@ -14,6 +14,7 @@
 #include "mpq/mpq_common.hpp"
 #include "utils/cl2_to_clx.hpp"
 #include "utils/endian.hpp"
+#include "utils/endian_write.hpp"
 #include "utils/pointer_value_union.hpp"
 #include "utils/static_vector.hpp"
 #include "utils/status_macros.hpp"

--- a/Source/levels/reencode_dun_cels.cpp
+++ b/Source/levels/reencode_dun_cels.cpp
@@ -12,6 +12,7 @@
 #include "levels/dun_tile.hpp"
 #include "utils/attributes.h"
 #include "utils/endian.hpp"
+#include "utils/endian_write.hpp"
 #include "utils/format_int.hpp"
 #include "utils/log.hpp"
 

--- a/Source/utils/cel_to_clx.cpp
+++ b/Source/utils/cel_to_clx.cpp
@@ -13,6 +13,7 @@
 #include "appfat.h"
 #include "utils/clx_encode.hpp"
 #include "utils/endian.hpp"
+#include "utils/endian_write.hpp"
 
 namespace devilution {
 

--- a/Source/utils/cl2_to_clx.cpp
+++ b/Source/utils/cl2_to_clx.cpp
@@ -8,6 +8,7 @@
 #include "utils/clx_decode.hpp"
 #include "utils/clx_encode.hpp"
 #include "utils/endian.hpp"
+#include "utils/endian_write.hpp"
 
 namespace devilution {
 

--- a/Source/utils/endian.hpp
+++ b/Source/utils/endian.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
-
-#include <SDL_endian.h>
 
 namespace devilution {
 
@@ -37,18 +34,6 @@ constexpr uint32_t LoadBE32(const T *b)
 	static_assert(sizeof(T) == 1, "invalid argument");
 	// NOLINTNEXTLINE(readability-magic-numbers)
 	return (static_cast<uint8_t>(b[0]) << 24) | (static_cast<uint8_t>(b[1]) << 16) | (static_cast<uint8_t>(b[2]) << 8) | static_cast<uint8_t>(b[3]);
-}
-
-inline void WriteLE16(void *out, uint16_t val)
-{
-	const uint16_t littleEndian = SDL_SwapLE16(val);
-	memcpy(out, &littleEndian, 2);
-}
-
-inline void WriteLE32(void *out, uint32_t val)
-{
-	const uint32_t littleEndian = SDL_SwapLE32(val);
-	memcpy(out, &littleEndian, 4);
 }
 
 } // namespace devilution

--- a/Source/utils/endian_stream.hpp
+++ b/Source/utils/endian_stream.hpp
@@ -7,6 +7,7 @@
 #include <cstring>
 
 #include "utils/endian.hpp"
+#include "utils/endian_write.hpp"
 #include "utils/log.hpp"
 
 namespace devilution {

--- a/Source/utils/endian_write.hpp
+++ b/Source/utils/endian_write.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+#include <SDL_endian.h>
+
+namespace devilution {
+
+inline void WriteLE16(void *out, uint16_t val)
+{
+	const uint16_t littleEndian = SDL_SwapLE16(val);
+	memcpy(out, &littleEndian, 2);
+}
+
+inline void WriteLE32(void *out, uint32_t val)
+{
+	const uint32_t littleEndian = SDL_SwapLE32(val);
+	memcpy(out, &littleEndian, 4);
+}
+
+} // namespace devilution

--- a/Source/utils/pcx_to_clx.cpp
+++ b/Source/utils/pcx_to_clx.cpp
@@ -13,6 +13,7 @@
 #include "appfat.h"
 #include "utils/clx_encode.hpp"
 #include "utils/endian.hpp"
+#include "utils/endian_write.hpp"
 #include "utils/pcx.hpp"
 
 #ifdef DEBUG_PCX_TO_CL2_SIZE

--- a/Source/utils/surface_to_clx.cpp
+++ b/Source/utils/surface_to_clx.cpp
@@ -6,6 +6,7 @@
 
 #include "utils/clx_encode.hpp"
 #include "utils/endian.hpp"
+#include "utils/endian_write.hpp"
 
 #ifdef DEBUG_SURFACE_TO_CLX_SIZE
 #include <iomanip>


### PR DESCRIPTION
Only `endian_write` functions require SDL, splitting them out will allow us to clean up the dependencies a bit.

Extracted from #7554 