### PR TITLE
Reload Lua mods when enabling/disabling

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -22,6 +22,7 @@
 #include "engine/demomode.h"
 #include "engine/sound_defs.hpp"
 #include "hwcursor.hpp"
+#include "lua/lua.hpp"
 #include "options.h"
 #include "platform/locale.hpp"
 #include "qol/monhealthbar.h"
@@ -1832,6 +1833,13 @@ std::vector<ModOptions::ModEntry> &ModOptions::GetModEntries()
 		newModEntries.emplace_back(modName);
 	}
 	return newModEntries;
+}
+
+ModOptions::ModEntry::ModEntry(std::string_view name)
+    : name(name)
+    , enabled(this->name, OptionEntryFlags::None, this->name.c_str(), "", false)
+{
+	enabled.SetValueChangedCallback(LuaReloadActiveMods);
 }
 
 namespace {

--- a/Source/options.h
+++ b/Source/options.h
@@ -811,12 +811,7 @@ struct ModOptions : OptionCategoryBase {
 
 private:
 	struct ModEntry {
-		ModEntry(std::string_view name)
-		    : name(name)
-		    , enabled(this->name, OptionEntryFlags::None, this->name.c_str(), "", false)
-		{
-		}
-
+		ModEntry(std::string_view name);
 		std::string name;
 		OptionEntryBoolean enabled;
 	};


### PR DESCRIPTION
Looks like the settings menu was already functional after the last PR.

![image](https://github.com/user-attachments/assets/7e4055cf-6375-4dc5-bb62-a63a83416f55)

This PR adds the `ValueChangedCallback` to reload the Lua mods when adjusting these settings. Tested using a simple Hello World mod.

```lua
local events = require("devilutionx.events")

events.GameStart.add(function()
    print("Hello world!")
end)
```