### PR TITLE
Fix gcc/MSVC compiler warnings

### DIFF
--- a/3rdParty/libzt/CMakeLists.txt
+++ b/3rdParty/libzt/CMakeLists.txt
@@ -22,6 +22,7 @@ foreach(
   lwip_obj
   miniupnpc_obj
   zto_pic
+  zt_pic
   natpmp_pic
   lwip_pic
   miniupnpc_pic

--- a/Source/engine/path.cpp
+++ b/Source/engine/path.cpp
@@ -170,7 +170,7 @@ int ReconstructPath(const ExploredNodes &explored, PointT dest, int8_t *path, si
 	}
 	std::reverse(path, path + len);
 	std::fill(path + len, path + maxPathLength, -1);
-	return len;
+	return static_cast<int>(len);
 }
 
 } // namespace

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4271,7 +4271,6 @@ void UseItem(Player &player, item_misc_id mid, SpellID spellID, int spellFrom)
 		if (ControlMode == ControlTypes::KeyboardAndMouse && GetSpellData(spellID).isTargeted()) {
 			prepareSpellID = spellID;
 		} else {
-			const int spellLevel = player.GetSpellLevel(spellID);
 			// Find a valid target for the spell because tile coords
 			// will be validated when processing the network message
 			Point target = cursPosition;


### PR DESCRIPTION
gcc:
```
/home/runner/work/devilutionX/devilutionX/Source/items.cpp: In function ‘void devilution::UseItem(Player&, item_misc_id, SpellID, int)’:
/home/runner/work/devilutionX/devilutionX/Source/items.cpp:4274:35: warning: unused variable ‘spellLevel’ [-Wunused-variable]
 4274 |                         const int spellLevel = player.GetSpellLevel(spellID);
      |                                   ^~~~~~~~~~
```

Also, this doesn't show up in CI, probably because the build folder is cached, but libzt was generating a large number of warnings on my system because we weren't applying the `-w` flag to the `zt_pic` library.

---

MSVC:
> Warning: D:\a\devilutionX\devilutionX\Source\engine\path.cpp(173): warning C4267: 'return': conversion from 'size_t' to 'int', possible loss of data