### PR TITLE
Fix issue with Hellfire items morphing when transferred to Diablo

### DIFF
--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -332,7 +332,9 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 		RecreateEar(item, ic, iseed, ivalue & 0xFF, heroName);
 	} else {
 		item = {};
-		item.dwBuff = SDL_SwapLE32(packedItem.dwBuff);
+		// Item generation logic will assign CF_HELLFIRE based on isHellfire
+		// so if we carry it over from packedItem, it may be incorrect
+		item.dwBuff = SDL_SwapLE32(packedItem.dwBuff) & ~CF_HELLFIRE;
 		RecreateItem(player, item, idx, SDL_SwapLE16(packedItem.iCreateInfo), SDL_SwapLE32(packedItem.iSeed), SDL_SwapLE16(packedItem.wValue), isHellfire);
 		item._iIdentified = (packedItem.bId & 1) != 0;
 		item._iMaxDur = packedItem.bMDur;


### PR DESCRIPTION
Another issue introduced by the complicated hidden requirements of `LoadMatchingItems()`. The unpacked item must get the `CF_HELLFIRE` flag from the item regeneration logic instead of the `dwBuff` field from the packed data. Otherwise, `LoadMatchingItems()` won't be able to tell if it was unpacked as a Diablo item or a Hellfire item.

https://github.com/diasurgical/devilutionX/blob/d92bdd248f9fb5d866b027313ebc88c1dfb2aa97/Source/loadsave.cpp#L997-L999

This resolves #7742