### PR TITLE
Fix UiFlags::KerningFitSpacing

### DIFF
--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -318,8 +318,8 @@ void DrawChr(const Surface &out)
 			DrawString(
 			    out,
 			    tmp.text,
-			    { entry.position + Displacement { pos.x + 5, pos.y + PanelFieldPaddingTop }, { entry.length - 10, PanelFieldInnerHeight } },
-			    { .flags = UiFlags::KerningFitSpacing | UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style });
+			    { entry.position + Displacement { pos.x, pos.y + PanelFieldPaddingTop }, { entry.length, PanelFieldInnerHeight } },
+			    { .flags = UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style, .spacing = tmp.spacing });
 		}
 	}
 	DrawStatButtons(out);

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -318,8 +318,8 @@ void DrawChr(const Surface &out)
 			DrawString(
 			    out,
 			    tmp.text,
-			    { entry.position + Displacement { pos.x, pos.y + PanelFieldPaddingTop }, { entry.length, PanelFieldInnerHeight } },
-			    { .flags = UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style, .spacing = tmp.spacing });
+			    { entry.position + Displacement { pos.x + 5, pos.y + PanelFieldPaddingTop }, { entry.length - 10, PanelFieldInnerHeight } },
+			    { .flags = UiFlags::KerningFitSpacing | UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style });
 		}
 	}
 	DrawStatButtons(out);


### PR DESCRIPTION
When using `UiFlags::KerningFitSpacing`, the text alignment was computed using unadjusted spacing. Later, during drawing, the spacing was reduced to "squish" the text so it fits inside its rect. This mismatch caused the final drawn text to be narrower than expected, resulting in left-shifted text that would have been word-wrapped without the use of `UiFlags::KerningFitSpacing`.

We now compute the adjusted spacing before calculating the starting X coordinate for text. The changes are as follows:

- First, measure the text width using the default spacing.
- Use `AdjustSpacingToFitHorizontally` to determine the new spacing that ensures the text fits within the available width.
- Recalculate the line width using the adjusted spacing and compute the starting X position (with `GetLineStartX`) based on this new width.
- Update the text render options with the adjusted spacing before passing them to the drawing routine, ensuring that both the alignment calculation and the drawing use the same spacing.