### PR TITLE
[1.5] Add scroll wheel support to keymapper

### DIFF
--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -447,6 +447,19 @@ void UiSettingsMenu()
 						break;
 					}
 					break;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+				case SDL_MOUSEWHEEL:
+					if (event.wheel.y > 0) {
+						key = MouseScrollUpButton;
+					} else if (event.wheel.y < 0) {
+						key = MouseScrollDownButton;
+					} else if (event.wheel.x > 0) {
+						key = MouseScrollLeftButton;
+					} else if (event.wheel.x < 0) {
+						key = MouseScrollRightButton;
+					}
+					break;
+#endif
 				}
 				// Ignore unknown keys
 				if (key == SDLK_UNKNOWN)

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -767,6 +767,35 @@ void GameEventHandler(const SDL_Event &event, uint16_t modState)
 		MousePosition = { event.button.x, event.button.y };
 		HandleMouseButtonUp(event.button.button, modState);
 		return;
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	case SDL_MOUSEWHEEL:
+		if (event.wheel.y > 0) { // Up
+			if (stextflag != TalkID::None) {
+				StoreUp();
+			} else if (QuestLogIsOpen) {
+				QuestlogUp();
+			} else if (HelpFlag) {
+				HelpScrollUp();
+			} else if (ChatLogFlag) {
+				ChatLogScrollUp();
+			} else if (IsStashOpen) {
+				Stash.PreviousPage();
+			}
+		} else if (event.wheel.y < 0) { // down
+			if (stextflag != TalkID::None) {
+				StoreDown();
+			} else if (QuestLogIsOpen) {
+				QuestlogDown();
+			} else if (HelpFlag) {
+				HelpScrollDown();
+			} else if (ChatLogFlag) {
+				ChatLogScrollDown();
+			} else if (IsStashOpen) {
+				Stash.NextPage();
+			}
+		}
+		break;
+#endif
 	default:
 		if (IsCustomEvent(event.type)) {
 			if (gbIsMultiplayer)

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -780,6 +780,8 @@ void GameEventHandler(const SDL_Event &event, uint16_t modState)
 				ChatLogScrollUp();
 			} else if (IsStashOpen) {
 				Stash.PreviousPage();
+			} else {
+				sgOptions.Keymapper.KeyPressed(MouseScrollUpButton);
 			}
 		} else if (event.wheel.y < 0) { // down
 			if (stextflag != TalkID::None) {
@@ -792,7 +794,13 @@ void GameEventHandler(const SDL_Event &event, uint16_t modState)
 				ChatLogScrollDown();
 			} else if (IsStashOpen) {
 				Stash.NextPage();
+			} else {
+				sgOptions.Keymapper.KeyPressed(MouseScrollDownButton);
 			}
+		} else if (event.wheel.x > 0) { // left
+			sgOptions.Keymapper.KeyPressed(MouseScrollLeftButton);
+		} else if (event.wheel.x < 0) { // right
+			sgOptions.Keymapper.KeyPressed(MouseScrollRightButton);
 		}
 		break;
 #endif

--- a/Source/engine/events.cpp
+++ b/Source/engine/events.cpp
@@ -100,6 +100,7 @@ bool FetchMessage_Real(SDL_Event *event, uint16_t *modState)
 	case SDL_TEXTEDITING:
 	case SDL_TEXTINPUT:
 	case SDL_WINDOWEVENT:
+	case SDL_MOUSEWHEEL:
 #else
 	case SDL_ACTIVEEVENT:
 #endif
@@ -119,18 +120,6 @@ bool FetchMessage_Real(SDL_Event *event, uint16_t *modState)
 		*event = e;
 		break;
 #ifndef USE_SDL1
