### PR TITLE
Decouple Golems from Players and use SpawnMonster for Golem

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2342,22 +2342,25 @@ void AddGolem(Missile &missile, AddMissileParameter &parameter)
 
 	int playerId = missile._misource;
 	Player &player = Players[playerId];
-	Monster &golem = Monsters[playerId];
+	Monster *golem = FindGolemForPlayer(player);
 
-	if (golem.position.tile != GolemHoldingCell && &player == MyPlayer)
-		KillMyGolem();
-
-	if (golem.position.tile == GolemHoldingCell) {
-		std::optional<Point> spawnPosition = FindClosestValidPosition(
-		    [start = missile.position.start](Point target) {
-			    return !IsTileOccupied(target) && LineClearMissile(start, target);
-		    },
-		    parameter.dst, 0, 5);
-
-		if (spawnPosition) {
-			SpawnGolem(player, golem, *spawnPosition, missile);
-		}
+	// Is Golem alive?
+	if (golem != nullptr) {
+		if (&player == MyPlayer)
+			KillGolem(*golem);
+		return;
 	}
+
+	std::optional<Point> spawnPosition = FindClosestValidPosition(
+	    [start = missile.position.start](Point target) {
+		    return !IsTileOccupied(target) && LineClearMissile(start, target);
+	    },
+	    parameter.dst, 0, 5);
+
+	if (!spawnPosition)
+		return;
+
+	SpawnGolem(player, *golem, *spawnPosition, missile);
 }
 
 void AddApocalypseBoom(Missile &missile, AddMissileParameter &parameter)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2346,8 +2346,7 @@ void AddGolem(Missile &missile, AddMissileParameter &parameter)
 
 	// Is Golem alive?
 	if (golem != nullptr) {
-		if (&player == MyPlayer)
-			KillGolem(*golem);
+		KillGolem(*golem);
 		return;
 	}
 
@@ -2360,7 +2359,18 @@ void AddGolem(Missile &missile, AddMissileParameter &parameter)
 	if (!spawnPosition)
 		return;
 
-	SpawnGolem(player, *golem, *spawnPosition, missile);
+	if (&player != MyPlayer)
+		return;
+
+	uint8_t spellLevel = static_cast<uint8_t>(missile._mispllvl);
+
+	// The command is only executed for the level owner, to prevent desyncs in multiplayer.
+	if (!MyPlayer->isLevelOwnedByLocalClient()) {
+		// If we are not the level owner, request the level owner to spawn the golem for us
+		NetSendCmdLocParam1(true, CMD_REQUESTSPAWNGOLEM, *spawnPosition, spellLevel);
+		return;
+	}
+	SpawnGolem(player, *spawnPosition, spellLevel);
 }
 
 void AddApocalypseBoom(Missile &missile, AddMissileParameter &parameter)

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4672,23 +4672,23 @@ bool CanTalkToMonst(const Monster &monster)
 	return IsAnyOf(monster.goal, MonsterGoal::Inquiring, MonsterGoal::Talking);
 }
 
-int encode_enemy(Monster &monster)
+uint8_t encode_enemy(Monster &monster)
 {
 	if ((monster.flags & MFLAG_TARGETS_MONSTER) != 0)
-		return monster.enemy + MAX_PLRS;
+		return monster.enemy;
 
-	return monster.enemy;
+	return monster.enemy + MaxMonsters;
 }
 
