### PR TITLE
Fix off-by-one in path finding logic

### DIFF
--- a/Source/engine/path.cpp
+++ b/Source/engine/path.cpp
@@ -160,13 +160,13 @@ int ReconstructPath(const ExploredNodes &explored, PointT dest, int8_t *path, si
 		const auto it = explored.find(cur);
 		if (it == explored.end()) app_fatal("Failed to reconstruct path");
 		if (it->second.g == 0) break; // reached start
-		path[len++] = GetPathDirection(it->second.prev, cur);
-		cur = it->second.prev;
 		if (len == maxPathLength) {
 			// Path too long.
 			len = 0;
 			break;
 		}
+		path[len++] = GetPathDirection(it->second.prev, cur);
+		cur = it->second.prev;
 	}
 	std::reverse(path, path + len);
 	std::fill(path + len, path + maxPathLength, -1);

--- a/test/path_test.cpp
+++ b/test/path_test.cpp
@@ -91,7 +91,8 @@ std::vector<Dir> ToSyms(std::span<const int8_t> indices)
 
 void CheckPath(Point startPosition, Point destinationPosition, std::vector<std::string> expectedSteps)
 {
-	constexpr size_t MaxPathLength = 25;
+	// Restrict tests to the longest possible path length in vanilla Diablo
+	constexpr size_t MaxPathLength = 24;
 	int8_t pathSteps[MaxPathLength];
 	auto pathLength = FindPath(
 	    /*canStep=*/[](Point, Point) { return true; },
@@ -153,7 +154,7 @@ TEST(PathTest, LongPaths)
 	// Starting from the middle of the world and trying to path to a border exceeds the maximum path size
 	CheckPath({ 56, 56 }, { 0, 0 }, {});
 
-	// Longest possible path is currently 24 steps meaning tiles 24 units away are reachable
+	// Longest possible path used to be 24 steps meaning tiles 24 units away are reachable
 	Point startingPosition { 56, 56 };
 	CheckPath(startingPosition, startingPosition + Displacement { 24, 24 }, std::vector<std::string>(24, "↘"));
 


### PR DESCRIPTION
This fixes an issue where items and objects can no longer be interacted with unless the player is on top of them.

In the following conditional statement, the call to `GetDistance()` always returned zero. The reason is that the logic thought that a path of length 1 exceeds the maximum path length of 1 that was passed in via the second argument.

https://github.com/diasurgical/devilutionX/blob/20c0a8dae8b27ac2d5c3e768af2073efa5b18381/Source/controls/plrctrls.cpp#L171-L174

This resolves #7681