### PR TITLE
Extract Is{Any,None}Of out of engine.hpp

### DIFF
--- a/Source/DiabloUI/credits.cpp
+++ b/Source/DiabloUI/credits.cpp
@@ -14,6 +14,7 @@
 #include "engine/render/text_render.hpp"
 #include "hwcursor.hpp"
 #include "utils/display.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/log.hpp"
 #include "utils/sdl_compat.h"

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -24,6 +24,7 @@
 #include "hwcursor.hpp"
 #include "utils/algorithm/container.hpp"
 #include "utils/display.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/log.hpp"
 #include "utils/pcx_to_clx.hpp"

--- a/Source/DiabloUI/dialogs.cpp
+++ b/Source/DiabloUI/dialogs.cpp
@@ -16,6 +16,7 @@
 #include "engine/palette.h"
 #include "hwcursor.hpp"
 #include "utils/display.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/log.hpp"
 

--- a/Source/DiabloUI/progress.cpp
+++ b/Source/DiabloUI/progress.cpp
@@ -12,6 +12,7 @@
 #include "engine/render/clx_render.hpp"
 #include "hwcursor.hpp"
 #include "utils/display.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 
 namespace devilution {

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -14,6 +14,7 @@
 #include "engine/render/text_render.hpp"
 #include "hwcursor.hpp"
 #include "options.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/utf8.hpp"
 

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -19,6 +19,7 @@
 #include "player.h"
 #include "utils/attributes.h"
 #include "utils/enum_traits.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/ui_fwd.h"
 #include "utils/utf8.hpp"

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -7,9 +7,9 @@
 
 #include <cstdint>
 
-#include "engine.h"
 #include "engine/displacement.hpp"
 #include "engine/point.hpp"
+#include "engine/surface.hpp"
 #include "levels/gendung.h"
 #include "utils/attributes.h"
 

--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -13,6 +13,7 @@
 #include "controls/touch/gamepad.h"
 #include "engine/demomode.h"
 #include "options.h"
+#include "utils/is_of.hpp"
 #include "utils/log.hpp"
 
 namespace devilution {

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -16,6 +16,7 @@
 #include "panels/spell_list.hpp"
 #include "qol/stash.h"
 #include "stores.h"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -38,6 +38,7 @@
 #include "stores.h"
 #include "towners.h"
 #include "track.h"
+#include "utils/is_of.hpp"
 #include "utils/log.hpp"
 #include "utils/str_cat.hpp"
 

--- a/Source/controls/touch/event_handlers.cpp
+++ b/Source/controls/touch/event_handlers.cpp
@@ -12,6 +12,7 @@
 #include "panels/spell_list.hpp"
 #include "qol/stash.h"
 #include "stores.h"
+#include "utils/is_of.hpp"
 #include "utils/ui_fwd.h"
 
 namespace devilution {

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -34,6 +34,7 @@
 #include "towners.h"
 #include "track.h"
 #include "utils/attributes.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/sdl_bilinear_scale.hpp"
 #include "utils/surface_to_clx.hpp"

--- a/Source/data/file.hpp
+++ b/Source/data/file.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <string_view>
 

--- a/Source/data/parser.hpp
+++ b/Source/data/parser.hpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <string_view>
 
-#include "engine.h" // For IsAnyOf
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -86,6 +86,7 @@
 #include "track.h"
 #include "utils/console.h"
 #include "utils/display.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/parse_int.hpp"
 #include "utils/paths.h"

--- a/Source/dvlnet/base_protocol.h
+++ b/Source/dvlnet/base_protocol.h
@@ -11,6 +11,7 @@
 #include "dvlnet/packet.h"
 #include "player.h"
 #include "utils/algorithm/container.hpp"
+#include "utils/is_of.hpp"
 #include "utils/log.hpp"
 
 namespace devilution::net {

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -19,6 +19,7 @@
 #include "engine/sound_position.hpp"
 #include "init.h"
 #include "player.h"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -40,18 +40,6 @@
 
 namespace devilution {
 
-template <typename V, typename X, typename... Xs>
-DVL_ALWAYS_INLINE constexpr bool IsAnyOf(const V &v, X x, Xs... xs)
-{
-	return v == x || ((v == xs) || ...);
-}
-
-template <typename V, typename X, typename... Xs>
-DVL_ALWAYS_INLINE constexpr bool IsNoneOf(const V &v, X x, Xs... xs)
-{
-	return v != x && ((v != xs) && ...);
-}
-
 /**
  * @brief Fill a rectangle with the given color.
  */

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -21,6 +21,7 @@
 #include "utils/console.h"
 #include "utils/display.h"
 #include "utils/endian_stream.hpp"
+#include "utils/is_of.hpp"
 #include "utils/paths.h"
 #include "utils/str_cat.hpp"
 

--- a/Source/engine/displacement.hpp
+++ b/Source/engine/displacement.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
+
 #ifdef BUILD_TESTING
 #include <ostream>
 #endif

--- a/Source/engine/events.cpp
+++ b/Source/engine/events.cpp
@@ -9,6 +9,7 @@
 #include "movie.h"
 #include "options.h"
 #include "panels/console.hpp"
+#include "utils/is_of.hpp"
 #include "utils/log.hpp"
 
 #ifdef USE_SDL1

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -54,6 +54,7 @@
 #include "towners.h"
 #include "utils/attributes.h"
 #include "utils/display.h"
+#include "utils/is_of.hpp"
 #include "utils/log.hpp"
 #include "utils/str_cat.hpp"
 

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -27,6 +27,7 @@
 #include "engine/render/clx_render.hpp"
 #include "utils/algorithm/container.hpp"
 #include "utils/display.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/sdl_compat.h"
 #include "utils/utf8.hpp"

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -33,6 +33,7 @@
 #include "stores.h"
 #include "towners.h"
 #include "utils/format_int.hpp"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/sdl_geometry.h"
 #include "utils/str_cat.hpp"

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -41,6 +41,7 @@
 #include "spells.h"
 #include "stores.h"
 #include "utils/format_int.hpp"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/log.hpp"
 #include "utils/math.h"

--- a/Source/items.h
+++ b/Source/items.h
@@ -15,6 +15,7 @@
 #include "engine/point.hpp"
 #include "itemdat.h"
 #include "monster.h"
+#include "utils/is_of.hpp"
 #include "utils/string_or_view.hpp"
 
 namespace devilution {

--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -12,6 +12,7 @@
 #include "monstdat.h"
 #include "player.h"
 #include "spells.h"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -11,6 +11,7 @@
 #include "player.h"
 #include "quests.h"
 #include "utils/bitset2d.hpp"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/levels/drlg_l2.cpp
+++ b/Source/levels/drlg_l2.cpp
@@ -19,6 +19,7 @@
 #include "levels/setmaps.h"
 #include "player.h"
 #include "quests.h"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/levels/drlg_l3.cpp
+++ b/Source/levels/drlg_l3.cpp
@@ -14,6 +14,7 @@
 #include "objects.h"
 #include "player.h"
 #include "quests.h"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -14,6 +14,7 @@
 #include "multi.h"
 #include "objdat.h"
 #include "player.h"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -25,6 +25,7 @@
 #include "lighting.h"
 #include "options.h"
 #include "utils/bitset2d.hpp"
+#include "utils/is_of.hpp"
 #include "utils/log.hpp"
 #include "utils/status_macros.hpp"
 

--- a/Source/levels/themes.cpp
+++ b/Source/levels/themes.cpp
@@ -18,6 +18,7 @@
 #include "objects.h"
 #include "quests.h"
 #include "utils/algorithm/container.hpp"
+#include "utils/is_of.hpp"
 #include "utils/str_cat.hpp"
 
 namespace devilution {

--- a/Source/levels/trigs.cpp
+++ b/Source/levels/trigs.cpp
@@ -16,6 +16,7 @@
 #include "diablo_msg.hpp"
 #include "init.h"
 #include "utils/algorithm/container.hpp"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/utf8.hpp"
 

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -18,6 +18,7 @@
 #include "engine/points_in_rectangle_range.hpp"
 #include "player.h"
 #include "utils/attributes.h"
+#include "utils/is_of.hpp"
 #include "utils/status_macros.hpp"
 
 namespace devilution {

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -38,6 +38,7 @@
 #include "stores.h"
 #include "utils/algorithm/container.hpp"
 #include "utils/endian.hpp"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/status_macros.hpp"
 

--- a/Source/lua/modules/dev/items.cpp
+++ b/Source/lua/modules/dev/items.cpp
@@ -12,6 +12,7 @@
 #include "lua/metadoc.hpp"
 #include "pack.h"
 #include "player.h"
+#include "utils/is_of.hpp"
 #include "utils/str_case.hpp"
 #include "utils/str_cat.hpp"
 

--- a/Source/lua/modules/dev/quests.cpp
+++ b/Source/lua/modules/dev/quests.cpp
@@ -9,6 +9,7 @@
 #include "engine.h"
 #include "lua/metadoc.hpp"
 #include "quests.h"
+#include "utils/is_of.hpp"
 #include "utils/str_cat.hpp"
 
 namespace devilution {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -27,6 +27,7 @@
 #include "lighting.h"
 #include "monster.h"
 #include "spells.h"
+#include "utils/is_of.hpp"
 #include "utils/str_cat.hpp"
 
 namespace devilution {

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -16,6 +16,7 @@
 #include "monster.h"
 #include "player.h"
 #include "spelldat.h"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -47,6 +47,7 @@
 #include "utils/attributes.h"
 #include "utils/cl2_to_clx.hpp"
 #include "utils/file_name_generator.hpp"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/log.hpp"
 #include "utils/static_vector.hpp"

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -42,6 +42,7 @@
 #include "sync.h"
 #include "tmsg.h"
 #include "towners.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/str_cat.hpp"
 #include "utils/utf8.hpp"

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -29,6 +29,7 @@
 #include "sync.h"
 #include "tmsg.h"
 #include "utils/endian.hpp"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/str_cat.hpp"
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -44,6 +44,7 @@
 #include "towners.h"
 #include "track.h"
 #include "utils/algorithm/container.hpp"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/log.hpp"
 #include "utils/str_cat.hpp"

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -21,6 +21,7 @@
 #include "objdat.h"
 #include "textdat.h"
 #include "utils/attributes.h"
+#include "utils/is_of.hpp"
 #include "utils/string_or_view.hpp"
 
 namespace devilution {

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -30,6 +30,7 @@
 #include "utils/display.h"
 #include "utils/file_util.h"
 #include "utils/ini.hpp"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/log.hpp"
 #include "utils/logged_fstream.hpp"

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -15,6 +15,7 @@
 #include "plrmsg.h"
 #include "stores.h"
 #include "utils/endian.hpp"
+#include "utils/is_of.hpp"
 #include "utils/log.hpp"
 #include "utils/utf8.hpp"
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -43,6 +43,7 @@
 #include "spells.h"
 #include "stores.h"
 #include "towners.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/log.hpp"
 #include "utils/str_cat.hpp"

--- a/Source/player.h
+++ b/Source/player.h
@@ -27,6 +27,7 @@
 #include "spelldat.h"
 #include "utils/attributes.h"
 #include "utils/enum_traits.h"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -28,6 +28,7 @@
 #include "panels/ui_panels.hpp"
 #include "stores.h"
 #include "towners.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/utf8.hpp"
 

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -11,6 +11,7 @@
 #include "lighting.h"
 #include "monster.h"
 #include "player.h"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -10,6 +10,7 @@
 #include "inv.h"
 #include "minitext.h"
 #include "stores.h"
+#include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/str_case.hpp"
 

--- a/Source/utils/is_of.hpp
+++ b/Source/utils/is_of.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "utils/attributes.h"
+
+namespace devilution {
+
+template <typename V, typename X, typename... Xs>
+DVL_ALWAYS_INLINE constexpr bool IsAnyOf(const V &v, X x, Xs... xs)
+{
+	return v == x || ((v == xs) || ...);
+}
+
+template <typename V, typename X, typename... Xs>
+DVL_ALWAYS_INLINE constexpr bool IsNoneOf(const V &v, X x, Xs... xs)
+{
+	return v != x && ((v != xs) && ...);
+}
+
+} // namespace devilution

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -6,6 +6,7 @@
 #include "monstdat.h"
 #include "pack.h"
 #include "playerdat.hpp"
+#include "utils/is_of.hpp"
 #include "utils/paths.h"
 
 namespace devilution {


### PR DESCRIPTION
Untangles some of the dependencies, such as `data/parser.hpp` depending on `engine.h`.

Extracted from #7554.