-void decode_enemy(Monster &monster, int enemyId)
+void decode_enemy(Monster &monster, uint8_t enemyId)
 {
-	if (enemyId < MAX_PLRS) {
+	if (enemyId >= MaxMonsters) {
+		enemyId -= MaxMonsters;
 		monster.flags &= ~MFLAG_TARGETS_MONSTER;
 		monster.enemy = enemyId;
 		monster.enemyPosition = Players[enemyId].position.future;
 	} else {
 		monster.flags |= MFLAG_TARGETS_MONSTER;
-		enemyId -= MAX_PLRS;
 		monster.enemy = enemyId;
 		monster.enemyPosition = Monsters[enemyId].position.future;
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -3837,7 +3837,7 @@ void KillMyGolem()
 {
 	Monster &golem = Monsters[MyPlayerId];
 	delta_kill_monster(golem, golem.position.tile, *MyPlayer);
-	NetSendCmdLoc(MyPlayerId, false, CMD_KILLGOLEM, golem.position.tile);
+	NetSendCmdLocParam1(false, CMD_MONSTDEATH, golem.position.tile, static_cast<uint16_t>(golem.getId()));
 	M_StartKill(golem, *MyPlayer);
 }
 

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -80,6 +80,9 @@ constexpr int HellToHitBonus = 120;
 constexpr int NightmareAcBonus = 50;
 constexpr int HellAcBonus = 80;
 
+/** @brief Reserved some entries in @Monster for golems. For vanilla compatibility, this must remain 4. */
+constexpr int ReservedMonsterSlotsForGolems = 4;
+
 /** Tracks which missile files are already loaded */
 size_t totalmonsters;
 int monstimgtot;
@@ -3518,7 +3521,7 @@ void WeakenNaKrul()
 void InitGolems()
 {
 	if (!setlevel) {
-		for (int i = 0; i < MAX_PLRS; i++)
+		for (int i = 0; i < ReservedMonsterSlotsForGolems; i++)
 			AddMonster(GolemHoldingCell, Direction::South, 0, false);
 	}
 }
@@ -3588,7 +3591,7 @@ tl::expected<void, std::string> SetMapMonsters(const uint16_t *dunData, Point st
 {
 	RETURN_IF_ERROR(AddMonsterType(MT_GOLEM, PLACE_SPECIAL));
 	if (setlevel)
-		for (int i = 0; i < MAX_PLRS; i++)
+		for (int i = 0; i < ReservedMonsterSlotsForGolems; i++)
 			AddMonster(GolemHoldingCell, Direction::South, 0, false);
 
 	WorldTileSize size = GetDunSize(dunData);
@@ -4012,7 +4015,7 @@ void GolumAi(Monster &golem)
 
 void DeleteMonsterList()
 {
-	for (int i = 0; i < MAX_PLRS; i++) {
+	for (int i = 0; i < ReservedMonsterSlotsForGolems; i++) {
 		Monster &golem = Monsters[i];
 		if (!golem.isInvalid)
 			continue;
@@ -4023,7 +4026,7 @@ void DeleteMonsterList()
 		golem.isInvalid = false;
 	}
 
-	for (size_t i = MAX_PLRS; i < ActiveMonsterCount;) {
+	for (size_t i = ReservedMonsterSlotsForGolems; i < ActiveMonsterCount;) {
 		if (Monsters[ActiveMonsters[i]].isInvalid) {
 			if (pcursmonst == static_cast<int>(ActiveMonsters[i])) // Unselect monster if player highlighted it
 				pcursmonst = -1;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1068,7 +1068,7 @@ void MonsterAttackMonster(Monster &attacker, Monster &target, int hper, int mind
 	ApplyMonsterDamage(DamageType::Physical, target, dam);
 
 	if (attacker.isPlayerMinion()) {
-		size_t playerId = attacker.getId();
+		size_t playerId = static_cast<size_t>(attacker.goalVar3);
 		const Player &player = Players[playerId];
 		target.tag(player);
 	}
@@ -3833,9 +3833,8 @@ void StartMonsterDeath(Monster &monster, const Player &player, bool sendmsg)
 	MonsterDeath(monster, md, sendmsg);
 }
 
-void KillMyGolem()
+void KillGolem(Monster &golem)
 {
-	Monster &golem = Monsters[MyPlayerId];
 	delta_kill_monster(golem, golem.position.tile, *MyPlayer);
 	NetSendCmdLocParam1(false, CMD_MONSTDEATH, golem.position.tile, static_cast<uint16_t>(golem.getId()));
 	M_StartKill(golem, *MyPlayer);
@@ -4001,7 +4000,7 @@ void GolumAi(Monster &golem)
 	if (golem.pathCount > 8)
 		golem.pathCount = 5;
 
-	if (RandomWalk(golem, Players[golem.getId()]._pdir))
+	if (RandomWalk(golem, Players[golem.goalVar3]._pdir))
 		return;
 
 	Direction md = Left(golem.direction);
@@ -4516,6 +4515,24 @@ Monster *FindUniqueMonster(UniqueMonsterType monsterType)
 	return nullptr;
 }
 
+Monster *FindGolemForPlayer(const Player &player)
+{
+	for (size_t i = 0; i < ActiveMonsterCount; i++) {
+		int monsterId = ActiveMonsters[i];
+		Monster &monster = Monsters[monsterId];
+		if (monster.type().type != MT_GOLEM)
+			continue;
+		if (monster.position.tile == GolemHoldingCell)
+			continue;
+		if (monster.goalVar3 != player.getId())
+			continue;
+		if (monster.hitPoints == 0)
+			continue;
+		return &monster;
+	}
+	return nullptr;
+}
+
 bool IsTileAvailable(const Monster &monster, Point position)
 {
 	if (!IsTileAvailable(position))
@@ -4654,6 +4671,7 @@ void SpawnGolem(Player &player, Monster &golem, Point position, Missile &missile
 	golem.minDamage = 2 * (missile._mispllvl + 4);
 	golem.maxDamage = 2 * (missile._mispllvl + 8);
 	golem.flags |= MFLAG_GOLEM;
+	golem.goalVar3 = player.getId();
 	StartSpecialStand(golem, Direction::South);
 	UpdateEnemy(golem);
 	if (&player == MyPlayer) {

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -177,6 +177,7 @@ void InitMonster(Monster &monster, Direction rd, size_t typeIndex, Point positio
 	monster.goalVar2 = 0;
 	monster.goalVar3 = 0;
 	monster.pathCount = 0;
+	monster.enemy = 0;
 	monster.isInvalid = false;
 	monster.uniqueType = UniqueMonsterType::None;
 	monster.activeForTicks = 0;
@@ -3133,6 +3134,20 @@ void EnsureMonsterIndexIsActive(size_t monsterId)
 	}
 }
 
+void InitGolem(devilution::Monster &monster, uint8_t golemOwnerPlayerId, int16_t golemSpellLevel)
+{
+	monster.flags |= MFLAG_GOLEM;
+	monster.goalVar3 = static_cast<int8_t>(golemOwnerPlayerId);
+	const Player &player = Players[golemOwnerPlayerId];
+	monster.maxHitPoints = 2 * (320 * golemSpellLevel + player._pMaxMana / 3);
+	monster.hitPoints = monster.maxHitPoints;
+	monster.armorClass = 25;
+	monster.golemToHit = 5 * (golemSpellLevel + 8) + 2 * player.getCharacterLevel();
+	monster.minDamage = 2 * (golemSpellLevel + 4);
+	monster.maxDamage = 2 * (golemSpellLevel + 8);
+	UpdateEnemy(monster);
+}
+
 } // namespace
 
 tl::expected<size_t, std::string> AddMonsterType(_monster_id type, placeflag placeflag)
@@ -3641,11 +3656,11 @@ void SpawnMonster(Point position, Direction dir, size_t typeIndex, bool startSpe
 	ActiveMonsterCount += 1;
 	uint32_t seed = GetLCGEngineState();
 	// Update local state immediately to increase ActiveMonsterCount instantly (this allows multiple monsters to be spawned in one game tick)
-	InitializeSpawnedMonster(position, dir, typeIndex, monsterIndex, seed);
-	NetSendCmdSpawnMonster(position, dir, static_cast<uint16_t>(typeIndex), static_cast<uint16_t>(monsterIndex), seed);
+	InitializeSpawnedMonster(position, dir, typeIndex, monsterIndex, seed, 0, 0);
+	NetSendCmdSpawnMonster(position, dir, static_cast<uint16_t>(typeIndex), static_cast<uint16_t>(monsterIndex), seed, 0, 0);
 }
 
-void LoadDeltaSpawnedMonster(size_t typeIndex, size_t monsterId, uint32_t seed)
+void LoadDeltaSpawnedMonster(size_t typeIndex, size_t monsterId, uint32_t seed, uint8_t golemOwnerPlayerId, int16_t golemSpellLevel)
 {
 	SetRndSeed(seed);
 	EnsureMonsterIndexIsActive(monsterId);
@@ -3653,9 +3668,12 @@ void LoadDeltaSpawnedMonster(size_t typeIndex, size_t monsterId, uint32_t seed)
 	Monster &monster = Monsters[monsterId];
 	M_ClearSquares(monster);
 	InitMonster(monster, Direction::South, typeIndex, position);
+	if (monster.type().type == MT_GOLEM) {
+		InitGolem(monster, golemOwnerPlayerId, golemSpellLevel);
+	}
 }
 
-void InitializeSpawnedMonster(Point position, Direction dir, size_t typeIndex, size_t monsterId, uint32_t seed)
+void InitializeSpawnedMonster(Point position, Direction dir, size_t typeIndex, size_t monsterId, uint32_t seed, uint8_t golemOwnerPlayerId, int16_t golemSpellLevel)
 {
 	SetRndSeed(seed);
 	EnsureMonsterIndexIsActive(monsterId);
@@ -3678,10 +3696,14 @@ void InitializeSpawnedMonster(Point position, Direction dir, size_t typeIndex, s
 	monster.occupyTile(position, false);
 	InitMonster(monster, dir, typeIndex, position);
 
-	if (IsSkel(monster.type().type))
+	if (monster.type().type == MT_GOLEM) {
+		InitGolem(monster, golemOwnerPlayerId, golemSpellLevel);
 		StartSpecialStand(monster, dir);
-	else
+	} else if (IsSkel(monster.type().type)) {
+		StartSpecialStand(monster, dir);
+	} else {
 		M_StartStand(monster, dir);
+	}
 }
 
 void AddDoppelganger(Monster &monster)
@@ -4657,32 +4679,44 @@ void TalktoMonster(Player &player, Monster &monster)
 	}
 }
 
-void SpawnGolem(Player &player, Monster &golem, Point position, Missile &missile)
+void SpawnGolem(const Player &player, Point position, uint8_t spellLevel)
 {
-	golem.occupyTile(position, false);
-	golem.position.tile = position;
-	golem.position.future = position;
-	golem.position.old = position;
-	golem.pathCount = 0;
-	golem.maxHitPoints = 2 * (320 * missile._mispllvl + player._pMaxMana / 3);
-	golem.hitPoints = golem.maxHitPoints;
-	golem.armorClass = 25;
-	golem.golemToHit = 5 * (missile._mispllvl + 8) + 2 * player.getCharacterLevel();
-	golem.minDamage = 2 * (missile._mispllvl + 4);
-	golem.maxDamage = 2 * (missile._mispllvl + 8);
-	golem.flags |= MFLAG_GOLEM;
-	golem.goalVar3 = player.getId();
-	StartSpecialStand(golem, Direction::South);
-	UpdateEnemy(golem);
-	if (&player == MyPlayer) {
-		NetSendCmdGolem(
-		    golem.position.tile.x,
-		    golem.position.tile.y,
-		    golem.direction,
-		    golem.enemy,
-		    golem.hitPoints,
-		    GetLevelForMultiplayer(player));
+	// Search monster index to use for the new golem
+	Monster *golem = nullptr;
+	// 1. Prefer MonsterIndex = PlayerIndex for vanilla compatibility
+	if (player.getId() < ReservedMonsterSlotsForGolems) {
+		Monster &reservedGolem = Monsters[player.getId()];
+		if (reservedGolem.position.tile == GolemHoldingCell || reservedGolem.hitPoints == 0)
+			golem = &reservedGolem;
 	}
+	// 2. Use reserved slots, so additional Monsters can spawn
+	if (golem == nullptr) {
+		for (int i = 0; i < ReservedMonsterSlotsForGolems; i++) {
+			Monster &reservedGolem = Monsters[i];
+			if (reservedGolem.position.tile == GolemHoldingCell || reservedGolem.hitPoints == 0) {
+				golem = &reservedGolem;
+				break;
+			}
+		}
+	}
+	// 3. Use normal monster slot
+	if (golem == nullptr) {
+		if (ActiveMonsterCount >= MaxMonsters)
+			return;
+		size_t monsterIndex = ActiveMonsters[ActiveMonsterCount];
+		ActiveMonsterCount += 1;
+		golem = &Monsters[monsterIndex];
+	}
+
+	if (golem == nullptr)
+		return;
+
+	size_t monsterIndex = golem->getId();
+	uint32_t seed = GetLCGEngineState();
+
+	// Update local state immediately to increase ActiveMonsterCount instantly (this allows multiple monsters to be spawned in one game tick)
+	InitializeSpawnedMonster(position, Direction::South, 0, monsterIndex, seed, player.getId(), spellLevel);
+	NetSendCmdSpawnMonster(position, Direction::South, 0, static_cast<uint16_t>(monsterIndex), seed, player.getId(), spellLevel);
 }
 
 bool CanTalkToMonst(const Monster &monster)

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -514,11 +514,11 @@ void SpawnMonster(Point position, Direction dir, size_t typeIndex, bool startSpe
 /**
  * @brief Loads data for a dynamically spawned monster when entering a level in multiplayer.
  */
-void LoadDeltaSpawnedMonster(size_t typeIndex, size_t monsterId, uint32_t seed);
+void LoadDeltaSpawnedMonster(size_t typeIndex, size_t monsterId, uint32_t seed, uint8_t golemOwnerPlayerId, int16_t golemSpellLevel);
 /**
  * @brief Initialize a spanwed monster (from a network message or from SpawnMonster-function).
  */
-void InitializeSpawnedMonster(Point position, Direction dir, size_t typeIndex, size_t monsterId, uint32_t seed);
+void InitializeSpawnedMonster(Point position, Direction dir, size_t typeIndex, size_t monsterId, uint32_t seed, uint8_t golemOwnerPlayerId, int16_t golemSpellLevel);
 void AddDoppelganger(Monster &monster);
 void ApplyMonsterDamage(DamageType damageType, Monster &monster, int damage);
 bool M_Talker(const Monster &monster);
@@ -569,7 +569,7 @@ bool IsGoat(_monster_id mt);
 void ActivateSkeleton(Monster &monster, Point position);
 Monster *PreSpawnSkeleton();
 void TalktoMonster(Player &player, Monster &monster);
-void SpawnGolem(Player &player, Monster &golem, Point position, Missile &missile);
+void SpawnGolem(const Player &player, Point position, uint8_t spellLevel);
 bool CanTalkToMonst(const Monster &monster);
 uint8_t encode_enemy(Monster &monster);
 void decode_enemy(Monster &monster, uint8_t enemyId);

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -570,7 +570,7 @@ Monster *PreSpawnSkeleton();
 void TalktoMonster(Player &player, Monster &monster);
 void SpawnGolem(Player &player, Monster &golem, Point position, Missile &missile);
 bool CanTalkToMonst(const Monster &monster);
-int encode_enemy(Monster &monster);
-void decode_enemy(Monster &monster, int enemyId);
+uint8_t encode_enemy(Monster &monster);
+void decode_enemy(Monster &monster, uint8_t enemyId);
 
 } // namespace devilution

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -237,7 +237,7 @@ struct Monster { // note: missing field _mAFNum
 
 	/**
 	 * @brief Controls monster's behaviour regarding special actions.
-	 * Used only by @p ScavengerAi and @p MegaAi.
+	 * Used only by @p ScavengerAi, @p MegaAi and @p GolemAi.
 	 */
 	int8_t goalVar3;
 
@@ -529,7 +529,7 @@ void M_StartHit(Monster &monster, int dam);
 void M_StartHit(Monster &monster, const Player &player, int dam);
 void StartMonsterDeath(Monster &monster, const Player &player, bool sendmsg);
 void MonsterDeath(Monster &monster, Direction md, bool sendmsg);
-void KillMyGolem();
+void KillGolem(Monster &golem);
 void M_StartKill(Monster &monster, const Player &player);
 void M_SyncStartKill(Monster &monster, Point position, const Player &player);
 void M_UpdateRelations(const Monster &monster);
@@ -553,6 +553,7 @@ void MissToMonst(Missile &missile, Point position);
 
 Monster *FindMonsterAtPosition(Point position, bool ignoreMovingMonsters = false);
 Monster *FindUniqueMonster(UniqueMonsterType monsterType);
+Monster *FindGolemForPlayer(const Player &player);
 
 /**
  * @brief Check that the given tile is available to the monster

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -169,7 +169,7 @@ std::string_view CmdIdString(_cmd_id cmd)
 	case CMD_ITEMEXTRA: return "CMD_ITEMEXTRA";
 	case CMD_SYNCPUTITEM: return "CMD_SYNCPUTITEM";
 	case CMD_SYNCQUEST: return "CMD_SYNCQUEST";
-	case CMD_AWAKEGOLEM: return "CMD_AWAKEGOLEM";
+	case CMD_REQUESTSPAWNGOLEM: return "CMD_REQUESTSPAWNGOLEM";
 	case CMD_SETSHIELD: return "CMD_SETSHIELD";
 	case CMD_REMSHIELD: return "CMD_REMSHIELD";
 	case CMD_SETREFLECT: return "CMD_SETREFLECT";
@@ -213,6 +213,8 @@ struct DObjectStr {
 struct DSpawnedMonster {
 	size_t typeIndex;
 	uint32_t seed;
+	uint8_t golemOwnerPlayerId;
+	int16_t golemSpellLevel;
 };
 
 struct DLevel {
@@ -729,19 +731,6 @@ size_t OnLevelData(uint8_t pnum, const TCmd *pCmd)
 	memcpy(&sgRecvBuf[wOffset], &message + 1, wBytes);
 	sgdwRecvOffset += wBytes;
 	return wBytes + sizeof(message);
-}
-
-void DeltaSyncGolem(const TCmdGolem &message, const Player &player, uint8_t level)
-{
-	if (!gbIsMultiplayer)
-		return;
-
-	DMonsterStr &monster = GetDeltaLevel(level).monster[player.getId()];
-	monster.position.x = message._mx;
-	monster.position.y = message._my;
-	monster._mactive = UINT8_MAX;
-	monster._menemy = message._menemy;
-	monster.hitPoints = SDL_SwapLE32(message._mhitpoints);
 }
 
 void DeltaLeaveSync(uint8_t bLevel)
@@ -1768,27 +1757,16 @@ size_t OnMonstDeath(const TCmd *pCmd, Player &player)
 	return sizeof(message);
 }
 
-size_t OnAwakeGolem(const TCmd *pCmd, Player &player)
+size_t OnRequestSpawnGolem(const TCmd *pCmd, const Player &player)
 {
-	const auto &message = *reinterpret_cast<const TCmdGolem *>(pCmd);
-	const Point position { message._mx, message._my };
+	const auto &message = *reinterpret_cast<const TCmdLocParam1 *>(pCmd);
+	if (gbBufferMsgs == 1)
+		return sizeof(message);
 
-	if (gbBufferMsgs == 1) {
-		SendPacket(player, &message, sizeof(message));
-	} else if (InDungeonBounds(position)) {
-		if (!player.isOnActiveLevel()) {
-			DeltaSyncGolem(message, player, message._currlevel);
-		} else if (&player != MyPlayer) {
-			// Check if this player already has an active golem
-			for (auto &missile : Missiles) {
-				if (missile._mitype == MissileID::Golem && &Players[missile._misource] == &player) {
-					return sizeof(message);
-				}
-			}
+	const WorldTilePosition position { message.x, message.y };
 
-			AddMissile(player.position.tile, position, message._mdir, MissileID::Golem, TARGET_MONSTERS, player, 0, 1);
-		}
-	}
+	if (player.isLevelOwnedByLocalClient() && InDungeonBounds(position))
+		SpawnGolem(player, position, static_cast<uint8_t>(message.wParam1));
 
 	return sizeof(message);
 }
@@ -2368,10 +2346,15 @@ size_t OnSpawnMonster(const TCmd *pCmd, const Player &player)
 
 	size_t typeIndex = static_cast<size_t>(SDL_SwapLE16(message.typeIndex));
 	size_t monsterId = static_cast<size_t>(SDL_SwapLE16(message.monsterId));
+	uint8_t golemOwnerPlayerId = message.golemOwnerPlayerId;
+	if (golemOwnerPlayerId >= Players.size()) {
+		return sizeof(message);
+	}
+	uint8_t golemSpellLevel = std::min(message.golemSpellLevel, static_cast<uint8_t>(MaxSpellLevel + Players[golemOwnerPlayerId]._pISplLvlAdd));
 
 	DLevel &deltaLevel = GetDeltaLevel(player);
 
-	deltaLevel.spawnedMonsters[monsterId] = { typeIndex, message.seed };
+	deltaLevel.spawnedMonsters[monsterId] = { typeIndex, message.seed, golemOwnerPlayerId, golemSpellLevel };
 	// Override old monster delta information
 	auto &deltaMonster = deltaLevel.monster[monsterId];
 	deltaMonster.position = position;
@@ -2380,7 +2363,7 @@ size_t OnSpawnMonster(const TCmd *pCmd, const Player &player)
 	deltaMonster._mactive = 0;
 
 	if (player.isOnActiveLevel() && &player != MyPlayer)
-		InitializeSpawnedMonster(position, message.dir, typeIndex, monsterId, message.seed);
+		InitializeSpawnedMonster(position, message.dir, typeIndex, monsterId, message.seed, golemOwnerPlayerId, golemSpellLevel);
 	return sizeof(message);
 }
 
@@ -2675,7 +2658,8 @@ void DeltaLoadLevel()
 	DLevel &deltaLevel = GetDeltaLevel(localLevel);
 	if (leveltype != DTYPE_TOWN) {
 		for (auto &deltaSpawnedMonster : deltaLevel.spawnedMonsters) {
-			LoadDeltaSpawnedMonster(deltaSpawnedMonster.second.typeIndex, deltaSpawnedMonster.first, deltaSpawnedMonster.second.seed);
+			auto &monsterData = deltaSpawnedMonster.second;
+			LoadDeltaSpawnedMonster(deltaSpawnedMonster.second.typeIndex, deltaSpawnedMonster.first, monsterData.seed, monsterData.golemOwnerPlayerId, monsterData.golemSpellLevel);
 			assert(deltaLevel.monster[deltaSpawnedMonster.first].position.x != 0xFF);
 		}
 		for (size_t i = 0; i < MaxMonsters; i++) {
@@ -2804,21 +2788,7 @@ void NetSendCmd(bool bHiPri, _cmd_id bCmd)
 		NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
-void NetSendCmdGolem(uint8_t mx, uint8_t my, Direction dir, uint8_t menemy, int hp, uint8_t cl)
-{
-	TCmdGolem cmd;
-
-	cmd.bCmd = CMD_AWAKEGOLEM;
-	cmd._mx = mx;
-	cmd._my = my;
-	cmd._mdir = dir;
-	cmd._menemy = menemy;
-	cmd._mhitpoints = hp;
-	cmd._currlevel = cl;
-	NetSendLoPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
-}
-
-void NetSendCmdSpawnMonster(Point position, Direction dir, uint16_t typeIndex, uint16_t monsterId, uint32_t seed)
+void NetSendCmdSpawnMonster(Point position, Direction dir, uint16_t typeIndex, uint16_t monsterId, uint32_t seed, uint8_t golemOwnerPlayerId, uint8_t golemSpellLevel)
 {
 	TCmdSpawnMonster cmd;
 
@@ -2829,6 +2799,8 @@ void NetSendCmdSpawnMonster(Point position, Direction dir, uint16_t typeIndex, u
 	cmd.typeIndex = SDL_SwapLE16(typeIndex);
 	cmd.monsterId = SDL_SwapLE16(monsterId);
 	cmd.seed = SDL_SwapLE32(seed);
+	cmd.golemOwnerPlayerId = golemOwnerPlayerId;
+	cmd.golemSpellLevel = golemSpellLevel;
 	NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));
 }
 
@@ -3243,8 +3215,8 @@ size_t ParseCmd(uint8_t pnum, const TCmd *pCmd)
 		return OnWarp(pCmd, player);
 	case CMD_MONSTDEATH:
 		return OnMonstDeath(pCmd, player);
-	case CMD_AWAKEGOLEM:
-		return OnAwakeGolem(pCmd, player);
+	case CMD_REQUESTSPAWNGOLEM:
+		return OnRequestSpawnGolem(pCmd, player);
 	case CMD_MONSTDAMAGE:
 		return OnMonstDamage(pCmd, player);
 	case CMD_PLRDEAD:

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -168,7 +168,6 @@ std::string_view CmdIdString(_cmd_id cmd)
 	case CMD_SPELLXYD: return "CMD_SPELLXYD";
 	case CMD_ITEMEXTRA: return "CMD_ITEMEXTRA";
 	case CMD_SYNCPUTITEM: return "CMD_SYNCPUTITEM";
-	case CMD_KILLGOLEM: return "CMD_KILLGOLEM";
 	case CMD_SYNCQUEST: return "CMD_SYNCQUEST";
 	case CMD_AWAKEGOLEM: return "CMD_AWAKEGOLEM";
 	case CMD_SETSHIELD: return "CMD_SETSHIELD";
@@ -1769,25 +1768,6 @@ size_t OnMonstDeath(const TCmd *pCmd, Player &player)
 	return sizeof(message);
 }
 
-size_t OnKillGolem(const TCmd *pCmd, Player &player)
-{
-	const auto &message = *reinterpret_cast<const TCmdLoc *>(pCmd);
-	const Point position { message.x, message.y };
-
-	if (gbBufferMsgs != 1) {
-		if (&player != MyPlayer && InDungeonBounds(position)) {
-			Monster &monster = Monsters[player.getId()];
-			if (player.isOnActiveLevel())
-				M_SyncStartKill(monster, position, player);
-			delta_kill_monster(monster, position, player); // BUGFIX: should be p->wParam1, plrlevel will be incorrect if golem is killed because player changed levels
-		}
-	} else {
-		SendPacket(player, &message, sizeof(message));
-	}
-
-	return sizeof(message);
-}
-
 size_t OnAwakeGolem(const TCmd *pCmd, Player &player)
 {
 	const auto &message = *reinterpret_cast<const TCmdGolem *>(pCmd);
@@ -3263,8 +3243,6 @@ size_t ParseCmd(uint8_t pnum, const TCmd *pCmd)
 		return OnWarp(pCmd, player);
 	case CMD_MONSTDEATH:
 		return OnMonstDeath(pCmd, player);
-	case CMD_KILLGOLEM:
-		return OnKillGolem(pCmd, player);
 	case CMD_AWAKEGOLEM:
 		return OnAwakeGolem(pCmd, player);
 	case CMD_MONSTDAMAGE:

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -389,13 +389,6 @@ enum _cmd_id : uint8_t {
 	//
 	// body (TCmdPItem)
 	CMD_SYNCPUTITEM,
-	// Golem death at location.
-	//
-	// body (TCmdLocParam1):
-	//    int8_t x
-	//    int8_t y
-	//    int16_t dlvl
-	CMD_KILLGOLEM,
 	// Synchronize quest state.
 	//
 	// body (TCmdQuest)

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -393,10 +393,10 @@ enum _cmd_id : uint8_t {
 	//
 	// body (TCmdQuest)
 	CMD_SYNCQUEST,
-	// Spawn golem at target location.
+	// Request to spawn a golem at target location.
 	//
-	// body (TCmdGolem)
-	CMD_AWAKEGOLEM,
+	// body (TCmdLocParam1)
+	CMD_REQUESTSPAWNGOLEM,
 	// Enable mana shield of player (render).
 	//
 	// body (TCmd)
@@ -500,16 +500,6 @@ struct TCmdParam4 {
 	uint16_t wParam4;
 };
 
-struct TCmdGolem {
-	_cmd_id bCmd;
-	uint8_t _mx;
-	uint8_t _my;
-	Direction _mdir;
-	int8_t _menemy;
-	int32_t _mhitpoints;
-	uint8_t _currlevel;
-};
-
 struct TCmdSpawnMonster {
 	_cmd_id bCmd;
 	uint8_t x;
@@ -518,6 +508,8 @@ struct TCmdSpawnMonster {
 	uint16_t typeIndex;
 	uint16_t monsterId;
 	uint32_t seed;
+	uint8_t golemOwnerPlayerId;
+	uint8_t golemSpellLevel;
 };
 
 struct TCmdQuest {
@@ -743,8 +735,7 @@ void DeltaLoadLevel();
 /** @brief Clears last sent player command for the local player. This is used when a game tick changes. */
 void ClearLastSentPlayerCmd();
 void NetSendCmd(bool bHiPri, _cmd_id bCmd);
-void NetSendCmdGolem(uint8_t mx, uint8_t my, Direction dir, uint8_t menemy, int hp, uint8_t cl);
-void NetSendCmdSpawnMonster(Point position, Direction dir, uint16_t typeIndex, uint16_t monsterId, uint32_t seed);
+void NetSendCmdSpawnMonster(Point position, Direction dir, uint16_t typeIndex, uint16_t monsterId, uint32_t seed, uint8_t golemOwnerPlayerId, uint8_t golemSpellLevel);
 void NetSendCmdLoc(uint8_t playerId, bool bHiPri, _cmd_id bCmd, Point position);
 void NetSendCmdLocParam1(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1);
 void NetSendCmdLocParam2(bool bHiPri, _cmd_id bCmd, Point position, uint16_t wParam1, uint16_t wParam2);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2812,14 +2812,14 @@ void SyncPlrKill(Player &player, DeathReason deathReason)
 void RemovePlrMissiles(const Player &player)
 {
 	if (leveltype != DTYPE_TOWN && &player == MyPlayer) {
-		Monster &golem = Monsters[MyPlayerId];
-		if (golem.position.tile.x != 1 || golem.position.tile.y != 0) {
-			KillMyGolem();
-			AddCorpse(golem.position.tile, golem.type().corpseId, golem.direction);
-			int mx = golem.position.tile.x;
-			int my = golem.position.tile.y;
+		Monster *golem = FindGolemForPlayer(player);
+		if (golem != nullptr) {
+			KillGolem(*golem);
+			AddCorpse(golem->position.tile, golem->type().corpseId, golem->direction);
+			int mx = golem->position.tile.x;
+			int my = golem->position.tile.y;
 			dMonster[mx][my] = 0;
-			golem.isInvalid = true;
+			golem->isInvalid = true;
 			DeleteMonsterList();
 		}
 	}

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2811,16 +2811,10 @@ void SyncPlrKill(Player &player, DeathReason deathReason)
 
 void RemovePlrMissiles(const Player &player)
 {
-	if (leveltype != DTYPE_TOWN && &player == MyPlayer) {
-		Monster *golem = FindGolemForPlayer(player);
-		if (golem != nullptr) {
+	if (leveltype != DTYPE_TOWN) {
+		Monster *golem;
+		while ((golem = FindGolemForPlayer(player)) != nullptr) {
 			KillGolem(*golem);
-			AddCorpse(golem->position.tile, golem->type().corpseId, golem->direction);
-			int mx = golem->position.tile.x;
-			int my = golem->position.tile.y;
-			dMonster[mx][my] = 0;
-			golem->isInvalid = true;
-			DeleteMonsterList();
 		}
 	}
 

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -160,7 +160,7 @@ void SyncMonster(bool isOwner, const TSyncMonster &monsterSync)
 	}
 
 	const Point position { monsterSync._mx, monsterSync._my };
-	const int enemyId = monsterSync._menemy;
+	const uint8_t enemyId = monsterSync._menemy;
 
 	if (monster.activeForTicks != 0) {
 		uint32_t delta = MyPlayer->position.tile.ManhattanDistance(monster.position.tile);
@@ -205,19 +205,13 @@ void SyncMonster(bool isOwner, const TSyncMonster &monsterSync)
 	monster.whoHit |= monsterSync.mWhoHit;
 }
 
-bool IsEnemyIdValid(const Monster &monster, int enemyId)
+bool IsEnemyIdValid(const Monster &monster, uint8_t enemyId)
 {
-	if (enemyId < 0) {
-		return false;
-	}
-
-	if (enemyId < MAX_PLRS) {
+	if (enemyId > MaxMonsters) {
+		enemyId -= MaxMonsters;
+		if (enemyId >= Players.size())
+			return false;
 		return Players[enemyId].plractive;
-	}
-
-	enemyId -= MAX_PLRS;
-	if (static_cast<size_t>(enemyId) >= MaxMonsters) {
-		return false;
 	}
 
 	const Monster &enemy = Monsters[enemyId];


### PR DESCRIPTION
Contributes to #543 and supports #7663

In master and vanilla golems are tied to a specific monster id. This monster id corresponds 1:1 to the player id. This is how the relation player<->golem relationship is maintained and that's also why the game reserves the first 4 monster slots for golems (max player count in multiplayer).

This PR changes that by 
- using `goalVar3` to maintain the golem<->player relationship (should be 0 in singleplayer saves)
- introducing a helper to find golems for a player
- using `SpawnMonster` logic to spawn golems (similar to how monsters are spawned dynamically, see #6890)
- to maintain vanilla compatibility, the first 4 slots are still reserved for golems. In singleplayer, the first monster slot is always used.

Additional notes
- Allows multiple golems to be spawned by removing the `KillGolem` call in `AddGolem` for existing golems (allows better mods).
- This PR supports up to 55 players because we still store the enemy id in a `uint8_t` (could be changed later).
- This PR can be tested with the current player count by changing `ReservedMonsterSlotsForGolems` to a lower number (I tested with 2 players and set it to 0 and 1).