### PR TITLE
[Bugfix/Rebalance] Monster Pathing Fixes

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1679,9 +1679,14 @@ bool IsTileAvailable(Point position)
  */
 bool IsTileAccessible(const Monster &monster, Point position)
 {
-	for (const TriggerStruct trig : trigs) {
+	for (const TriggerStruct &trig : trigs) {
 		if (position == trig.position && IsAnyOf(trig._tmsg, WM_DIABNEXTLVL, WM_DIABPREVLVL, WM_DIABTOWNWARP)) {
-			return false;
+			if (!std::any_of(Players.begin(), Players.end(), [&](const Player &player) {
+				    return position.WalkingDistance(player.position.tile) < 2;
+			    })) {
+				return false;
+			}
+			break;
 		}
 	}
 


### PR DESCRIPTION
Fixes some of the biggest issues with Monster pathing that are most obvious to the player:
- Monsters getting stuck in Cathedral stair trigger tiles
- The Butcher getting stuck on obstacles, such as in the wall in his room

The first fix prevents Monster pathing from recognizing Down Stairs, Up Stairs, and Town Warp Stairs as valid options as a part of the planned path.

The second fix gives the Butcher the smarter `AiPlanWalk()` function for figuring out the best way to the player, as well as refining how direction is obtained. `RandomWalk()` is included as a fallback in case `AiPlanWalk()` fails.