### PR TITLE
Fix d-pad in main menu

### DIFF
--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -92,8 +92,7 @@ bool TriggersQuickSpellAction(ControllerButton button)
 
 bool IsPressedForMovement(ControllerButton button)
 {
-	return gbRunGame
-	    && !PadMenuNavigatorActive
+	return !PadMenuNavigatorActive
 	    && IsControllerButtonPressed(button)
 	    && !IsMovementOverriddenByPadmapper(button)
 	    && !(SpellSelectFlag && TriggersQuickSpellAction(button));


### PR DESCRIPTION
The d-pad stopped working in the main menu after 4113805. As far as I can tell, the check for `gbRunGame` in `IsPressedForMovement()` is unnecessary.