-	case SDL_MOUSEWHEEL:
-		event->type = SDL_KEYDOWN;
-		if (e.wheel.y > 0) {
-			event->key.keysym.sym = (SDL_GetModState() & KMOD_CTRL) != 0 ? SDLK_KP_PLUS : SDLK_UP;
-		} else if (e.wheel.y < 0) {
-			event->key.keysym.sym = (SDL_GetModState() & KMOD_CTRL) != 0 ? SDLK_KP_MINUS : SDLK_DOWN;
-		} else if (e.wheel.x > 0) {
-			event->key.keysym.sym = SDLK_LEFT;
-		} else if (e.wheel.x < 0) {
-			event->key.keysym.sym = SDLK_RIGHT;
-		}
-		break;
 #if SDL_VERSION_ATLEAST(2, 0, 4)
 	case SDL_AUDIODEVICEADDED:
 		return FalseAvail("SDL_AUDIODEVICEADDED", e.adevice.which);

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1327,6 +1327,10 @@ KeymapperOptions::KeymapperOptions()
 	keyIDToKeyName.emplace(SDL_BUTTON_MIDDLE | KeymapperMouseButtonMask, "MMOUSE");
 	keyIDToKeyName.emplace(SDL_BUTTON_X1 | KeymapperMouseButtonMask, "X1MOUSE");
 	keyIDToKeyName.emplace(SDL_BUTTON_X2 | KeymapperMouseButtonMask, "X2MOUSE");
+	keyIDToKeyName.emplace(MouseScrollUpButton, "SCROLlUPMOUSE");
+	keyIDToKeyName.emplace(MouseScrollDownButton, "SCROLLDOWNMOUSE");
+	keyIDToKeyName.emplace(MouseScrollLeftButton, "SCROLlLEFTMOUSE");
+	keyIDToKeyName.emplace(MouseScrollRightButton, "SCROLLRIGHTMOUSE");
 
 	keyNameToKeyID.reserve(keyIDToKeyName.size());
 	for (const auto &kv : keyIDToKeyName) {

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1327,9 +1327,9 @@ KeymapperOptions::KeymapperOptions()
 	keyIDToKeyName.emplace(SDL_BUTTON_MIDDLE | KeymapperMouseButtonMask, "MMOUSE");
 	keyIDToKeyName.emplace(SDL_BUTTON_X1 | KeymapperMouseButtonMask, "X1MOUSE");
 	keyIDToKeyName.emplace(SDL_BUTTON_X2 | KeymapperMouseButtonMask, "X2MOUSE");
-	keyIDToKeyName.emplace(MouseScrollUpButton, "SCROLlUPMOUSE");
+	keyIDToKeyName.emplace(MouseScrollUpButton, "SCROLLUPMOUSE");
 	keyIDToKeyName.emplace(MouseScrollDownButton, "SCROLLDOWNMOUSE");
-	keyIDToKeyName.emplace(MouseScrollLeftButton, "SCROLlLEFTMOUSE");
+	keyIDToKeyName.emplace(MouseScrollLeftButton, "SCROLLLEFTMOUSE");
 	keyIDToKeyName.emplace(MouseScrollRightButton, "SCROLLRIGHTMOUSE");
 
 	keyNameToKeyID.reserve(keyIDToKeyName.size());

--- a/Source/options.h
+++ b/Source/options.h
@@ -654,6 +654,10 @@ struct LanguageOptions : OptionCategoryBase {
 };
 
 constexpr uint32_t KeymapperMouseButtonMask = 1 << 31;
+constexpr uint32_t MouseScrollUpButton = 65536 | KeymapperMouseButtonMask;
+constexpr uint32_t MouseScrollDownButton = 65537 | KeymapperMouseButtonMask;
+constexpr uint32_t MouseScrollLeftButton = 65538 | KeymapperMouseButtonMask;
+constexpr uint32_t MouseScrollRightButton = 65539 | KeymapperMouseButtonMask;
 
 /** The Keymapper maps keys to actions. */
 struct KeymapperOptions : OptionCategoryBase {

--- a/Source/panels/spell_list.cpp
+++ b/Source/panels/spell_list.cpp
@@ -274,6 +274,13 @@ void SetSpeedSpell(size_t slot)
 		return;
 	}
 	Player &myPlayer = *MyPlayer;
+
+	if (myPlayer._pSplHotKey[slot] == pSpell && myPlayer._pSplTHotKey[slot] == pSplType) {
+		// Unset spell hotkey
+		myPlayer._pSplHotKey[slot] = SpellID::Invalid;
+		return;
+	}
+
 	for (size_t i = 0; i < NumHotkeys; ++i) {
 		if (myPlayer._pSplHotKey[i] == pSpell && myPlayer._pSplTHotKey[i] == pSplType)
 			myPlayer._pSplHotKey[i] = SpellID::Invalid;


### PR DESCRIPTION
Most of #6861 except the actual quick spell cycling feature (can be backported separately in a follow-up PR if we want to) + 41189060ef221b9d560fc5e23fec48e5fd804205 for 1.5