### PR TITLE
[Rebalance] Remove Multiplayer Difficulty Gate

### DIFF
--- a/Source/DiabloUI/multi/selgame.cpp
+++ b/Source/DiabloUI/multi/selgame.cpp
@@ -402,31 +402,8 @@ void selgame_Diff_Focus(size_t value)
 	CopyUtf8(selgame_Description, WordWrapString(selgame_Description, DESCRIPTION_WIDTH), sizeof(selgame_Description));
 }
 
-bool IsDifficultyAllowed(int value)
-{
-	if (value == 0 || (value == 1 && heroLevel >= 20) || (value == 2 && heroLevel >= 30)) {
-		return true;
-	}
-
-	selgame_Free();
-
-	if (value == 1)
-		UiSelOkDialog(title, _("Your character must reach level 20 before you can enter a multiplayer game of Nightmare difficulty.").data(), false);
-	if (value == 2)
-		UiSelOkDialog(title, _("Your character must reach level 30 before you can enter a multiplayer game of Hell difficulty.").data(), false);
-
-	selgame_Init();
-
-	return false;
-}
-
 void selgame_Diff_Select(size_t value)
 {
-	if (selhero_isMultiPlayer && !IsDifficultyAllowed(vecSelGameDlgItems[value]->m_value)) {
-		selgame_GameSelection_Select(selgame_selectedGame);
-		return;
-	}
-
 	nDifficulty = (_difficulty)vecSelGameDlgItems[value]->m_value;
 
 	if (!selhero_isMultiPlayer) {
@@ -589,7 +566,7 @@ void selgame_Password_Init(size_t /*value*/)
 static bool IsGameCompatibleWithErrorMessage(const GameData &data)
 {
 	if (IsGameCompatible(data))
-		return IsDifficultyAllowed(data.nDifficulty);
+		return true;
 
 	selgame_Free();
 


### PR DESCRIPTION
Unifies inconsistent behavior with difficulty selection by removing level requirements. Currently within DevilutionX, you can enter a Nightmare or Hell game with a level 1 character in Single Player, and are met with level requirements in any form of Multiplayer.

![image](https://github.com/user-attachments/assets/5d051882-af71-4eb2-96f1-4b69ea04048f)

Since it's possible to enter Nightmare and Hell difficulties in both SP and MP, in both Diablo and Hellfire with a level 1 character, while in vanilla under specific circumstances, I opted to outright remove the level gate. The change that I thought would be an improvement would be gating by difficulty completion, rather by level, however the change in this PR remains more faithful to what can be done in vanilla, and is less restrictive on players.