### PR TITLE
Character Panel Number spacing

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -715,11 +715,15 @@ uint32_t DrawString(const Surface &out, std::string_view text, const Rectangle &
 	const text_color color = GetColorFromFlags(opts.flags);
 
 	int charactersInLine = 0;
-	int lineWidth = 0;
-	if (HasAnyOf(opts.flags, (UiFlags::AlignCenter | UiFlags::AlignRight | UiFlags::KerningFitSpacing)))
-		lineWidth = GetLineWidth(text, size, opts.spacing, &charactersInLine);
+	int unadjustedWidth = GetLineWidth(text, size, opts.spacing, &charactersInLine);
+	int adjustedSpacing = HasAnyOf(opts.flags, UiFlags::KerningFitSpacing)
+	    ? AdjustSpacingToFitHorizontally(unadjustedWidth, opts.spacing, charactersInLine, rect.size.width)
+	    : opts.spacing;
+	int adjustedLineWidth = GetLineWidth(text, size, adjustedSpacing, &charactersInLine);
+	Point characterPosition { GetLineStartX(opts.flags, rect, adjustedLineWidth), rect.position.y };
 
-	Point characterPosition { GetLineStartX(opts.flags, rect, lineWidth), rect.position.y };
+	opts.spacing = adjustedSpacing;
+
 	const int initialX = characterPosition.x;
 
 	const int rightMargin = rect.position.x + rect.size.width;
@@ -745,7 +749,7 @@ uint32_t DrawString(const Surface &out, std::string_view text, const Rectangle &
 	}
 
 	const uint32_t bytesDrawn = DoDrawString(clippedOut, text, rect, characterPosition,
-	    lineWidth, charactersInLine, rightMargin, bottomMargin, size, color, outlined, opts);
+	    unadjustedWidth, charactersInLine, rightMargin, bottomMargin, size, color, outlined, opts);
 
 	if (HasAnyOf(opts.flags, UiFlags::PentaCursor)) {
 		const ClxSprite sprite = (*pSPentSpn2Cels)[PentSpn2Spin()];

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -715,15 +715,11 @@ uint32_t DrawString(const Surface &out, std::string_view text, const Rectangle &
 	const text_color color = GetColorFromFlags(opts.flags);
 
 	int charactersInLine = 0;
-	int unadjustedWidth = GetLineWidth(text, size, opts.spacing, &charactersInLine);
-	int adjustedSpacing = HasAnyOf(opts.flags, UiFlags::KerningFitSpacing)
-	    ? AdjustSpacingToFitHorizontally(unadjustedWidth, opts.spacing, charactersInLine, rect.size.width)
-	    : opts.spacing;
-	int adjustedLineWidth = GetLineWidth(text, size, adjustedSpacing, &charactersInLine);
-	Point characterPosition { GetLineStartX(opts.flags, rect, adjustedLineWidth), rect.position.y };
+	int lineWidth = 0;
+	if (HasAnyOf(opts.flags, (UiFlags::AlignCenter | UiFlags::AlignRight | UiFlags::KerningFitSpacing)))
+		lineWidth = GetLineWidth(text, size, opts.spacing, &charactersInLine);
 
-	opts.spacing = adjustedSpacing;
-
+	Point characterPosition { GetLineStartX(opts.flags, rect, lineWidth), rect.position.y };
 	const int initialX = characterPosition.x;
 
 	const int rightMargin = rect.position.x + rect.size.width;
@@ -749,7 +745,7 @@ uint32_t DrawString(const Surface &out, std::string_view text, const Rectangle &
 	}
 
 	const uint32_t bytesDrawn = DoDrawString(clippedOut, text, rect, characterPosition,
-	    unadjustedWidth, charactersInLine, rightMargin, bottomMargin, size, color, outlined, opts);
+	    lineWidth, charactersInLine, rightMargin, bottomMargin, size, color, outlined, opts);
 
 	if (HasAnyOf(opts.flags, UiFlags::PentaCursor)) {
 		const ClxSprite sprite = (*pSPentSpn2Cels)[PentSpn2Spin()];

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -134,8 +134,7 @@ PanelEntry panelEntries[] = {
 	    []() { return StyledText { UiFlags::ColorWhite, StrCat(InspectPlayer->getCharacterLevel()) }; } },
 	{ N_("Experience"), { TopRightLabelX, 52 }, 99, 91,
 	    []() {
-	        int spacing = ((InspectPlayer->_pExperience >= 1000000000) ? 0 : 1);
-	        return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->_pExperience), spacing };
+	        return StyledText { UiFlags::ColorWhite, FormatInteger(InspectPlayer->_pExperience) };
 	    } },
 	{ N_("Next level"), { TopRightLabelX, 80 }, 99, 198,
 	    []() {
@@ -143,8 +142,7 @@ PanelEntry panelEntries[] = {
 		        return StyledText { UiFlags::ColorWhitegold, std::string(_("None")) };
 	        }
 	        uint32_t nextExperienceThreshold = InspectPlayer->getNextExperienceThreshold();
-	        int spacing = ((nextExperienceThreshold >= 1000000000) ? 0 : 1);
-	        return StyledText { UiFlags::ColorWhite, FormatInteger(nextExperienceThreshold), spacing };
+	        return StyledText { UiFlags::ColorWhite, FormatInteger(nextExperienceThreshold) };
 	    } },
 
 	{ N_("Base"), { LeftColumnLabelX, /* set dynamically */ 0 }, 0, 44, {} },
