### PR TITLE
[MinGW] Do not deploy files to /usr/cmake

### DIFF
--- a/Packaging/windows/mingw-prep.sh
+++ b/Packaging/windows/mingw-prep.sh
@@ -37,6 +37,7 @@ cd "tmp-mingw-${MINGW_ARCH}-prep"
 
 wget -q https://www.libsdl.org/release/SDL2-devel-${SDLDEV_VERS}-mingw.tar.gz -OSDL2-devel-${SDLDEV_VERS}-mingw.tar.gz
 tar -xzf SDL2-devel-${SDLDEV_VERS}-mingw.tar.gz
+sed -i '/$(CROSS_PATH)\/cmake/ s/^/#/' SDL2*/Makefile
 CROSS_PATH=/usr ARCHITECTURES=${MINGW_ARCH} $SUDO make -eC SDL2*/ cross
 
 wget -q https://github.com/jedisct1/libsodium/releases/download/${SODIUM_VERS}-RELEASE/libsodium-${SODIUM_VERS}-mingw.tar.gz -Olibsodium-${SODIUM_VERS}-mingw.tar.gz


### PR DESCRIPTION
This PR introduces a command into the MinGW setup script that comments two lines in the SDL2 Makefile, preventing the script from creating the `/usr/cmake` directory and deploying files to it.

Normally, the script deploys these two files:
* `/usr/cmake/sdl2-config.cmake`
* `/usr/cmake/sdl2-config-version.cmake`

These files appear to be unnecessary for compiling using MinGW compilers, but their presence does cause problems when attempting to build using native gcc compilers.

---

I encountered several warnings during CMake configuration when these files were present. This happens during first time configuration after having run the `Packaging/windows/mingw-prep64.sh` script, so you may not encounter this error if you have files already in your build folder or if you haven't tried building using MinGW compilers. The warnings all look very similar to the following.

```
CMake Warning at CMakeLists.txt:345 (add_executable):
  Cannot generate a safe linker search path for target devilutionx because
  files in some directories may conflict with libraries in implicit
  directories:

    link library [libm.so] in /usr/lib/x86_64-linux-gnu may be hidden by files in:
      /usr/x86_64-w64-mingw32/lib

  Some of these libraries may not be found correctly.
```

After seeing this warning, I encountered an error when attempting to build.

```
c++: error: unrecognized command-line option ‘-mwindows’
```

Anyone who has encountered these warnings/errors after having compiled this project using MinGW compilers should check their `/usr/cmake` directory. Likely, you can just delete the whole thing since SDL2 seems to be the only library that uses it. Here is a safe way to handle it.

```bash
sudo rm /usr/cmake/sdl2-*
sudo rmdir /usr/cmake
```