### PR TITLE
Allow lua debug quick messages in singleplayer

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1688,20 +1688,24 @@ bool CheckKeypress(SDL_Keycode vkey)
 
 void DiabloHotkeyMsg(uint32_t dwMsg)
 {
+	assert(dwMsg < QuickMessages.size());
+
+#ifdef _DEBUG
+	constexpr std::string_view LuaPrefix = "/lua ";
+	for (const std::string &msg : GetOptions().Chat.szHotKeyMsgs[dwMsg]) {
+		if (!msg.starts_with(LuaPrefix)) continue;
+		InitConsole();
+		RunInConsole(std::string_view(msg).substr(LuaPrefix.size()));
+	}
+#endif
+
 	if (!IsChatAvailable()) {
 		return;
 	}
 
-	assert(dwMsg < QuickMessages.size());
-
 	for (const std::string &msg : GetOptions().Chat.szHotKeyMsgs[dwMsg]) {
 #ifdef _DEBUG
-		constexpr std::string_view LuaPrefix = "/lua ";
-		if (msg.starts_with(LuaPrefix)) {
-			InitConsole();
-			RunInConsole(std::string_view(msg).substr(LuaPrefix.size()));
-			continue;
-		}
+		if (msg.starts_with(LuaPrefix)) continue;
 #endif
 		char charMsg[MAX_SEND_STR_LEN];
 		CopyUtf8(charMsg, msg, sizeof(charMsg));


### PR DESCRIPTION
When debugging, it's possible to use quick messages to execute lua scripts.
This is useful when debugging to execute lua commands very quickly.
However, in singleplayer chat is disabled (`IsChatAvailable` returns false) and so no quick messages are processed.
This PR changes that so that `/lua` quick messages will work in singleplayer.
Note: Normal chat functionality is still disabled even in debug singleplayer, as we now have a great lua console with autocomplete.