### PR TITLE
[1.5] [MinGW] Do not deploy files to /usr/cmake

### DIFF
--- a/.github/workflows/Linux_x86_64_SDL1.yml
+++ b/.github/workflows/Linux_x86_64_SDL1.yml
@@ -33,8 +33,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: build
-        key: ${{ github.workflow }}-v2-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v2-
+        key: ${{ github.workflow }}-v3-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v3-
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/Linux_x86_64_test.yml
+++ b/.github/workflows/Linux_x86_64_test.yml
@@ -29,12 +29,13 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y cmake curl g++ git lcov libgtest-dev libgmock-dev libfmt-dev libsdl2-dev libsodium-dev libpng-dev libbz2-dev wget
+
     - name: Cache CMake build folder
       uses: actions/cache@v3
       with:
         path: build
-        key: ${{ github.workflow }}-v1-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v1-
+        key: ${{ github.workflow }}-v2-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v2-
 
     - name: Build tests
       run: |

--- a/Packaging/windows/mingw-prep.sh
+++ b/Packaging/windows/mingw-prep.sh
@@ -33,6 +33,7 @@ fi
 
 wget -q https://www.libsdl.org/release/SDL2-devel-${SDLDEV_VERS}-mingw.tar.gz -OSDL2-devel-${SDLDEV_VERS}-mingw.tar.gz
 tar -xzf SDL2-devel-${SDLDEV_VERS}-mingw.tar.gz
+sed -i '/$(CROSS_PATH)\/cmake/ s/^/#/' SDL2*/Makefile
 CROSS_PATH=/usr ARCHITECTURES=${MINGW_ARCH} $SUDO make -eC SDL2*/ cross
 
 wget -q https://github.com/jedisct1/libsodium/releases/download/${SODIUM_VERS}-RELEASE/libsodium-${SODIUM_VERS}-mingw.tar.gz -Olibsodium-${SODIUM_VERS}-mingw.tar.gz


### PR DESCRIPTION
Backports #7759 into the 1.5 branch

So we don't accidentally screw with `/usr/cmake` when testing the 1.5 version, though sadly there's not much we can do if you target the 1.5.4 tag.