@@ -180,8 +178,7 @@ PanelEntry panelEntries[] = {
 	{ N_("Damage"), { RightColumnLabelX, 219 }, 57, RightColumnLabelWidth,
 	    []() {
 	        const auto [dmgMin, dmgMax] = GetDamage();
-	        int spacing = ((dmgMin >= 100) ? -1 : 1);
-	        return StyledText { GetValueColor(InspectPlayer->_pIBonusDam), StrCat(dmgMin, "-", dmgMax), spacing };
+	        return StyledText { GetValueColor(InspectPlayer->_pIBonusDam), StrCat(dmgMin, "-", dmgMax) };
 	    } },
 
 	{ N_("Life"), { LeftColumnLabelX, 284 }, 45, LeftColumnLabelWidth,
@@ -206,6 +203,7 @@ OptionalOwnedClxSpriteList Panel;
 constexpr int PanelFieldHeight = 24;
 constexpr int PanelFieldPaddingTop = 3;
 constexpr int PanelFieldPaddingBottom = 3;
+constexpr int PanelFieldPaddingSide = 5;
 constexpr int PanelFieldInnerHeight = PanelFieldHeight - PanelFieldPaddingTop - PanelFieldPaddingBottom;
 
 void DrawPanelField(const Surface &out, Point pos, int len, ClxSprite left, ClxSprite middle, ClxSprite right)
@@ -318,8 +316,8 @@ void DrawChr(const Surface &out)
 			DrawString(
 			    out,
 			    tmp.text,
-			    { entry.position + Displacement { pos.x, pos.y + PanelFieldPaddingTop }, { entry.length, PanelFieldInnerHeight } },
-			    { .flags = UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style, .spacing = tmp.spacing });
+			    { entry.position + Displacement { pos.x + PanelFieldPaddingSide, pos.y + PanelFieldPaddingTop }, { entry.length - (PanelFieldPaddingSide * 2), PanelFieldInnerHeight } },
+			    { .flags = UiFlags::KerningFitSpacing | UiFlags::AlignCenter | UiFlags::VerticalCenter | tmp.style });
 		}
 	}
 	DrawStatButtons(out);


### PR DESCRIPTION
Depends on: https://github.com/diasurgical/devilutionX/pull/7705
Fixes: https://github.com/diasurgical/devilutionX/issues/7692
Obsoletes: https://github.com/diasurgical/devilutionX/pull/7688

Removes hardcoding from the Character Panel for spacing numbers, and prevents them from extending too far onto the box edges.