### PR TITLE
Update cache version of Linux CI build scripts

### DIFF
--- a/.github/workflows/Linux_aarch64.yml
+++ b/.github/workflows/Linux_aarch64.yml
@@ -64,8 +64,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: build
-        key: ${{ github.workflow }}-v6-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v6-
+        key: ${{ github.workflow }}-v7-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v7-
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -55,8 +55,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: build
-        key: ${{ github.workflow }}-v5-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v5-
+        key: ${{ github.workflow }}-v6-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v6-
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/.github/workflows/Linux_x86_64.yml
+++ b/.github/workflows/Linux_x86_64.yml
@@ -53,8 +53,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: build
-        key: ${{ github.workflow }}-v5-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v5-
+        key: ${{ github.workflow }}-v6-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v6-
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/.github/workflows/Linux_x86_64_SDL1.yml
+++ b/.github/workflows/Linux_x86_64_SDL1.yml
@@ -35,8 +35,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: build
-        key: ${{ github.workflow }}-v2-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v2-
+        key: ${{ github.workflow }}-v3-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v3-
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/Linux_x86_64_test.yml
+++ b/.github/workflows/Linux_x86_64_test.yml
@@ -31,12 +31,13 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y cmake curl g++ git lcov libgtest-dev libgmock-dev libbenchmark-dev libfmt-dev libsdl2-dev libsodium-dev libpng-dev libbz2-dev wget
+
     - name: Cache CMake build folder
       uses: actions/cache@v4
       with:
         path: build
-        key: ${{ github.workflow }}-v1-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v1-
+        key: ${{ github.workflow }}-v2-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v2-
 
     # We specify `-DDEVILUTIONX_SYSTEM_BENCHMARK=OFF` to work around the following error:
     # lto1: fatal error: bytecode stream in file ‘/usr/lib/x86_64-linux-gnu/libbenchmark_main.a’ generated with LTO version 11.2 instead of the expected 11.3


### PR DESCRIPTION
Renaming the repo broke these caches because the Linux filesystem is case sensitive.