### PR TITLE
[Bugfix] Revise Spectral Usability

### DIFF
--- a/Source/inv.h
+++ b/Source/inv.h
@@ -385,6 +385,27 @@ inline bool RemoveInventoryOrBeltItemById(Player &player, _item_indexes id)
 }
 
 /**
+ * @brief Marks all Spectral Elixir items in the player's inventory as permanently usable
+ *        by setting the CF_USEFUL flag in the item's creation info.
+ *
+ * This ensures that Spectral Elixirs remain usable across game sessions, regardless of
+ * quest status, while maintaining reverse compatibility with the original game.
+ *
+ * @param player The player whose inventory is being updated.
+ */
+inline void SetSpectralUsable(Player &player)
+{
+	if (player.InvList->isEmpty())
+		return;
+
+	for (Item &item : player.InvList) {
+		if (item.IDidx == IDI_SPECELIX) {
+			item._iCreateInfo |= CF_ONLYGOOD; // Set the unused flag to mark as permanently usable
+		}
+	}
+}
+
+/**
  * @brief Removes the first inventory or belt scroll with the player's current spell.
  */
 void ConsumeScroll(Player &player);

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -395,9 +395,6 @@ inline bool RemoveInventoryOrBeltItemById(Player &player, _item_indexes id)
  */
 inline void SetSpectralUsable(Player &player)
 {
-	if (player.InvList->isEmpty())
-		return;
-
 	for (Item &item : player.InvList) {
 		if (item.IDidx == IDI_SPECELIX) {
 			item._iCreateInfo |= CF_ONLYGOOD; // Set the unused flag to mark as permanently usable

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4779,8 +4779,13 @@ void PutItemRecord(uint32_t nSeed, uint16_t wCI, int nIndex)
 
 bool Item::isUsable() const
 {
-	if (IDidx == IDI_SPECELIX && Quests[Q_MUSHROOM]._qactive != QUEST_DONE)
+	// If the item is a Spectral Elixir
+	if (IDidx == IDI_SPECELIX) {
+		if ((_iCreateInfo & CF_ONLYGOOD) != 0 || Quests[Q_MUSHROOM]._qactive == QUEST_DONE)
+			return true;
 		return false;
+	}
+
 	return AllItemsList[IDidx].iUsable;
 }
 

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -450,6 +450,7 @@ void TalkToWitch(Player &player, Towner & /*witch*/)
 					return;
 				}
 				if (HasInventoryOrBeltItemWithId(player, IDI_SPECELIX)) {
+					SetSpectralUsable(player);
 					Quests[Q_MUSHROOM]._qactive = QUEST_DONE;
 					NetSendCmdQuest(true, Quests[Q_MUSHROOM]);
 					InitQTextMsg(TEXT_MUSH12);


### PR DESCRIPTION
Allows Spectral Elixir to become permanently usable when completing the mushroom quest. Previous, the usability of the elixir is based on quest completion on a game to game basis.