### PR TITLE
Fix Import Data shortcut in debug builds

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -26,7 +26,7 @@ android {
 	}
 	buildTypes {
 		debug {
-			applicationIdSuffix "dev"
+			applicationIdSuffix ".dev"
 		}
 		release {
 			minifyEnabled false

--- a/android-project/app/src/debug/res/xml/shortcuts.xml
+++ b/android-project/app/src/debug/res/xml/shortcuts.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+	<shortcut
+		android:shortcutId="import"
+		android:enabled="true"
+		android:icon="@mipmap/ic_launcher_import_data"
+		android:shortcutShortLabel="@string/import_short_label">
+		<intent
+			android:action="android.intent.action.VIEW"
+			android:targetPackage="org.diasurgical.devilutionx.dev"
+			android:targetClass="org.diasurgical.devilutionx.ImportActivity" />
+	</shortcut>
+</shortcuts>


### PR DESCRIPTION
1. Android Studio warned that the `applicationIdSuffix` is supposed to start with a period. This doesn't seem to make any difference except to get rid of the warning.
2. The shortcut requires that the `applicationIdSuffix` should be included in the `targetPackage` field of the intent that invokes the `ImportActivity`. Otherwise, I get a message on my Pixel 6a that states the "App isn't installed" when I try to use the shortcut.