### PR TITLE
Add missiles to tile data debug command

### DIFF
--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -144,19 +144,20 @@ void SetDebugGridTextType(DebugGridTextItem value)
 	SelectedDebugGridTextItem = value;
 }
 
-bool GetDebugGridText(Point dungeonCoords, char *debugGridTextBuffer)
+bool GetDebugGridText(Point dungeonCoords, std::string &debugGridText)
 {
 	int info = 0;
 	int blankValue = 0;
+	debugGridText.clear();
 	Point megaCoords = dungeonCoords.worldToMega();
 	switch (SelectedDebugGridTextItem) {
 	case DebugGridTextItem::coords:
-		*BufCopy(debugGridTextBuffer, dungeonCoords.x, ":", dungeonCoords.y) = '\0';
+		StrAppend(debugGridText, dungeonCoords.x, ":", dungeonCoords.y);
 		return true;
 	case DebugGridTextItem::cursorcoords:
 		if (dungeonCoords != cursPosition)
 			return false;
-		*BufCopy(debugGridTextBuffer, dungeonCoords.x, ":", dungeonCoords.y) = '\0';
+		StrAppend(debugGridText, dungeonCoords.x, ":", dungeonCoords.y);
 		return true;
 	case DebugGridTextItem::objectindex: {
 		info = 0;
@@ -167,23 +168,21 @@ bool GetDebugGridText(Point dungeonCoords, char *debugGridTextBuffer)
 		break;
 	}
 	case DebugGridTextItem::microTiles: {
-		std::string result;
 		const MICROS &micros = DPieceMicros[dPiece[dungeonCoords.x][dungeonCoords.y]];
 		for (const LevelCelBlock tile : micros.mt) {
 			if (!tile.hasValue()) break;
-			if (!result.empty()) result += '\n';
-			StrAppend(result, tile.frame(), " ");
+			if (!debugGridText.empty()) debugGridText += '\n';
+			StrAppend(debugGridText, tile.frame(), " ");
 			switch (tile.type()) {
-			case TileType::Square: StrAppend(result, "S"); break;
-			case TileType::TransparentSquare: StrAppend(result, "T"); break;
-			case TileType::LeftTriangle: StrAppend(result, "<"); break;
-			case TileType::RightTriangle: StrAppend(result, ">"); break;
-			case TileType::LeftTrapezoid: StrAppend(result, "\\"); break;
-			case TileType::RightTrapezoid: StrAppend(result, "/"); break;
+			case TileType::Square: StrAppend(debugGridText, "S"); break;
+			case TileType::TransparentSquare: StrAppend(debugGridText, "T"); break;
+			case TileType::LeftTriangle: StrAppend(debugGridText, "<"); break;
+			case TileType::RightTriangle: StrAppend(debugGridText, ">"); break;
+			case TileType::LeftTrapezoid: StrAppend(debugGridText, "\\"); break;
+			case TileType::RightTrapezoid: StrAppend(debugGridText, "/"); break;
 			}
 		}
-		if (result.empty()) return false;
-		*BufCopy(debugGridTextBuffer, result) = '\0';
+		if (debugGridText.empty()) return false;
 		return true;
 	} break;
 	case DebugGridTextItem::dPiece:
@@ -251,7 +250,7 @@ bool GetDebugGridText(Point dungeonCoords, char *debugGridTextBuffer)
 	}
 	if (info == blankValue)
 		return false;
-	*BufCopy(debugGridTextBuffer, info) = '\0';
+	StrAppend(debugGridText, info);
 	return true;
 }
 

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -19,6 +19,7 @@
 #include "engine/load_cel.hpp"
 #include "engine/point.hpp"
 #include "lighting.h"
+#include "missiles.h"
 #include "monster.h"
 #include "plrmsg.h"
 #include "utils/str_case.hpp"
@@ -208,6 +209,16 @@ bool GetDebugGridText(Point dungeonCoords, std::string &debugGridText)
 	case DebugGridTextItem::dMonster:
 		info = dMonster[dungeonCoords.x][dungeonCoords.y];
 		break;
