### PR TITLE
Do not depend on FileExists() when opening save files for writing

### DIFF
--- a/Source/mpq/mpq_writer.cpp
+++ b/Source/mpq/mpq_writer.cpp
@@ -91,9 +91,9 @@ MpqWriter::MpqWriter(const char *path)
 	const std::string dir = std::string(Dirname(path));
 	RecursivelyCreateDir(dir.c_str());
 	LogVerbose("Opening {}", path);
+	bool isNewFile = false;
 	std::string error;
-	bool exists = FileExists(path);
-	if (!exists) {
+	if (!FileExists(path)) {
 		// FileExists() may return false in the case of an error
 		// so we use "ab" instead of "wb" to avoid accidentally
 		// truncating an existing file
@@ -112,6 +112,7 @@ MpqWriter::MpqWriter(const char *path)
 		goto on_error;
 	}
 	size_ = static_cast<uint32_t>(fileSize);
+	isNewFile = size_ == 0;
 	LogVerbose("GetFileSize(\"{}\") = {}", path, size_);
 
 	if (!stream_.Open(path, "r+b")) {
@@ -124,7 +125,7 @@ MpqWriter::MpqWriter(const char *path)
 
 	if (blockTable_ == nullptr || hashTable_ == nullptr) {
 		MpqFileHeader fhdr;
-		if (!exists) {
+		if (isNewFile) {
 			InitDefaultMpqHeader(&fhdr);
 		} else if (!ReadMPQHeader(&fhdr)) {
 			error = "Failed to read MPQ header";
@@ -162,7 +163,7 @@ MpqWriter::MpqWriter(const char *path)
 
 		// Write garbage header and tables because some platforms cannot `Seekp` beyond EOF.
 		// The data is incorrect at this point, it will be overwritten on Close.
-		if (!exists)
+		if (isNewFile)
 			WriteHeaderAndTables();
 #endif
 	}


### PR DESCRIPTION
Because the `ab` file mode doesn't outright fail when the save file already exists, then it turns out a false negative result from `FileExists()` can still wipe out a save file. The good news is that `GetFileSize()` can't retrieve a valid value for `size_` if an error occurs. Since we are querying the file size anyway, we can rely on that result to determine whether the MPQ we opened is a newly created file.