### PR TITLE
Fix Viper Lunge

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3680,7 +3680,7 @@ void ProcessRhino(Missile &missile)
 	}
 	UpdateMissilePos(missile);
 	Point newPos = missile.position.tile;
-	if (!IsTileAvailable(monster, newPos) || (monster.ai == MonsterAIID::Snake && !IsTileAvailable(monster, newPosSnake))) {
+	if (!IsTileAvailable(monster, newPos) || (monster.ai == MonsterAIID::Snake && (!IsTileAvailable(monster, newPosSnake) || missile._miAnimFrame == missile._miAnimLen))) {
 		MissToMonst(missile, prevPos);
 		missile._miDelFlag = true;
 		return;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3680,7 +3680,7 @@ void ProcessRhino(Missile &missile)
 	}
 	UpdateMissilePos(missile);
 	Point newPos = missile.position.tile;
-	if (!IsTileAvailable(monster, newPos) || (monster.ai == MonsterAIID::Snake && (!IsTileAvailable(monster, newPosSnake) || missile._miAnimFrame == missile._miAnimLen))) {
+	if (!IsTileAvailable(monster, newPos) || (monster.ai == MonsterAIID::Snake && (!IsTileAvailable(monster, newPosSnake) || missile._miAnimFrame >= missile._miAnimLen))) {
 		MissToMonst(missile, prevPos);
 		missile._miDelFlag = true;
 		return;


### PR DESCRIPTION
The initial frame for the Viper's Rhino/Lunge attack is hardcoded to start the animation at frame 7, giving context that the attack is intended to start at frame 7 and not exceed past the end of the animation. The lunge only occurs when the viper is exactly 2 tiles away from the player. The lunge also does not deal any damage, or cause knockback. This fix consistently stops the viper at the end of the animation length, which by testing has resulted in the desired behavior, where the viper will not stop short of reaching their target, but also will not continuously run into the distance if the target is missed.

Fixes: https://github.com/diasurgical/DevilutionX/issues/7034