### PR TITLE
Move MPQs from init to engine/assets

### DIFF
--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -10,7 +10,6 @@
 #ifdef _DEBUG
 #include "monstdat.h"
 #endif
-#include "init.h"
 #include "levels/gendung.h"
 #include "utils/attributes.h"
 #include "utils/endian.hpp"

--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -17,6 +17,26 @@
 
 namespace devilution {
 
+#ifdef UNPACKED_MPQS
+std::optional<std::string> spawn_data_path;
+std::optional<std::string> diabdat_data_path;
+std::optional<std::string> hellfire_data_path;
+std::optional<std::string> font_data_path;
+std::optional<std::string> lang_data_path;
+#else
+std::optional<MpqArchive> spawn_mpq;
+std::optional<MpqArchive> diabdat_mpq;
+std::optional<MpqArchive> hellfire_mpq;
+std::optional<MpqArchive> hfmonk_mpq;
+std::optional<MpqArchive> hfbard_mpq;
+std::optional<MpqArchive> hfbarb_mpq;
+std::optional<MpqArchive> hfmusic_mpq;
+std::optional<MpqArchive> hfvoice_mpq;
+std::optional<MpqArchive> devilutionx_mpq;
+std::optional<MpqArchive> lang_mpq;
+std::optional<MpqArchive> font_mpq;
+#endif
+
 namespace {
 
 #ifdef UNPACKED_MPQS

--- a/Source/engine/assets.hpp
+++ b/Source/engine/assets.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -13,11 +14,18 @@
 
 #include "appfat.h"
 #include "diablo.h"
-#include "mpq/mpq_reader.hpp"
 #include "utils/file_util.h"
 #include "utils/language.h"
 #include "utils/str_cat.hpp"
 #include "utils/string_or_view.hpp"
+
+#ifndef UNPACKED_MPQS
+#include "mpq/mpq_reader.hpp"
+#endif
+
+#ifdef USE_SDL1
+#include "utils/sdl2_to_1_2_backports.h"
+#endif
 
 namespace devilution {
 
@@ -267,5 +275,28 @@ struct AssetData {
 };
 
 tl::expected<AssetData, std::string> LoadAsset(std::string_view path);
+
+#ifdef UNPACKED_MPQS
+extern DVL_API_FOR_TEST std::optional<std::string> spawn_data_path;
+extern DVL_API_FOR_TEST std::optional<std::string> diabdat_data_path;
+extern std::optional<std::string> hellfire_data_path;
+extern std::optional<std::string> font_data_path;
+extern std::optional<std::string> lang_data_path;
+#else
+/** A handle to the spawn.mpq archive. */
+extern DVL_API_FOR_TEST std::optional<MpqArchive> spawn_mpq;
+/** A handle to the diabdat.mpq archive. */
+extern DVL_API_FOR_TEST std::optional<MpqArchive> diabdat_mpq;
+/** A handle to an hellfire.mpq archive. */
+extern std::optional<MpqArchive> hellfire_mpq;
+extern std::optional<MpqArchive> hfmonk_mpq;
+extern std::optional<MpqArchive> hfbard_mpq;
+extern std::optional<MpqArchive> hfbarb_mpq;
+extern std::optional<MpqArchive> hfmusic_mpq;
+extern std::optional<MpqArchive> hfvoice_mpq;
+extern std::optional<MpqArchive> font_mpq;
+extern std::optional<MpqArchive> lang_mpq;
+extern std::optional<MpqArchive> devilutionx_mpq;
+#endif
 
 } // namespace devilution

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -55,26 +55,6 @@ bool gbVanilla;
 /** Whether the Hellfire mode is required (forced). */
 bool forceHellfire;
 
-#ifdef UNPACKED_MPQS
-std::optional<std::string> spawn_data_path;
-std::optional<std::string> diabdat_data_path;
-std::optional<std::string> hellfire_data_path;
-std::optional<std::string> font_data_path;
-std::optional<std::string> lang_data_path;
-#else
-std::optional<MpqArchive> spawn_mpq;
-std::optional<MpqArchive> diabdat_mpq;
-std::optional<MpqArchive> hellfire_mpq;
-std::optional<MpqArchive> hfmonk_mpq;
-std::optional<MpqArchive> hfbard_mpq;
-std::optional<MpqArchive> hfbarb_mpq;
-std::optional<MpqArchive> hfmusic_mpq;
-std::optional<MpqArchive> hfvoice_mpq;
-std::optional<MpqArchive> devilutionx_mpq;
-std::optional<MpqArchive> lang_mpq;
-std::optional<MpqArchive> font_mpq;
-#endif
-
 namespace {
 
 constexpr char DevilutionXMpqVersion[] = "1\n";

--- a/Source/init.h
+++ b/Source/init.h
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "engine/assets.hpp"
 #include "utils/attributes.h"
 
 #ifdef UNPACKED_MPQS
@@ -15,38 +16,14 @@
 #include "mpq/mpq_reader.hpp"
 #endif
 
-#include <SDL.h>
-
 namespace devilution {
 
+/** True if the game is the current active window */
 extern bool gbActive;
 extern DVL_API_FOR_TEST bool gbIsSpawn;
 extern DVL_API_FOR_TEST bool gbIsHellfire;
 extern DVL_API_FOR_TEST bool gbVanilla;
 extern bool forceHellfire;
-
-#ifdef UNPACKED_MPQS
-extern DVL_API_FOR_TEST std::optional<std::string> spawn_data_path;
-extern DVL_API_FOR_TEST std::optional<std::string> diabdat_data_path;
-extern std::optional<std::string> hellfire_data_path;
-extern std::optional<std::string> font_data_path;
-extern std::optional<std::string> lang_data_path;
-#else
-/** A handle to the spawn.mpq archive. */
-extern DVL_API_FOR_TEST std::optional<MpqArchive> spawn_mpq;
-/** A handle to the diabdat.mpq archive. */
-extern DVL_API_FOR_TEST std::optional<MpqArchive> diabdat_mpq;
-/** A handle to an hellfire.mpq archive. */
-extern std::optional<MpqArchive> hellfire_mpq;
-extern std::optional<MpqArchive> hfmonk_mpq;
-extern std::optional<MpqArchive> hfbard_mpq;
-extern std::optional<MpqArchive> hfbarb_mpq;
-extern std::optional<MpqArchive> hfmusic_mpq;
-extern std::optional<MpqArchive> hfvoice_mpq;
-extern std::optional<MpqArchive> font_mpq;
-extern std::optional<MpqArchive> lang_mpq;
-extern std::optional<MpqArchive> devilutionx_mpq;
-#endif
 
 inline bool HaveSpawn()
 {

--- a/Source/platform/android/CMakeLists.txt
+++ b/Source/platform/android/CMakeLists.txt
@@ -1,3 +1,7 @@
 include(functions/devilutionx_library)
 add_devilutionx_object_library(libdevilutionx_android android.cpp)
-target_link_libraries(libdevilutionx_android PUBLIC DevilutionX::SDL)
+target_link_libraries(libdevilutionx_android PUBLIC
+  DevilutionX::SDL
+  fmt::fmt
+  tl
+)

--- a/Source/platform/vita/CMakeLists.txt
+++ b/Source/platform/vita/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(libdevilutionx_vita PUBLIC
   SceAppUtil_stub
   SceNet_stub
   SceNetCtl_stub
+  fmt::fmt
   tl
   unordered_dense::unordered_dense
 )


### PR DESCRIPTION
Untangles some of the dependencies.

Extracted from #7554 