### PR TITLE
Do not process vision for remote players when they are between dungeon levels

### DIFF
--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -598,7 +598,7 @@ void ProcessVisionList()
 		if (!VisionActive[id])
 			continue;
 		Light &vision = VisionList[id];
-		if (!player.plractive || !player.isOnActiveLevel()) {
+		if (!player.plractive || !player.isOnActiveLevel() || (player._pLvlChanging && &player != MyPlayer)) {
 			DoUnVision(vision.position.tile, vision.radius);
 			VisionActive[id] = false;
 			continue;


### PR DESCRIPTION
When the remote player transitions from their current level to the loading screen, the local client...

* Receives `CMD_NEWLVL`
* Calls `player.setLevel()` to update `player.plrlevel`
* Sets `player._pLvlChanging` to true

When the remote player transitions from the loading screen to their new level, the local client...

* Receives `CMD_PLAYER_JOINLEVEL`
* Sets `player._pLvlChanging` to false
* Calls `StartStand()` which calls `FixPlayerLocation()` to update the player's position
* Calls `ActivateVision()` on the remote player instance

When the local player transitions from their current level to the loading screen after processing `CMD_NEWLVL` but before processing `CMD_PLAYER_JOINLEVEL`, the `player.isOnActiveLevel()` function will return true for the remote player because `player.setLevel()` was already called, but the remote player's location won't have been updated because `FixPlayerLocation()` hasn't been called.

This means that when `LoadGameLevelLightVision()` calls `ProcessVisionList()`, it will call `DoVision()` on the remote player in the wrong location. Since we know the local client will eventually call `ActivateVision()` on the remote player instance when `CMD_PLAYER_JOINLEVEL` is processed, it's okay to keep the remote player's vision deactivated while `player._pLvlChanging` is true.

This resolves #7745