### PR TITLE
Fix item description rendering issues

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -5,6 +5,7 @@
  */
 #include "text_render.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -391,8 +392,9 @@ void MaybeWrap(Point &characterPosition, int characterWidth, int rightMargin, in
 
 int GetLineStartX(UiFlags flags, const Rectangle &rect, int lineWidth)
 {
-	if (HasAnyOf(flags, UiFlags::AlignCenter))
-		return rect.position.x + (rect.size.width - lineWidth) / 2;
+	if (HasAnyOf(flags, UiFlags::AlignCenter)) {
+		return std::max(rect.position.x, rect.position.x + (rect.size.width - lineWidth) / 2);
+	}
 	if (HasAnyOf(flags, UiFlags::AlignRight))
 		return rect.position.x + rect.size.width - lineWidth;
 	return rect.position.x;


### PR DESCRIPTION
Fixes #7651

The initial issue in the unique item info box was caused by `GetLineStartX` returning a negative value for long strings.
Fixing that made the text fit but the renderer breaks at arbitrary points, so we further use `WordWrapString` to break at word boundaries:

![image](https://github.com/user-attachments/assets/6e0238c7-eb6b-4248-be34-8f71e3939483)

The info box issue was caused by `KerningFitSpacing` only taking the first line into account.
This PR fixes that by recalculating the kerning fit on each new line:

![image](https://github.com/user-attachments/assets/74947c80-e980-479b-82ca-158c02feca87)

An alternative fix to would be to add a version of `GetLineWidth` that calculates the maximum width across all lines. This would make the kerning the same for all lines.

I went with kerning fit per line here but I don't have a strong preference either way.

/cc @Riccila