### PR TITLE
Delete copy constructor in ModEntry

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1724,7 +1724,7 @@ std::vector<OptionEntryBase *> ModOptions::GetEntries()
 	return optionEntries;
 }
 
-std::vector<ModOptions::ModEntry> &ModOptions::GetModEntries()
+std::forward_list<ModOptions::ModEntry> &ModOptions::GetModEntries()
 {
 	if (modEntries)
 		return *modEntries;
@@ -1738,10 +1738,11 @@ std::vector<ModOptions::ModEntry> &ModOptions::GetModEntries()
 		modNames.emplace_back(modName);
 	}
 
-	std::vector<ModOptions::ModEntry> &newModEntries = modEntries.emplace();
+	std::forward_list<ModOptions::ModEntry> &newModEntries = modEntries.emplace();
 	for (auto &modName : modNames) {
-		newModEntries.emplace_back(modName);
+		newModEntries.emplace_front(modName);
 	}
+	newModEntries.reverse();
 	return newModEntries;
 }
 

--- a/Source/options.h
+++ b/Source/options.h
@@ -819,13 +819,17 @@ struct ModOptions : OptionCategoryBase {
 
 private:
 	struct ModEntry {
+		// OptionEntryBase::key references ModEntry::name.
+		// The implicit copy constructor would copy that reference instead of referencing the copy.
+		ModEntry(const ModEntry &) = delete;
+
 		ModEntry(std::string_view name);
 		std::string name;
 		OptionEntryBoolean enabled;
 	};
 
-	std::vector<ModEntry> &GetModEntries();
-	std::optional<std::vector<ModEntry>> modEntries;
+	std::forward_list<ModEntry> &GetModEntries();
+	std::optional<std::forward_list<ModEntry>> modEntries;
 };
 
 struct Options {


### PR DESCRIPTION
See #5437

In this case, `ModEntry` isn't an implementation of `OptionEntryBase`, but `OptionEntryBoolean` does take a parameter of type `std::string_view` and so the copy constructor for `ModEntry` was still pulling the rug out from under it.