### PR TITLE
Trigger deactivate event for virtual gamepad

### DIFF
--- a/Source/controls/touch/event_handlers.h
+++ b/Source/controls/touch/event_handlers.h
@@ -89,5 +89,6 @@ private:
 };
 
 void HandleTouchEvent(const SDL_Event &event);
+void DeactivateTouchEventHandlers();
 
 } // namespace devilution

--- a/Source/controls/touch/gamepad.cpp
+++ b/Source/controls/touch/gamepad.cpp
@@ -3,6 +3,7 @@
 #include <SDL.h>
 
 #include "control.h"
+#include "controls/touch/event_handlers.h"
 #include "controls/touch/gamepad.h"
 #include "quests.h"
 #include "utils/display.h"
@@ -188,6 +189,7 @@ void ActivateVirtualGamepad()
 void DeactivateVirtualGamepad()
 {
 	VirtualGamepadState.Deactivate();
+	DeactivateTouchEventHandlers();
 }
 
 void VirtualGamepad::Deactivate()


### PR DESCRIPTION
This PR resolves an issue reported by Discord user Ensl:

> So I noticed When I enter a new level on the dev app sometimes there's an issue with the button interface and it causes the directional stick or the spell button to get "stuck" and spam spells or render movement inoperable.

Prior to #7513, the loading screens would call `FetchMessage()` in `interface_msg_pump()` to process events whenever the loading bar updates. `FetchMessage()` would delegate the event to the virtual gamepad event handler, meaning that `SDL_FINGERUP` events that occur during the loading screen would still be handled.

Now, with the async loading implementation, we are explicitly bypassing `FetchMessage()` and calling `SDL_PollEvent()` directly. This means the virtual gamepad event handlers aren't handling those finger up events.

https://github.com/diasurgical/devilutionX/blob/a3eea0fb8867ab982dd62f1c9568a46f81796559/Source/interfac.cpp#L686-L688

Rather than relying on the user to remove their finger from the screen during the loading sequence, I figured it would make more sense to go ahead and reset the event handler state the same way we do for d-pad and button state when calling `DeactivateVirtualGamepad()`.