### PR TITLE
Settings: Use the full height and up to 720 width

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -686,10 +686,10 @@ void UiAddBackground(std::vector<std::unique_ptr<UiItemBase>> *vecDialog)
 	}
 }
 
-void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog)
+void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int y)
 {
 	vecDialog->push_back(std::make_unique<UiImageAnimatedClx>(
-	    *ArtLogo, MakeSdlRect(0, GetUIRectangle().position.y, 0, 0), UiFlags::AlignCenter));
+	    *ArtLogo, MakeSdlRect(0, y, 0, 0), UiFlags::AlignCenter));
 }
 
 void UiFadeIn()

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -103,7 +103,7 @@ void UiLoadDefaultPalette();
 bool UiLoadBlackBackground();
 void LoadBackgroundArt(const char *pszFile, int frames = 1);
 void UiAddBackground(std::vector<std::unique_ptr<UiItemBase>> *vecDialog);
-void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog);
+void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int y = GetUIRectangle().position.y);
 void UiFocusNavigationSelect();
 void UiFocusNavigationEsc();
 void UiFocusNavigationYesNo();

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -16,6 +16,7 @@
 #include "engine/render/text_render.hpp"
 #include "hwcursor.hpp"
 #include "options.h"
+#include "utils/display.h"
 #include "utils/is_of.hpp"
 #include "utils/language.h"
 #include "utils/utf8.hpp"
@@ -348,17 +349,20 @@ void UiSettingsMenu()
 	do {
 		endMenu = false;
 
+		// For the settings menu, we use the full height and allow some more width.
+		const int uiWidth = std::clamp<int>(gnScreenWidth, 640, 720);
+		const Rectangle uiRectangle = {
+			{ (gnScreenWidth - uiWidth) / 2, 0 },
+			{ uiWidth, gnScreenHeight }
+		};
+
 		UiLoadBlackBackground();
 		LoadScrollBar();
 		UiAddBackground(&vecDialog);
-		UiAddLogo(&vecDialog);
-
-		const Rectangle &uiRectangle = GetUIRectangle();
+		UiAddLogo(&vecDialog, uiRectangle.position.y);
 
 		const int descriptionLineHeight = IsSmallFontTall() ? 20 : 18;
 		const int descriptionMarginTop = IsSmallFontTall() ? 10 : 16;
-		rectList = { uiRectangle.position + Displacement { 50, 204 }, Size { 540, 208 } };
-		rectDescription = { rectList.position + Displacement { -26, rectList.size.height + descriptionMarginTop }, Size { 590, 80 - descriptionMarginTop } };
 
 		optionDescription[0] = '\0';
 
@@ -375,8 +379,6 @@ void UiSettingsMenu()
 			break;
 		}
 		vecDialog.push_back(std::make_unique<UiArtText>(titleText.data(), MakeSdlRect(uiRectangle.position.x, uiRectangle.position.y + 161, uiRectangle.size.width, 35), UiFlags::FontSize30 | UiFlags::ColorUiSilver | UiFlags::AlignCenter, 8));
-		vecDialog.push_back(std::make_unique<UiScrollbar>((*ArtScrollBarBackground)[0], (*ArtScrollBarThumb)[0], *ArtScrollBarArrow, MakeSdlRect(rectList.position.x + rectList.size.width + 5, rectList.position.y, 25, rectList.size.height)));
-		vecDialog.push_back(std::make_unique<UiArtText>(optionDescription, MakeSdlRect(rectDescription), UiFlags::FontSize12 | UiFlags::ColorUiSilverDark | UiFlags::AlignCenter, 1, descriptionLineHeight));
 
 		size_t itemToSelect = 0;
 		std::optional<tl::function_ref<bool(SDL_Event &)>> eventHandler;
@@ -532,7 +534,17 @@ void UiSettingsMenu()
 		vecDialogItems.push_back(std::make_unique<UiListItem>("", static_cast<int>(SpecialMenuEntry::None), UiFlags::ElementDisabled));
 		vecDialogItems.push_back(std::make_unique<UiListItem>(_("Previous Menu"), static_cast<int>(SpecialMenuEntry::PreviousMenu), UiFlags::ColorUiGold));
 
-		vecDialog.push_back(std::make_unique<UiList>(vecDialogItems, rectList.size.height / 26, rectList.position.x, rectList.position.y, rectList.size.width, 26, UiFlags::FontSize24 | UiFlags::AlignCenter));
+		constexpr int ListItemHeight = 26;
+		rectList = { uiRectangle.position + Displacement { 50, 204 },
+			Size { uiRectangle.size.width - 100, std::min<int>(vecDialogItems.size() * ListItemHeight, uiRectangle.size.height - 272) } };
+		rectDescription = { rectList.position + Displacement { -26, rectList.size.height + descriptionMarginTop },
+			Size { uiRectangle.size.width - 50, 80 - descriptionMarginTop } };
+		vecDialog.push_back(std::make_unique<UiScrollbar>((*ArtScrollBarBackground)[0], (*ArtScrollBarThumb)[0],
+		    *ArtScrollBarArrow, MakeSdlRect(rectList.position.x + rectList.size.width + 5, rectList.position.y, 25, rectList.size.height)));
+		vecDialog.push_back(std::make_unique<UiArtText>(optionDescription, MakeSdlRect(rectDescription),
+		    UiFlags::FontSize12 | UiFlags::ColorUiSilverDark | UiFlags::AlignCenter, 1, descriptionLineHeight));
+		vecDialog.push_back(std::make_unique<UiList>(vecDialogItems, rectList.size.height / ListItemHeight,
+		    rectList.position.x, rectList.position.y, rectList.size.width, ListItemHeight, UiFlags::FontSize24 | UiFlags::AlignCenter));
 
 		UiInitList(ItemFocused, ItemSelected, EscPressed, vecDialog, true, FullscreenChanged, nullptr, itemToSelect);
 


### PR DESCRIPTION
This makes it easier to navigate sections, such as gameplay and keymapping.

1920x1080:

![image](https://github.com/user-attachments/assets/c1cee51f-bc7c-4ec7-b645-e83d9da36899)

![image](https://github.com/user-attachments/assets/35dd127e-f878-4729-a6e1-07ef753bad11)

![image](https://github.com/user-attachments/assets/12c6c5ad-005d-4e97-ae17-fd8efa793f3c)

![image](https://github.com/user-attachments/assets/9da16ba9-efc8-4ee1-9107-b124d87b5e0e)

The 720 width makes all the keymapping options fit on a single line. I also tried 800 max width but that places the focused item markers too far from the item text.