### PR TITLE
Remove Murphy's Shrine from list of Shrines to disable with Disable Crippling Shrines

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -3629,7 +3629,7 @@ bool Object::IsDisabled() const
 	if (!IsShrine()) {
 		return false;
 	}
-	return IsAnyOf(static_cast<shrine_type>(_oVar1), shrine_type::ShrineFascinating, shrine_type::ShrineOrnate, shrine_type::ShrineSacred, shrine_type::ShrineMurphys);
+	return IsAnyOf(static_cast<shrine_type>(_oVar1), shrine_type::ShrineFascinating, shrine_type::ShrineOrnate, shrine_type::ShrineSacred);
 }
 
 Object *FindObjectAtPosition(Point position, bool considerLargeObjects)


### PR DESCRIPTION
Murphy's Shrine's effect doesn't have a permanent negative effect on the character, therefore it shouldn't be included.