+	case DebugGridTextItem::missiles: {
+		for (auto &missile : Missiles) {
+			if (missile.position.tile == dungeonCoords) {
+				if (!debugGridText.empty()) debugGridText += '\n';
+				debugGridText.append(std::to_string((int)missile._mitype));
+			}
+		}
+		if (debugGridText.empty()) return false;
+		return true;
+	} break;
 	case DebugGridTextItem::dCorpse:
 		info = dCorpse[dungeonCoords.x][dungeonCoords.y];
 		break;

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -43,6 +43,7 @@ enum class DebugGridTextItem : uint16_t {
 	dFlags,
 	dPlayer,
 	dMonster,
+	missiles,
 	dCorpse,
 	dObject,
 	dItem,

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -73,7 +73,7 @@ bool IsDebugGridTextNeeded();
 bool IsDebugGridInMegatiles();
 DebugGridTextItem GetDebugGridTextType();
 void SetDebugGridTextType(DebugGridTextItem value);
-bool GetDebugGridText(Point dungeonCoords, char *debugGridTextBuffer);
+bool GetDebugGridText(Point dungeonCoords, std::string &debugGridText);
 bool IsDebugAutomapHighlightNeeded();
 bool ShouldHighlightDebugAutomapTile(Point position);
 void AddDebugAutomapMonsterHighlight(std::string_view name);

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1158,7 +1158,7 @@ void DrawView(const Surface &out, Point startPosition)
 	if (debugGridTextNeeded || DebugGrid) {
 		// force redrawing or debug stuff stays on panel on 640x480 resolution
 		RedrawEverything();
-		char debugGridTextBuffer[10];
+		std::string debugGridText;
 		bool megaTiles = IsDebugGridInMegatiles();
 
 		for (auto [dunCoordVal, pixelCoords] : DebugCoordsMap) {
@@ -1169,11 +1169,11 @@ void DrawView(const Surface &out, Point startPosition)
 				pixelCoords += Displacement { 0, TILE_HEIGHT / 2 };
 			if (*GetOptions().Graphics.zoom)
 				pixelCoords *= 2;
-			if (debugGridTextNeeded && GetDebugGridText(dunCoords, debugGridTextBuffer)) {
+			if (debugGridTextNeeded && GetDebugGridText(dunCoords, debugGridText)) {
 				Size tileSize = { TILE_WIDTH, TILE_HEIGHT };
 				if (*GetOptions().Graphics.zoom)
 					tileSize *= 2;
-				DrawString(out, debugGridTextBuffer, { pixelCoords - Displacement { 0, tileSize.height }, tileSize },
+				DrawString(out, debugGridText, { pixelCoords - Displacement { 0, tileSize.height }, tileSize },
 				    { .flags = UiFlags::ColorRed | UiFlags::AlignCenter | UiFlags::VerticalCenter });
 			}
 			if (DebugGrid) {

--- a/Source/lua/modules/dev/display.cpp
+++ b/Source/lua/modules/dev/display.cpp
@@ -42,7 +42,7 @@ std::string DebugCmdFullbright(std::optional<bool> on)
 
 std::string DebugCmdShowTileData(std::optional<std::string_view> dataType)
 {
-	static const std::array<std::string_view, 22> DataTypes {
+	static const std::array<std::string_view, 23> DataTypes {
 		"microTiles",
 		"dPiece",
 		"dTransVal",
@@ -51,6 +51,7 @@ std::string DebugCmdShowTileData(std::optional<std::string_view> dataType)
 		"dFlags",
 		"dPlayer",
 		"dMonster",
+		"missiles",
 		"dCorpse",
 		"dObject",
 		"dItem",


### PR DESCRIPTION
This adds a new `missiles` data type to the debug lua `tileData` command.

After adding this, it turned out that `debugGridTextBuffer` can be too small (only 10 characters). This can be exceeded if there are many missiles on a tile or if there are many microTiles on a tile (e.g. cathedral levels).
This PR changes `debugGridText` to `std::string` to avoid such situations.

Example video:

https://github.com/user-attachments/assets/7a617a6d-c5e5-4fd4-a748-c94fca56f017

