### PR TITLE
Update gamepad scroll descriptions to match logic in plrctrls

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1837,20 +1837,21 @@ void PrintItemMisc(const Item &item)
 	    || (item._iMiscId > IMISC_OILFIRST && item._iMiscId < IMISC_OILLAST)
 	    || (item._iMiscId > IMISC_RUNEFIRST && item._iMiscId < IMISC_RUNELAST)
 	    || item._iMiscId == IMISC_ARENAPOT;
-	const bool isCastOnTarget = (item._iMiscId == IMISC_SCROLLT && item._iSpell != SpellID::Flash)
+	const bool mouseRequiresTarget = (item._iMiscId == IMISC_SCROLLT && item._iSpell != SpellID::Flash)
 	    || (item._iMiscId == IMISC_SCROLL && IsAnyOf(item._iSpell, SpellID::TownPortal, SpellID::Identify));
+	const bool gamepadRequiresTarget = item.isScroll() && TargetsMonster(item._iSpell);
 
 	switch (ControlMode) {
 	case ControlTypes::None:
 		break;
 	case ControlTypes::KeyboardAndMouse:
-		printItemMiscKBM(item, isOil, isCastOnTarget);
+		printItemMiscKBM(item, isOil, mouseRequiresTarget);
 		break;
 	case ControlTypes::VirtualGamepad:
-		printItemMiscGenericGamepad(item, isOil, isCastOnTarget);
+		printItemMiscGenericGamepad(item, isOil, gamepadRequiresTarget);
 		break;
 	case ControlTypes::Gamepad:
-		printItemMiscGamepad(item, isOil, isCastOnTarget);
+		printItemMiscGamepad(item, isOil, gamepadRequiresTarget);
 		break;
 	}
 }


### PR DESCRIPTION
Updates the logic for gamepad scroll descriptions in `PrintItemMisc()` to match the logic in `CtrlUseInvItem()`.

Based on the following snippet in `CtrlUseInvTime()`, scrolls that target monsters are not usable from the inventory. All other scrolls should be usable.

https://github.com/diasurgical/DevilutionX/blob/a2365c754ec0caf5d58df3a55367568eaf85f9f2/Source/controls/plrctrls.cpp#L2106-L2109

This resolves #7761