### PR TITLE
Extract `HeadlessMode` from `diablo.h`

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -16,6 +16,7 @@ set(libdevilutionx_SRCS
   game_mode.cpp
   gamemenu.cpp
   gmenu.cpp
+  headless_mode.cpp
   help.cpp
   hwcursor.cpp
   init.cpp

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -28,6 +28,7 @@
 #include "engine/render/text_render.hpp"
 #include "engine/trn.hpp"
 #include "gamemenu.h"
+#include "headless_mode.hpp"
 #include "init.h"
 #include "inv.h"
 #include "inv_iterators.hpp"

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -24,6 +24,7 @@
 #include "engine/render/clx_render.hpp"
 #include "engine/render/primitive_render.hpp"
 #include "engine/trn.hpp"
+#include "headless_mode.hpp"
 #include "hwcursor.hpp"
 #include "inv.h"
 #include "levels/trigs.h"

--- a/Source/data/file.cpp
+++ b/Source/data/file.cpp
@@ -1,5 +1,12 @@
 #include "file.hpp"
 
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+
+#include <expected.hpp>
 #include <fmt/format.h>
 
 #include "engine/assets.hpp"

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #include "diablo.h"
+#include "headless_mode.hpp"
 #include "levels/gendung.h"
 #include "lighting.h"
 #include "misdat.h"

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -41,6 +41,7 @@
 #include "game_mode.hpp"
 #include "gamemenu.h"
 #include "gmenu.h"
+#include "headless_mode.hpp"
 #include "help.h"
 #include "hwcursor.hpp"
 #include "init.h"
@@ -125,7 +126,6 @@ bool cineflag;
 int PauseMode;
 bool gbBard;
 bool gbBarbarian;
-bool HeadlessMode = false;
 clicktype sgbMouseDown;
 uint16_t gnTickDelay = 50;
 char gszProductName[64] = "DevilutionX vUnknown";

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -71,10 +71,6 @@ extern void FontsCleanup();
 extern DVL_API_FOR_TEST int PauseMode;
 extern bool gbBard;
 extern bool gbBarbarian;
-/**
- * @brief Don't load UI or show Messageboxes or other user-interaction. Needed for UnitTests.
- */
-extern DVL_API_FOR_TEST bool HeadlessMode;
 extern clicktype sgbMouseDown;
 extern uint16_t gnTickDelay;
 extern char gszProductName[64];

--- a/Source/engine/assets.hpp
+++ b/Source/engine/assets.hpp
@@ -13,8 +13,8 @@
 #include <fmt/format.h>
 
 #include "appfat.h"
-#include "diablo.h"
 #include "game_mode.hpp"
+#include "headless_mode.hpp"
 #include "utils/file_util.h"
 #include "utils/language.h"
 #include "utils/str_cat.hpp"

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -14,6 +14,7 @@
 #include "controls/plrctrls.h"
 #include "engine/events.hpp"
 #include "gmenu.h"
+#include "headless_mode.hpp"
 #include "menu.h"
 #include "nthread.h"
 #include "options.h"

--- a/Source/engine/dx.cpp
+++ b/Source/engine/dx.cpp
@@ -10,6 +10,7 @@
 
 #include "controls/plrctrls.h"
 #include "engine/render/primitive_render.hpp"
+#include "headless_mode.hpp"
 #include "options.h"
 #include "utils/display.h"
 #include "utils/log.hpp"

--- a/Source/engine/load_file.hpp
+++ b/Source/engine/load_file.hpp
@@ -7,11 +7,10 @@
 #include <memory>
 
 #include <expected.hpp>
-#include <fmt/core.h>
 
 #include "appfat.h"
-#include "diablo.h"
 #include "engine/assets.hpp"
+#include "headless_mode.hpp"
 #include "mpq/mpq_common.hpp"
 #include "utils/static_vector.hpp"
 #include "utils/str_cat.hpp"

--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -14,6 +14,7 @@
 #include "engine/dx.h"
 #include "engine/load_file.hpp"
 #include "engine/random.hpp"
+#include "headless_mode.hpp"
 #include "hwcursor.hpp"
 #include "options.h"
 #include "utils/display.h"

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -28,6 +28,7 @@
 #include "engine/trn.hpp"
 #include "engine/world_tile.hpp"
 #include "gmenu.h"
+#include "headless_mode.hpp"
 #include "help.h"
 #include "hwcursor.hpp"
 #include "init.h"

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -12,6 +12,7 @@
 #include "engine/sound.h"
 #include "engine/sound_defs.hpp"
 #include "gmenu.h"
+#include "headless_mode.hpp"
 #include "init.h"
 #include "loadsave.h"
 #include "options.h"

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -18,6 +18,7 @@
 #include "engine/render/clx_render.hpp"
 #include "engine/render/primitive_render.hpp"
 #include "engine/render/text_render.hpp"
+#include "headless_mode.hpp"
 #include "options.h"
 #include "stores.h"
 #include "utils/language.h"

--- a/Source/headless_mode.cpp
+++ b/Source/headless_mode.cpp
@@ -1,0 +1,7 @@
+#include "headless_mode.hpp"
+
+namespace devilution {
+
+bool HeadlessMode;
+
+} // namespace devilution

--- a/Source/headless_mode.hpp
+++ b/Source/headless_mode.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "utils/attributes.h"
+
+namespace devilution {
+
+/**
+ * @brief Don't load UI or show Messageboxes or other user-interaction. Needed for unit tests.
+ */
+extern DVL_API_FOR_TEST bool HeadlessMode;
+
+} // namespace devilution

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -22,6 +22,7 @@
 #include "engine/dx.h"
 #include "engine/events.hpp"
 #include "game_mode.hpp"
+#include "headless_mode.hpp"
 #include "hwcursor.hpp"
 #include "options.h"
 #include "pfile.h"

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -20,6 +20,7 @@
 #include "engine/palette.h"
 #include "engine/render/clx_render.hpp"
 #include "engine/render/primitive_render.hpp"
+#include "headless_mode.hpp"
 #include "hwcursor.hpp"
 #include "init.h"
 #include "loadsave.h"

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -27,6 +27,7 @@
 #include "engine/render/clx_render.hpp"
 #include "engine/render/primitive_render.hpp"
 #include "engine/render/text_render.hpp"
+#include "headless_mode.hpp"
 #include "init.h"
 #include "inv_iterators.hpp"
 #include "levels/town.h"

--- a/Source/misdat.cpp
+++ b/Source/misdat.cpp
@@ -15,6 +15,7 @@
 #include "data/file.hpp"
 #include "data/iterators.hpp"
 #include "data/record_reader.hpp"
+#include "headless_mode.hpp"
 #include "missiles.h"
 #include "mpq/mpq_common.hpp"
 #include "utils/file_name_generator.hpp"

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -22,6 +22,7 @@
 #include "engine/points_in_rectangle_range.hpp"
 #include "engine/random.hpp"
 #include "engine/render/primitive_render.hpp"
+#include "headless_mode.hpp"
 #include "init.h"
 #include "inv.h"
 #include "levels/dun_tile.hpp"

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -31,6 +31,7 @@
 #include "engine/sound_position.hpp"
 #include "engine/world_tile.hpp"
 #include "game_mode.hpp"
+#include "headless_mode.hpp"
 #include "init.h"
 #include "levels/crypt.h"
 #include "levels/drlg_l4.h"

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -26,6 +26,7 @@
 #include "engine/load_file.hpp"
 #include "engine/points_in_rectangle_range.hpp"
 #include "engine/random.hpp"
+#include "headless_mode.hpp"
 #include "init.h"
 #include "inv.h"
 #include "inv_iterators.hpp"

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -26,6 +26,7 @@
 #include "engine/world_tile.hpp"
 #include "game_mode.hpp"
 #include "gamemenu.h"
+#include "headless_mode.hpp"
 #include "help.h"
 #include "init.h"
 #include "inv_iterators.hpp"

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -17,6 +17,7 @@
 #include "engine/render/clx_render.hpp"
 #include "engine/render/text_render.hpp"
 #include "engine/size.hpp"
+#include "headless_mode.hpp"
 #include "hwcursor.hpp"
 #include "inv.h"
 #include "minitext.h"

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -13,6 +13,7 @@
 
 #include "dvlnet/abstract_net.h"
 #include "engine/demomode.h"
+#include "headless_mode.hpp"
 #include "menu.h"
 #include "options.h"
 #include "utils/stubs.h"

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -28,6 +28,7 @@
 #include "controls/touch/gamepad.h"
 #include "engine/backbuffer_state.hpp"
 #include "engine/dx.h"
+#include "headless_mode.hpp"
 #include "options.h"
 #include "utils/log.hpp"
 #include "utils/sdl_geometry.h"

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "diablo.h"
+#include "headless_mode.hpp"
 #include "options.h"
 #include "utils/paths.h"
 

--- a/test/timedemo_test.cpp
+++ b/test/timedemo_test.cpp
@@ -5,6 +5,7 @@
 #include "diablo.h"
 #include "engine/demomode.h"
 #include "game_mode.hpp"
+#include "headless_mode.hpp"
 #include "lua/lua.hpp"
 #include "monstdat.h"
 #include "options.h"


### PR DESCRIPTION
Untangles some dependencies.
Many places that use `HeadlessMode` do not need all of `diablo.h` (e.g. `assets`, `load_file`)

Extracted from #7554.