### PR TITLE
Lua: Add i18n module

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -119,6 +119,7 @@ set(libdevilutionx_SRCS
   lua/modules/dev/quests.cpp
   lua/modules/dev/search.cpp
   lua/modules/dev/towners.cpp
+  lua/modules/i18n.cpp
   lua/modules/log.cpp
   lua/modules/render.cpp
   lua/repl.cpp

--- a/Source/lua/lua.cpp
+++ b/Source/lua/lua.cpp
@@ -11,6 +11,7 @@
 #include "appfat.h"
 #include "engine/assets.hpp"
 #include "lua/modules/audio.hpp"
+#include "lua/modules/i18n.hpp"
 #include "lua/modules/log.hpp"
 #include "lua/modules/render.hpp"
 #include "options.h"
@@ -232,6 +233,7 @@ void LuaInitialize()
 	    "devilutionx.dev", LuaDevModule(lua),
 #endif
 	    "devilutionx.version", PROJECT_VERSION,
+	    "devilutionx.i18n", LuaI18nModule(lua),
 	    "devilutionx.log", LuaLogModule(lua),
 	    "devilutionx.audio", LuaAudioModule(lua),
 	    "devilutionx.render", LuaRenderModule(lua),

--- a/Source/lua/modules/i18n.cpp
+++ b/Source/lua/modules/i18n.cpp
@@ -1,0 +1,31 @@
+#include "lua/modules/i18n.hpp"
+
+#include <string_view>
+
+#include <fmt/format.h>
+#include <sol/sol.hpp>
+
+#include "lua/metadoc.hpp"
+#include "utils/language.h"
+
+namespace devilution {
+
+sol::table LuaI18nModule(sol::state_view &lua)
+{
+	sol::table table = lua.create_table();
+	SetDocumented(table, "language_code", "()",
+	    "Returns the current language code", GetLanguageCode);
+	SetDocumented(table, "translate", "(text: string)",
+	    "Translates the given string", [](const char *key) { return LanguageTranslate(key); });
+	SetDocumented(table, "plural_translate", "(singular: string, plural: string, count: integer)",
+	    "Returns a singular or plural translation for the given keys and count", [](const char *singular, std::string_view plural, int count) {
+		    return fmt::format(fmt::runtime(LanguagePluralTranslate(singular, plural, count)), count);
+	    });
+	SetDocumented(table, "particular_translate", "(context: string, text: string)",
+	    "Returns the translation for the given context identifier and key.", LanguageParticularTranslate);
+	SetDocumented(table, "is_small_font_tall", "()",
+	    "Whether the language's small font is tall (16px)", IsSmallFontTall);
+	return table;
+}
+
+} // namespace devilution

--- a/Source/lua/modules/i18n.hpp
+++ b/Source/lua/modules/i18n.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <sol/sol.hpp>
+
+namespace devilution {
+
+sol::table LuaI18nModule(sol::state_view &lua);
+
+} // namespace devilution

--- a/assets/lua/repl_prelude.lua
+++ b/assets/lua/repl_prelude.lua
@@ -1,4 +1,5 @@
 events = require('devilutionx.events')
+i18n = require('devilutionx.i18n')
 log = require('devilutionx.log')
 audio = require('devilutionx.audio')
 render = require('devilutionx.render')


### PR DESCRIPTION
Adds bindings for i18n functions.
Does not yet add support for loading mod-specific translations.

![Screenshot from 2025-01-10 15-15-05](https://github.com/user-attachments/assets/8854ac65-c9f3-4cf8-88a8-a39e02081a56)
