### PR TITLE
prevent the overwrite of existing mpq files

### DIFF
--- a/Source/mpq/mpq_writer.cpp
+++ b/Source/mpq/mpq_writer.cpp
@@ -93,7 +93,7 @@ MpqWriter::MpqWriter(const char *path)
 	LogVerbose("Opening {}", path);
 	std::string error;
 	bool exists = FileExists(path);
-	const char *mode = "wb";
+	const char *mode = "wbx";
 	if (exists) {
 		mode = "r+b";
 		std::uintmax_t fileSize;


### PR DESCRIPTION
Lifted from pionere's fork: https://github.com/pionere/devilutionX/commit/7866861cf2a264f8101a51078f10a56048e65c09

He simply adds the `x` flag to indicate that `wb` should not overwrite existing files. This should indeed prevent the issue of save files being wiped out. It might still be a good idea to handle error messages from `PathFileExistsW()` more explicitly, but this change seems like an obvious improvement to me.

This resolves #7672