### PR TITLE
Add a default clock mod

### DIFF
--- a/CMake/Assets.cmake
+++ b/CMake/Assets.cmake
@@ -149,6 +149,7 @@ set(devilutionx_assets
   lua_internal/get_lua_function_signature.lua
   lua/devilutionx/events.lua
   lua/inspect.lua
+  lua/mods/clock/init.lua
   lua/repl_prelude.lua
   nlevels/cutl5w.clx
   nlevels/cutl6w.clx

--- a/Source/lua/modules/render.cpp
+++ b/Source/lua/modules/render.cpp
@@ -4,13 +4,22 @@
 
 #include "engine/dx.h"
 #include "engine/render/text_render.hpp"
+#include "lua/metadoc.hpp"
+#include "utils/display.h"
 
 namespace devilution {
 
 sol::table LuaRenderModule(sol::state_view &lua)
 {
-	return lua.create_table_with(
-	    "string", [](std::string_view text, int x, int y) { DrawString(GlobalBackBuffer(), text, { x, y }); });
+	sol::table table = lua.create_table();
+	SetDocumented(table, "string", "(text: string, x: integer, y: integer)",
+	    "Renders a string at the given coordinates",
+	    [](std::string_view text, int x, int y) { DrawString(GlobalBackBuffer(), text, { x, y }); });
+	SetDocumented(table, "screen_width", "()",
+	    "Returns the screen width", []() { return gnScreenWidth; });
+	SetDocumented(table, "screen_height", "()",
+	    "Returns the screen height", []() { return gnScreenHeight; });
+	return table;
 }
 
 } // namespace devilution

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1829,7 +1829,15 @@ std::vector<ModOptions::ModEntry> &ModOptions::GetModEntries()
 	if (modEntries)
 		return *modEntries;
 
-	std::vector<std::string> modNames = ini->getKeys(name);
+	std::vector<std::string> modNames = ini->getKeys(key);
+
+	// Add mods available by default:
+	for (const std::string_view modName : { "clock" }) {
+		if (c_find(modNames, modName) != modNames.end()) continue;
+		ini->set(key, modName, false);
+		modNames.emplace_back(modName);
+	}
+
 	std::vector<ModOptions::ModEntry> &newModEntries = modEntries.emplace();
 	for (auto &modName : modNames) {
 		newModEntries.emplace_back(modName);

--- a/assets/lua/mods/clock/init.lua
+++ b/assets/lua/mods/clock/init.lua
@@ -1,0 +1,6 @@
+local events = require("devilutionx.events")
+local render = require("devilutionx.render")
+
+events.GameDrawComplete.add(function()
+  render.string(os.date('%H:%M:%S', os.time()), render.screen_width() - 69, 6)
+end)


### PR DESCRIPTION
This mod renders a clock in the top-right corner and is always available (disabled by default).

It is useful to have a mod available by default as we work on mod support.

![Screenshot from 2025-01-10 08-48-52](https://github.com/user-attachments/assets/481ccea5-ce28-4603-b52c-836d74402cb2)
