### PR TITLE
Fix ru.po [1.5]

### DIFF
--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -12,9 +12,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2025-01-22 19:43+0300\n"
+"POT-Creation-Date: 2025-02-22 15:53+0300\n"
 "PO-Revision-Date: \n"
-"Last-Translator: Dominus Iniquitatis <zerosaiko@gmail.com>\n"
+"Last-Translator: @Maderator3000\n"
 "Language-Team: \n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
@@ -110,7 +110,7 @@ msgstr "Помощник продюсера"
 msgid "Diablo Strike Team"
 msgstr "Ударная команда Diablo"
 
-#: Source/DiabloUI/credits_lines.cpp:77 Source/gamemenu.cpp:79
+#: Source/DiabloUI/credits_lines.cpp:77 Source/gamemenu.cpp:71
 msgid "Music"
 msgstr "Музыка"
 
@@ -324,81 +324,79 @@ msgstr "Круг Одной Тысячи"
 msgid "\tNo souls were sold in the making of this game."
 msgstr "\tНи одна душа не была продана во время разработки этой игры."
 
-#: Source/DiabloUI/dialogs.cpp:90 Source/DiabloUI/dialogs.cpp:102
-#: Source/DiabloUI/hero/selhero.cpp:178 Source/DiabloUI/hero/selhero.cpp:204
-#: Source/DiabloUI/hero/selhero.cpp:289 Source/DiabloUI/hero/selhero.cpp:529
-#: Source/DiabloUI/multi/selconn.cpp:84 Source/DiabloUI/multi/selgame.cpp:173
-#: Source/DiabloUI/multi/selgame.cpp:336 Source/DiabloUI/multi/selgame.cpp:362
-#: Source/DiabloUI/multi/selgame.cpp:504 Source/DiabloUI/multi/selgame.cpp:581
-#: Source/DiabloUI/selok.cpp:72
+#: Source/DiabloUI/dialogs.cpp:84 Source/DiabloUI/dialogs.cpp:96
+#: Source/DiabloUI/hero/selhero.cpp:177 Source/DiabloUI/hero/selhero.cpp:203
+#: Source/DiabloUI/hero/selhero.cpp:288 Source/DiabloUI/hero/selhero.cpp:528
+#: Source/DiabloUI/multi/selconn.cpp:82 Source/DiabloUI/multi/selgame.cpp:171
+#: Source/DiabloUI/multi/selgame.cpp:335 Source/DiabloUI/multi/selgame.cpp:361
+#: Source/DiabloUI/multi/selgame.cpp:503 Source/DiabloUI/multi/selgame.cpp:580
+#: Source/DiabloUI/selok.cpp:71
 msgid "OK"
 msgstr "ОК"
 
-#: Source/DiabloUI/hero/selhero.cpp:156
+#: Source/DiabloUI/hero/selhero.cpp:155
 msgid "Choose Class"
 msgstr "Выберите класс"
 
 #. TRANSLATORS: Player Block start
 #. HeroClass::Warrior
-#: Source/DiabloUI/hero/selhero.cpp:160 Source/playerdat.cpp:254
+#: Source/DiabloUI/hero/selhero.cpp:159 Source/playerdat.cpp:89
 msgid "Warrior"
 msgstr "Воин"
 
-#: Source/DiabloUI/hero/selhero.cpp:161 Source/playerdat.cpp:255
+#: Source/DiabloUI/hero/selhero.cpp:160 Source/playerdat.cpp:90
 msgid "Rogue"
 msgstr "Разбойник"
 
-#: Source/DiabloUI/hero/selhero.cpp:162 Source/playerdat.cpp:256
+#: Source/DiabloUI/hero/selhero.cpp:161 Source/playerdat.cpp:91
 msgid "Sorcerer"
 msgstr "Маг"
 
-#: Source/DiabloUI/hero/selhero.cpp:164 Source/playerdat.cpp:257
+#: Source/DiabloUI/hero/selhero.cpp:163 Source/playerdat.cpp:92
 msgid "Monk"
 msgstr "Монах"
 
-#: Source/DiabloUI/hero/selhero.cpp:166 Source/playerdat.cpp:258
+#: Source/DiabloUI/hero/selhero.cpp:166 Source/playerdat.cpp:93
 msgid "Bard"
 msgstr "Бард"
 
-#. TRANSLATORS: Player Block end
-#. HeroClass::Barbarian
-#: Source/DiabloUI/hero/selhero.cpp:169 Source/playerdat.cpp:260
+#: Source/DiabloUI/hero/selhero.cpp:169 Source/playerdat.cpp:94
 msgid "Barbarian"
 msgstr "Варвар"
 
-#: Source/DiabloUI/hero/selhero.cpp:181 Source/DiabloUI/hero/selhero.cpp:207
-#: Source/DiabloUI/hero/selhero.cpp:292 Source/DiabloUI/hero/selhero.cpp:537
-#: Source/DiabloUI/multi/selconn.cpp:87 Source/DiabloUI/progress.cpp:45
+#: Source/DiabloUI/hero/selhero.cpp:180 Source/DiabloUI/hero/selhero.cpp:206
+#: Source/DiabloUI/hero/selhero.cpp:291 Source/DiabloUI/hero/selhero.cpp:536
+#: Source/DiabloUI/multi/selconn.cpp:85 Source/DiabloUI/progress.cpp:44
 msgid "Cancel"
 msgstr "Отмена"
 
-#: Source/DiabloUI/hero/selhero.cpp:187 Source/DiabloUI/hero/selhero.cpp:277
+#: Source/DiabloUI/hero/selhero.cpp:186 Source/DiabloUI/hero/selhero.cpp:276
 msgid "New Multi Player Hero"
 msgstr "Новый герой сетевой игры"
 
-#: Source/DiabloUI/hero/selhero.cpp:187 Source/DiabloUI/hero/selhero.cpp:277
+#: Source/DiabloUI/hero/selhero.cpp:186 Source/DiabloUI/hero/selhero.cpp:276
 msgid "New Single Player Hero"
 msgstr "Новый герой одиночной игры"
 
 # Подобрано под размер меню.
-#: Source/DiabloUI/hero/selhero.cpp:196
+#: Source/DiabloUI/hero/selhero.cpp:195
 msgid "Save File Exists"
 msgstr "Есть файл сохранения"
 
-#: Source/DiabloUI/hero/selhero.cpp:199 Source/gamemenu.cpp:50
+#: Source/DiabloUI/hero/selhero.cpp:198 Source/gamemenu.cpp:42
 msgid "Load Game"
 msgstr "Загрузить игру"
 
-#: Source/DiabloUI/hero/selhero.cpp:200 Source/gamemenu.cpp:49
-#: Source/gamemenu.cpp:60 Source/multi.cpp:829
+#: Source/DiabloUI/hero/selhero.cpp:199 Source/gamemenu.cpp:41
+#: Source/gamemenu.cpp:52 Source/multi.cpp:816
 msgid "New Game"
 msgstr "Новая игра"
 
-#: Source/DiabloUI/hero/selhero.cpp:210 Source/DiabloUI/hero/selhero.cpp:543
+#: Source/DiabloUI/hero/selhero.cpp:209 Source/DiabloUI/hero/selhero.cpp:542
 msgid "Single Player Characters"
 msgstr "Персонажи одиночной игры"
 
-#: Source/DiabloUI/hero/selhero.cpp:269
+#: Source/DiabloUI/hero/selhero.cpp:268
 msgid ""
 "The Rogue and Sorcerer are only available in the full retail version of "
 "Diablo. Visit https://www.gog.com/game/diablo to purchase."
@@ -406,11 +404,11 @@ msgstr ""
 "Разбойник и маг доступны только в полной версии Diablo. Перейдите на https://"
 "www.gog.com/game/diablo для покупки."
 
-#: Source/DiabloUI/hero/selhero.cpp:283 Source/DiabloUI/hero/selhero.cpp:286
+#: Source/DiabloUI/hero/selhero.cpp:282 Source/DiabloUI/hero/selhero.cpp:285
 msgid "Enter Name"
 msgstr "Введите имя"
 
-#: Source/DiabloUI/hero/selhero.cpp:315
+#: Source/DiabloUI/hero/selhero.cpp:314
 msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
@@ -419,143 +417,143 @@ msgstr ""
 "ключевые слова и неанглийские буквы.\n"
 
 #. TRANSLATORS: Error Message
-#: Source/DiabloUI/hero/selhero.cpp:322
+#: Source/DiabloUI/hero/selhero.cpp:321
 msgid "Unable to create character."
 msgstr "Невозможно создать персонажа."
 
-#: Source/DiabloUI/hero/selhero.cpp:488
+#: Source/DiabloUI/hero/selhero.cpp:487
 msgid "Level:"
 msgstr "Уровень:"
 
-#: Source/DiabloUI/hero/selhero.cpp:492
+#: Source/DiabloUI/hero/selhero.cpp:491
 msgid "Strength:"
 msgstr "Сила:"
 
-#: Source/DiabloUI/hero/selhero.cpp:492
+#: Source/DiabloUI/hero/selhero.cpp:491
 msgid "Magic:"
 msgstr "Магия:"
 
-#: Source/DiabloUI/hero/selhero.cpp:492
+#: Source/DiabloUI/hero/selhero.cpp:491
 msgid "Dexterity:"
 msgstr "Ловкость:"
 
-#: Source/DiabloUI/hero/selhero.cpp:492
+#: Source/DiabloUI/hero/selhero.cpp:491
 msgid "Vitality:"
 msgstr "Живучесть:"
 
-#: Source/DiabloUI/hero/selhero.cpp:494
+#: Source/DiabloUI/hero/selhero.cpp:493
 msgid "Savegame:"
 msgstr "Сохранение:"
 
-#: Source/DiabloUI/hero/selhero.cpp:513
+#: Source/DiabloUI/hero/selhero.cpp:512
 msgid "Select Hero"
 msgstr "Выбрать героя"
 
-#: Source/DiabloUI/hero/selhero.cpp:521
+#: Source/DiabloUI/hero/selhero.cpp:520
 msgid "New Hero"
 msgstr "Новый герой"
 
-#: Source/DiabloUI/hero/selhero.cpp:532
+#: Source/DiabloUI/hero/selhero.cpp:531
 msgid "Delete"
 msgstr "Удалить"
 
-#: Source/DiabloUI/hero/selhero.cpp:541
+#: Source/DiabloUI/hero/selhero.cpp:540
 msgid "Multi Player Characters"
 msgstr "Персонажи сетевой игры"
 
-#: Source/DiabloUI/hero/selhero.cpp:592
+#: Source/DiabloUI/hero/selhero.cpp:591
 msgid "Delete Multi Player Hero"
 msgstr "Удалить персонажа сетевой игры"
 
-#: Source/DiabloUI/hero/selhero.cpp:594
+#: Source/DiabloUI/hero/selhero.cpp:593
 msgid "Delete Single Player Hero"
 msgstr "Удалить персонажа одиночной игры"
 
-#: Source/DiabloUI/hero/selhero.cpp:596
+#: Source/DiabloUI/hero/selhero.cpp:595
 #, c++-format
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Вы действительно хотите удалить персонажа \"{:s}\"?"
 
-#: Source/DiabloUI/mainmenu.cpp:40
+#: Source/DiabloUI/mainmenu.cpp:38
 msgid "Single Player"
 msgstr "Одиночная игра"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:39
 msgid "Multi Player"
 msgstr "Сетевая игра"
 
-#: Source/DiabloUI/mainmenu.cpp:42 Source/DiabloUI/settingsmenu.cpp:372
+#: Source/DiabloUI/mainmenu.cpp:40 Source/DiabloUI/settingsmenu.cpp:370
 msgid "Settings"
 msgstr "Настройки"
 
-#: Source/DiabloUI/mainmenu.cpp:43
+#: Source/DiabloUI/mainmenu.cpp:41
 msgid "Support"
 msgstr "Поддержка"
 
-#: Source/DiabloUI/mainmenu.cpp:44
+#: Source/DiabloUI/mainmenu.cpp:42
 msgid "Show Credits"
 msgstr "Титры"
 
-#: Source/DiabloUI/mainmenu.cpp:46
+#: Source/DiabloUI/mainmenu.cpp:44
 msgid "Exit Hellfire"
 msgstr "Выйти из Hellfire"
 
-#: Source/DiabloUI/mainmenu.cpp:46
+#: Source/DiabloUI/mainmenu.cpp:44
 msgid "Exit Diablo"
 msgstr "Выйти из Diablo"
 
-#: Source/DiabloUI/mainmenu.cpp:64
+#: Source/DiabloUI/mainmenu.cpp:62
 msgid "Shareware"
 msgstr "Shareware"
 
-#: Source/DiabloUI/multi/selconn.cpp:16
+#: Source/DiabloUI/multi/selconn.cpp:14
 msgid "Client-Server (TCP)"
 msgstr "Клиент-сервер (TCP)"
 
-#: Source/DiabloUI/multi/selconn.cpp:17
+#: Source/DiabloUI/multi/selconn.cpp:15
 msgid "Offline"
 msgstr "Оффлайн"
 
-#: Source/DiabloUI/multi/selconn.cpp:58 Source/DiabloUI/multi/selgame.cpp:648
-#: Source/DiabloUI/multi/selgame.cpp:674
+#: Source/DiabloUI/multi/selconn.cpp:56 Source/DiabloUI/multi/selgame.cpp:647
+#: Source/DiabloUI/multi/selgame.cpp:673
 msgid "Multi Player Game"
 msgstr "Сетевая игра"
 
-#: Source/DiabloUI/multi/selconn.cpp:64
+#: Source/DiabloUI/multi/selconn.cpp:62
 msgid "Requirements:"
 msgstr "Требования:"
 
-#: Source/DiabloUI/multi/selconn.cpp:70
+#: Source/DiabloUI/multi/selconn.cpp:68
 msgid "no gateway needed"
 msgstr "шлюз не требуется"
 
-#: Source/DiabloUI/multi/selconn.cpp:76
+#: Source/DiabloUI/multi/selconn.cpp:74
 msgid "Select Connection"
 msgstr "Выбрать подключение"
 
-#: Source/DiabloUI/multi/selconn.cpp:79
+#: Source/DiabloUI/multi/selconn.cpp:77
 msgid "Change Gateway"
 msgstr "Сменить шлюз"
 
-#: Source/DiabloUI/multi/selconn.cpp:112
+#: Source/DiabloUI/multi/selconn.cpp:110
 msgid "All computers must be connected to a TCP-compatible network."
 msgstr "Все компьютеры должны быть подключены к TCP-совместимой сети."
 
-#: Source/DiabloUI/multi/selconn.cpp:116
+#: Source/DiabloUI/multi/selconn.cpp:114
 msgid "All computers must be connected to the internet."
 msgstr "Все компьютеры должны быть подключены к Интернету."
 
-#: Source/DiabloUI/multi/selconn.cpp:120
+#: Source/DiabloUI/multi/selconn.cpp:118
 msgid "Play by yourself with no network exposure."
 msgstr "Играть одному без доступа к сети."
 
-#: Source/DiabloUI/multi/selconn.cpp:125
+#: Source/DiabloUI/multi/selconn.cpp:123
 #, c++-format
 msgid "Players Supported: {:d}"
 msgstr "Количество игроков: {:d}"
 
-#: Source/DiabloUI/multi/selgame.cpp:86 Source/options.cpp:387
-#: Source/options.cpp:435 Source/quests.cpp:58
+#: Source/DiabloUI/multi/selgame.cpp:86 Source/options.cpp:566
+#: Source/options.cpp:616 Source/quests.cpp:53
 msgid "Diablo"
 msgstr "Diablo"
 
@@ -563,8 +561,8 @@ msgstr "Diablo"
 msgid "Diablo Shareware"
 msgstr "Diablo Shareware"
 
-#: Source/DiabloUI/multi/selgame.cpp:92 Source/options.cpp:389
-#: Source/options.cpp:449
+#: Source/DiabloUI/multi/selgame.cpp:92 Source/options.cpp:568
+#: Source/options.cpp:630
 msgid "Hellfire"
 msgstr "Hellfire"
 
@@ -587,53 +585,53 @@ msgstr "Хост запустил режим игры ({:s}), отличный �
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr "Ваша версия ({:s}) не соответствует хосту ({:d}.{:d}.{:d})"
 
-#: Source/DiabloUI/multi/selgame.cpp:139 Source/DiabloUI/multi/selgame.cpp:567
+#: Source/DiabloUI/multi/selgame.cpp:137 Source/DiabloUI/multi/selgame.cpp:566
 msgid "Description:"
 msgstr "Описание:"
 
-#: Source/DiabloUI/multi/selgame.cpp:145
+#: Source/DiabloUI/multi/selgame.cpp:143
 msgid "Select Action"
 msgstr "Выберите действие"
 
-#: Source/DiabloUI/multi/selgame.cpp:148 Source/DiabloUI/multi/selgame.cpp:324
-#: Source/DiabloUI/multi/selgame.cpp:485
+#: Source/DiabloUI/multi/selgame.cpp:146 Source/DiabloUI/multi/selgame.cpp:323
+#: Source/DiabloUI/multi/selgame.cpp:484
 msgid "Create Game"
 msgstr "Создать игру"
 
-#: Source/DiabloUI/multi/selgame.cpp:150
+#: Source/DiabloUI/multi/selgame.cpp:148
 msgid "Create Public Game"
 msgstr "Публичная игра"
 
-#: Source/DiabloUI/multi/selgame.cpp:151
+#: Source/DiabloUI/multi/selgame.cpp:149
 msgid "Join Game"
 msgstr "Подключиться к игре"
 
-#: Source/DiabloUI/multi/selgame.cpp:155
+#: Source/DiabloUI/multi/selgame.cpp:153
 msgid "Public Games"
 msgstr "Публичные игры"
 
-#: Source/DiabloUI/multi/selgame.cpp:160 Source/diablo_msg.cpp:72
+#: Source/DiabloUI/multi/selgame.cpp:158 Source/error.cpp:67
 msgid "Loading..."
 msgstr "Загрузка..."
 
 #. TRANSLATORS: type of dungeon (i.e. Cathedral, Caves)
-#: Source/DiabloUI/multi/selgame.cpp:162 Source/discord/discord.cpp:86
-#: Source/options.cpp:421 Source/options.cpp:793
-#: Source/panels/charpanel.cpp:143
+#: Source/DiabloUI/multi/selgame.cpp:160 Source/discord/discord.cpp:73
+#: Source/options.cpp:602 Source/options.cpp:992
+#: Source/panels/charpanel.cpp:137
 msgid "None"
 msgstr "Нет"
 
-#: Source/DiabloUI/multi/selgame.cpp:176 Source/DiabloUI/multi/selgame.cpp:339
-#: Source/DiabloUI/multi/selgame.cpp:365 Source/DiabloUI/multi/selgame.cpp:507
-#: Source/DiabloUI/multi/selgame.cpp:584
+#: Source/DiabloUI/multi/selgame.cpp:174 Source/DiabloUI/multi/selgame.cpp:338
+#: Source/DiabloUI/multi/selgame.cpp:364 Source/DiabloUI/multi/selgame.cpp:506
+#: Source/DiabloUI/multi/selgame.cpp:583
 msgid "CANCEL"
 msgstr "ОТМЕНА"
 
-#: Source/DiabloUI/multi/selgame.cpp:215
+#: Source/DiabloUI/multi/selgame.cpp:214
 msgid "Create a new game with a difficulty setting of your choice."
 msgstr "Создайте новую игру с настройкой сложности по вашему выбору."
 
-#: Source/DiabloUI/multi/selgame.cpp:218
+#: Source/DiabloUI/multi/selgame.cpp:217
 msgid ""
 "Create a new public game that anyone can join with a difficulty setting of "
 "your choice."
@@ -641,82 +639,82 @@ msgstr ""
 "Создайте публичную игру, к которой может присоединиться любой, с настройкой "
 "сложности по вашему выбору."
 
-#: Source/DiabloUI/multi/selgame.cpp:222
+#: Source/DiabloUI/multi/selgame.cpp:221
 msgid "Enter Game ID to join a game already in progress."
 msgstr "Введите ID игры для подключения к существующей игре."
 
-#: Source/DiabloUI/multi/selgame.cpp:224
+#: Source/DiabloUI/multi/selgame.cpp:223
 msgid "Enter an IP or a hostname to join a game already in progress."
 msgstr "Введите IP-адрес или имя хоста для подключения с существующей игре."
 
-#: Source/DiabloUI/multi/selgame.cpp:229
+#: Source/DiabloUI/multi/selgame.cpp:228
 msgid "Join the public game already in progress."
 msgstr "Присоединиться к существующей публичной игре."
 
-#: Source/DiabloUI/multi/selgame.cpp:235 Source/DiabloUI/multi/selgame.cpp:329
-#: Source/DiabloUI/multi/selgame.cpp:390 Source/DiabloUI/multi/selgame.cpp:496
-#: Source/DiabloUI/multi/selgame.cpp:516 Source/automap.cpp:1458
-#: Source/discord/discord.cpp:114
+#: Source/DiabloUI/multi/selgame.cpp:234 Source/DiabloUI/multi/selgame.cpp:328
+#: Source/DiabloUI/multi/selgame.cpp:389 Source/DiabloUI/multi/selgame.cpp:495
+#: Source/DiabloUI/multi/selgame.cpp:515 Source/automap.cpp:780
+#: Source/discord/discord.cpp:102
 msgid "Normal"
 msgstr "Нормальная"
 
-#: Source/DiabloUI/multi/selgame.cpp:238 Source/DiabloUI/multi/selgame.cpp:330
-#: Source/DiabloUI/multi/selgame.cpp:394 Source/automap.cpp:1461
-#: Source/discord/discord.cpp:114
+#: Source/DiabloUI/multi/selgame.cpp:237 Source/DiabloUI/multi/selgame.cpp:329
+#: Source/DiabloUI/multi/selgame.cpp:393 Source/automap.cpp:783
+#: Source/discord/discord.cpp:102
 msgid "Nightmare"
 msgstr "Кошмарная"
 
-#: Source/DiabloUI/multi/selgame.cpp:241 Source/DiabloUI/multi/selgame.cpp:331
-#: Source/DiabloUI/multi/selgame.cpp:398 Source/automap.cpp:1464
-#: Source/discord/discord.cpp:81 Source/discord/discord.cpp:114
+#: Source/DiabloUI/multi/selgame.cpp:240 Source/DiabloUI/multi/selgame.cpp:330
+#: Source/DiabloUI/multi/selgame.cpp:397 Source/automap.cpp:786
+#: Source/discord/discord.cpp:68 Source/discord/discord.cpp:102
 msgid "Hell"
 msgstr "Адская"
 
 #. TRANSLATORS: {:s} means: Game Difficulty.
-#: Source/DiabloUI/multi/selgame.cpp:244 Source/automap.cpp:1468
+#: Source/DiabloUI/multi/selgame.cpp:243 Source/automap.cpp:790
 #, c++-format
 msgid "Difficulty: {:s}"
 msgstr "Сложность: {:s}"
 
-#: Source/DiabloUI/multi/selgame.cpp:248 Source/gamemenu.cpp:175
+#: Source/DiabloUI/multi/selgame.cpp:247 Source/gamemenu.cpp:167
 msgid "Speed: Normal"
 msgstr "Скорость: Нормальная"
 
-#: Source/DiabloUI/multi/selgame.cpp:251 Source/gamemenu.cpp:173
+#: Source/DiabloUI/multi/selgame.cpp:250 Source/gamemenu.cpp:165
 msgid "Speed: Fast"
 msgstr "Скорость: Быстрая"
 
-#: Source/DiabloUI/multi/selgame.cpp:254 Source/gamemenu.cpp:171
+#: Source/DiabloUI/multi/selgame.cpp:253 Source/gamemenu.cpp:163
 msgid "Speed: Faster"
 msgstr "Скорость: Очень быстрая"
 
-#: Source/DiabloUI/multi/selgame.cpp:257 Source/gamemenu.cpp:169
+#: Source/DiabloUI/multi/selgame.cpp:256 Source/gamemenu.cpp:161
 msgid "Speed: Fastest"
 msgstr "Скорость: Самая быстрая"
 
-#: Source/DiabloUI/multi/selgame.cpp:265
+#: Source/DiabloUI/multi/selgame.cpp:264
 msgid "Players: "
 msgstr "Игроки: "
 
-#: Source/DiabloUI/multi/selgame.cpp:327
+#: Source/DiabloUI/multi/selgame.cpp:326
 msgid "Select Difficulty"
 msgstr "Выберите сложность"
 
-#: Source/DiabloUI/multi/selgame.cpp:345
+#: Source/DiabloUI/multi/selgame.cpp:344
 #, c++-format
 msgid "Join {:s} Games"
 msgstr "Присоединиться к {:s} играм"
 
-#: Source/DiabloUI/multi/selgame.cpp:350
+#: Source/DiabloUI/multi/selgame.cpp:349
 msgid "Enter Game ID"
 msgstr "Введите ID игры"
 
-#: Source/DiabloUI/multi/selgame.cpp:352
+#: Source/DiabloUI/multi/selgame.cpp:351
 msgid "Enter address"
 msgstr "Введите адрес"
 
 # Подобрано под размер меню.
-#: Source/DiabloUI/multi/selgame.cpp:391
+#: Source/DiabloUI/multi/selgame.cpp:390
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -725,7 +723,7 @@ msgstr ""
 "Отсюда новичкам стоит начинать путь к победы над Диабло."
 
 # Подобрано под размер меню.
-#: Source/DiabloUI/multi/selgame.cpp:395
+#: Source/DiabloUI/multi/selgame.cpp:394
 msgid ""
 "Nightmare Difficulty\n"
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
@@ -736,7 +734,7 @@ msgstr ""
 "Рекомендуется только для опытных персонажей."
 
 # Подобрано под размер меню.
-#: Source/DiabloUI/multi/selgame.cpp:399
+#: Source/DiabloUI/multi/selgame.cpp:398
 msgid ""
 "Hell Difficulty\n"
 "The most powerful of the underworld's creatures lurk at the gateway into "
@@ -746,7 +744,7 @@ msgstr ""
 "Самые могущественные существа подземного мира скрываются у врат в Ад. Только "
 "опытным героям стоит входить в этот мир."
 
-#: Source/DiabloUI/multi/selgame.cpp:414
+#: Source/DiabloUI/multi/selgame.cpp:413
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
@@ -754,7 +752,7 @@ msgstr ""
 "Ваш персонаж должен достигнуть 20 уровня, прежде чем вы сможете войти в "
 "сетевую игру на Кошмарной сложности."
 
-#: Source/DiabloUI/multi/selgame.cpp:416
+#: Source/DiabloUI/multi/selgame.cpp:415
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
@@ -762,24 +760,24 @@ msgstr ""
 "Ваш персонаж должен достигнуть 30 уровня, прежде чем вы сможете войти в "
 "сетевую игру на Адской сложности."
 
-#: Source/DiabloUI/multi/selgame.cpp:494
+#: Source/DiabloUI/multi/selgame.cpp:493
 msgid "Select Game Speed"
 msgstr "Скорость игры"
 
-#: Source/DiabloUI/multi/selgame.cpp:497 Source/DiabloUI/multi/selgame.cpp:520
+#: Source/DiabloUI/multi/selgame.cpp:496 Source/DiabloUI/multi/selgame.cpp:519
 msgid "Fast"
 msgstr "Быстрая"
 
-#: Source/DiabloUI/multi/selgame.cpp:498 Source/DiabloUI/multi/selgame.cpp:524
+#: Source/DiabloUI/multi/selgame.cpp:497 Source/DiabloUI/multi/selgame.cpp:523
 msgid "Faster"
 msgstr "Очень быстрая"
 
-#: Source/DiabloUI/multi/selgame.cpp:499 Source/DiabloUI/multi/selgame.cpp:528
+#: Source/DiabloUI/multi/selgame.cpp:498 Source/DiabloUI/multi/selgame.cpp:527
 msgid "Fastest"
 msgstr "Самая быстрая"
 
 # Подобрано под размер меню.
-#: Source/DiabloUI/multi/selgame.cpp:517
+#: Source/DiabloUI/multi/selgame.cpp:516
 msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -788,7 +786,7 @@ msgstr ""
 "Отсюда новичкам стоит начинать путь к победы над Диабло."
 
 # Подобрано под размер меню.
-#: Source/DiabloUI/multi/selgame.cpp:521
+#: Source/DiabloUI/multi/selgame.cpp:520
 msgid ""
 "Fast Speed\n"
 "The denizens of the Labyrinth have been hastened and will prove to be a "
@@ -799,7 +797,7 @@ msgstr ""
 "Рекомендуется только для опытных персонажей."
 
 # Подобрано под размер меню.
-#: Source/DiabloUI/multi/selgame.cpp:525
+#: Source/DiabloUI/multi/selgame.cpp:524
 msgid ""
 "Faster Speed\n"
 "Most monsters of the dungeon will seek you out quicker than ever before. "
@@ -810,7 +808,7 @@ msgstr ""
 "испытать свою удачу на такой скорости."
 
 # Подобрано под размер меню.
-#: Source/DiabloUI/multi/selgame.cpp:529
+#: Source/DiabloUI/multi/selgame.cpp:528
 msgid ""
 "Fastest Speed\n"
 "The minions of the underworld will rush to attack without hesitation. Only a "
@@ -820,7 +818,7 @@ msgstr ""
 "Приспешники преисподней бросятся в атаку без колебаний. Только истинный "
 "демон скорости может войти в такой темп."
 
-#: Source/DiabloUI/multi/selgame.cpp:573 Source/DiabloUI/multi/selgame.cpp:578
+#: Source/DiabloUI/multi/selgame.cpp:572 Source/DiabloUI/multi/selgame.cpp:577
 msgid "Enter Password"
 msgstr "Введите пароль"
 
@@ -832,39 +830,39 @@ msgstr "Войти в Hellfire"
 msgid "Switch to Diablo"
 msgstr "Переключиться на Diablo"
 
-#: Source/DiabloUI/selyesno.cpp:57 Source/stores.cpp:966
+#: Source/DiabloUI/selyesno.cpp:57 Source/stores.cpp:1001
 msgid "Yes"
 msgstr "Да"
 
-#: Source/DiabloUI/selyesno.cpp:58 Source/stores.cpp:967
+#: Source/DiabloUI/selyesno.cpp:58 Source/stores.cpp:1002
 msgid "No"
 msgstr "Нет"
 
-#: Source/DiabloUI/settingsmenu.cpp:150
+#: Source/DiabloUI/settingsmenu.cpp:147
 msgid "Press gamepad buttons to change."
 msgstr "Нажмите любую кнопку для изменения."
 
-#: Source/DiabloUI/settingsmenu.cpp:427
+#: Source/DiabloUI/settingsmenu.cpp:426
 msgid "Bound key:"
 msgstr "Привязать клавишу:"
 
-#: Source/DiabloUI/settingsmenu.cpp:476
+#: Source/DiabloUI/settingsmenu.cpp:475
 msgid "Press any key to change."
 msgstr "Нажмите любую клавишу для изменения."
 
-#: Source/DiabloUI/settingsmenu.cpp:478
+#: Source/DiabloUI/settingsmenu.cpp:477
 msgid "Unbind key"
 msgstr "Отвязать клавишу"
 
-#: Source/DiabloUI/settingsmenu.cpp:482
+#: Source/DiabloUI/settingsmenu.cpp:481
 msgid "Bound button combo:"
 msgstr "Привязать комбинацию кнопок:"
 
-#: Source/DiabloUI/settingsmenu.cpp:491
+#: Source/DiabloUI/settingsmenu.cpp:490
 msgid "Unbind button combo"
 msgstr "Отвязать комбинацию"
 
-#: Source/DiabloUI/settingsmenu.cpp:535 Source/gamemenu.cpp:73
+#: Source/DiabloUI/settingsmenu.cpp:534 Source/gamemenu.cpp:65
 msgid "Previous Menu"
 msgstr "Предыдущее меню"
 
@@ -922,16 +920,16 @@ msgstr ""
 "лицензированы по CC-BY 4.0. В порте также используется SDL, лицензируемая по "
 "zlib-license. Более подробную информацию смотрите в ReadMe."
 
-#: Source/DiabloUI/title.cpp:59
+#: Source/DiabloUI/title.cpp:57
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:63
+#: Source/appfat.cpp:52
 msgid "Error"
 msgstr "Ошибка"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:77
+#: Source/appfat.cpp:67
 #, c++-format
 msgid ""
 "{:s}\n"
@@ -942,11 +940,7 @@ msgstr ""
 "\n"
 "Ошибка в: {:s} линия {:d}"
 
-#: Source/appfat.cpp:83
-msgid "Data File Error"
-msgstr "Ошибка файла данных"
-
-#: Source/appfat.cpp:84
+#: Source/appfat.cpp:76
 #, c++-format
 msgid ""
 "Unable to open main data archive ({:s}).\n"
@@ -957,12 +951,12 @@ msgstr ""
 "\n"
 "Убедитесь, что файлы находятся в папке игры."
 
-#: Source/appfat.cpp:93
-msgid "Read-Only Directory Error"
-msgstr "Папка только для чтения"
+#: Source/appfat.cpp:81
+msgid "Data File Error"
+msgstr "Ошибка файла данных"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:94
+#: Source/appfat.cpp:87
 #, c++-format
 msgid ""
 "Unable to write to location:\n"
@@ -971,98 +965,104 @@ msgstr ""
 "Невозможно записать в:\n"
 "{:s}"
 
-#: Source/automap.cpp:1413
+#: Source/appfat.cpp:89
+msgid "Read-Only Directory Error"
+msgstr "Папка только для чтения"
+
+#: Source/automap.cpp:735
 msgid "Game: "
 msgstr "Игра: "
 
-#: Source/automap.cpp:1421
+#: Source/automap.cpp:743
 msgid "Offline Game"
 msgstr "Оффлайн игра"
 
-#: Source/automap.cpp:1423
+#: Source/automap.cpp:745
 msgid "Password: "
 msgstr "Пароль: "
 
-#: Source/automap.cpp:1426
+#: Source/automap.cpp:748
 msgid "Public Game"
 msgstr "Публичная игра"
 
-#: Source/automap.cpp:1440
+#: Source/automap.cpp:762
 #, c++-format
 msgid "Level: Nest {:d}"
 msgstr "Уровень: Гнездо {:d}"
 
-#: Source/automap.cpp:1443
+#: Source/automap.cpp:765
 #, c++-format
 msgid "Level: Crypt {:d}"
 msgstr "Уровень: Склеп {:d}"
 
-#: Source/automap.cpp:1446 Source/discord/discord.cpp:81 Source/objects.cpp:156
+#: Source/automap.cpp:768 Source/discord/discord.cpp:68 Source/objects.cpp:151
 msgid "Town"
 msgstr "Город"
 
-#: Source/automap.cpp:1449
+#: Source/automap.cpp:771
 #, c++-format
 msgid "Level: {:d}"
 msgstr "Уровень: {:d}"
 
-#: Source/control.cpp:197
+#: Source/control.cpp:160
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:197
+#: Source/control.cpp:160
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:197
+#: Source/control.cpp:160
 msgid "Enter"
 msgstr "Enter"
 
-#: Source/control.cpp:200
+#: Source/control.cpp:163
 msgid "Character Information"
 msgstr "Информация о персонаже"
 
-#: Source/control.cpp:201
+#: Source/control.cpp:164
 msgid "Quests log"
 msgstr "Журнал"
 
-#: Source/control.cpp:202
+#: Source/control.cpp:165
 msgid "Automap"
 msgstr "Автокарта"
 
-#: Source/control.cpp:203
+#: Source/control.cpp:166
 msgid "Main Menu"
 msgstr "Главное меню"
 
-#: Source/control.cpp:204 Source/diablo.cpp:1821 Source/diablo.cpp:2163
+#: Source/control.cpp:167 Source/diablo.cpp:1756 Source/diablo.cpp:2080
 msgid "Inventory"
 msgstr "Инвентарь"
 
-#: Source/control.cpp:205
+#: Source/control.cpp:168
 msgid "Spell book"
 msgstr "Книга заклинаний"
 
-#: Source/control.cpp:206
+#: Source/control.cpp:169
 msgid "Send Message"
 msgstr "Отправить сообщение"
 
-#: Source/control.cpp:401
+#: Source/control.cpp:348
 msgid "Available Commands:"
 msgstr "Доступные команды:"
 
-#: Source/control.cpp:409 Source/control.cpp:599
+#: Source/control.cpp:356
 msgid "Command "
 msgstr "Команда "
 
-#: Source/control.cpp:409 Source/control.cpp:599
-msgid " is unknown."
+#: Source/control.cpp:356
+#, fuzzy
+#| msgid " is unknown."
+msgid " is unkown."
 msgstr " неизвестна."
 
-#: Source/control.cpp:412 Source/control.cpp:413
+#: Source/control.cpp:359 Source/control.cpp:360
 msgid "Description: "
 msgstr "Описание: "
 
-#: Source/control.cpp:412
+#: Source/control.cpp:359
 msgid ""
 "\n"
 "Parameters: No additional parameter needed."
@@ -1070,7 +1070,7 @@ msgstr ""
 "\n"
 "Параметры: Дополнительные параметры не требуются."
 
-#: Source/control.cpp:413
+#: Source/control.cpp:360
 msgid ""
 "\n"
 "Parameters: "
@@ -1078,121 +1078,147 @@ msgstr ""
 "\n"
 "Параметры: "
 
-#: Source/control.cpp:433 Source/control.cpp:465
+#: Source/control.cpp:380 Source/control.cpp:412
 msgid "Arenas are only supported in multiplayer."
 msgstr "Арены поддерживаются только в сетевой игре."
 
-#: Source/control.cpp:438
+#: Source/control.cpp:385
 msgid "What arena do you want to visit?"
 msgstr "Какую арену желаете посетить?"
 
-#: Source/control.cpp:446
+#: Source/control.cpp:393
 msgid "Invalid arena-number. Valid numbers are:"
 msgstr "Несуществующий номер арены. Существующие номера:"
 
-#: Source/control.cpp:452
+#: Source/control.cpp:399
 msgid "To enter a arena, you need to be in town or another arena."
 msgstr "Чтобы попасть на арену, надо быть в городе или на другой арене."
 
-#: Source/control.cpp:490
+#: Source/control.cpp:436
 msgid "Inspecting only supported in multiplayer."
 msgstr "Проверка поддерживается только в сетевой игре."
 
-#: Source/control.cpp:495 Source/control.cpp:782
+#: Source/control.cpp:441 Source/control.cpp:730
 msgid "Stopped inspecting players."
 msgstr "Остановить проверку игроков."
 
-#: Source/control.cpp:510
-msgid "No players found with such a name"
-msgstr "Игрок с таким именем не найден"
-
-#: Source/control.cpp:516
+#: Source/control.cpp:451
 msgid "Inspecting player: "
 msgstr "Проверяется игрок: "
 
-#: Source/control.cpp:585
+#: Source/control.cpp:460
+msgid "No players found with such a name"
+msgstr "Игрок с таким именем не найден"
+
+#: Source/control.cpp:524
+msgid "/help"
+msgstr ""
+
+#: Source/control.cpp:524
 msgid "Prints help overview or help for a specific command."
 msgstr "Выводит окно помощи или помощь по нужной команде."
 
-#: Source/control.cpp:585
+#: Source/control.cpp:524
 msgid "[command]"
 msgstr "[command]"
 
-#: Source/control.cpp:586
+#: Source/control.cpp:525
+msgid "/arena"
+msgstr ""
+
+#: Source/control.cpp:525
 msgid "Enter a PvP Arena."
 msgstr "Войти на PvP Арену."
 
-#: Source/control.cpp:586
+#: Source/control.cpp:525
 msgid "<arena-number>"
 msgstr "<arena-number>"
 
-#: Source/control.cpp:587
+#: Source/control.cpp:526
+msgid "/arenapot"
+msgstr ""
+
+#: Source/control.cpp:526
 msgid "Gives Arena Potions."
 msgstr "Даёт Зелья Арены."
 
-#: Source/control.cpp:587
+#: Source/control.cpp:526
 msgid "<number>"
 msgstr "<number>"
 
-#: Source/control.cpp:588
+#: Source/control.cpp:527
+msgid "/inspect"
+msgstr ""
+
+#: Source/control.cpp:527
 msgid "Inspects stats and equipment of another player."
 msgstr "Проверяет статистику и экипировку другого игрока."
 
-#: Source/control.cpp:588
+#: Source/control.cpp:527
 msgid "<player name>"
 msgstr "<player name>"
 
-#: Source/control.cpp:589
+#: Source/control.cpp:528
+msgid "/seedinfo"
+msgstr ""
+
+#: Source/control.cpp:528
 msgid "Show seed infos for current level."
 msgstr "Показать информацию о сиде для этого уровня."
 
-#: Source/control.cpp:1085
+#: Source/control.cpp:538
+#, fuzzy
+#| msgid "Command "
+msgid "Command \""
+msgstr "Команда "
+
+#: Source/control.cpp:1013
 msgid "Player friendly"
 msgstr "Игрок дружественен"
 
-#: Source/control.cpp:1087
+#: Source/control.cpp:1015
 msgid "Player attack"
 msgstr "Игрок атакует"
 
-#: Source/control.cpp:1090
+#: Source/control.cpp:1018
 #, c++-format
 msgid "Hotkey: {:s}"
 msgstr "Горячая клавиша: {:s}"
 
 # Оставил именно этот вариант, так как полностью корректный перевод в игре выглядит глупо.
-#: Source/control.cpp:1102
+#: Source/control.cpp:1025
 msgid "Select current spell button"
 msgstr "Выберите текущее заклинание"
 
-#: Source/control.cpp:1105
+#: Source/control.cpp:1028
 msgid "Hotkey: 's'"
 msgstr "Горячая клавиша: 's'"
 
-#: Source/control.cpp:1111 Source/panels/spell_list.cpp:152
+#: Source/control.cpp:1034 Source/panels/spell_list.cpp:151
 #, c++-format
 msgid "{:s} Skill"
 msgstr "Навык {:s}"
 
-#: Source/control.cpp:1114 Source/panels/spell_list.cpp:159
+#: Source/control.cpp:1037 Source/panels/spell_list.cpp:158
 #, c++-format
 msgid "{:s} Spell"
 msgstr "Заклинание {:s}"
 
-#: Source/control.cpp:1116 Source/panels/spell_list.cpp:164
+#: Source/control.cpp:1039 Source/panels/spell_list.cpp:163
 msgid "Spell Level 0 - Unusable"
 msgstr "Уровень заклинания 0 - Неприменимо"
 
-#: Source/control.cpp:1116 Source/panels/spell_list.cpp:166
+#: Source/control.cpp:1039 Source/panels/spell_list.cpp:165
 #, c++-format
 msgid "Spell Level {:d}"
 msgstr "Уровень заклинания {:d}"
 
-#: Source/control.cpp:1119 Source/panels/spell_list.cpp:173
+#: Source/control.cpp:1042 Source/panels/spell_list.cpp:172
 #, c++-format
 msgid "Scroll of {:s}"
 msgstr "Свиток {:s}"
 
-#: Source/control.cpp:1123 Source/panels/spell_list.cpp:177
+#: Source/control.cpp:1047 Source/panels/spell_list.cpp:177
 #, c++-format
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
@@ -1200,12 +1226,12 @@ msgstr[0] "{:d} свиток"
 msgstr[1] "{:d} свитка"
 msgstr[2] "{:d} свитков"
 
-#: Source/control.cpp:1126 Source/panels/spell_list.cpp:184
+#: Source/control.cpp:1050 Source/panels/spell_list.cpp:184
 #, c++-format
 msgid "Staff of {:s}"
 msgstr "Посох {:s}"
 
-#: Source/control.cpp:1127 Source/panels/spell_list.cpp:186
+#: Source/control.cpp:1051 Source/panels/spell_list.cpp:186
 #, c++-format
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
@@ -1213,7 +1239,7 @@ msgstr[0] "{:d} заряд"
 msgstr[1] "{:d} заряда"
 msgstr[2] "{:d} зарядов"
 
-#: Source/control.cpp:1247 Source/inv.cpp:1974 Source/items.cpp:3818
+#: Source/control.cpp:1176 Source/inv.cpp:1872 Source/items.cpp:3654
 #, c++-format
 msgid "{:s} gold piece"
 msgid_plural "{:s} gold pieces"
@@ -1221,26 +1247,26 @@ msgstr[0] "{:s} золотой"
 msgstr[1] "{:s} золотых"
 msgstr[2] "{:s} золотых"
 
-#: Source/control.cpp:1249
+#: Source/control.cpp:1178
 msgid "Requirements not met"
 msgstr "Требования не выполнены"
 
-#: Source/control.cpp:1278
+#: Source/control.cpp:1207
 #, c++-format
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Уровень: {:d}"
 
-#: Source/control.cpp:1279
+#: Source/control.cpp:1208
 #, c++-format
 msgid "Hit Points {:d} of {:d}"
 msgstr "Здоровье {:d} из {:d}"
 
-#: Source/control.cpp:1316
+#: Source/control.cpp:1239
 msgid "Level Up"
 msgstr "Новый уровень"
 
 #. TRANSLATORS: {:s} is a number with separators. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1429
+#: Source/control.cpp:1347
 #, c++-format
 msgid "You have {:s} gold piece. How many do you want to remove?"
 msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
@@ -1248,161 +1274,139 @@ msgstr[0] "У вас {:s} золотой. Сколько вы хотите за�
 msgstr[1] "У вас {:s} золотых. Сколько вы хотите забрать?"
 msgstr[2] "У вас {:s} золотых. Сколько вы хотите забрать?"
 
-#: Source/cursor.cpp:611
+#: Source/cursor.cpp:326
 msgid "Town Portal"
 msgstr "Городской портал"
 
-#: Source/cursor.cpp:612
+#: Source/cursor.cpp:327
 #, c++-format
 msgid "from {:s}"
 msgstr "от {:s}"
 
-#: Source/cursor.cpp:625
+#: Source/cursor.cpp:340
 msgid "Portal to"
 msgstr "Портал в"
 
-#: Source/cursor.cpp:626
+#: Source/cursor.cpp:341
 msgid "The Unholy Altar"
 msgstr "Нечестивый Алтарь"
 
-#: Source/cursor.cpp:626
+#: Source/cursor.cpp:341
 msgid "level 15"
 msgstr "уровень 15"
 
-#. TRANSLATORS: Error message when a data file is missing or corrupt. Arguments are {file name}
-#: Source/data/file.cpp:52
-#, c++-format
-msgid "Unable to load data from file {0}"
-msgstr "Не удаётся загрузить данные из файла {0}"
+#: Source/diablo.cpp:126
+#, fuzzy
+#| msgid "I need help! Come here!"
+msgid "I need help! Come Here!"
+msgstr "Мне нужна помощь! Ко мне!"
 
-#. TRANSLATORS: Error message when a data file is empty or only contains the header row. Arguments are {file name}
-#: Source/data/file.cpp:57
-#, c++-format
-msgid "{0} is incomplete, please check the file contents."
-msgstr "{0} является неполным, пожалуйста, проверьте содержимое файла."
+#: Source/diablo.cpp:127
+msgid "Follow me."
+msgstr "Иди за мной."
 
-#. TRANSLATORS: Error message when a data file doesn't contain the expected columns. Arguments are {file name}
-#: Source/data/file.cpp:62
-#, c++-format
-msgid ""
-"Your {0} file doesn't have the expected columns, please make sure it matches "
-"the documented format."
-msgstr ""
-"В вашем файле {0} нет нужных столбцов, пожалуйста, убедитесь, что он "
-"соответствует документированному формату."
+#: Source/diablo.cpp:128
+msgid "Here's something for you."
+msgstr "Вот кое-что для тебя."
 
-#. TRANSLATORS: Error message when parsing a data file and a text value is encountered when a number is expected. Arguments are {found value}, {column heading}, {file name}, {row/record number}, {column/field number}
-#: Source/data/file.cpp:77
-#, c++-format
-msgid "Non-numeric value {0} for {1} in {2} at row {3} and column {4}"
-msgstr "Нечисловое значение {0} для {1} в {2} в строке {3} и столбце {4}"
-
-#. TRANSLATORS: Error message when parsing a data file and we find a number larger than expected. Arguments are {found value}, {column heading}, {file name}, {row/record number}, {column/field number}
-#: Source/data/file.cpp:83
-#, c++-format
-msgid "Out of range value {0} for {1} in {2} at row {3} and column {4}"
-msgstr "Значение вне диапазона {0} для {1} в {2} в строке {3} и столбце {4}"
-
-#. TRANSLATORS: Error message when we find an unrecognised value in a key column. Arguments are {found value}, {column heading}, {file name}, {row/record number}, {column/field number}
-#: Source/data/file.cpp:89
-#, c++-format
-msgid "Invalid value {0} for {1} in {2} at row {3} and column {4}"
-msgstr "Недопустимое значение {0} для {1} в {2} в строке {3} и столбце {4}"
+#: Source/diablo.cpp:129
+msgid "Now you DIE!"
+msgstr "Сейчас ты СДОХНЕШЬ!"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:946
+#: Source/diablo.cpp:972
 msgid "Print this message and exit"
 msgstr "Написать это сообщение и выйти"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:947
+#: Source/diablo.cpp:973
 msgid "Print the version and exit"
 msgstr "Написать версию и выйти"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:948
+#: Source/diablo.cpp:974
 msgid "Specify the folder of diabdat.mpq"
 msgstr "Указать папку с diabdat.mpq"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:949
+#: Source/diablo.cpp:975
 msgid "Specify the folder of save files"
 msgstr "Указать папку с сохранениями"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:950
+#: Source/diablo.cpp:976
 msgid "Specify the location of diablo.ini"
 msgstr "Указать путь к diablo.ini"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:951
+#: Source/diablo.cpp:977
 msgid "Specify the language code (e.g. en or pt_BR)"
 msgstr "Указать код языка (например en или ru_RU)"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:952
+#: Source/diablo.cpp:978
 msgid "Skip startup videos"
 msgstr "Пропустить вступительные ролики"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:953
+#: Source/diablo.cpp:979
 msgid "Display frames per second"
 msgstr "Отобразить FPS"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:954
+#: Source/diablo.cpp:980
 msgid "Enable verbose logging"
 msgstr "Включить подробное логирование"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:956
+#: Source/diablo.cpp:982
 msgid "Record a demo file"
 msgstr "Записать демо"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:957
+#: Source/diablo.cpp:983
 msgid "Play a demo file"
 msgstr "Воспроизвести демо"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:958
+#: Source/diablo.cpp:984
 msgid "Disable all frame limiting during demo playback"
 msgstr "Отключить ограничение кадров во время проигрывания демо"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:961
+#: Source/diablo.cpp:987
 msgid "Game selection:"
 msgstr "Выбор игры:"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:963
+#: Source/diablo.cpp:989
 msgid "Force Shareware mode"
 msgstr "Запустить режим Shareware"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:964
+#: Source/diablo.cpp:990
 msgid "Force Diablo mode"
 msgstr "Запустить режим Diablo"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:965
+#: Source/diablo.cpp:991
 msgid "Force Hellfire mode"
 msgstr "Запустить режим Hellfire"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:966
+#: Source/diablo.cpp:992
 msgid "Hellfire options:"
 msgstr "Параметры Hellfire:"
 
-#: Source/diablo.cpp:976
+#: Source/diablo.cpp:1002
 msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
 msgstr "Сообщайте об ошибках на https://github.com/diasurgical/devilutionX/"
 
-#: Source/diablo.cpp:1143
+#: Source/diablo.cpp:1158
 msgid "Please update devilutionx.mpq and fonts.mpq to the latest version"
 msgstr "Пожалуйста, обновите devilutionx.mpq и fonts.mpq до последней версии"
 
-#: Source/diablo.cpp:1145
+#: Source/diablo.cpp:1160
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -1412,504 +1416,520 @@ msgstr ""
 "\n"
 "Убедитесь, что devilutionx.mpq находится в папке с игрой и он обновлён."
 
-#: Source/diablo.cpp:1149
+#: Source/diablo.cpp:1164
 msgid "Please update fonts.mpq to the latest version"
 msgstr "Пожалуйста, обновите файл fonts.mpq до последней версии"
 
-#: Source/diablo.cpp:1479
+#: Source/diablo.cpp:1478
 msgid "-- Network timeout --"
 msgstr "-- Тайм-аут сети --"
 
-#: Source/diablo.cpp:1480
+#: Source/diablo.cpp:1479
 msgid "-- Waiting for players --"
 msgstr "-- Ожидание игроков --"
 
-#: Source/diablo.cpp:1503
+#: Source/diablo.cpp:1502
 msgid "No help available"
 msgstr "Помощь недоступна"
 
-#: Source/diablo.cpp:1504
+#: Source/diablo.cpp:1503
 msgid "while in stores"
 msgstr "в магазинах"
 
-#: Source/diablo.cpp:1683 Source/diablo.cpp:1995
+#: Source/diablo.cpp:1642 Source/diablo.cpp:1912
 #, c++-format
 msgid "Belt item {}"
 msgstr "Предметы на поясе {}"
 
-#: Source/diablo.cpp:1684 Source/diablo.cpp:1996
+#: Source/diablo.cpp:1643 Source/diablo.cpp:1913
 msgid "Use Belt item."
 msgstr "Использовать предмет на поясе."
 
-#: Source/diablo.cpp:1699 Source/diablo.cpp:2011
+#: Source/diablo.cpp:1658 Source/diablo.cpp:1928
 #, c++-format
 msgid "Quick spell {}"
 msgstr "Быстрое заклинание {}"
 
-#: Source/diablo.cpp:1700 Source/diablo.cpp:2012
+#: Source/diablo.cpp:1659 Source/diablo.cpp:1929
 msgid "Hotkey for skill or spell."
 msgstr "Установить горячую клавишу для заклинания."
 
-#: Source/diablo.cpp:1718
-msgid "Previous quick spell"
-msgstr "Предыдущее заклинание"
-
-#: Source/diablo.cpp:1719
-msgid "Selects the previous quick spell (cycles)."
-msgstr "Выбрать предыдущее заклинание (циклично)."
-
-#: Source/diablo.cpp:1726
-msgid "Next quick spell"
-msgstr "Следующее заклинание"
-
-#: Source/diablo.cpp:1727
-msgid "Selects the next quick spell (cycles)."
-msgstr "Выбрать следующее заклинание (циклично)."
-
-#: Source/diablo.cpp:1734 Source/diablo.cpp:2139
+#: Source/diablo.cpp:1677 Source/diablo.cpp:2056
 msgid "Use health potion"
 msgstr "Использовать зелье здоровья"
 
-#: Source/diablo.cpp:1735 Source/diablo.cpp:2140
+#: Source/diablo.cpp:1678 Source/diablo.cpp:2057
 msgid "Use health potions from belt."
 msgstr "Использовать зелье здоровья с поясе."
 
-#: Source/diablo.cpp:1742 Source/diablo.cpp:2147
+#: Source/diablo.cpp:1685 Source/diablo.cpp:2064
 msgid "Use mana potion"
 msgstr "Использовать зелье маны"
 
-#: Source/diablo.cpp:1743 Source/diablo.cpp:2148
+#: Source/diablo.cpp:1686 Source/diablo.cpp:2065
 msgid "Use mana potions from belt."
 msgstr "Использовать зелье маны с пояса."
 
 # ХЗ как это назвать по-русски.
 # ---------------------------------------
 # При вычитке перевёл как "Быстрые заклинания". Логически больше ничего не подходит. Может претендовать "Книга скорочтения", но...
-#: Source/diablo.cpp:1750 Source/diablo.cpp:2193
+#: Source/diablo.cpp:1693 Source/diablo.cpp:2110
 msgid "Speedbook"
 msgstr "Быстрые заклинания"
 
-#: Source/diablo.cpp:1751 Source/diablo.cpp:2194
+#: Source/diablo.cpp:1694 Source/diablo.cpp:2111
 msgid "Open Speedbook."
 msgstr "Открыть быстрые заклинания."
 
-#: Source/diablo.cpp:1758 Source/diablo.cpp:2326
+#: Source/diablo.cpp:1701 Source/diablo.cpp:2243
 msgid "Quick save"
 msgstr "Быстрое сохранение"
 
-#: Source/diablo.cpp:1759 Source/diablo.cpp:2327
+#: Source/diablo.cpp:1702 Source/diablo.cpp:2244
 msgid "Saves the game."
 msgstr "Сохраняет игру."
 
-#: Source/diablo.cpp:1766 Source/diablo.cpp:2334
+#: Source/diablo.cpp:1709 Source/diablo.cpp:2251
 msgid "Quick load"
 msgstr "Быстрая загрузка"
 
-#: Source/diablo.cpp:1767 Source/diablo.cpp:2335
+#: Source/diablo.cpp:1710 Source/diablo.cpp:2252
 msgid "Loads the game."
 msgstr "Загружает игру."
 
-#: Source/diablo.cpp:1775
+#: Source/diablo.cpp:1718
 msgid "Quit game"
 msgstr "Выйти из игры"
 
-#: Source/diablo.cpp:1776
+#: Source/diablo.cpp:1719
 msgid "Closes the game."
 msgstr "Закрывает игру."
 
-#: Source/diablo.cpp:1782
+#: Source/diablo.cpp:1725
 msgid "Stop hero"
 msgstr "Остановить персонажа"
 
-#: Source/diablo.cpp:1783
+#: Source/diablo.cpp:1726
 msgid "Stops walking and cancel pending actions."
 msgstr "Останавливает ходьбу и отменяет отложенные действия."
 
 # Подсвечиваем всё-таки не один предмет, а все. Так логичнее.
-#: Source/diablo.cpp:1790 Source/diablo.cpp:2342
+#: Source/diablo.cpp:1733 Source/diablo.cpp:2259
 msgid "Item highlighting"
 msgstr "Подсветка предметов"
 
-#: Source/diablo.cpp:1791 Source/diablo.cpp:2343
+#: Source/diablo.cpp:1734 Source/diablo.cpp:2260
 msgid "Show/hide items on ground."
 msgstr "Показать/скрыть предметы на земле."
 
-#: Source/diablo.cpp:1797 Source/diablo.cpp:2349
+#: Source/diablo.cpp:1740 Source/diablo.cpp:2266
 msgid "Toggle item highlighting"
 msgstr "Переключить подсветку предметов"
 
-#: Source/diablo.cpp:1798 Source/diablo.cpp:2350
+#: Source/diablo.cpp:1741 Source/diablo.cpp:2267
 msgid "Permanent show/hide items on ground."
 msgstr "Постоянное отображение/сокрытие предметов на земле."
 
-#: Source/diablo.cpp:1804 Source/diablo.cpp:2203
+#: Source/diablo.cpp:1747 Source/diablo.cpp:2120
 msgid "Toggle automap"
 msgstr "Переключить автокарту"
 
-#: Source/diablo.cpp:1805 Source/diablo.cpp:2204
+#: Source/diablo.cpp:1748 Source/diablo.cpp:2121
 msgid "Toggles if automap is displayed."
 msgstr "Переключает отображение автокарты."
 
-#: Source/diablo.cpp:1812
-msgid "Cycle map type"
-msgstr "Тип цикла карты"
-
-#: Source/diablo.cpp:1813
-msgid "Opaque -> Transparent -> Minimap -> None"
-msgstr "Непрозрачный -> Прозрачный -> Миникарта -> Нет"
-
-#: Source/diablo.cpp:1822 Source/diablo.cpp:2164
+#: Source/diablo.cpp:1757 Source/diablo.cpp:2081
 msgid "Open Inventory screen."
 msgstr "Открыть экран инвентаря."
 
-#: Source/diablo.cpp:1829 Source/diablo.cpp:2155
+#: Source/diablo.cpp:1764 Source/diablo.cpp:2072
 msgid "Character"
 msgstr "Персонаж"
 
-#: Source/diablo.cpp:1830 Source/diablo.cpp:2156
+#: Source/diablo.cpp:1765 Source/diablo.cpp:2073
 msgid "Open Character screen."
 msgstr "Открыть экран персонажа."
 
-#: Source/diablo.cpp:1837 Source/diablo.cpp:2173
+#: Source/diablo.cpp:1772 Source/diablo.cpp:2090
 msgid "Quest log"
 msgstr "Журнал"
 
-#: Source/diablo.cpp:1838 Source/diablo.cpp:2174
+#: Source/diablo.cpp:1773 Source/diablo.cpp:2091
 msgid "Open Quest log."
 msgstr "Открыть журнал заданий."
 
-#: Source/diablo.cpp:1845 Source/diablo.cpp:2183
+#: Source/diablo.cpp:1780 Source/diablo.cpp:2100
 msgid "Spellbook"
 msgstr "Книга заклинаний"
 
-#: Source/diablo.cpp:1846 Source/diablo.cpp:2184
+#: Source/diablo.cpp:1781 Source/diablo.cpp:2101
 msgid "Open Spellbook."
 msgstr "Открыть книгу заклинаний."
 
-#: Source/diablo.cpp:1854
+#: Source/diablo.cpp:1789
 #, c++-format
 msgid "Quick Message {}"
 msgstr "Быстрое сообщение {}"
 
-#: Source/diablo.cpp:1855
+#: Source/diablo.cpp:1790
 msgid "Use Quick Message in chat."
 msgstr "Используйте быстрое сообщение в чате."
 
 # "Экран" в "панель" .
-#: Source/diablo.cpp:1864 Source/diablo.cpp:2356
+#: Source/diablo.cpp:1799 Source/diablo.cpp:2273
 msgid "Hide Info Screens"
 msgstr "Скрыть информационные панели"
 
-#: Source/diablo.cpp:1865 Source/diablo.cpp:2357
+#: Source/diablo.cpp:1800 Source/diablo.cpp:2274
 msgid "Hide all info screens."
 msgstr "Скрыть все информационные панели."
 
-#: Source/diablo.cpp:1888 Source/diablo.cpp:2380 Source/options.cpp:800
+#: Source/diablo.cpp:1820 Source/diablo.cpp:2294 Source/options.cpp:999
 msgid "Zoom"
 msgstr "Приближение"
 
-#: Source/diablo.cpp:1889 Source/diablo.cpp:2381
+#: Source/diablo.cpp:1821 Source/diablo.cpp:2295
 msgid "Zoom Game Screen."
 msgstr "Приблизить игровой экран."
 
-#: Source/diablo.cpp:1899 Source/diablo.cpp:2391
+#: Source/diablo.cpp:1831 Source/diablo.cpp:2305
 msgid "Pause Game"
 msgstr "Пауза"
 
-#: Source/diablo.cpp:1900 Source/diablo.cpp:1906 Source/diablo.cpp:2392
+#: Source/diablo.cpp:1832 Source/diablo.cpp:1838 Source/diablo.cpp:2306
 msgid "Pauses the game."
 msgstr "Ставит игру на паузу."
 
-#: Source/diablo.cpp:1905
+#: Source/diablo.cpp:1837
 msgid "Pause Game (Alternate)"
 msgstr "Пауза (Альтернатива)"
 
-#: Source/diablo.cpp:1911 Source/diablo.cpp:2397
+#: Source/diablo.cpp:1843 Source/diablo.cpp:2311
 msgid "Decrease Gamma"
 msgstr "Уменьшить гамму"
 
-#: Source/diablo.cpp:1912 Source/diablo.cpp:2398
+#: Source/diablo.cpp:1844 Source/diablo.cpp:2312
 msgid "Reduce screen brightness."
 msgstr "Уменьшить яркость экрана."
 
-#: Source/diablo.cpp:1919 Source/diablo.cpp:2405
+#: Source/diablo.cpp:1851 Source/diablo.cpp:2319
 msgid "Increase Gamma"
 msgstr "Увеличить гамму"
 
-#: Source/diablo.cpp:1920 Source/diablo.cpp:2406
+#: Source/diablo.cpp:1852 Source/diablo.cpp:2320
 msgid "Increase screen brightness."
 msgstr "Увеличить яркость экрана."
 
-#: Source/diablo.cpp:1927 Source/diablo.cpp:2413
+#: Source/diablo.cpp:1859 Source/diablo.cpp:2327
 msgid "Help"
 msgstr "Помощь"
 
-#: Source/diablo.cpp:1928 Source/diablo.cpp:2414
+#: Source/diablo.cpp:1860 Source/diablo.cpp:2328
 msgid "Open Help Screen."
 msgstr "Открыть экран помощи."
 
-#: Source/diablo.cpp:1935 Source/diablo.cpp:2421
+#: Source/diablo.cpp:1867 Source/diablo.cpp:2335
 msgid "Screenshot"
 msgstr "Снимок экрана"
 
-#: Source/diablo.cpp:1936 Source/diablo.cpp:2422
+#: Source/diablo.cpp:1868 Source/diablo.cpp:2336
 msgid "Takes a screenshot."
 msgstr "Делает снимок экрана."
 
-#: Source/diablo.cpp:1942 Source/diablo.cpp:2428
+#: Source/diablo.cpp:1874 Source/diablo.cpp:2342
 msgid "Game info"
 msgstr "Информация об игре"
 
-#: Source/diablo.cpp:1943 Source/diablo.cpp:2429
+#: Source/diablo.cpp:1875 Source/diablo.cpp:2343
 msgid "Displays game infos."
 msgstr "Отображает информацию об игре."
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
-#: Source/diablo.cpp:1947 Source/diablo.cpp:2433
+#: Source/diablo.cpp:1879 Source/diablo.cpp:2347
 #, c++-format
 msgid "{:s} {:s}"
 msgstr "{:s} {:s}"
 
-#: Source/diablo.cpp:1956 Source/diablo.cpp:2450
+#: Source/diablo.cpp:1888 Source/diablo.cpp:2356
 msgid "Chat Log"
 msgstr "Журнал чата"
 
-#: Source/diablo.cpp:1957 Source/diablo.cpp:2451
+#: Source/diablo.cpp:1889 Source/diablo.cpp:2357
 msgid "Displays chat log."
 msgstr "Отображает журнал чата."
 
-#: Source/diablo.cpp:1964 Source/diablo.cpp:2442
-msgid "Sort Inventory"
-msgstr "Сортировка инвентаря"
-
-#: Source/diablo.cpp:1965 Source/diablo.cpp:2443
-msgid "Sorts the inventory."
-msgstr "Сортирует инвентарь."
-
-#: Source/diablo.cpp:1973
-msgid "Console"
-msgstr "Консоль"
-
-#: Source/diablo.cpp:1974
-msgid "Opens Lua console."
-msgstr "Открывает консоль Lua."
-
-#: Source/diablo.cpp:2030
+#: Source/diablo.cpp:1947
 msgid "Primary action"
 msgstr "Основное действие"
 
-#: Source/diablo.cpp:2031
+#: Source/diablo.cpp:1948
 msgid "Attack monsters, talk to towners, lift and place inventory items."
 msgstr ""
 "Атакуйте монстров, разговаривайте с горожанами, поднимайте и размещайте "
 "предметы инвентаря."
 
-#: Source/diablo.cpp:2045
+#: Source/diablo.cpp:1962
 msgid "Secondary action"
 msgstr "Вторичное действие"
 
-#: Source/diablo.cpp:2046
+#: Source/diablo.cpp:1963
 msgid "Open chests, interact with doors, pick up items."
 msgstr "Открывайте сундуки и двери, подбирайте предметы."
 
-#: Source/diablo.cpp:2060
+#: Source/diablo.cpp:1977
 msgid "Spell action"
 msgstr "Применить заклинание"
 
-#: Source/diablo.cpp:2061
+#: Source/diablo.cpp:1978
 msgid "Cast the active spell."
 msgstr "Применяет выбранное заклинание."
 
-#: Source/diablo.cpp:2075
+#: Source/diablo.cpp:1992
 msgid "Cancel action"
 msgstr "Отмена действия"
 
-#: Source/diablo.cpp:2076
+#: Source/diablo.cpp:1993
 msgid "Close menus."
 msgstr "Закрывает меню."
 
-#: Source/diablo.cpp:2101
+#: Source/diablo.cpp:2018
 msgid "Move up"
 msgstr "Движение вверх"
 
-#: Source/diablo.cpp:2102
+#: Source/diablo.cpp:2019
 msgid "Moves the player character up."
 msgstr "Перемещает персонажа вверх."
 
-#: Source/diablo.cpp:2107
+#: Source/diablo.cpp:2024
 msgid "Move down"
 msgstr "Движение вниз"
 
-#: Source/diablo.cpp:2108
+#: Source/diablo.cpp:2025
 msgid "Moves the player character down."
 msgstr "Перемещает персонажа вниз."
 
-#: Source/diablo.cpp:2113
+#: Source/diablo.cpp:2030
 msgid "Move left"
 msgstr "Движение влево"
 
-#: Source/diablo.cpp:2114
+#: Source/diablo.cpp:2031
 msgid "Moves the player character left."
 msgstr "Перемещает персонажа влево."
 
-#: Source/diablo.cpp:2119
+#: Source/diablo.cpp:2036
 msgid "Move right"
 msgstr "Движение вправо"
 
-#: Source/diablo.cpp:2120
+#: Source/diablo.cpp:2037
 msgid "Moves the player character right."
 msgstr "Перемещает персонажа вправо."
 
-#: Source/diablo.cpp:2125
+#: Source/diablo.cpp:2042
 msgid "Stand ground"
 msgstr "Стоять на месте"
 
-#: Source/diablo.cpp:2126
+#: Source/diablo.cpp:2043
 msgid "Hold to prevent the player from moving."
 msgstr "Удерживайте, чтобы персонаж не ходил."
 
-#: Source/diablo.cpp:2131
+#: Source/diablo.cpp:2048
 msgid "Toggle stand ground"
 msgstr "Переключить на стойку смирно"
 
-#: Source/diablo.cpp:2132
+#: Source/diablo.cpp:2049
 msgid "Toggle whether the player moves."
 msgstr "Переключить на ходьбу."
 
-#: Source/diablo.cpp:2209
+#: Source/diablo.cpp:2126
 msgid "Move mouse up"
 msgstr "Движение курсора вверх"
 
-#: Source/diablo.cpp:2210
+#: Source/diablo.cpp:2127
 msgid "Simulates upward mouse movement."
 msgstr "Перемещает курсор вверх."
 
-#: Source/diablo.cpp:2215
+#: Source/diablo.cpp:2132
 msgid "Move mouse down"
 msgstr "Движение курсора вниз"
 
-#: Source/diablo.cpp:2216
+#: Source/diablo.cpp:2133
 msgid "Simulates downward mouse movement."
 msgstr "Перемещает курсор вниз."
 
-#: Source/diablo.cpp:2221
+#: Source/diablo.cpp:2138
 msgid "Move mouse left"
 msgstr "Движение курсора влево"
 
-#: Source/diablo.cpp:2222
+#: Source/diablo.cpp:2139
 msgid "Simulates leftward mouse movement."
 msgstr "Перемещает курсор влево."
 
-#: Source/diablo.cpp:2227
+#: Source/diablo.cpp:2144
 msgid "Move mouse right"
 msgstr "Движение курсора вправо"
 
-#: Source/diablo.cpp:2228
+#: Source/diablo.cpp:2145
 msgid "Simulates rightward mouse movement."
 msgstr "Перемещает курсор вправо."
 
-#: Source/diablo.cpp:2246 Source/diablo.cpp:2253
+#: Source/diablo.cpp:2163 Source/diablo.cpp:2170
 msgid "Left mouse click"
 msgstr "Левая кнопка мыши"
 
-#: Source/diablo.cpp:2247 Source/diablo.cpp:2254
+#: Source/diablo.cpp:2164 Source/diablo.cpp:2171
 msgid "Simulates the left mouse button."
 msgstr "Работает как левая кнопка мыши."
 
-#: Source/diablo.cpp:2271 Source/diablo.cpp:2278
+#: Source/diablo.cpp:2188 Source/diablo.cpp:2195
 msgid "Right mouse click"
 msgstr "Правая кнопка мыши"
 
-#: Source/diablo.cpp:2272 Source/diablo.cpp:2279
+#: Source/diablo.cpp:2189 Source/diablo.cpp:2196
 msgid "Simulates the right mouse button."
 msgstr "Работает как правая кнопка мыши."
 
-#: Source/diablo.cpp:2285
+#: Source/diablo.cpp:2202
 msgid "Gamepad hotspell menu"
 msgstr "Меню быстрых заклинаний"
 
-#: Source/diablo.cpp:2286
+#: Source/diablo.cpp:2203
 msgid "Hold to set or use spell hotkeys."
 msgstr "Удерживать для установки или применения заклинания."
 
-#: Source/diablo.cpp:2292
+#: Source/diablo.cpp:2209
 msgid "Gamepad menu navigator"
 msgstr "Навигационное меню"
 
-#: Source/diablo.cpp:2293
+#: Source/diablo.cpp:2210
 msgid "Hold to access gamepad menu navigation."
 msgstr "Удерживать для открытия навигационного мею."
 
-#: Source/diablo.cpp:2308 Source/diablo.cpp:2317
+#: Source/diablo.cpp:2225 Source/diablo.cpp:2234
 msgid "Toggle game menu"
 msgstr "Переключение меню"
 
-#: Source/diablo.cpp:2309 Source/diablo.cpp:2318
+#: Source/diablo.cpp:2226 Source/diablo.cpp:2235
 msgid "Opens the game menu."
 msgstr "Открыть меню игры."
 
-#: Source/diablo_msg.cpp:63
+#: Source/discord/discord.cpp:68
+msgid "Cathedral"
+msgstr "Собор"
+
+#: Source/discord/discord.cpp:68
+msgid "Catacombs"
+msgstr "Катакомбы"
+
+#: Source/discord/discord.cpp:68
+msgid "Caves"
+msgstr "Пещеры"
+
+#: Source/discord/discord.cpp:68
+msgid "Nest"
+msgstr "Гнездо"
+
+#: Source/discord/discord.cpp:68
+msgid "Crypt"
+msgstr "Склеп"
+
+#. TRANSLATORS: dungeon type and floor number i.e. "Cathedral 3"
+#: Source/discord/discord.cpp:84
+#, c++-format
+msgid "{} {}"
+msgstr "{} {}"
+
+#. TRANSLATORS: Discord character, i.e. "Lv 6 Warrior"
+#: Source/discord/discord.cpp:92
+#, c++-format
+msgid "Lv {} {}"
+msgstr "Ур {} {}"
+
+#. TRANSLATORS: Discord state i.e. "Nightmare difficulty"
+#: Source/discord/discord.cpp:104
+#, c++-format
+msgid "{} difficulty"
+msgstr "{} сложность"
+
+#. TRANSLATORS: Discord activity, not in game
+#: Source/discord/discord.cpp:185
+msgid "In Menu"
+msgstr "В меню"
+
+#: Source/dvlnet/loopback.cpp:118
+msgid "loopback"
+msgstr "loopback"
+
+#: Source/dvlnet/tcp_client.cpp:67
+msgid "Unable to connect"
+msgstr "Невозможно соединиться"
+
+# Счётная форма.
+#: Source/dvlnet/tcp_client.cpp:93
+msgid "error: read 0 bytes from server"
+msgstr "ошибка: прочитано 0 байт с сервера"
+
+#: Source/error.cpp:58
 msgid "Game saved"
 msgstr "Игра сохранена"
 
-#: Source/diablo_msg.cpp:64
+#: Source/error.cpp:59
 msgid "No multiplayer functions in demo"
 msgstr "Сетевая игра недоступна в демоверсии"
 
-#: Source/diablo_msg.cpp:65
+#: Source/error.cpp:60
 msgid "Direct Sound Creation Failed"
 msgstr "Ошибка создания Direct Sound"
 
-#: Source/diablo_msg.cpp:66
+#: Source/error.cpp:61
 msgid "Not available in shareware version"
 msgstr "Недоступно в shareware-версии"
 
-#: Source/diablo_msg.cpp:67
+#: Source/error.cpp:62
 msgid "Not enough space to save"
 msgstr "Недостаточно места для сохранения"
 
-#: Source/diablo_msg.cpp:68
+#: Source/error.cpp:63
 msgid "No Pause in town"
 msgstr "Пауза недоступна в городе"
 
-#: Source/diablo_msg.cpp:69
+#: Source/error.cpp:64
 msgid "Copying to a hard disk is recommended"
 msgstr "Рекомендуется копирование на жёсткий диск"
 
-#: Source/diablo_msg.cpp:70
+#: Source/error.cpp:65
 msgid "Multiplayer sync problem"
 msgstr "Проблема синхронизации сетевой игры"
 
-#: Source/diablo_msg.cpp:71
+#: Source/error.cpp:66
 msgid "No pause in multiplayer"
 msgstr "Пауза недоступна в сетевой игре"
 
-#: Source/diablo_msg.cpp:73
+#: Source/error.cpp:68
 msgid "Saving..."
 msgstr "Сохранение..."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:74
+#: Source/error.cpp:69
 msgid "Some are weakened as one grows strong"
 msgstr "Чем сильнее один, тем слабее другие"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:75
+#: Source/error.cpp:70
 msgid "New strength is forged through destruction"
 msgstr "Прочность куётся из обломков"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:76
+#: Source/error.cpp:71
 msgid "Those who defend seldom attack"
 msgstr "Те, кто защищаются, редко атакуют"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:77
+#: Source/error.cpp:72
 msgid "The sword of justice is swift and sharp"
 msgstr "Меч правосудия быстр и остр"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:78
+#: Source/error.cpp:73
 msgid "While the spirit is vigilant the body thrives"
 msgstr "В здоровом теле здоровый дух"
 
@@ -1917,416 +1937,230 @@ msgstr "В здоровом теле здоровый дух"
 # ---------------------------------------------
 # Поменял на "мощь". Больше пафоса!
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:79
+#: Source/error.cpp:74
 msgid "The powers of mana refocused renews"
 msgstr "Мощь маны воспряла вновь"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:80
+#: Source/error.cpp:75
 msgid "Time cannot diminish the power of steel"
 msgstr "Время не уменьшит силу стали"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:81
+#: Source/error.cpp:76
 msgid "Magic is not always what it seems to be"
 msgstr "Магия не всегда то, чем кажется"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:82
+#: Source/error.cpp:77
 msgid "What once was opened now is closed"
 msgstr "Что было открыто - закрыто теперь"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:83
+#: Source/error.cpp:78
 msgid "Intensity comes at the cost of wisdom"
 msgstr "Интенсивность достигается за счёт мудрости"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:84
+#: Source/error.cpp:79
 msgid "Arcane power brings destruction"
 msgstr "Тайная сила приносит разруху"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:85
+#: Source/error.cpp:80
 msgid "That which cannot be held cannot be harmed"
 msgstr "Не сломать того, что не взять"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:86
+#: Source/error.cpp:81
 msgid "Crimson and Azure become as the sun"
 msgstr "Кровь и лазурь становятся солнцем"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:87
+#: Source/error.cpp:82
 msgid "Knowledge and wisdom at the cost of self"
 msgstr "Знания и мудрость ценой себя"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:88
+#: Source/error.cpp:83
 msgid "Drink and be refreshed"
 msgstr "Пей и освежись"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:89
+#: Source/error.cpp:84
 msgid "Wherever you go, there you are"
 msgstr "Куда бы вы ни пошли, вот и вы"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:90
+#: Source/error.cpp:85
 msgid "Energy comes at the cost of wisdom"
 msgstr "Энергия приходит за счёт мудрости"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:91
+#: Source/error.cpp:86
 msgid "Riches abound when least expected"
 msgstr "Изобилие богатства, когда меньше всего ждёшь"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:92
+#: Source/error.cpp:87
 msgid "Where avarice fails, patience gains reward"
 msgstr "Где жадность терпит поражение, терпение вознаграждается"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:93
+#: Source/error.cpp:88
 msgid "Blessed by a benevolent companion!"
 msgstr "Благословлён великодушным спутником!"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:94
+#: Source/error.cpp:89
 msgid "The hands of men may be guided by fate"
 msgstr "Руки человека может направлять судьба"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:95
+#: Source/error.cpp:90
 msgid "Strength is bolstered by heavenly faith"
 msgstr "Сила подкрепляется небесной верой"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:96
+#: Source/error.cpp:91
 msgid "The essence of life flows from within"
 msgstr "Суть жизни течёт изнутри"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:97
+#: Source/error.cpp:92
 msgid "The way is made clear when viewed from above"
 msgstr "С высоты путь виднее"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:98
+#: Source/error.cpp:93
 msgid "Salvation comes at the cost of wisdom"
 msgstr "Спасение достигается ценой мудрости"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:99
+#: Source/error.cpp:94
 msgid "Mysteries are revealed in the light of reason"
 msgstr "Тайны раскрываются светом разума"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:100
+#: Source/error.cpp:95
 msgid "Those who are last may yet be first"
 msgstr "Последние могут быть первыми"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:101
+#: Source/error.cpp:96
 msgid "Generosity brings its own rewards"
 msgstr "Щедрость приносит свои плоды"
 
-#: Source/diablo_msg.cpp:102
+#: Source/error.cpp:97
 msgid "You must be at least level 8 to use this."
 msgstr "Вы должны быть не ниже 8 уровня, чтобы использовать это."
 
-#: Source/diablo_msg.cpp:103
+#: Source/error.cpp:98
 msgid "You must be at least level 13 to use this."
 msgstr "Вы должны быть не ниже 13 уровня, чтобы использовать это."
 
-#: Source/diablo_msg.cpp:104
+#: Source/error.cpp:99
 msgid "You must be at least level 17 to use this."
 msgstr "Вы должны быть не ниже 17 уровня, чтобы использовать это."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:105
+#: Source/error.cpp:100
 msgid "Arcane knowledge gained!"
 msgstr "Постигнуты тайные знания!"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:106
+#: Source/error.cpp:101
 msgid "That which does not kill you..."
 msgstr "То, что тебя не убивает..."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:107
+#: Source/error.cpp:102
 msgid "Knowledge is power."
 msgstr "Знание - сила."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:108
+#: Source/error.cpp:103
 msgid "Give and you shall receive."
 msgstr "Давайте - и вам дано будет."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:109
+#: Source/error.cpp:104
 msgid "Some experience is gained by touch."
 msgstr "Некоторый опыт приобретается на ощупь."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:110
+#: Source/error.cpp:105
 msgid "There's no place like home."
 msgstr "Нет места лучше дома."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:111
+#: Source/error.cpp:106
 msgid "Spiritual energy is restored."
 msgstr "Духовная энергия восстановлена."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:112
+#: Source/error.cpp:107
 msgid "You feel more agile."
 msgstr "Вы чувствуете себя более подвижным."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:113
+#: Source/error.cpp:108
 msgid "You feel stronger."
 msgstr "Вы чувствуете себя сильнее."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:114
+#: Source/error.cpp:109
 msgid "You feel wiser."
 msgstr "Вы чувствуете себя мудрее."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:115
+#: Source/error.cpp:110
 msgid "You feel refreshed."
 msgstr "Вы чувствуете себя отдохнувшим."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:116
+#: Source/error.cpp:111
 msgid "That which can break will."
 msgstr "То, что может сломать волю."
 
-#: Source/discord/discord.cpp:81
-msgid "Cathedral"
-msgstr "Собор"
-
-#: Source/discord/discord.cpp:81
-msgid "Catacombs"
-msgstr "Катакомбы"
-
-#: Source/discord/discord.cpp:81
-msgid "Caves"
-msgstr "Пещеры"
-
-#: Source/discord/discord.cpp:81
-msgid "Nest"
-msgstr "Гнездо"
-
-#: Source/discord/discord.cpp:81
-msgid "Crypt"
-msgstr "Склеп"
-
-#. TRANSLATORS: dungeon type and floor number i.e. "Cathedral 3"
-#: Source/discord/discord.cpp:97
-#, c++-format
-msgid "{} {}"
-msgstr "{} {}"
-
-#. TRANSLATORS: Discord character, i.e. "Lv 6 Warrior"
-#: Source/discord/discord.cpp:104
-#, c++-format
-msgid "Lv {} {}"
-msgstr "Ур {} {}"
-
-#. TRANSLATORS: Discord state i.e. "Nightmare difficulty"
-#: Source/discord/discord.cpp:116
-#, c++-format
-msgid "{} difficulty"
-msgstr "{} сложность"
-
-#. TRANSLATORS: Discord activity, not in game
-#: Source/discord/discord.cpp:197
-msgid "In Menu"
-msgstr "В меню"
-
-#: Source/dvlnet/loopback.cpp:117
-msgid "loopback"
-msgstr "loopback"
-
-#: Source/dvlnet/tcp_client.cpp:112
-msgid "Unable to connect"
-msgstr "Невозможно соединиться"
-
-# Счётная форма.
-#: Source/dvlnet/tcp_client.cpp:150
-msgid "error: read 0 bytes from server"
-msgstr "ошибка: прочитано 0 байт с сервера"
-
-#: Source/engine/assets.cpp:264
-#, c++-format
-msgid ""
-"Failed to open file:\n"
-"{:s}\n"
-"\n"
-"{:s}\n"
-"\n"
-"The MPQ file(s) might be damaged. Please check the file integrity."
-msgstr ""
-"Не удалось открыть файл:\n"
-"{:s}\n"
-"\n"
-"{:s}\n"
-"\n"
-"Возможно, файл(ы) MPQ поврежден(ы). Пожалуйста, проверьте целостность файла."
-
-#: Source/engine/assets.cpp:414 Source/engine/assets.cpp:448
-msgid "diabdat.mpq or spawn.mpq"
-msgstr "diabdat.mpq или spawn.mpq"
-
-#: Source/engine/assets.cpp:430 Source/engine/assets.cpp:465
-msgid "Some Hellfire MPQs are missing"
-msgstr "Некоторые MPQ Hellfire отсутствуют"
-
-#: Source/engine/assets.cpp:430 Source/engine/assets.cpp:465
-msgid ""
-"Not all Hellfire MPQs were found.\n"
-"Please copy all the hf*.mpq files."
-msgstr ""
-"Не все MPQ Hellfire были найдены.\n"
-"Скопируйте все файлы hf*.mpq."
-
-#: Source/engine/demomode.cpp:181 Source/options.cpp:497
-msgid "Resolution"
-msgstr "Разрешение"
-
-#: Source/engine/demomode.cpp:183 Source/options.cpp:845
-msgid "Run in Town"
-msgstr "Бег в городе"
-
-#: Source/engine/demomode.cpp:184 Source/options.cpp:848
-msgid "Theo Quest"
-msgstr "Задание Тео"
-
-#: Source/engine/demomode.cpp:185 Source/options.cpp:849
-msgid "Cow Quest"
-msgstr "Коровье задание"
-
-#: Source/engine/demomode.cpp:186 Source/options.cpp:859
-msgid "Auto Gold Pickup"
-msgstr "Автоподбор золота"
-
-#: Source/engine/demomode.cpp:187 Source/options.cpp:860
-msgid "Auto Elixir Pickup"
-msgstr "Автоподбор элексиров"
-
-#: Source/engine/demomode.cpp:188 Source/options.cpp:861
-msgid "Auto Oil Pickup"
-msgstr "Автоподбор масел"
-
-#: Source/engine/demomode.cpp:189 Source/options.cpp:862
-msgid "Auto Pickup in Town"
-msgstr "Автоподбор в городе"
-
-#: Source/engine/demomode.cpp:190 Source/options.cpp:863
-msgid "Adria Refills Mana"
-msgstr "Адрия восполняет ману"
-
-#: Source/engine/demomode.cpp:191 Source/options.cpp:864
-msgid "Auto Equip Weapons"
-msgstr "Автоэкипирование оружия"
-
-#: Source/engine/demomode.cpp:192 Source/options.cpp:865
-msgid "Auto Equip Armor"
-msgstr "Автоэкипирование брони"
-
-#: Source/engine/demomode.cpp:193 Source/options.cpp:866
-msgid "Auto Equip Helms"
-msgstr "Автоэкипирование шлемов"
-
-#: Source/engine/demomode.cpp:194 Source/options.cpp:867
-msgid "Auto Equip Shields"
-msgstr "Автоэкипирование щитов"
-
-#: Source/engine/demomode.cpp:195 Source/options.cpp:868
-msgid "Auto Equip Jewelry"
-msgstr "Автоэкипирование украшений"
-
-#: Source/engine/demomode.cpp:196 Source/options.cpp:869
-msgid "Randomize Quests"
-msgstr "Рандомизировать задания"
-
-#: Source/engine/demomode.cpp:197 Source/options.cpp:871
-msgid "Show Item Labels"
-msgstr "Показать имя предметов"
-
-#: Source/engine/demomode.cpp:198 Source/options.cpp:872
-msgid "Auto Refill Belt"
-msgstr "Автопополнение пояса"
-
-#: Source/engine/demomode.cpp:199 Source/options.cpp:873
-msgid "Disable Crippling Shrines"
-msgstr "Отключить калечащие святилища"
-
-# Пункт здесь и ниже находится в меню перед числом, так что.. так будет логичнее.
-#: Source/engine/demomode.cpp:203 Source/options.cpp:875
-msgid "Heal Potion Pickup"
-msgstr "Подбор Зелий Исцеления"
-
-#: Source/engine/demomode.cpp:204 Source/options.cpp:876
-msgid "Full Heal Potion Pickup"
-msgstr "Подбор Зелий Полного Исцеления"
-
-#: Source/engine/demomode.cpp:205 Source/options.cpp:877
-msgid "Mana Potion Pickup"
-msgstr "Подбор Зелий Маны"
-
-#: Source/engine/demomode.cpp:206 Source/options.cpp:878
-msgid "Full Mana Potion Pickup"
-msgstr "Подбор Зелий Полной Маны"
-
-#: Source/engine/demomode.cpp:207 Source/options.cpp:879
-msgid "Rejuvenation Potion Pickup"
-msgstr "Подбор Зелий Омоложения"
-
-#: Source/engine/demomode.cpp:208 Source/options.cpp:880
-msgid "Full Rejuvenation Potion Pickup"
-msgstr "Подбор Зелий Полного Омоложения"
-
-#: Source/gamemenu.cpp:47
+#: Source/gamemenu.cpp:39
 msgid "Save Game"
 msgstr "Сохранить игру"
 
-#: Source/gamemenu.cpp:48 Source/gamemenu.cpp:59
+#: Source/gamemenu.cpp:40 Source/gamemenu.cpp:51
 msgid "Options"
 msgstr "Настройки"
 
-#: Source/gamemenu.cpp:51 Source/gamemenu.cpp:62
+#: Source/gamemenu.cpp:43 Source/gamemenu.cpp:54
 msgid "Quit Game"
 msgstr "Выйти из игры"
 
-#: Source/gamemenu.cpp:61
+#: Source/gamemenu.cpp:53
 msgid "Restart In Town"
 msgstr "Начать в городе"
 
-#: Source/gamemenu.cpp:71
+#: Source/gamemenu.cpp:63
 msgid "Gamma"
 msgstr "Гамма"
 
 # Более логичный перевод залазит на элемент интерфейса в настройках.
-#: Source/gamemenu.cpp:72 Source/gamemenu.cpp:181
+#: Source/gamemenu.cpp:64 Source/gamemenu.cpp:173
 msgid "Speed"
 msgstr "Темп"
 
-#: Source/gamemenu.cpp:80
+#: Source/gamemenu.cpp:72
 msgid "Music Disabled"
 msgstr "Музыка выключена"
 
-#: Source/gamemenu.cpp:84
+#: Source/gamemenu.cpp:76
 msgid "Sound"
 msgstr "Звук"
 
-#: Source/gamemenu.cpp:85
+#: Source/gamemenu.cpp:77
 msgid "Sound Disabled"
 msgstr "Звук выключен"
 
-#: Source/gmenu.cpp:178
+#: Source/gmenu.cpp:177
 msgid "Pause"
 msgstr "Пауза"
 
@@ -2573,229 +2407,2011 @@ msgstr "Помощь по Shareware Diablo"
 msgid "Diablo Help"
 msgstr "Помощь по Diablo"
 
-#: Source/help.cpp:234 Source/qol/chatlog.cpp:199
+#: Source/help.cpp:233 Source/qol/chatlog.cpp:189
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Нажмите ESC для завершения или клавиши со стрелками для прокрутки."
 
-#: Source/init.cpp:149
+#: Source/init.cpp:297 Source/init.cpp:337
+msgid "diabdat.mpq or spawn.mpq"
+msgstr "diabdat.mpq или spawn.mpq"
+
+#: Source/init.cpp:318 Source/init.cpp:358
+msgid "Some Hellfire MPQs are missing"
+msgstr "Некоторые MPQ Hellfire отсутствуют"
+
+#: Source/init.cpp:318 Source/init.cpp:358
+msgid ""
+"Not all Hellfire MPQs were found.\n"
+"Please copy all the hf*.mpq files."
+msgstr ""
+"Не все MPQ Hellfire были найдены.\n"
+"Скопируйте все файлы hf*.mpq."
+
+#: Source/init.cpp:367
 msgid "Unable to create main window"
 msgstr "Невозможно создать главное окно"
 
-#: Source/inv.cpp:2221
+#: Source/inv.cpp:2122
 msgid "No room for item"
 msgstr "Не хватает места"
 
-#: Source/items.cpp:176 Source/translation_dummy.cpp:360
-msgid "Oil of Accuracy"
-msgstr "Масло Точности"
+#: Source/itemdat.cpp:53 Source/itemdat.cpp:236 Source/panels/charpanel.cpp:165
+msgid "Gold"
+msgstr "Золото"
 
-#: Source/items.cpp:177
-msgid "Oil of Mastery"
-msgstr "Масло Мастерства"
+#: Source/itemdat.cpp:54 Source/itemdat.cpp:172
+msgid "Short Sword"
+msgstr "Короткий Меч"
 
-#: Source/items.cpp:178 Source/translation_dummy.cpp:361
-msgid "Oil of Sharpness"
-msgstr "Масло Остроты"
+#: Source/itemdat.cpp:55 Source/itemdat.cpp:124
+msgid "Buckler"
+msgstr "Круглый Щит"
 
-#: Source/items.cpp:179
-msgid "Oil of Death"
-msgstr "Масло Смерти"
+#: Source/itemdat.cpp:56 Source/itemdat.cpp:192 Source/itemdat.cpp:193
+msgid "Club"
+msgstr "Дубина"
 
-#: Source/items.cpp:180
-msgid "Oil of Skill"
-msgstr "Масло Умения"
+#: Source/itemdat.cpp:57 Source/itemdat.cpp:196
+msgid "Short Bow"
+msgstr "Короткий Лук"
 
-#: Source/items.cpp:181 Source/translation_dummy.cpp:282
-#: Source/translation_dummy.cpp:359
+#: Source/itemdat.cpp:58
+msgid "Short Staff of Mana"
+msgstr "Короткий Посох Маны"
+
+#: Source/itemdat.cpp:59
+msgid "Cleaver"
+msgstr "Тесак"
+
+#: Source/itemdat.cpp:60 Source/itemdat.cpp:435
+msgid "The Undead Crown"
+msgstr "Корона Нежити"
+
+#: Source/itemdat.cpp:61 Source/itemdat.cpp:436
+msgid "Empyrean Band"
+msgstr "Эмпирейское Кольцо"
+
+#: Source/itemdat.cpp:62
+msgid "Magic Rock"
+msgstr "Волшебный Камень"
+
+#: Source/itemdat.cpp:63 Source/itemdat.cpp:437
+msgid "Optic Amulet"
+msgstr "Оптический Амулет"
+
+#: Source/itemdat.cpp:64 Source/itemdat.cpp:438
+msgid "Ring of Truth"
+msgstr "Кольцо Истины"
+
+#: Source/itemdat.cpp:65
+msgid "Tavern Sign"
+msgstr "Вывеска Таверны"
+
+# Или просто шапка/шлем
+#: Source/itemdat.cpp:66 Source/itemdat.cpp:439
+msgid "Harlequin Crest"
+msgstr "Гребень Арлекина"
+
+#: Source/itemdat.cpp:67 Source/itemdat.cpp:440
+msgid "Veil of Steel"
+msgstr "Стальная Завеса"
+
+#: Source/itemdat.cpp:68
+msgid "Golden Elixir"
+msgstr "Золотой Эликсир"
+
+#: Source/itemdat.cpp:69 Source/quests.cpp:58
+msgid "Anvil of Fury"
+msgstr "Дьявольская Наковальня"
+
+#: Source/itemdat.cpp:70 Source/quests.cpp:49
+msgid "Black Mushroom"
+msgstr "Чёрный Гриб"
+
+#: Source/itemdat.cpp:71
+msgid "Brain"
+msgstr "Мозг"
+
+#: Source/itemdat.cpp:72
+msgid "Fungal Tome"
+msgstr "Грибной Фолиант"
+
+#: Source/itemdat.cpp:73
+msgid "Spectral Elixir"
+msgstr "Призрачный Эликсир"
+
+#: Source/itemdat.cpp:74
+msgid "Blood Stone"
+msgstr "Кровавый Камень"
+
+#: Source/itemdat.cpp:75
+msgid "Cathedral Map"
+msgstr "Карта Собора"
+
+#: Source/itemdat.cpp:76
+msgid "Heart"
+msgstr "Сердце"
+
+#: Source/itemdat.cpp:77 Source/itemdat.cpp:130
+msgid "Potion of Healing"
+msgstr "Зелье Исцеления"
+
+#: Source/itemdat.cpp:78 Source/itemdat.cpp:132
+msgid "Potion of Mana"
+msgstr "Зелье Маны"
+
+#: Source/itemdat.cpp:79 Source/itemdat.cpp:147
+msgid "Scroll of Identify"
+msgstr "Свиток Идентификации"
+
+#: Source/itemdat.cpp:80 Source/itemdat.cpp:151
+msgid "Scroll of Town Portal"
+msgstr "Свиток Портала в Город"
+
+#: Source/itemdat.cpp:81 Source/itemdat.cpp:441
+msgid "Arkaine's Valor"
+msgstr "Отвага Аркейна"
+
+#: Source/itemdat.cpp:82 Source/itemdat.cpp:131
+msgid "Potion of Full Healing"
+msgstr "Зелье Полного Исцеления"
+
+#: Source/itemdat.cpp:83 Source/itemdat.cpp:133
+msgid "Potion of Full Mana"
+msgstr "Зелье Полной Маны"
+
+#: Source/itemdat.cpp:84 Source/itemdat.cpp:442
+msgid "Griswold's Edge"
+msgstr "Лезвие Гризвольда"
+
+#: Source/itemdat.cpp:85 Source/itemdat.cpp:443
+msgid "Bovine Plate"
+msgstr "Бычьи Доспехи"
+
+#: Source/itemdat.cpp:86
+msgid "Staff of Lazarus"
+msgstr "Посох Лазаря"
+
+#: Source/itemdat.cpp:87 Source/itemdat.cpp:148
+msgid "Scroll of Resurrect"
+msgstr "Свиток Воскрешения"
+
+#: Source/itemdat.cpp:88 Source/itemdat.cpp:136 Source/items.cpp:180
 msgid "Blacksmith Oil"
 msgstr "Кузнечное Масло"
 
-#: Source/items.cpp:182
+#: Source/itemdat.cpp:89 Source/itemdat.cpp:204
+msgid "Short Staff"
+msgstr "Короткий Посох"
+
+#: Source/itemdat.cpp:90 Source/itemdat.cpp:172 Source/itemdat.cpp:173
+#: Source/itemdat.cpp:174 Source/itemdat.cpp:175 Source/itemdat.cpp:178
+#: Source/itemdat.cpp:179 Source/itemdat.cpp:180 Source/itemdat.cpp:181
+#: Source/itemdat.cpp:182
+msgid "Sword"
+msgstr "Меч"
+
+#: Source/itemdat.cpp:91 Source/itemdat.cpp:171
+msgid "Dagger"
+msgstr "Кинжал"
+
+#: Source/itemdat.cpp:92
+msgid "Rune Bomb"
+msgstr "Рунная Бомба"
+
+#: Source/itemdat.cpp:93
+msgid "Theodore"
+msgstr "Теодор"
+
+#: Source/itemdat.cpp:94
+msgid "Auric Amulet"
+msgstr "Золотой Амулет"
+
+#: Source/itemdat.cpp:95
+msgid "Torn Note 1"
+msgstr "Обрывок Записки 1"
+
+#: Source/itemdat.cpp:96
+msgid "Torn Note 2"
+msgstr "Обрывок Записки 2"
+
+#: Source/itemdat.cpp:97
+msgid "Torn Note 3"
+msgstr "Обрывок Записки 3"
+
+#: Source/itemdat.cpp:98
+msgid "Reconstructed Note"
+msgstr "Восстановленная Записка"
+
+#: Source/itemdat.cpp:99
+msgid "Brown Suit"
+msgstr "Коричневый Костюм"
+
+#: Source/itemdat.cpp:100
+msgid "Grey Suit"
+msgstr "Серый Костюм"
+
+#: Source/itemdat.cpp:101 Source/itemdat.cpp:102
+msgid "Cap"
+msgstr "Шапка"
+
+#: Source/itemdat.cpp:102
+msgid "Skull Cap"
+msgstr "Тюбетейка"
+
+#: Source/itemdat.cpp:103 Source/itemdat.cpp:104 Source/itemdat.cpp:106
+msgid "Helm"
+msgstr "Шлем"
+
+#: Source/itemdat.cpp:104
+msgid "Full Helm"
+msgstr "Закрытый Шлем"
+
+#: Source/itemdat.cpp:105
+msgid "Crown"
+msgstr "Корона"
+
+#: Source/itemdat.cpp:106
+msgid "Great Helm"
+msgstr "Большой Шлем"
+
+#: Source/itemdat.cpp:107
+msgid "Cape"
+msgstr "Плащ"
+
+#: Source/itemdat.cpp:108
+msgid "Rags"
+msgstr "Тряпьё"
+
+#: Source/itemdat.cpp:109
+msgid "Cloak"
+msgstr "Мантия"
+
+#: Source/itemdat.cpp:110
+msgid "Robe"
+msgstr "Роба"
+
+#: Source/itemdat.cpp:111
+msgid "Quilted Armor"
+msgstr "Стёганые Доспехи"
+
+#: Source/itemdat.cpp:111 Source/itemdat.cpp:112 Source/itemdat.cpp:113
+#: Source/itemdat.cpp:114 Source/objects.cpp:4964
+msgid "Armor"
+msgstr "Доспехи"
+
+#: Source/itemdat.cpp:112
+msgid "Leather Armor"
+msgstr "Кожаная Броня"
+
+#: Source/itemdat.cpp:113
+msgid "Hard Leather Armor"
+msgstr "Дублёная Кожаная Броня"
+
+#: Source/itemdat.cpp:114
+msgid "Studded Leather Armor"
+msgstr "Клёпаный Кожаный Доспех"
+
+#: Source/itemdat.cpp:115
+msgid "Ring Mail"
+msgstr "Кольцевая Кольчуга"
+
+#: Source/itemdat.cpp:115 Source/itemdat.cpp:116 Source/itemdat.cpp:117
+#: Source/itemdat.cpp:119
+msgid "Mail"
+msgstr "Кольчуга"
+
+#: Source/itemdat.cpp:116
+msgid "Chain Mail"
+msgstr "Кольчатая Кольчуга"
+
+#: Source/itemdat.cpp:117
+msgid "Scale Mail"
+msgstr "Чешуйчатая Кольчуга"
+
+#: Source/itemdat.cpp:118
+msgid "Breast Plate"
+msgstr "Нагрудник"
+
+#: Source/itemdat.cpp:118 Source/itemdat.cpp:120 Source/itemdat.cpp:121
+#: Source/itemdat.cpp:122 Source/itemdat.cpp:123
+msgid "Plate"
+msgstr "Латы"
+
+#: Source/itemdat.cpp:119
+msgid "Splint Mail"
+msgstr "Шинная Кольчуга"
+
+#: Source/itemdat.cpp:120
+msgid "Plate Mail"
+msgstr "Пластинчатый Доспех"
+
+#: Source/itemdat.cpp:121
+msgid "Field Plate"
+msgstr "Полевая Пластина"
+
+#: Source/itemdat.cpp:122
+msgid "Gothic Plate"
+msgstr "Готическая Пластина"
+
+#: Source/itemdat.cpp:123
+msgid "Full Plate Mail"
+msgstr "Полная Пластинчатая Кольчуга"
+
+#: Source/itemdat.cpp:124 Source/itemdat.cpp:125 Source/itemdat.cpp:126
+#: Source/itemdat.cpp:127 Source/itemdat.cpp:128 Source/itemdat.cpp:129
+msgid "Shield"
+msgstr "Щит"
+
+#: Source/itemdat.cpp:125
+msgid "Small Shield"
+msgstr "Маленький Щит"
+
+#: Source/itemdat.cpp:126
+msgid "Large Shield"
+msgstr "Большой Щит"
+
+#: Source/itemdat.cpp:127
+msgid "Kite Shield"
+msgstr "Треугольный Щит"
+
+#: Source/itemdat.cpp:128
+msgid "Tower Shield"
+msgstr "Башенный Щит"
+
+#: Source/itemdat.cpp:129
+msgid "Gothic Shield"
+msgstr "Готический Щит"
+
+#: Source/itemdat.cpp:134
+msgid "Potion of Rejuvenation"
+msgstr "Зелье Омоложения"
+
+#: Source/itemdat.cpp:135
+msgid "Potion of Full Rejuvenation"
+msgstr "Зелье Полного Омоложения"
+
+#: Source/itemdat.cpp:137 Source/items.cpp:175
+msgid "Oil of Accuracy"
+msgstr "Масло Точности"
+
+#: Source/itemdat.cpp:138 Source/items.cpp:177
+msgid "Oil of Sharpness"
+msgstr "Масло Остроты"
+
+#: Source/itemdat.cpp:139
+msgid "Oil"
+msgstr "Масло"
+
+#: Source/itemdat.cpp:140
+msgid "Elixir of Strength"
+msgstr "Эликсир Силы"
+
+#: Source/itemdat.cpp:141
+msgid "Elixir of Magic"
+msgstr "Эликсир Магии"
+
+#: Source/itemdat.cpp:142
+msgid "Elixir of Dexterity"
+msgstr "Эликсир Ловкости"
+
+#: Source/itemdat.cpp:143
+msgid "Elixir of Vitality"
+msgstr "Эликсир Живучести"
+
+#: Source/itemdat.cpp:144
+msgid "Scroll of Healing"
+msgstr "Свиток Исцеления"
+
+#: Source/itemdat.cpp:145
+msgid "Scroll of Search"
+msgstr "Свиток Поиска"
+
+#: Source/itemdat.cpp:146
+msgid "Scroll of Lightning"
+msgstr "Свиток Молнии"
+
+#: Source/itemdat.cpp:149
+msgid "Scroll of Fire Wall"
+msgstr "Свиток Стены Огня"
+
+#: Source/itemdat.cpp:150
+msgid "Scroll of Inferno"
+msgstr "Свиток Преисподней"
+
+#: Source/itemdat.cpp:152
+msgid "Scroll of Flash"
+msgstr "Свиток Вспышки"
+
+#: Source/itemdat.cpp:153
+msgid "Scroll of Infravision"
+msgstr "Свиток Инфразрения"
+
+#: Source/itemdat.cpp:154
+msgid "Scroll of Phasing"
+msgstr "Свиток Перемещения"
+
+#: Source/itemdat.cpp:155
+msgid "Scroll of Mana Shield"
+msgstr "Свиток Щита Маны"
+
+#: Source/itemdat.cpp:156
+msgid "Scroll of Flame Wave"
+msgstr "Свиток Волны Огня"
+
+#: Source/itemdat.cpp:157
+msgid "Scroll of Fireball"
+msgstr "Свиток Огненного Шара"
+
+#: Source/itemdat.cpp:158
+msgid "Scroll of Stone Curse"
+msgstr "Свиток Окаменения"
+
+#: Source/itemdat.cpp:159
+msgid "Scroll of Chain Lightning"
+msgstr "Свиток Цепной Молнии"
+
+#: Source/itemdat.cpp:160
+msgid "Scroll of Guardian"
+msgstr "Свиток Защитника"
+
+#: Source/itemdat.cpp:162
+msgid "Scroll of Nova"
+msgstr "Свиток Новы"
+
+#: Source/itemdat.cpp:163
+msgid "Scroll of Golem"
+msgstr "Свиток Голема"
+
+#: Source/itemdat.cpp:165
+msgid "Scroll of Teleport"
+msgstr "Свиток Телепорта"
+
+#: Source/itemdat.cpp:166
+msgid "Scroll of Apocalypse"
+msgstr "Свиток Апокалипсиса"
+
+#: Source/itemdat.cpp:167 Source/itemdat.cpp:168 Source/itemdat.cpp:169
+#: Source/itemdat.cpp:170
+#, fuzzy
+#| msgid "Book of {:s}"
+msgid "Book of "
+msgstr "Книга {:s}"
+
+#: Source/itemdat.cpp:173
+msgid "Falchion"
+msgstr "Фальшион"
+
+#: Source/itemdat.cpp:174
+msgid "Scimitar"
+msgstr "Ятаган"
+
+#: Source/itemdat.cpp:175
+msgid "Claymore"
+msgstr "Клеймор"
+
+#: Source/itemdat.cpp:176
+msgid "Blade"
+msgstr "Клинок"
+
+#: Source/itemdat.cpp:177
+msgid "Sabre"
+msgstr "Сабля"
+
+#: Source/itemdat.cpp:178
+msgid "Long Sword"
+msgstr "Длинный Меч"
+
+#: Source/itemdat.cpp:179
+msgid "Broad Sword"
+msgstr "Широкий Меч"
+
+#: Source/itemdat.cpp:180
+msgid "Bastard Sword"
+msgstr "Полуторный Меч"
+
+#: Source/itemdat.cpp:181
+msgid "Two-Handed Sword"
+msgstr "Двуручный Меч"
+
+#: Source/itemdat.cpp:182
+msgid "Great Sword"
+msgstr "Великий Меч"
+
+#: Source/itemdat.cpp:183
+msgid "Small Axe"
+msgstr "Маленький Топор"
+
+#: Source/itemdat.cpp:183 Source/itemdat.cpp:184 Source/itemdat.cpp:185
+#: Source/itemdat.cpp:186 Source/itemdat.cpp:187 Source/itemdat.cpp:188
+msgid "Axe"
+msgstr "Топор"
+
+#: Source/itemdat.cpp:185
+msgid "Large Axe"
+msgstr "Большой Топор"
+
+#: Source/itemdat.cpp:186
+msgid "Broad Axe"
+msgstr "Широкий Топор"
+
+#: Source/itemdat.cpp:187
+msgid "Battle Axe"
+msgstr "Боевой Топор"
+
+#: Source/itemdat.cpp:188
+msgid "Great Axe"
+msgstr "Двуручный Топор"
+
+#: Source/itemdat.cpp:189 Source/itemdat.cpp:190
+msgid "Mace"
+msgstr "Булава"
+
+#: Source/itemdat.cpp:190
+msgid "Morning Star"
+msgstr "Моргенштерн"
+
+#: Source/itemdat.cpp:191
+msgid "War Hammer"
+msgstr "Боевой Молот"
+
+#: Source/itemdat.cpp:191
+msgid "Hammer"
+msgstr "Молот"
+
+#: Source/itemdat.cpp:192
+msgid "Spiked Club"
+msgstr "Шипованная Дубина"
+
+#: Source/itemdat.cpp:194
+msgid "Flail"
+msgstr "Цеп"
+
+#: Source/itemdat.cpp:195
+msgid "Maul"
+msgstr "Кувалда"
+
+#: Source/itemdat.cpp:196 Source/itemdat.cpp:197 Source/itemdat.cpp:198
+#: Source/itemdat.cpp:199 Source/itemdat.cpp:200 Source/itemdat.cpp:201
+#: Source/itemdat.cpp:202 Source/itemdat.cpp:203
+msgid "Bow"
+msgstr "Лук"
+
+#: Source/itemdat.cpp:197
+msgid "Hunter's Bow"
+msgstr "Охотничий Лук"
+
+#: Source/itemdat.cpp:198
+msgid "Long Bow"
+msgstr "Длинный Лук"
+
+#: Source/itemdat.cpp:199
+msgid "Composite Bow"
+msgstr "Композитный Лук"
+
+#: Source/itemdat.cpp:200
+msgid "Short Battle Bow"
+msgstr "Короткий Боевой Лук"
+
+#: Source/itemdat.cpp:201
+msgid "Long Battle Bow"
+msgstr "Длинный Боевой Лук"
+
+#: Source/itemdat.cpp:202
+msgid "Short War Bow"
+msgstr "Короткий Военный Лук"
+
+#: Source/itemdat.cpp:203
+msgid "Long War Bow"
+msgstr "Длинный Военный Лук"
+
+#: Source/itemdat.cpp:204 Source/itemdat.cpp:205 Source/itemdat.cpp:206
+#: Source/itemdat.cpp:207 Source/itemdat.cpp:208
+#: Source/panels/spell_list.cpp:183
+msgid "Staff"
+msgstr "Посох"
+
+#: Source/itemdat.cpp:205
+msgid "Long Staff"
+msgstr "Длинный Посох"
+
+#: Source/itemdat.cpp:206
+msgid "Composite Staff"
+msgstr "Композитный Посох"
+
+#: Source/itemdat.cpp:207
+msgid "Quarter Staff"
+msgstr "Короткий Посох"
+
+#: Source/itemdat.cpp:208
+msgid "War Staff"
+msgstr "Военный Посох"
+
+#: Source/itemdat.cpp:209 Source/itemdat.cpp:210 Source/itemdat.cpp:211
+msgid "Ring"
+msgstr "Кольцо"
+
+#: Source/itemdat.cpp:212 Source/itemdat.cpp:213
+msgid "Amulet"
+msgstr "Амулет"
+
+#: Source/itemdat.cpp:214
+msgid "Rune of Fire"
+msgstr "Руна Огня"
+
+#: Source/itemdat.cpp:214 Source/itemdat.cpp:215 Source/itemdat.cpp:216
+#: Source/itemdat.cpp:217 Source/itemdat.cpp:218
+msgid "Rune"
+msgstr "Руна"
+
+#: Source/itemdat.cpp:215
+msgid "Rune of Lightning"
+msgstr "Руна Молнии"
+
+#: Source/itemdat.cpp:216
+msgid "Greater Rune of Fire"
+msgstr "Великая Руна Огня"
+
+#: Source/itemdat.cpp:217
+msgid "Greater Rune of Lightning"
+msgstr "Великая Руна Молнии"
+
+#: Source/itemdat.cpp:218
+msgid "Rune of Stone"
+msgstr "Руна Камня"
+
+#: Source/itemdat.cpp:219
+msgid "Short Staff of Charged Bolt"
+msgstr "Короткий Посох Заряженной Стрелы"
+
+#: Source/itemdat.cpp:220
+msgid "Arena Potion"
+msgstr "Зелье Арены"
+
+# Хотелось бы как-то добавить средний и женский род для всех последующих слов до Doppelganger's включительно. Оловянный дубина/кольцо
+#. TRANSLATORS: Item prefix section.
+#: Source/itemdat.cpp:230
+msgid "Tin"
+msgstr "Оловянный"
+
+#: Source/itemdat.cpp:231
+msgid "Brass"
+msgstr "Латунный"
+
+#: Source/itemdat.cpp:232
+msgid "Bronze"
+msgstr "Бронзовый"
+
+#: Source/itemdat.cpp:233
+msgid "Iron"
+msgstr "Железный"
+
+#: Source/itemdat.cpp:234
+msgid "Steel"
+msgstr "Стальной"
+
+#: Source/itemdat.cpp:235
+msgid "Silver"
+msgstr "Серебряный"
+
+#: Source/itemdat.cpp:237
+msgid "Platinum"
+msgstr "Платиновый"
+
+#: Source/itemdat.cpp:238
+msgid "Mithril"
+msgstr "Мифриловый"
+
+#: Source/itemdat.cpp:239
+msgid "Meteoric"
+msgstr "Метеоритный"
+
+#: Source/itemdat.cpp:240 Source/objects.cpp:124
+msgid "Weird"
+msgstr "Причудливый"
+
+#: Source/itemdat.cpp:241
+msgid "Strange"
+msgstr "Странный"
+
+#: Source/itemdat.cpp:242
+msgid "Useless"
+msgstr "Бесполезный"
+
+#: Source/itemdat.cpp:243
+msgid "Bent"
+msgstr "Согнутый"
+
+#: Source/itemdat.cpp:244
+msgid "Weak"
+msgstr "Хлипкий"
+
+#: Source/itemdat.cpp:245
+msgid "Jagged"
+msgstr "Зубчатый"
+
+#: Source/itemdat.cpp:246
+msgid "Deadly"
+msgstr "Смертоносный"
+
+#: Source/itemdat.cpp:247
+msgid "Heavy"
+msgstr "Тяжелый"
+
+#: Source/itemdat.cpp:248
+msgid "Vicious"
+msgstr "Порочный"
+
+#: Source/itemdat.cpp:249
+msgid "Brutal"
+msgstr "Жестокий"
+
+#: Source/itemdat.cpp:250
+msgid "Massive"
+msgstr "Массивный"
+
+#: Source/itemdat.cpp:251
+msgid "Savage"
+msgstr "Дикий"
+
+#: Source/itemdat.cpp:252
+msgid "Ruthless"
+msgstr "Беспощадный"
+
+#: Source/itemdat.cpp:253
+msgid "Merciless"
+msgstr "Безжалостный"
+
+#: Source/itemdat.cpp:254
+msgid "Clumsy"
+msgstr "Неуклюжий"
+
+#: Source/itemdat.cpp:255
+msgid "Dull"
+msgstr "Тупой"
+
+#: Source/itemdat.cpp:256
+msgid "Sharp"
+msgstr "Острый"
+
+#: Source/itemdat.cpp:257 Source/itemdat.cpp:267
+msgid "Fine"
+msgstr "Изящный"
+
+#: Source/itemdat.cpp:258
+msgid "Warrior's"
+msgstr "Воинский"
+
+#: Source/itemdat.cpp:259
+msgid "Soldier's"
+msgstr "Солдатский"
+
+# Лордский...
+# ---------------------------------------------
+# Тут либо "господский", либо "властелинский".
+#: Source/itemdat.cpp:260
+msgid "Lord's"
+msgstr "Господский"
+
+#: Source/itemdat.cpp:261
+msgid "Knight's"
+msgstr "Рыцарский"
+
+#: Source/itemdat.cpp:262
+msgid "Master's"
+msgstr "Мастерский"
+
+#: Source/itemdat.cpp:263
+msgid "Champion's"
+msgstr "Чемпионский"
+
+#: Source/itemdat.cpp:264
+msgid "King's"
+msgstr "Королевский"
+
+#: Source/itemdat.cpp:265
+msgid "Vulnerable"
+msgstr "Уязвимый"
+
+#: Source/itemdat.cpp:266
+msgid "Rusted"
+msgstr "Ржавый"
+
+#: Source/itemdat.cpp:268
+msgid "Strong"
+msgstr "Сильный"
+
+#: Source/itemdat.cpp:269
+msgid "Grand"
+msgstr "Великий"
+
+#: Source/itemdat.cpp:270
+msgid "Valiant"
+msgstr "Доблестный"
+
+#: Source/itemdat.cpp:271
+msgid "Glorious"
+msgstr "Великолепный"
+
+#: Source/itemdat.cpp:272
+msgid "Blessed"
+msgstr "Благославенный"
+
+#: Source/itemdat.cpp:273
+msgid "Saintly"
+msgstr "Освящённый"
+
+#: Source/itemdat.cpp:274
+msgid "Awesome"
+msgstr "Устрашающий"
+
+#: Source/itemdat.cpp:275 Source/objects.cpp:136
+msgid "Holy"
+msgstr "Святой"
+
+#: Source/itemdat.cpp:276
+msgid "Godly"
+msgstr "Благочестивый"
+
+#: Source/itemdat.cpp:277
+msgid "Red"
+msgstr "Красный"
+
+#: Source/itemdat.cpp:278 Source/itemdat.cpp:279
+msgid "Crimson"
+msgstr "Багровый"
+
+#: Source/itemdat.cpp:280
+msgid "Garnet"
+msgstr "Гранатовый"
+
+#: Source/itemdat.cpp:281
+msgid "Ruby"
+msgstr "Рубиновый"
+
+#: Source/itemdat.cpp:282
+msgid "Blue"
+msgstr "Голубой"
+
+#: Source/itemdat.cpp:283
+msgid "Azure"
+msgstr "Лазурный"
+
+#: Source/itemdat.cpp:284
+msgid "Lapis"
+msgstr "Лазуритовый"
+
+#: Source/itemdat.cpp:285
+msgid "Cobalt"
+msgstr "Кобальтовый"
+
+#: Source/itemdat.cpp:286
+msgid "Sapphire"
+msgstr "Сапфировый"
+
+#: Source/itemdat.cpp:287
+msgid "White"
+msgstr "Белый"
+
+#: Source/itemdat.cpp:288
+msgid "Pearl"
+msgstr "Жемчужный"
+
+#: Source/itemdat.cpp:289
+msgid "Ivory"
+msgstr "Слоновой Кости"
+
+#: Source/itemdat.cpp:290
+msgid "Crystal"
+msgstr "Кристальный"
+
+#: Source/itemdat.cpp:291
+msgid "Diamond"
+msgstr "Алмазный"
+
+#: Source/itemdat.cpp:292
+msgid "Topaz"
+msgstr "Топазовый"
+
+#: Source/itemdat.cpp:293
+msgid "Amber"
+msgstr "Янтарный"
+
+#: Source/itemdat.cpp:294
+msgid "Jade"
+msgstr "Нефритовый"
+
+#: Source/itemdat.cpp:295
+msgid "Obsidian"
+msgstr "Обсидиановый"
+
+#: Source/itemdat.cpp:296
+msgid "Emerald"
+msgstr "Изумрудный"
+
+#: Source/itemdat.cpp:297
+msgid "Hyena's"
+msgstr "Гиений"
+
+#: Source/itemdat.cpp:298
+msgid "Frog's"
+msgstr "Лягушачий"
+
+#: Source/itemdat.cpp:299
+msgid "Spider's"
+msgstr "Паучий"
+
+#: Source/itemdat.cpp:300
+msgid "Raven's"
+msgstr "Вороний"
+
+#: Source/itemdat.cpp:301
+msgid "Snake's"
+msgstr "Змеиный"
+
+#: Source/itemdat.cpp:302
+msgid "Serpent's"
+msgstr "Гадючий"
+
+#: Source/itemdat.cpp:303
+msgid "Drake's"
+msgstr "Змиевый"
+
+#: Source/itemdat.cpp:304
+msgid "Dragon's"
+msgstr "Драконий"
+
+#: Source/itemdat.cpp:305
+msgid "Wyrm's"
+msgstr "Змеевой"
+
+#: Source/itemdat.cpp:306
+msgid "Hydra's"
+msgstr "Гидры"
+
+#: Source/itemdat.cpp:307
+msgid "Angel's"
+msgstr "Ангельский"
+
+#: Source/itemdat.cpp:308
+msgid "Arch-Angel's"
+msgstr "Архангельский"
+
+#: Source/itemdat.cpp:309
+msgid "Plentiful"
+msgstr "Богатый"
+
+#: Source/itemdat.cpp:310
+msgid "Bountiful"
+msgstr "Щедрый"
+
+#: Source/itemdat.cpp:311
+msgid "Flaming"
+msgstr "Пылающий"
+
+#: Source/itemdat.cpp:312
+msgid "Lightning"
+msgstr "Светящийся"
+
+#: Source/itemdat.cpp:313
+msgid "Jester's"
+msgstr "Шутовской"
+
+#: Source/itemdat.cpp:314
+msgid "Crystalline"
+msgstr "Кристаллический"
+
+#. TRANSLATORS: Item prefix section end.
+#: Source/itemdat.cpp:316
+msgid "Doppelganger's"
+msgstr "Двойникский"
+
+#. TRANSLATORS: Item suffix section. All items will have a word binding word. (Format: {:s} of {:s} - e.g. Rags of Valor)
+#: Source/itemdat.cpp:326
+msgid "quality"
+msgstr "качества"
+
+#: Source/itemdat.cpp:327
+msgid "maiming"
+msgstr "увеличения"
+
+#: Source/itemdat.cpp:328
+msgid "slaying"
+msgstr "убийства"
+
+# крови уже есть, если есть адекватный перевод, меняйте немедленно
+# ---------------------------------------------
+# Научное название запёкшейся крови – струп.
+#: Source/itemdat.cpp:329
+msgid "gore"
+msgstr "струпа"
+
+#: Source/itemdat.cpp:330
+msgid "carnage"
+msgstr "бойни"
+
+#: Source/itemdat.cpp:331
+msgid "slaughter"
+msgstr "резни"
+
+#: Source/itemdat.cpp:332
+msgid "pain"
+msgstr "боли"
+
+#: Source/itemdat.cpp:333
+msgid "tears"
+msgstr "слёз"
+
+#: Source/itemdat.cpp:334
+msgid "health"
+msgstr "здоровья"
+
+#: Source/itemdat.cpp:335
+msgid "protection"
+msgstr "защиты"
+
+#: Source/itemdat.cpp:336
+msgid "absorption"
+msgstr "поглощения"
+
+#: Source/itemdat.cpp:337
+msgid "deflection"
+msgstr "отклонения"
+
+#: Source/itemdat.cpp:338
+msgid "osmosis"
+msgstr "осмоса"
+
+#: Source/itemdat.cpp:339
+msgid "frailty"
+msgstr "хрупкости"
+
+#: Source/itemdat.cpp:340
+msgid "weakness"
+msgstr "слабости"
+
+#: Source/itemdat.cpp:341
+msgid "strength"
+msgstr "силы"
+
+#: Source/itemdat.cpp:342
+msgid "might"
+msgstr "мощи"
+
+#: Source/itemdat.cpp:343
+msgid "power"
+msgstr "могущества"
+
+#: Source/itemdat.cpp:344
+msgid "giants"
+msgstr "гигантов"
+
+#: Source/itemdat.cpp:345
+msgid "titans"
+msgstr "титанов"
+
+#: Source/itemdat.cpp:346
+msgid "paralysis"
+msgstr "паралича"
+
+#: Source/itemdat.cpp:347
+msgid "atrophy"
+msgstr "атрофии"
+
+#: Source/itemdat.cpp:348
+msgid "dexterity"
+msgstr "ловкости"
+
+#: Source/itemdat.cpp:349
+msgid "skill"
+msgstr "умения"
+
+#: Source/itemdat.cpp:350
+msgid "accuracy"
+msgstr "меткости"
+
+#: Source/itemdat.cpp:351
+msgid "precision"
+msgstr "точности"
+
+#: Source/itemdat.cpp:352
+msgid "perfection"
+msgstr "совершенства"
+
+#: Source/itemdat.cpp:353
+msgid "the fool"
+msgstr "дурака"
+
+#: Source/itemdat.cpp:354
+msgid "dyslexia"
+msgstr "дислексии"
+
+#: Source/itemdat.cpp:355
+msgid "magic"
+msgstr "магии"
+
+#: Source/itemdat.cpp:356
+msgid "the mind"
+msgstr "разума"
+
+#: Source/itemdat.cpp:357
+msgid "brilliance"
+msgstr "блеска"
+
+#: Source/itemdat.cpp:358
+msgid "sorcery"
+msgstr "колдовства"
+
+#: Source/itemdat.cpp:359
+msgid "wizardry"
+msgstr "волшебства"
+
+#: Source/itemdat.cpp:360
+msgid "illness"
+msgstr "хвори"
+
+#: Source/itemdat.cpp:361
+msgid "disease"
+msgstr "болезни"
+
+#: Source/itemdat.cpp:362
+msgid "vitality"
+msgstr "живучести"
+
+# Change at will
+#: Source/itemdat.cpp:363
+msgid "zest"
+msgstr "жара"
+
+#: Source/itemdat.cpp:364
+msgid "vim"
+msgstr "напора"
+
+#: Source/itemdat.cpp:365
+msgid "vigor"
+msgstr "силы"
+
+#: Source/itemdat.cpp:366
+msgid "life"
+msgstr "жизни"
+
+#: Source/itemdat.cpp:367
+msgid "trouble"
+msgstr "неприятности"
+
+#: Source/itemdat.cpp:368
+msgid "the pit"
+msgstr "ямы"
+
+#: Source/itemdat.cpp:369
+msgid "the sky"
+msgstr "небес"
+
+#: Source/itemdat.cpp:370
+msgid "the moon"
+msgstr "луны"
+
+#: Source/itemdat.cpp:371
+msgid "the stars"
+msgstr "звёзд"
+
+#: Source/itemdat.cpp:372
+msgid "the heavens"
+msgstr "небес"
+
+#: Source/itemdat.cpp:373
+msgid "the zodiac"
+msgstr "зодиака"
+
+#: Source/itemdat.cpp:374
+msgid "the vulture"
+msgstr "стервятника"
+
+#: Source/itemdat.cpp:375
+msgid "the jackal"
+msgstr "шакала"
+
+#: Source/itemdat.cpp:376
+msgid "the fox"
+msgstr "лисы"
+
+#: Source/itemdat.cpp:377
+msgid "the jaguar"
+msgstr "ягуара"
+
+#: Source/itemdat.cpp:378
+msgid "the eagle"
+msgstr "орла"
+
+#: Source/itemdat.cpp:379
+msgid "the wolf"
+msgstr "волка"
+
+#: Source/itemdat.cpp:380
+msgid "the tiger"
+msgstr "тигра"
+
+#: Source/itemdat.cpp:381
+msgid "the lion"
+msgstr "льва"
+
+#: Source/itemdat.cpp:382
+msgid "the mammoth"
+msgstr "мамонта"
+
+#: Source/itemdat.cpp:383
+msgid "the whale"
+msgstr "кита"
+
+#: Source/itemdat.cpp:384
+msgid "fragility"
+msgstr "хрупкости"
+
+#: Source/itemdat.cpp:385
+msgid "brittleness"
+msgstr "ломкости"
+
+#: Source/itemdat.cpp:386
+msgid "sturdiness"
+msgstr "прочности"
+
+#: Source/itemdat.cpp:387
+msgid "craftsmanship"
+msgstr "мастерства"
+
+#: Source/itemdat.cpp:388
+msgid "structure"
+msgstr "структуры"
+
+#: Source/itemdat.cpp:389
+msgid "the ages"
+msgstr "веков"
+
+#: Source/itemdat.cpp:390
+msgid "the dark"
+msgstr "тьмы"
+
+#: Source/itemdat.cpp:391
+msgid "the night"
+msgstr "ночи"
+
+#: Source/itemdat.cpp:392
+msgid "light"
+msgstr "света"
+
+#: Source/itemdat.cpp:393
+msgid "radiance"
+msgstr "сияния"
+
+#: Source/itemdat.cpp:394
+msgid "flame"
+msgstr "пламени"
+
+#: Source/itemdat.cpp:395
+msgid "fire"
+msgstr "огня"
+
+#: Source/itemdat.cpp:396
+msgid "burning"
+msgstr "горения"
+
+#: Source/itemdat.cpp:397
+msgid "shock"
+msgstr "шока"
+
+#: Source/itemdat.cpp:398
+msgid "lightning"
+msgstr "молнии"
+
+#: Source/itemdat.cpp:399
+msgid "thunder"
+msgstr "грома"
+
+#: Source/itemdat.cpp:400
+msgid "many"
+msgstr "множества"
+
+#: Source/itemdat.cpp:401
+msgid "plenty"
+msgstr "достатка"
+
+#: Source/itemdat.cpp:402
+msgid "thorns"
+msgstr "шипов"
+
+# коррупции - слишком в духе уголовного кодекса
+#: Source/itemdat.cpp:403
+msgid "corruption"
+msgstr "разложения"
+
+#: Source/itemdat.cpp:404
+msgid "thieves"
+msgstr "воров"
+
+#: Source/itemdat.cpp:405
+msgid "the bear"
+msgstr "медведя"
+
+#: Source/itemdat.cpp:406
+msgid "the bat"
+msgstr "летучей мыши"
+
+#: Source/itemdat.cpp:407
+msgid "vampires"
+msgstr "вампиров"
+
+#: Source/itemdat.cpp:408
+msgid "the leech"
+msgstr "пиявки"
+
+#: Source/itemdat.cpp:409
+msgid "blood"
+msgstr "крови"
+
+#: Source/itemdat.cpp:410
+msgid "piercing"
+msgstr "протыкания"
+
+#: Source/itemdat.cpp:411
+msgid "puncturing"
+msgstr "прокалывания"
+
+#: Source/itemdat.cpp:412
+msgid "bashing"
+msgstr "избиения"
+
+#: Source/itemdat.cpp:413
+msgid "readiness"
+msgstr "готовности"
+
+#: Source/itemdat.cpp:414
+msgid "swiftness"
+msgstr "стремительности"
+
+#: Source/itemdat.cpp:415
+msgid "speed"
+msgstr "скорости"
+
+#: Source/itemdat.cpp:416
+msgid "haste"
+msgstr "спешки"
+
+#: Source/itemdat.cpp:417
+msgid "balance"
+msgstr "баланса"
+
+#: Source/itemdat.cpp:418
+msgid "stability"
+msgstr "стабильности"
+
+#: Source/itemdat.cpp:419
+msgid "harmony"
+msgstr "гармонии"
+
+#: Source/itemdat.cpp:420
+msgid "blocking"
+msgstr "блокирования"
+
+#: Source/itemdat.cpp:421
+msgid "devastation"
+msgstr "опустошения"
+
+#: Source/itemdat.cpp:422
+msgid "decay"
+msgstr "разложения"
+
+#. TRANSLATORS: Item suffix section end.
+#: Source/itemdat.cpp:424
+msgid "peril"
+msgstr "опасности"
+
+#. TRANSLATORS: Unique Item section
+#: Source/itemdat.cpp:434
+msgid "The Butcher's Cleaver"
+msgstr "Тесак Мясника"
+
+#: Source/itemdat.cpp:444
+msgid "The Rift Bow"
+msgstr "Лук Разлома"
+
+#: Source/itemdat.cpp:445
+msgid "The Needler"
+msgstr "Игольщик"
+
+#: Source/itemdat.cpp:446
+msgid "The Celestial Bow"
+msgstr "Небесный Лук"
+
+#: Source/itemdat.cpp:447
+msgid "Deadly Hunter"
+msgstr "Смертоносный Охотник"
+
+#: Source/itemdat.cpp:448
+msgid "Bow of the Dead"
+msgstr "Лук Мёртвых"
+
+#: Source/itemdat.cpp:449
+msgid "The Blackoak Bow"
+msgstr "Лук из Чёрного Дуба"
+
+#: Source/itemdat.cpp:450
+msgid "Flamedart"
+msgstr "Пламенный Дротик"
+
+#: Source/itemdat.cpp:451
+msgid "Fleshstinger"
+msgstr "Жало Плоти"
+
+#: Source/itemdat.cpp:452
+msgid "Windforce"
+msgstr "Сила Ветра"
+
+#: Source/itemdat.cpp:453
+msgid "Eaglehorn"
+msgstr "Орлиный Рог"
+
+#: Source/itemdat.cpp:454
+msgid "Gonnagal's Dirk"
+msgstr "Кортик Гоннагала"
+
+#: Source/itemdat.cpp:455
+msgid "The Defender"
+msgstr "Защитник"
+
+#: Source/itemdat.cpp:456
+msgid "Gryphon's Claw"
+msgstr "Коготь Грифона"
+
+#: Source/itemdat.cpp:457
+msgid "Black Razor"
+msgstr "Чёрная Бритва"
+
+#: Source/itemdat.cpp:458
+msgid "Gibbous Moon"
+msgstr "Лучезарная Луна"
+
+#: Source/itemdat.cpp:459
+msgid "Ice Shank"
+msgstr "Ледяной Хвостовик"
+
+#: Source/itemdat.cpp:460
+msgid "The Executioner's Blade"
+msgstr "Клинок Палача"
+
+#: Source/itemdat.cpp:461
+msgid "The Bonesaw"
+msgstr "Костепил"
+
+#: Source/itemdat.cpp:462
+msgid "Shadowhawk"
+msgstr "Теневой Ястреб"
+
+#: Source/itemdat.cpp:463
+msgid "Wizardspike"
+msgstr "Волшебный Шип"
+
+#: Source/itemdat.cpp:464
+msgid "Lightsabre"
+msgstr "Световой Меч"
+
+#: Source/itemdat.cpp:465
+msgid "The Falcon's Talon"
+msgstr "Коготь Сокола"
+
+#: Source/itemdat.cpp:466
+msgid "Inferno"
+msgstr "Преисподняя"
+
+#: Source/itemdat.cpp:467
+msgid "Doombringer"
+msgstr "Несущий Гибель"
+
+#: Source/itemdat.cpp:468
+msgid "The Grizzly"
+msgstr "Гризли"
+
+#: Source/itemdat.cpp:469
+msgid "The Grandfather"
+msgstr "Дедушка"
+
+#: Source/itemdat.cpp:470
+msgid "The Mangler"
+msgstr "Увечитель"
+
+#: Source/itemdat.cpp:471
+msgid "Sharp Beak"
+msgstr "Острый Клюв"
+
+#: Source/itemdat.cpp:472
+msgid "BloodSlayer"
+msgstr "Кровоубийца"
+
+#: Source/itemdat.cpp:473
+msgid "The Celestial Axe"
+msgstr "Небесный Топор"
+
+#: Source/itemdat.cpp:474
+msgid "Wicked Axe"
+msgstr "Злой Топор"
+
+#: Source/itemdat.cpp:475
+msgid "Stonecleaver"
+msgstr "Каменный Тесак"
+
+# I'm pretty sure it pronounced as "Агинара", not "Агуинара".
+# ---------------------------------------------
+# Так и есть.
+#: Source/itemdat.cpp:476
+msgid "Aguinara's Hatchet"
+msgstr "Топор Агинары"
+
+#: Source/itemdat.cpp:477
+msgid "Hellslayer"
+msgstr "Адский Убийца"
+
+#: Source/itemdat.cpp:478
+msgid "Messerschmidt's Reaver"
+msgstr "Разоритель Мессершмидта"
+
+#: Source/itemdat.cpp:479
+msgid "Crackrust"
+msgstr "Трещины Ржавчины"
+
+#: Source/itemdat.cpp:480
+msgid "Hammer of Jholm"
+msgstr "Молот Джхольма"
+
+#: Source/itemdat.cpp:481
+msgid "Civerb's Cudgel"
+msgstr "Дубинка Сиверба"
+
+#: Source/itemdat.cpp:482
+msgid "The Celestial Star"
+msgstr "Небесная Звезда"
+
+#: Source/itemdat.cpp:483
+msgid "Baranar's Star"
+msgstr "Звезда Баранара"
+
+#: Source/itemdat.cpp:484
+msgid "Gnarled Root"
+msgstr "Корявый Корень"
+
+#: Source/itemdat.cpp:485
+msgid "The Cranium Basher"
+msgstr "Черепобойник"
+
+#: Source/itemdat.cpp:486
+msgid "Schaefer's Hammer"
+msgstr "Молот Шефера"
+
+#: Source/itemdat.cpp:487
+msgid "Dreamflange"
+msgstr "Кромка Грёз"
+
+#: Source/itemdat.cpp:488
+msgid "Staff of Shadows"
+msgstr "Посох Теней"
+
+#: Source/itemdat.cpp:489
+msgid "Immolator"
+msgstr "Поджигатель"
+
+#: Source/itemdat.cpp:490
+msgid "Storm Spire"
+msgstr "Острие Бури"
+
+#: Source/itemdat.cpp:491
+msgid "Gleamsong"
+msgstr "Мерцающая Песнь"
+
+#: Source/itemdat.cpp:492
+msgid "Thundercall"
+msgstr "Громовой Зов"
+
+#: Source/itemdat.cpp:493
+msgid "The Protector"
+msgstr "Защитник"
+
+#: Source/itemdat.cpp:494
+msgid "Naj's Puzzler"
+msgstr "Головоломка Наджа"
+
+#: Source/itemdat.cpp:495
+msgid "Mindcry"
+msgstr "Крик Разума"
+
+#: Source/itemdat.cpp:496
+msgid "Rod of Onan"
+msgstr "Жезл Онана"
+
+#: Source/itemdat.cpp:497
+msgid "Helm of Spirits"
+msgstr "Шлем Духов"
+
+#: Source/itemdat.cpp:498
+msgid "Thinking Cap"
+msgstr "Шапка Размышлений"
+
+#: Source/itemdat.cpp:499
+msgid "OverLord's Helm"
+msgstr "Шлем Владыки"
+
+#: Source/itemdat.cpp:500
+msgid "Fool's Crest"
+msgstr "Гребень Дурака"
+
+#: Source/itemdat.cpp:501
+msgid "Gotterdamerung"
+msgstr "Гибель Богов"
+
+#: Source/itemdat.cpp:502
+msgid "Royal Circlet"
+msgstr "Королевский Венец"
+
+#: Source/itemdat.cpp:503
+msgid "Torn Flesh of Souls"
+msgstr "Разорванная Плоть Душ"
+
+#: Source/itemdat.cpp:504
+msgid "The Gladiator's Bane"
+msgstr "Проклятие Гладиатора"
+
+#: Source/itemdat.cpp:505
+msgid "The Rainbow Cloak"
+msgstr "Плащ Радуги"
+
+#: Source/itemdat.cpp:506
+msgid "Leather of Aut"
+msgstr "Кожа Аута"
+
+#: Source/itemdat.cpp:507
+msgid "Wisdom's Wrap"
+msgstr "Накидка Мудрости"
+
+#: Source/itemdat.cpp:508
+msgid "Sparking Mail"
+msgstr "Сверкающая Кольчуга"
+
+#: Source/itemdat.cpp:509
+msgid "Scavenger Carapace"
+msgstr "Панцирь Мусорщика"
+
+#: Source/itemdat.cpp:510
+msgid "Nightscape"
+msgstr "Ночной Пейзаж"
+
+#: Source/itemdat.cpp:511
+msgid "Naj's Light Plate"
+msgstr "Лёгкая Пластина Наджа"
+
+#: Source/itemdat.cpp:512
+msgid "Demonspike Coat"
+msgstr "Покров Демонских Шипов"
+
+#: Source/itemdat.cpp:513
+msgid "The Deflector"
+msgstr "Отражатель"
+
+#: Source/itemdat.cpp:514
+msgid "Split Skull Shield"
+msgstr "Щит из Расколотого Черепа"
+
+#: Source/itemdat.cpp:515
+msgid "Dragon's Breach"
+msgstr "Разлом Дракона"
+
+#: Source/itemdat.cpp:516
+msgid "Blackoak Shield"
+msgstr "Щит из Чёрного Дуба"
+
+#: Source/itemdat.cpp:517
+msgid "Holy Defender"
+msgstr "Святой Защитник"
+
+#: Source/itemdat.cpp:518
+msgid "Stormshield"
+msgstr "Грозовой Щит"
+
+#: Source/itemdat.cpp:519
+msgid "Bramble"
+msgstr "Ежевика"
+
+#: Source/itemdat.cpp:520
+msgid "Ring of Regha"
+msgstr "Кольцо Регхи"
+
+#: Source/itemdat.cpp:521
+msgid "The Bleeder"
+msgstr "Проливатель Крови"
+
+#: Source/itemdat.cpp:522
+msgid "Constricting Ring"
+msgstr "Сужающее Кольцо"
+
+#: Source/itemdat.cpp:523
+msgid "Ring of Engagement"
+msgstr "Обручальное Кольцо"
+
+#: Source/itemdat.cpp:524
+msgid "Giant's Knuckle"
+msgstr "Кастет Гиганта"
+
+#: Source/itemdat.cpp:525
+msgid "Mercurial Ring"
+msgstr "Ртутное Кольцо"
+
+#: Source/itemdat.cpp:526
+msgid "Xorine's Ring"
+msgstr "Кольцо Ксорин"
+
+#: Source/itemdat.cpp:527
+msgid "Karik's Ring"
+msgstr "Кольцо Карика"
+
+#: Source/itemdat.cpp:528
+msgid "Ring of Magma"
+msgstr "Кольцо Магмы"
+
+#: Source/itemdat.cpp:529
+msgid "Ring of the Mystics"
+msgstr "Кольцо Мистики"
+
+#: Source/itemdat.cpp:530
+msgid "Ring of Thunder"
+msgstr "Кольцо Грома"
+
+#: Source/itemdat.cpp:531
+msgid "Amulet of Warding"
+msgstr "Защитный Амулет"
+
+#: Source/itemdat.cpp:532
+msgid "Gnat Sting"
+msgstr "Жало Комара"
+
+#: Source/itemdat.cpp:533
+msgid "Flambeau"
+msgstr "Факел"
+
+#: Source/itemdat.cpp:534
+msgid "Armor of Gloom"
+msgstr "Доспех Мрака"
+
+#: Source/itemdat.cpp:535
+msgid "Blitzen"
+msgstr "Блитцен"
+
+#: Source/itemdat.cpp:536
+msgid "Thunderclap"
+msgstr "Удар Грома"
+
+#: Source/itemdat.cpp:537
+msgid "Shirotachi"
+msgstr "Широтачи"
+
+#: Source/itemdat.cpp:538
+msgid "Eater of Souls"
+msgstr "Пожиратель Душ"
+
+#: Source/itemdat.cpp:539
+msgid "Diamondedge"
+msgstr "Кромка Алмаза"
+
+#: Source/itemdat.cpp:540
+msgid "Bone Chain Armor"
+msgstr "Костяная Броня"
+
+#: Source/itemdat.cpp:541
+msgid "Demon Plate Armor"
+msgstr "Демонический Доспех"
+
+#: Source/itemdat.cpp:542
+msgid "Acolyte's Amulet"
+msgstr "Амулет Приспешника"
+
+#. TRANSLATORS: Unique Item section end.
+#: Source/itemdat.cpp:544
+msgid "Gladiator's Ring"
+msgstr "Кольцо Гладиатора"
+
+#: Source/items.cpp:176
+msgid "Oil of Mastery"
+msgstr "Масло Мастерства"
+
+#: Source/items.cpp:178
+msgid "Oil of Death"
+msgstr "Масло Смерти"
+
+#: Source/items.cpp:179
+msgid "Oil of Skill"
+msgstr "Масло Умения"
+
+#: Source/items.cpp:181
 msgid "Oil of Fortitude"
 msgstr "Масло Стойкости"
 
-#: Source/items.cpp:183
+#: Source/items.cpp:182
 msgid "Oil of Permanence"
 msgstr "Масло Постоянства"
 
-#: Source/items.cpp:184
+#: Source/items.cpp:183
 msgid "Oil of Hardening"
 msgstr "Масло Закалки"
 
-#: Source/items.cpp:185
+#: Source/items.cpp:184
 msgid "Oil of Imperviousness"
 msgstr "Масло Непроницаемости"
 
 #. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
-#: Source/items.cpp:1097
+#: Source/items.cpp:1119
 #, c++-format
 msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{0} {1}"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1109
+#: Source/items.cpp:1131
 #, c++-format
 msgctxt "spell"
 msgid "{0} {1} of {2}"
 msgstr "{0} {1} {2}"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
-#: Source/items.cpp:1147
+#: Source/items.cpp:1169
 #, c++-format
 msgid "{0} {1} of {2}"
 msgstr "{0} {1} {2}"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#: Source/items.cpp:1150
+#: Source/items.cpp:1172
 #, c++-format
 msgid "{0} {1}"
 msgstr "{0} {1}"
 
 #. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
-#: Source/items.cpp:1153
+#: Source/items.cpp:1175
 #, c++-format
 msgid "{0} of {1}"
 msgstr "{0} {1}"
 
-#: Source/items.cpp:1650 Source/items.cpp:1658
+#: Source/items.cpp:1706 Source/items.cpp:1714
 msgid "increases a weapon's"
 msgstr "увеличивает"
 
-#: Source/items.cpp:1651
+#: Source/items.cpp:1707
 msgid "chance to hit"
 msgstr "шанс попадания"
 
-#: Source/items.cpp:1654
+#: Source/items.cpp:1710
 msgid "greatly increases a"
 msgstr "значительно увеличивает"
 
-#: Source/items.cpp:1655
+#: Source/items.cpp:1711
 msgid "weapon's chance to hit"
 msgstr "шанс попадания оружия"
 
-#: Source/items.cpp:1659
+#: Source/items.cpp:1715
 msgid "damage potential"
 msgstr "потенциал урона"
 
-#: Source/items.cpp:1662
+#: Source/items.cpp:1718
 msgid "greatly increases a weapon's"
 msgstr "сильно улучшает"
 
-#: Source/items.cpp:1663
+#: Source/items.cpp:1719
 msgid "damage potential - not bows"
 msgstr "потенциал урона - не луки"
 
-#: Source/items.cpp:1666
+#: Source/items.cpp:1722
 msgid "reduces attributes needed"
 msgstr "уменьшает требуемые атрибуты"
 
-#: Source/items.cpp:1667
+#: Source/items.cpp:1723
 msgid "to use armor or weapons"
 msgstr "для использования брони или оружия"
 
-#: Source/items.cpp:1670
+#: Source/items.cpp:1726
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "восстанавливает 20%"
 
-#: Source/items.cpp:1671
+#: Source/items.cpp:1727
 msgid "item's durability"
 msgstr "прочности предмета"
 
-#: Source/items.cpp:1674
+#: Source/items.cpp:1730
 msgid "increases an item's"
 msgstr "увеличивает"
 
-#: Source/items.cpp:1675
+#: Source/items.cpp:1731
 msgid "current and max durability"
 msgstr "текущую и максимальную прочность"
 
-#: Source/items.cpp:1678
+#: Source/items.cpp:1734
 msgid "makes an item indestructible"
 msgstr "делает предмет нерушимым"
 
-#: Source/items.cpp:1681
+#: Source/items.cpp:1737
 msgid "increases the armor class"
 msgstr "увеличивает класс брони"
 
-#: Source/items.cpp:1682
+#: Source/items.cpp:1738
 msgid "of armor and shields"
 msgstr "брони и щитов"
 
-#: Source/items.cpp:1685
+#: Source/items.cpp:1741
 msgid "greatly increases the armor"
 msgstr "значительно улучшает класс брони"
 
-#: Source/items.cpp:1686
+#: Source/items.cpp:1742
 msgid "class of armor and shields"
 msgstr "щитов и брони"
 
-#: Source/items.cpp:1689 Source/items.cpp:1696
+#: Source/items.cpp:1745 Source/items.cpp:1752
 msgid "sets fire trap"
 msgstr "устанавливает ловушку"
 
-#: Source/items.cpp:1693
+#: Source/items.cpp:1749
 msgid "sets lightning trap"
 msgstr "устанавливает ловушку-молнию"
 
-#: Source/items.cpp:1699
+#: Source/items.cpp:1755
 msgid "sets petrification trap"
 msgstr "устанавливает ловушку-окаменение"
 
-#: Source/items.cpp:1702
+#: Source/items.cpp:1758
 msgid "restore all life"
 msgstr "восстановит всё здоровье"
 
-#: Source/items.cpp:1705
+#: Source/items.cpp:1761
 msgid "restore some life"
 msgstr "восстановит часть здоровья"
 
-#: Source/items.cpp:1708
+#: Source/items.cpp:1764
 msgid "restore some mana"
 msgstr "восстановит часть маны"
 
-#: Source/items.cpp:1711
+#: Source/items.cpp:1767
 msgid "restore all mana"
 msgstr "восстановит всю ману"
 
-#: Source/items.cpp:1714
+#: Source/items.cpp:1770
 msgid "increase strength"
 msgstr "увеличить силу"
 
-#: Source/items.cpp:1717
+#: Source/items.cpp:1773
 msgid "increase magic"
 msgstr "увеличить магию"
 
-#: Source/items.cpp:1720
+#: Source/items.cpp:1776
 msgid "increase dexterity"
 msgstr "увеличить ловкость"
 
-#: Source/items.cpp:1723
+#: Source/items.cpp:1779
 msgid "increase vitality"
 msgstr "увеличить живучесть"
 
-#: Source/items.cpp:1726
+#: Source/items.cpp:1782
 msgid "restore some life and mana"
 msgstr "восстановит часть здоровья и маны"
 
-#: Source/items.cpp:1729 Source/items.cpp:1732
+#: Source/items.cpp:1785 Source/items.cpp:1788
 msgid "restore all life and mana"
 msgstr "восстановить всё здороье и ману"
 
-#: Source/items.cpp:1733
+#: Source/items.cpp:1789
 msgid "(works only in arenas)"
 msgstr "(работает только на аренах)"
 
-#: Source/items.cpp:1768
+#: Source/items.cpp:1803
 msgid "Right-click to view"
 msgstr "Правый клик для просмотра"
 
-#: Source/items.cpp:1771
+#: Source/items.cpp:1806
 msgid "Right-click to use"
 msgstr "Правый клик для использования"
 
-#: Source/items.cpp:1773
+#: Source/items.cpp:1808
 msgid ""
 "Right-click to read, then\n"
 "left-click to target"
@@ -2803,24 +4419,24 @@ msgstr ""
 "Правый клик для чтения, затем\n"
 "левый клик по цели"
 
-#: Source/items.cpp:1775
+#: Source/items.cpp:1810
 msgid "Right-click to read"
 msgstr "Правый клик для чтения"
 
-#: Source/items.cpp:1782
+#: Source/items.cpp:1817
 msgid "Activate to view"
 msgstr "Активируйте для просмотра"
 
-#: Source/items.cpp:1786 Source/items.cpp:1811
+#: Source/items.cpp:1821 Source/items.cpp:1859
 msgid "Open inventory to use"
 msgstr "Открыть инвентарь для использования"
 
-#: Source/items.cpp:1788
+#: Source/items.cpp:1823
 msgid "Activate to use"
 msgstr "Активируйте, чтобы использовать"
 
 # Оставил именно этот вариант, так как полностью корректный перевод в игре выглядит глупо.
-#: Source/items.cpp:1791
+#: Source/items.cpp:1826
 msgid ""
 "Select from spell book, then\n"
 "cast spell to read"
@@ -2828,21 +4444,21 @@ msgstr ""
 "Выберите в книге заклинаний, затем\n"
 "примените заклинание для чтения"
 
-#: Source/items.cpp:1793
+#: Source/items.cpp:1828
 msgid "Activate to read"
 msgstr "Активируйте для чтения"
 
-#: Source/items.cpp:1807
+#: Source/items.cpp:1855
 #, c++-format
 msgid "{} to view"
 msgstr "{} для осмотра"
 
-#: Source/items.cpp:1813
+#: Source/items.cpp:1861
 #, c++-format
 msgid "{} to use"
 msgstr "{} для использования"
 
-#: Source/items.cpp:1816
+#: Source/items.cpp:1864
 #, c++-format
 msgid ""
 "Select from spell book,\n"
@@ -2851,118 +4467,112 @@ msgstr ""
 "Выберите в книге заклинаний\n"
 "и нажмите {} для чтения"
 
-#: Source/items.cpp:1818
+#: Source/items.cpp:1866
 #, c++-format
 msgid "{} to read"
 msgstr "{} для чтения"
 
-#: Source/items.cpp:1825
+#: Source/items.cpp:1873
 #, c++-format
 msgctxt "player"
 msgid "Level: {:d}"
 msgstr "Уровень: {:d}"
 
-#: Source/items.cpp:1829
+#: Source/items.cpp:1877
 msgid "Doubles gold capacity"
 msgstr "Удваивает вместимость золота"
 
-#: Source/items.cpp:1861 Source/stores.cpp:326
+#: Source/items.cpp:1910 Source/stores.cpp:325
 msgid "Required:"
 msgstr "Требуется:"
 
-#: Source/items.cpp:1863 Source/stores.cpp:328
+#: Source/items.cpp:1912 Source/stores.cpp:327
 #, c++-format
 msgid " {:d} Str"
 msgstr " {:d} Силы"
 
-#: Source/items.cpp:1865 Source/stores.cpp:330
+#: Source/items.cpp:1914 Source/stores.cpp:329
 #, c++-format
 msgid " {:d} Mag"
 msgstr " {:d} Маг"
 
-#: Source/items.cpp:1867 Source/stores.cpp:332
+#: Source/items.cpp:1916 Source/stores.cpp:331
 #, c++-format
 msgid " {:d} Dex"
 msgstr " {:d} Ловк"
 
-#. TRANSLATORS: {:s} will be a spell name
-#: Source/items.cpp:2226
-#, c++-format
-msgid "Book of {:s}"
-msgstr "Книга {:s}"
-
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:2228
+#: Source/items.cpp:2291
 #, c++-format
 msgid "Ear of {:s}"
 msgstr "Ухо {:s}"
 
-#: Source/items.cpp:3884
+#: Source/items.cpp:3720
 #, c++-format
 msgid "chance to hit: {:+d}%"
 msgstr "меткость: {:+d}%"
 
-#: Source/items.cpp:3887
+#: Source/items.cpp:3723
 #, no-c-format, c++-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% урона"
 
-#: Source/items.cpp:3890 Source/items.cpp:4072
+#: Source/items.cpp:3726 Source/items.cpp:3910
 #, c++-format
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "меткость: {:+d}%, {:+d}% урона"
 
-#: Source/items.cpp:3893
+#: Source/items.cpp:3729
 #, no-c-format, c++-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% брони"
 
-#: Source/items.cpp:3896
+#: Source/items.cpp:3732
 #, c++-format
 msgid "armor class: {:d}"
 msgstr "класс брони: {:d}"
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:3736
 #, c++-format
 msgid "Resist Fire: {:+d}%"
 msgstr "Сопротивление огню: {:+d}%"
 
-#: Source/items.cpp:3902
+#: Source/items.cpp:3738
 #, c++-format
 msgid "Resist Fire: {:+d}% MAX"
 msgstr "Сопротивление огню: {:+d}% МАКС"
 
-#: Source/items.cpp:3906
+#: Source/items.cpp:3742
 #, c++-format
 msgid "Resist Lightning: {:+d}%"
 msgstr "Сопротивление молнии: {:+d}%"
 
-#: Source/items.cpp:3908
+#: Source/items.cpp:3744
 #, c++-format
 msgid "Resist Lightning: {:+d}% MAX"
 msgstr "Сопротивление молнии: {:+d}% МАКС"
 
-#: Source/items.cpp:3912
+#: Source/items.cpp:3748
 #, c++-format
 msgid "Resist Magic: {:+d}%"
 msgstr "Сопротивление магии: {:+d}%"
 
-#: Source/items.cpp:3914
+#: Source/items.cpp:3750
 #, c++-format
 msgid "Resist Magic: {:+d}% MAX"
 msgstr "Сопротивление магии: {:+d}% МАКС"
 
-#: Source/items.cpp:3917
+#: Source/items.cpp:3753
 #, c++-format
 msgid "Resist All: {:+d}%"
 msgstr "Общее сопротивление: {:+d}%"
 
-#: Source/items.cpp:3919
+#: Source/items.cpp:3755
 #, c++-format
 msgid "Resist All: {:+d}% MAX"
 msgstr "Общее сопротивление: {:+d}% МАКС"
 
-#: Source/items.cpp:3922
+#: Source/items.cpp:3758
 #, c++-format
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
@@ -2970,7 +4580,7 @@ msgstr[0] "заклинания повышены на {:d} уровень"
 msgstr[1] "заклинания повышены на {:d} уровня"
 msgstr[2] "заклинания повышены на {:d} уровней"
 
-#: Source/items.cpp:3924
+#: Source/items.cpp:3760
 #, c++-format
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
@@ -2978,15 +4588,15 @@ msgstr[0] "заклинания понижены на {:d} уровень"
 msgstr[1] "заклинания понижены на {:d} уровня"
 msgstr[2] "заклинания понижены на {:d} уровней"
 
-#: Source/items.cpp:3926
+#: Source/items.cpp:3762
 msgid "spell levels unchanged (?)"
 msgstr "уровни заклинаний не измененены (?)"
 
-#: Source/items.cpp:3928
+#: Source/items.cpp:3764
 msgid "Extra charges"
 msgstr "Дополнительные заряды"
 
-#: Source/items.cpp:3930
+#: Source/items.cpp:3766
 #, c++-format
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
@@ -2994,213 +4604,213 @@ msgstr[0] "{:d} {:s} заряд"
 msgstr[1] "{:d} {:s} заряда"
 msgstr[2] "{:d} {:s} зарядов"
 
-#: Source/items.cpp:3933
+#: Source/items.cpp:3769
 #, c++-format
 msgid "Fire hit damage: {:d}"
 msgstr "Урон огнём: {:d}"
 
-#: Source/items.cpp:3935
+#: Source/items.cpp:3771
 #, c++-format
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Урон огнём: {:d}-{:d}"
 
-#: Source/items.cpp:3938
+#: Source/items.cpp:3774
 #, c++-format
 msgid "Lightning hit damage: {:d}"
 msgstr "Урон молнией: {:d}"
 
-#: Source/items.cpp:3940
+#: Source/items.cpp:3776
 #, c++-format
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Урон молнией: {:d}-{:d}"
 
-#: Source/items.cpp:3943
+#: Source/items.cpp:3779
 #, c++-format
 msgid "{:+d} to strength"
 msgstr "{:+d} к силе"
 
-#: Source/items.cpp:3946
+#: Source/items.cpp:3782
 #, c++-format
 msgid "{:+d} to magic"
 msgstr "{:+d} к магии"
 
-#: Source/items.cpp:3949
+#: Source/items.cpp:3785
 #, c++-format
 msgid "{:+d} to dexterity"
 msgstr "{:+d} к ловкости"
 
-#: Source/items.cpp:3952
+#: Source/items.cpp:3788
 #, c++-format
 msgid "{:+d} to vitality"
 msgstr "{:+d} к живучести"
 
-#: Source/items.cpp:3955
+#: Source/items.cpp:3791
 #, c++-format
 msgid "{:+d} to all attributes"
 msgstr "{:+d} ко всем атрибутам"
 
-#: Source/items.cpp:3958
+#: Source/items.cpp:3794
 #, c++-format
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} урон от врагов"
 
-#: Source/items.cpp:3961
+#: Source/items.cpp:3797
 #, c++-format
 msgid "Hit Points: {:+d}"
 msgstr "Здоровье: {:+d}"
 
-#: Source/items.cpp:3964
+#: Source/items.cpp:3800
 #, c++-format
 msgid "Mana: {:+d}"
 msgstr "Мана: {:+d}"
 
-#: Source/items.cpp:3966
+#: Source/items.cpp:3802
 msgid "high durability"
 msgstr "высокая прочность"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:3804
 msgid "decreased durability"
 msgstr "пониженная прочность"
 
-#: Source/items.cpp:3970
+#: Source/items.cpp:3806
 msgid "indestructible"
 msgstr "неразрушимое"
 
-#: Source/items.cpp:3972
+#: Source/items.cpp:3808
 #, no-c-format, c++-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% радиуса света"
 
-#: Source/items.cpp:3974
+#: Source/items.cpp:3810
 #, no-c-format, c++-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% радиуса света"
 
-#: Source/items.cpp:3976
+#: Source/items.cpp:3812
 msgid "multiple arrows per shot"
 msgstr "много стрел за выстрел"
 
-#: Source/items.cpp:3979
+#: Source/items.cpp:3815
 #, c++-format
 msgid "fire arrows damage: {:d}"
 msgstr "урон огненных стрел: {:d}"
 
-#: Source/items.cpp:3981
+#: Source/items.cpp:3817
 #, c++-format
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "урон огненных стрел: {:d}-{:d}"
 
-#: Source/items.cpp:3984
+#: Source/items.cpp:3820
 #, c++-format
 msgid "lightning arrows damage {:d}"
 msgstr "урон грозовых стрел: {:d}"
 
-#: Source/items.cpp:3986
+#: Source/items.cpp:3822
 #, c++-format
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "урон грозовых стрел: {:d}-{:d}"
 
 # "Fireball" is singular here.
-#: Source/items.cpp:3989
+#: Source/items.cpp:3825
 #, c++-format
 msgid "fireball damage: {:d}"
 msgstr "урон огненного шара: {:d}"
 
-#: Source/items.cpp:3991
+#: Source/items.cpp:3827
 #, c++-format
 msgid "fireball damage: {:d}-{:d}"
 msgstr "урон огненного шара: {:d}-{:d}"
 
-#: Source/items.cpp:3993
+#: Source/items.cpp:3829
 msgid "attacker takes 1-3 damage"
 msgstr "атакующий получает 1-3 урона"
 
-#: Source/items.cpp:3995
+#: Source/items.cpp:3831
 msgid "user loses all mana"
 msgstr "носящий теряет всю ману"
 
-#: Source/items.cpp:3997
+#: Source/items.cpp:3833
 msgid "absorbs half of trap damage"
 msgstr "поглощает половину урона ловушек"
 
-#: Source/items.cpp:3999
+#: Source/items.cpp:3835
 msgid "knocks target back"
 msgstr "отталкивает цель назад"
 
-#: Source/items.cpp:4001
+#: Source/items.cpp:3837
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% урона демонам"
 
-#: Source/items.cpp:4003
+#: Source/items.cpp:3839
 msgid "All Resistance equals 0"
 msgstr "Все сопротивления равны 0"
 
-#: Source/items.cpp:4006
+#: Source/items.cpp:3842
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "удар крадёт 3% маны"
 
-#: Source/items.cpp:4008
+#: Source/items.cpp:3844
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "удар крадёт 5% маны"
 
-#: Source/items.cpp:4012
+#: Source/items.cpp:3848
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "удар крадёт 3% здоровья"
 
-#: Source/items.cpp:4014
+#: Source/items.cpp:3850
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "удар крадёт 5% здоровья"
 
-#: Source/items.cpp:4017
+#: Source/items.cpp:3853
 msgid "penetrates target's armor"
 msgstr "пробивает броню цели"
 
-#: Source/items.cpp:4020
+#: Source/items.cpp:3856
 msgid "quick attack"
 msgstr "скорая атака"
 
-#: Source/items.cpp:4022
+#: Source/items.cpp:3858
 msgid "fast attack"
 msgstr "быстрая атака"
 
-#: Source/items.cpp:4024
+#: Source/items.cpp:3860
 msgid "faster attack"
 msgstr "более быстрая атака"
 
-#: Source/items.cpp:4026
+#: Source/items.cpp:3862
 msgid "fastest attack"
 msgstr "наибыстрейшая атака"
 
 # Что значит "NW"?
-#: Source/items.cpp:4027 Source/items.cpp:4035 Source/items.cpp:4082
+#: Source/items.cpp:3863 Source/items.cpp:3871 Source/items.cpp:3920
 msgid "Another ability (NW)"
 msgstr "Другая способность (NW)"
 
 # Сократил восстановление до восст., т.к. текст любит вылезать за рамки
-#: Source/items.cpp:4030
+#: Source/items.cpp:3866
 msgid "fast hit recovery"
 msgstr "быстрое восст. от удара"
 
 # Сократил восстановление до восст., т.к. текст любит вылезать за рамки
-#: Source/items.cpp:4032
+#: Source/items.cpp:3868
 msgid "faster hit recovery"
 msgstr "более быстрое восст. от удара"
 
 # Сократил восстановление до восст., т.к. текст любит вылезать за рамки
-#: Source/items.cpp:4034
+#: Source/items.cpp:3870
 msgid "fastest hit recovery"
 msgstr "наибыстрейшее восст. от удара"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:3873
 msgid "fast block"
 msgstr "быстрый блок"
 
-#: Source/items.cpp:4039
+#: Source/items.cpp:3875
 #, c++-format
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
@@ -3208,137 +4818,137 @@ msgstr[0] "добавляет {:d} очко к урону"
 msgstr[1] "добавляет {:d} очка к урону"
 msgstr[2] "добавляет {:d} очков к урону"
 
-#: Source/items.cpp:4041
+#: Source/items.cpp:3877
 msgid "fires random speed arrows"
 msgstr "выпускает случайные быстрые стрелы"
 
 # этот параметр бесполезен, можно хоть матом писать
 # ᅠ ᅠᅠ
 # Ну я придумал просто гениальную интерпретацию
-#: Source/items.cpp:4043
+#: Source/items.cpp:3879
 msgid "unusual item damage"
 msgstr "урон изменён разрабами"
 
-#: Source/items.cpp:4045
+#: Source/items.cpp:3881
 msgid "altered durability"
 msgstr "изменённая прочность"
 
-#: Source/items.cpp:4047
+#: Source/items.cpp:3883
 msgid "one handed sword"
 msgstr "одноручный меч"
 
-#: Source/items.cpp:4049
+#: Source/items.cpp:3885
 msgid "constantly lose hit points"
 msgstr "постоянная потеря здоровья"
 
-#: Source/items.cpp:4051
+#: Source/items.cpp:3887
 msgid "life stealing"
 msgstr "крадёт здоровье врагов"
 
-#: Source/items.cpp:4053
+#: Source/items.cpp:3889
 msgid "no strength requirement"
 msgstr "нет требований силы"
 
-#: Source/items.cpp:4056
+#: Source/items.cpp:3894
 #, c++-format
 msgid "lightning damage: {:d}"
 msgstr "урон молнией: {:d}"
 
-#: Source/items.cpp:4058
+#: Source/items.cpp:3896
 #, c++-format
 msgid "lightning damage: {:d}-{:d}"
 msgstr "урон молнией: {:d}-{:d}"
 
-#: Source/items.cpp:4060
+#: Source/items.cpp:3898
 msgid "charged bolts on hits"
 msgstr "выпускает заряженные болты при ударе"
 
-#: Source/items.cpp:4062
+#: Source/items.cpp:3900
 msgid "occasional triple damage"
 msgstr "случайный тройной урон"
 
 # Не гниющий, так не понятно. Надо подобрать слово, означающие постепенное исчерпывание бонуса к урону, который в итоге идёт в минус. Самое подходящее, что я подобрал - убывающие + урона
-#: Source/items.cpp:4064
+#: Source/items.cpp:3902
 #, no-c-format, c++-format
 msgid "decaying {:+d}% damage"
 msgstr "убывающие {:+d}% урона"
 
-#: Source/items.cpp:4066
+#: Source/items.cpp:3904
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x урона монстрам, 1x вам"
 
-#: Source/items.cpp:4068
+#: Source/items.cpp:3906
 #, no-c-format
 msgid "Random 0 - 600% damage"
 msgstr "Случайные 0 - 600% урона"
 
-#: Source/items.cpp:4070
+#: Source/items.cpp:3908
 #, no-c-format, c++-format
 msgid "low dur, {:+d}% damage"
 msgstr "низк прчн, {:+d}% урона"
 
 # ОБ=очки брони
 # Сделаю АС, сообщество привыкло к данной абривиатуре
-#: Source/items.cpp:4074
+#: Source/items.cpp:3912
 msgid "extra AC vs demons"
 msgstr "дополнительные АС против демонов"
 
-#: Source/items.cpp:4076
+#: Source/items.cpp:3914
 msgid "extra AC vs undead"
 msgstr "дополнительные АС против нежити"
 
-#: Source/items.cpp:4078
+#: Source/items.cpp:3916
 msgid "50% Mana moved to Health"
 msgstr "50% маны становятся здоровьем"
 
-#: Source/items.cpp:4080
+#: Source/items.cpp:3918
 msgid "40% Health moved to Mana"
 msgstr "40% здоровья становятся маной"
 
-#: Source/items.cpp:4116 Source/items.cpp:4157
+#: Source/items.cpp:3958 Source/items.cpp:3999
 #, c++-format
 msgid "damage: {:d}  Indestructible"
 msgstr "урон: {:d}  Нерушимый"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4118 Source/items.cpp:4159
+#: Source/items.cpp:3960 Source/items.cpp:4001
 #, c++-format
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "урон: {:d}  Прчн: {:d}/{:d}"
 
-#: Source/items.cpp:4121 Source/items.cpp:4162
+#: Source/items.cpp:3963 Source/items.cpp:4004
 #, c++-format
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "урон: {:d}-{:d}  Нерушимый"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4123 Source/items.cpp:4164
+#: Source/items.cpp:3965 Source/items.cpp:4006
 #, c++-format
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "урон: {:d}-{:d}  Прчн: {:d}/{:d}"
 
-#: Source/items.cpp:4128 Source/items.cpp:4174
+#: Source/items.cpp:3970 Source/items.cpp:4016
 #, c++-format
 msgid "armor: {:d}  Indestructible"
 msgstr "броня: {:d}  Нерушимая"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4130 Source/items.cpp:4176
+#: Source/items.cpp:3972 Source/items.cpp:4018
 #, c++-format
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "броня: {:d}  Прчн:{:d}/{:d}"
 
-#: Source/items.cpp:4133 Source/items.cpp:4167 Source/items.cpp:4180
-#: Source/stores.cpp:300
+#: Source/items.cpp:3975 Source/items.cpp:4009 Source/items.cpp:4022
+#: Source/stores.cpp:299
 #, c++-format
 msgid "Charges: {:d}/{:d}"
 msgstr "Заряды: {:d}/{:d}"
 
-#: Source/items.cpp:4142
+#: Source/items.cpp:3984
 msgid "unique item"
 msgstr "уникальный предмет"
 
-#: Source/items.cpp:4170 Source/items.cpp:4178 Source/items.cpp:4184
+#: Source/items.cpp:4012 Source/items.cpp:4020 Source/items.cpp:4026
 msgid "Not Identified"
 msgstr "Не идентифицировано"
 
@@ -3351,11 +4961,11 @@ msgid "Chamber of Bone"
 msgstr "Палата Костей"
 
 #. TRANSLATORS: Quest Map
-#: Source/levels/setmaps.cpp:29 Source/quests.cpp:104
+#: Source/levels/setmaps.cpp:29 Source/quests.cpp:99
 msgid "Maze"
 msgstr "Лабиринт"
 
-#: Source/levels/setmaps.cpp:30 Source/quests.cpp:66
+#: Source/levels/setmaps.cpp:30 Source/quests.cpp:61
 msgid "Poisoned Water Supply"
 msgstr "Отравленный Источник"
 
@@ -3375,92 +4985,92 @@ msgstr "Адская арена"
 msgid "Circle of Life Arena"
 msgstr "Арена Круга Жизни"
 
-#: Source/levels/trigs.cpp:354
+#: Source/levels/trigs.cpp:350
 msgid "Down to dungeon"
 msgstr "Спуститься в подземелье"
 
-#: Source/levels/trigs.cpp:363
+#: Source/levels/trigs.cpp:359
 msgid "Down to catacombs"
 msgstr "Спуститься в катакомбы"
 
-#: Source/levels/trigs.cpp:373
+#: Source/levels/trigs.cpp:369
 msgid "Down to caves"
 msgstr "Спуститься в пещеры"
 
-#: Source/levels/trigs.cpp:383
+#: Source/levels/trigs.cpp:379
 msgid "Down to hell"
 msgstr "Спуститься в ад"
 
-#: Source/levels/trigs.cpp:393
+#: Source/levels/trigs.cpp:389
 msgid "Down to Hive"
 msgstr "Спуститься в Улей"
 
-#: Source/levels/trigs.cpp:403
+#: Source/levels/trigs.cpp:399
 msgid "Down to Crypt"
 msgstr "Спуститься в Склеп"
 
-#: Source/levels/trigs.cpp:418 Source/levels/trigs.cpp:453
-#: Source/levels/trigs.cpp:499 Source/levels/trigs.cpp:551
+#: Source/levels/trigs.cpp:414 Source/levels/trigs.cpp:449
+#: Source/levels/trigs.cpp:495 Source/levels/trigs.cpp:547
 #, c++-format
 msgid "Up to level {:d}"
 msgstr "Подняться на {:d} уровень"
 
-#: Source/levels/trigs.cpp:420 Source/levels/trigs.cpp:482
-#: Source/levels/trigs.cpp:534 Source/levels/trigs.cpp:581
-#: Source/levels/trigs.cpp:643 Source/levels/trigs.cpp:692
-#: Source/levels/trigs.cpp:799
+#: Source/levels/trigs.cpp:416 Source/levels/trigs.cpp:478
+#: Source/levels/trigs.cpp:530 Source/levels/trigs.cpp:577
+#: Source/levels/trigs.cpp:639 Source/levels/trigs.cpp:688
+#: Source/levels/trigs.cpp:795
 msgid "Up to town"
 msgstr "Подняться в город"
 
-#: Source/levels/trigs.cpp:431 Source/levels/trigs.cpp:464
-#: Source/levels/trigs.cpp:516 Source/levels/trigs.cpp:563
-#: Source/levels/trigs.cpp:625
+#: Source/levels/trigs.cpp:427 Source/levels/trigs.cpp:460
+#: Source/levels/trigs.cpp:512 Source/levels/trigs.cpp:559
+#: Source/levels/trigs.cpp:621
 #, c++-format
 msgid "Down to level {:d}"
 msgstr "Спуститься на {:d} уровень"
 
-#: Source/levels/trigs.cpp:594
+#: Source/levels/trigs.cpp:590
 msgid "Down to Diablo"
 msgstr "Спуститься к Диабло"
 
-#: Source/levels/trigs.cpp:612
+#: Source/levels/trigs.cpp:608
 #, c++-format
 msgid "Up to Nest level {:d}"
 msgstr "Подняться на {:d} уровень Гнезда"
 
-#: Source/levels/trigs.cpp:660
+#: Source/levels/trigs.cpp:656
 #, c++-format
 msgid "Up to Crypt level {:d}"
 msgstr "Подняться на {:d} уровень Склепа"
 
-#: Source/levels/trigs.cpp:670 Source/quests.cpp:75
+#: Source/levels/trigs.cpp:666 Source/quests.cpp:70
 msgid "Cornerstone of the World"
 msgstr "Краеугольный Камень Мира"
 
-#: Source/levels/trigs.cpp:675
+#: Source/levels/trigs.cpp:671
 #, c++-format
 msgid "Down to Crypt level {:d}"
 msgstr "Спуститься в Склеп на {:d} уровень"
 
-#: Source/levels/trigs.cpp:723 Source/levels/trigs.cpp:737
-#: Source/levels/trigs.cpp:751
+#: Source/levels/trigs.cpp:719 Source/levels/trigs.cpp:733
+#: Source/levels/trigs.cpp:747
 #, c++-format
 msgid "Back to Level {:d}"
 msgstr "Вернуться на {:d} уровень"
 
-#: Source/loadsave.cpp:1911 Source/loadsave.cpp:2348
+#: Source/loadsave.cpp:1864 Source/loadsave.cpp:2299
 msgid "Unable to open save file archive"
 msgstr "Невозможно открыть файл сохранённой игры"
 
-#: Source/loadsave.cpp:2352
+#: Source/loadsave.cpp:2302
 msgid "Invalid save file"
 msgstr "Неправильный файл сохранения"
 
-#: Source/loadsave.cpp:2384
+#: Source/loadsave.cpp:2333
 msgid "Player is on a Hellfire only level"
 msgstr "Игрок на уровне Hellfire"
 
-#: Source/loadsave.cpp:2643
+#: Source/loadsave.cpp:2589
 msgid "Invalid game state"
 msgstr "Неправильное состояние игры"
 
@@ -3468,530 +5078,1656 @@ msgstr "Неправильное состояние игры"
 msgid "Unable to display mainmenu"
 msgstr "Невозможно отобразить главное меню"
 
-#: Source/monster.cpp:2940
+#. TRANSLATORS: Monster Block start
+#. MT_NZOMBIE
+#: Source/monstdat.cpp:33
+msgctxt "monster"
+msgid "Zombie"
+msgstr "Зомби"
+
+#: Source/monstdat.cpp:34
+msgctxt "monster"
+msgid "Ghoul"
+msgstr "Упырь"
+
+#: Source/monstdat.cpp:35
+msgctxt "monster"
+msgid "Rotting Carcass"
+msgstr "Гниющая Туша"
+
+#: Source/monstdat.cpp:36
+msgctxt "monster"
+msgid "Black Death"
+msgstr "Чёрная Смерть"
+
+#: Source/monstdat.cpp:37 Source/monstdat.cpp:45
+msgctxt "monster"
+msgid "Fallen One"
+msgstr "Падший"
+
+#: Source/monstdat.cpp:38 Source/monstdat.cpp:46
+msgctxt "monster"
+msgid "Carver"
+msgstr "Резчик"
+
+#: Source/monstdat.cpp:39 Source/monstdat.cpp:47
+msgctxt "monster"
+msgid "Devil Kin"
+msgstr "Дьяволёнок"
+
+#: Source/monstdat.cpp:40 Source/monstdat.cpp:48
+msgctxt "monster"
+msgid "Dark One"
+msgstr "Тёмный"
+
+#: Source/monstdat.cpp:41 Source/monstdat.cpp:53
+msgctxt "monster"
+msgid "Skeleton"
+msgstr "Скелет"
+
+#: Source/monstdat.cpp:42
+msgctxt "monster"
+msgid "Corpse Axe"
+msgstr "Мертвец с Топором"
+
+#: Source/monstdat.cpp:43 Source/monstdat.cpp:55
+msgctxt "monster"
+msgid "Burning Dead"
+msgstr "Горящий Мертвец"
+
+#: Source/monstdat.cpp:44 Source/monstdat.cpp:56
+msgctxt "monster"
+msgid "Horror"
+msgstr "Ужас"
+
+#: Source/monstdat.cpp:49
+msgctxt "monster"
+msgid "Scavenger"
+msgstr "Мусорщик"
+
+#: Source/monstdat.cpp:50
+msgctxt "monster"
+msgid "Plague Eater"
+msgstr "Пожиратель Душ"
+
+#: Source/monstdat.cpp:51
+msgctxt "monster"
+msgid "Shadow Beast"
+msgstr "Теневой Зверь"
+
+#: Source/monstdat.cpp:52
+msgctxt "monster"
+msgid "Bone Gasher"
+msgstr "Костепил"
+
+#: Source/monstdat.cpp:54
+msgctxt "monster"
+msgid "Corpse Bow"
+msgstr "Мертвец с Луком"
+
+#: Source/monstdat.cpp:57
+msgctxt "monster"
+msgid "Skeleton Captain"
+msgstr "Капитан Скелетов"
+
+#: Source/monstdat.cpp:58
+msgctxt "monster"
+msgid "Corpse Captain"
+msgstr "Капитан Мертвецов"
+
+#: Source/monstdat.cpp:59
+msgctxt "monster"
+msgid "Burning Dead Captain"
+msgstr "Капитан Горящих Мертвецов"
+
+#: Source/monstdat.cpp:60
+msgctxt "monster"
+msgid "Horror Captain"
+msgstr "Капитан Ужасов"
+
+#: Source/monstdat.cpp:61
+msgctxt "monster"
+msgid "Invisible Lord"
+msgstr "Невидимый Лорд"
+
+#: Source/monstdat.cpp:62
+msgctxt "monster"
+msgid "Hidden"
+msgstr "Скрытый"
+
+#: Source/monstdat.cpp:63
+msgctxt "monster"
+msgid "Stalker"
+msgstr "Преследователь"
+
+#: Source/monstdat.cpp:64
+msgctxt "monster"
+msgid "Unseen"
+msgstr "Незримый"
+
+#: Source/monstdat.cpp:65
+msgctxt "monster"
+msgid "Illusion Weaver"
+msgstr "Ткач Иллюзий"
+
+#: Source/monstdat.cpp:66
+msgctxt "monster"
+msgid "Satyr Lord"
+msgstr "Лорд Сатиров"
+
+#: Source/monstdat.cpp:67 Source/monstdat.cpp:75
+msgctxt "monster"
+msgid "Flesh Clan"
+msgstr "Клан Плоти"
+
+#: Source/monstdat.cpp:68 Source/monstdat.cpp:76
+msgctxt "monster"
+msgid "Stone Clan"
+msgstr "Клан Камня"
+
+#: Source/monstdat.cpp:69 Source/monstdat.cpp:77
+msgctxt "monster"
+msgid "Fire Clan"
+msgstr "Клан Огня"
+
+#: Source/monstdat.cpp:70 Source/monstdat.cpp:78
+msgctxt "monster"
+msgid "Night Clan"
+msgstr "Клан Ночи"
+
+# это летучая мышь
+#: Source/monstdat.cpp:71
+msgctxt "monster"
+msgid "Fiend"
+msgstr "Изверг"
+
+#: Source/monstdat.cpp:72
+msgctxt "monster"
+msgid "Blink"
+msgstr "Мерцающий"
+
+#: Source/monstdat.cpp:73
+msgctxt "monster"
+msgid "Gloom"
+msgstr "Мрак"
+
+#: Source/monstdat.cpp:74
+msgctxt "monster"
+msgid "Familiar"
+msgstr "Фамильяр"
+
+#: Source/monstdat.cpp:79
+msgctxt "monster"
+msgid "Acid Beast"
+msgstr "Кислотный Зверь"
+
+#: Source/monstdat.cpp:80
+msgctxt "monster"
+msgid "Poison Spitter"
+msgstr "Ядовитый Плеватель"
+
+#: Source/monstdat.cpp:81
+msgctxt "monster"
+msgid "Pit Beast"
+msgstr "Зверь Преисподней"
+
+#: Source/monstdat.cpp:82
+msgctxt "monster"
+msgid "Lava Maw"
+msgstr "Лавовая Пасть"
+
+#: Source/monstdat.cpp:83 Source/monstdat.cpp:344
+msgctxt "monster"
+msgid "Skeleton King"
+msgstr "Король-Скелет"
+
+#: Source/monstdat.cpp:84 Source/monstdat.cpp:352
+msgctxt "monster"
+msgid "The Butcher"
+msgstr "Мясник"
+
+#: Source/monstdat.cpp:85
+msgctxt "monster"
+msgid "Overlord"
+msgstr "Владыка"
+
+#: Source/monstdat.cpp:86
+msgctxt "monster"
+msgid "Mud Man"
+msgstr "Грязевой Человек"
+
+#: Source/monstdat.cpp:87
+msgctxt "monster"
+msgid "Toad Demon"
+msgstr "Лягушачий Демон"
+
+#: Source/monstdat.cpp:88
+msgctxt "monster"
+msgid "Flayed One"
+msgstr "Ободранный"
+
+#: Source/monstdat.cpp:89
+msgctxt "monster"
+msgid "Wyrm"
+msgstr "Змей"
+
+#: Source/monstdat.cpp:90
+msgctxt "monster"
+msgid "Cave Slug"
+msgstr "Пещерный Слизень"
+
+#: Source/monstdat.cpp:91
+msgctxt "monster"
+msgid "Devil Wyrm"
+msgstr "Дьявольский Змей"
+
+#: Source/monstdat.cpp:92
+msgctxt "monster"
+msgid "Devourer"
+msgstr "Пожиратель"
+
+#: Source/monstdat.cpp:93
+msgctxt "monster"
+msgid "Magma Demon"
+msgstr "Демон Магмы"
+
+#: Source/monstdat.cpp:94
+msgctxt "monster"
+msgid "Blood Stone"
+msgstr "Кровавый Камень"
+
+#: Source/monstdat.cpp:95
+msgctxt "monster"
+msgid "Hell Stone"
+msgstr "Адский Камень"
+
+#: Source/monstdat.cpp:96
+msgctxt "monster"
+msgid "Lava Lord"
+msgstr "Лавовый Лорд"
+
+#: Source/monstdat.cpp:97
+msgctxt "monster"
+msgid "Horned Demon"
+msgstr "Рогатый Демон"
+
+#: Source/monstdat.cpp:98
+msgctxt "monster"
+msgid "Mud Runner"
+msgstr "Грязевой Бегун"
+
+#: Source/monstdat.cpp:99
+msgctxt "monster"
+msgid "Frost Charger"
+msgstr "Морозный Бегун"
+
+#: Source/monstdat.cpp:100
+msgctxt "monster"
+msgid "Obsidian Lord"
+msgstr "Обсидиановый Лорд"
+
+#: Source/monstdat.cpp:101
+msgctxt "monster"
+msgid "oldboned"
+msgstr "старокостный"
+
+#: Source/monstdat.cpp:102
+msgctxt "monster"
+msgid "Red Death"
+msgstr "Красная Смерть"
+
+# "Li_t_ch", not "Licht".
+# (Also, see the translation of "The Arch-Litch Malignus" below.)
+#: Source/monstdat.cpp:103
+msgctxt "monster"
+msgid "Litch Demon"
+msgstr "Демон-Лич"
+
+#: Source/monstdat.cpp:104
+msgctxt "monster"
+msgid "Undead Balrog"
+msgstr "Балрог-Нежить"
+
+#: Source/monstdat.cpp:105
+msgctxt "monster"
+msgid "Incinerator"
+msgstr "Сжигатель"
+
+#: Source/monstdat.cpp:106
+msgctxt "monster"
+msgid "Flame Lord"
+msgstr "Пламенный Лорд"
+
+#: Source/monstdat.cpp:107
+msgctxt "monster"
+msgid "Doom Fire"
+msgstr "Роковой Огонь"
+
+#: Source/monstdat.cpp:108
+msgctxt "monster"
+msgid "Hell Burner"
+msgstr "Адский Сжигатель"
+
+#: Source/monstdat.cpp:109
+msgctxt "monster"
+msgid "Red Storm"
+msgstr "Красная Буря"
+
+#: Source/monstdat.cpp:110
+msgctxt "monster"
+msgid "Storm Rider"
+msgstr "Штормовой Всадник"
+
+#: Source/monstdat.cpp:111
+msgctxt "monster"
+msgid "Storm Lord"
+msgstr "Повелитель Бури"
+
+#: Source/monstdat.cpp:112
+msgctxt "monster"
+msgid "Maelstrom"
+msgstr "Вихрь"
+
+#: Source/monstdat.cpp:113
+msgctxt "monster"
+msgid "Devil Kin Brute"
+msgstr "Дьяволёнок-Громила"
+
+#: Source/monstdat.cpp:114
+msgctxt "monster"
+msgid "Winged-Demon"
+msgstr "Крылатый Демон"
+
+#: Source/monstdat.cpp:115
+msgctxt "monster"
+msgid "Gargoyle"
+msgstr "Горгулья"
+
+#: Source/monstdat.cpp:116
+msgctxt "monster"
+msgid "Blood Claw"
+msgstr "Кровавый Коготь"
+
+#: Source/monstdat.cpp:117
+msgctxt "monster"
+msgid "Death Wing"
+msgstr "Крыло Смерти"
+
+#: Source/monstdat.cpp:118
+msgctxt "monster"
+msgid "Slayer"
+msgstr "Убийца"
+
+#: Source/monstdat.cpp:119
+msgctxt "monster"
+msgid "Guardian"
+msgstr "Хранитель"
+
+#: Source/monstdat.cpp:120
+msgctxt "monster"
+msgid "Vortex Lord"
+msgstr "Лорд Вихря"
+
+#: Source/monstdat.cpp:121
+msgctxt "monster"
+msgid "Balrog"
+msgstr "Балрог"
+
+#: Source/monstdat.cpp:122
+msgctxt "monster"
+msgid "Cave Viper"
+msgstr "Пещерная Гадюка"
+
+#: Source/monstdat.cpp:123
+msgctxt "monster"
+msgid "Fire Drake"
+msgstr "Огненный Дракон"
+
+#: Source/monstdat.cpp:124
+msgctxt "monster"
+msgid "Gold Viper"
+msgstr "Золотая Гадюка"
+
+#: Source/monstdat.cpp:125
+msgctxt "monster"
+msgid "Azure Drake"
+msgstr "Лазурный Дракон"
+
+#: Source/monstdat.cpp:126
+msgctxt "monster"
+msgid "Black Knight"
+msgstr "Чёрный Рыцарь"
+
+#: Source/monstdat.cpp:127
+msgctxt "monster"
+msgid "Doom Guard"
+msgstr "Страж Рока"
+
+#: Source/monstdat.cpp:128
+msgctxt "monster"
+msgid "Steel Lord"
+msgstr "Лорд Стали"
+
+#: Source/monstdat.cpp:129
+msgctxt "monster"
+msgid "Blood Knight"
+msgstr "Рыцарь Крови"
+
+# Adjective.
+#: Source/monstdat.cpp:130
+msgctxt "monster"
+msgid "The Shredded"
+msgstr "Дроблёный"
+
+# Пустой?
+#: Source/monstdat.cpp:131
+msgctxt "monster"
+msgid "Hollow One"
+msgstr "Полый"
+
+# Можно "Мастер боли", но хозяин как-то жутче.
+#: Source/monstdat.cpp:132
+msgctxt "monster"
+msgid "Pain Master"
+msgstr "Хозяин Боли"
+
+#: Source/monstdat.cpp:133
+msgctxt "monster"
+msgid "Reality Weaver"
+msgstr "Ткач Реальности"
+
+#: Source/monstdat.cpp:134
+msgctxt "monster"
+msgid "Succubus"
+msgstr "Суккуб"
+
+#: Source/monstdat.cpp:135
+msgctxt "monster"
+msgid "Snow Witch"
+msgstr "Снежная Ведьма"
+
+#: Source/monstdat.cpp:136
+msgctxt "monster"
+msgid "Hell Spawn"
+msgstr "Адское Отродье"
+
+#: Source/monstdat.cpp:137
+msgctxt "monster"
+msgid "Soul Burner"
+msgstr "Сжигатель Душ"
+
+#: Source/monstdat.cpp:138
+msgctxt "monster"
+msgid "Counselor"
+msgstr "Советник"
+
+#: Source/monstdat.cpp:139
+msgctxt "monster"
+msgid "Magistrate"
+msgstr "Магистрат"
+
+#: Source/monstdat.cpp:140
+msgctxt "monster"
+msgid "Cabalist"
+msgstr "Заговорщик"
+
+#: Source/monstdat.cpp:141
+msgctxt "monster"
+msgid "Advocate"
+msgstr "Заступник"
+
+#: Source/monstdat.cpp:142
+msgctxt "monster"
+msgid "Golem"
+msgstr "Голем"
+
+#: Source/monstdat.cpp:143
+msgctxt "monster"
+msgid "The Dark Lord"
+msgstr "Тёмный Лорд"
+
+#: Source/monstdat.cpp:144
+msgctxt "monster"
+msgid "The Arch-Litch Malignus"
+msgstr "Архилич Малигнус"
+
+#: Source/monstdat.cpp:145
+msgctxt "monster"
+msgid "Hellboar"
+msgstr "Адский Вепрь"
+
+#: Source/monstdat.cpp:146
+msgctxt "monster"
+msgid "Stinger"
+msgstr "Жалитель"
+
+#: Source/monstdat.cpp:147
+msgctxt "monster"
+msgid "Psychorb"
+msgstr "Психорб"
+
+# FIXME: This creature is not a simple spider, so it might need a different translation.
+# "Арахнон"?
+# ---------------------------------------------
+# Да
+#: Source/monstdat.cpp:148
+msgctxt "monster"
+msgid "Arachnon"
+msgstr "Арахнон"
+
+#: Source/monstdat.cpp:149
+msgctxt "monster"
+msgid "Felltwin"
+msgstr "Падшие Близнецы"
+
+#: Source/monstdat.cpp:150
+msgctxt "monster"
+msgid "Hork Spawn"
+msgstr "Блюющее Отродье"
+
+#: Source/monstdat.cpp:151
+msgctxt "monster"
+msgid "Venomtail"
+msgstr "Скорпион"
+
+#: Source/monstdat.cpp:152
+msgctxt "monster"
+msgid "Necromorb"
+msgstr "Некроморб"
+
+#: Source/monstdat.cpp:153
+msgctxt "monster"
+msgid "Spider Lord"
+msgstr "Лорд Пауков"
+
+#: Source/monstdat.cpp:154
+msgctxt "monster"
+msgid "Lashworm"
+msgstr "Плёточный Червь"
+
+#: Source/monstdat.cpp:155
+msgctxt "monster"
+msgid "Torchant"
+msgstr "Огненный Муравей"
+
+#: Source/monstdat.cpp:156 Source/monstdat.cpp:353
+msgctxt "monster"
+msgid "Hork Demon"
+msgstr "Блюющий Демон"
+
+#: Source/monstdat.cpp:157
+msgctxt "monster"
+msgid "Hell Bug"
+msgstr "Адский Жук"
+
+#: Source/monstdat.cpp:158
+msgctxt "monster"
+msgid "Gravedigger"
+msgstr "Могилокопатель"
+
+#: Source/monstdat.cpp:159
+msgctxt "monster"
+msgid "Tomb Rat"
+msgstr "Крыса Подземелья"
+
+#: Source/monstdat.cpp:160
+msgctxt "monster"
+msgid "Firebat"
+msgstr "Огненная Летучая Мышь"
+
+#: Source/monstdat.cpp:161
+msgctxt "monster"
+msgid "Skullwing"
+msgstr "Черепокрыл"
+
+#: Source/monstdat.cpp:162
+msgctxt "monster"
+msgid "Lich"
+msgstr "Лич"
+
+#: Source/monstdat.cpp:163
+msgctxt "monster"
+msgid "Crypt Demon"
+msgstr "Демон Склепа"
+
+#: Source/monstdat.cpp:164
+msgctxt "monster"
+msgid "Hellbat"
+msgstr "Адская Летучая Мышь"
+
+#: Source/monstdat.cpp:165
+msgctxt "monster"
+msgid "Bone Demon"
+msgstr "Костяной Демон"
+
+#: Source/monstdat.cpp:166
+msgctxt "monster"
+msgid "Arch Lich"
+msgstr "Архилич"
+
+#: Source/monstdat.cpp:167
+msgctxt "monster"
+msgid "Biclops"
+msgstr "Биклоп"
+
+#: Source/monstdat.cpp:168
+msgctxt "monster"
+msgid "Flesh Thing"
+msgstr "Плоть"
+
+#: Source/monstdat.cpp:169
+msgctxt "monster"
+msgid "Reaper"
+msgstr "Жнец"
+
+#. TRANSLATORS: Monster Block end
+#. MT_NAKRUL
+#: Source/monstdat.cpp:171 Source/monstdat.cpp:355
+msgctxt "monster"
+msgid "Na-Krul"
+msgstr "На-Крул"
+
+#. TRANSLATORS: Unique Monster Block start
+#: Source/monstdat.cpp:343
+msgctxt "monster"
+msgid "Gharbad the Weak"
+msgstr "Гарбад Слабый"
+
+#: Source/monstdat.cpp:345
+msgctxt "monster"
+msgid "Zhar the Mad"
+msgstr "Зар Безумец"
+
+#: Source/monstdat.cpp:346
+msgctxt "monster"
+msgid "Snotspill"
+msgstr "Сморкун"
+
+#: Source/monstdat.cpp:347
+msgctxt "monster"
+msgid "Arch-Bishop Lazarus"
+msgstr "Архиепископ Лазарь"
+
+#: Source/monstdat.cpp:348
+msgctxt "monster"
+msgid "Red Vex"
+msgstr "Красная Ворожея"
+
+#: Source/monstdat.cpp:349
+msgctxt "monster"
+msgid "Black Jade"
+msgstr "Чернодейка"
+
+#: Source/monstdat.cpp:350
+msgctxt "monster"
+msgid "Lachdanan"
+msgstr "Лахданан"
+
+#: Source/monstdat.cpp:351
+msgctxt "monster"
+msgid "Warlord of Blood"
+msgstr "Кровавый Генерал"
+
+#: Source/monstdat.cpp:354
+msgctxt "monster"
+msgid "The Defiler"
+msgstr "Осквернитель"
+
+#: Source/monstdat.cpp:356
+msgctxt "monster"
+msgid "Bonehead Keenaxe"
+msgstr "Костеголовый Кинакс"
+
+#: Source/monstdat.cpp:357
+msgctxt "monster"
+msgid "Bladeskin the Slasher"
+msgstr "Лезвий Полосователь"
+
+#: Source/monstdat.cpp:358
+msgctxt "monster"
+msgid "Soulpus"
+msgstr "Душегной"
+
+#: Source/monstdat.cpp:359
+msgctxt "monster"
+msgid "Pukerat the Unclean"
+msgstr "Нечистый Блевокрыс"
+
+#: Source/monstdat.cpp:360
+msgctxt "monster"
+msgid "Boneripper"
+msgstr "Костедёр"
+
+#: Source/monstdat.cpp:361
+msgctxt "monster"
+msgid "Rotfeast the Hungry"
+msgstr "Гнилоед Голодный"
+
+# FIXME: "Guts" and "hank".
+# "Моток кишок"?
+# ---------------------------------------------
+# Есть перевод из WoW, там "Gutshank" переведён как "Потрошмяк". Оставил свой вариант.
+#: Source/monstdat.cpp:362
+msgctxt "monster"
+msgid "Gutshank the Quick"
+msgstr "Кишкокрут Быстрый"
+
+#: Source/monstdat.cpp:363
+msgctxt "monster"
+msgid "Brokenhead Bangshield"
+msgstr "Пусточереп Крепкощит"
+
+#: Source/monstdat.cpp:364
+msgctxt "monster"
+msgid "Bongo"
+msgstr "Бонго"
+
+#: Source/monstdat.cpp:365
+msgctxt "monster"
+msgid "Rotcarnage"
+msgstr "Гнилобой"
+
+#: Source/monstdat.cpp:366
+msgctxt "monster"
+msgid "Shadowbite"
+msgstr "Тенекус"
+
+#: Source/monstdat.cpp:367
+msgctxt "monster"
+msgid "Deadeye"
+msgstr "Мертвоглаз"
+
+#: Source/monstdat.cpp:368
+msgctxt "monster"
+msgid "Madeye the Dead"
+msgstr "Бесоглаз Мертвец"
+
+# https://en.wikipedia.org/wiki/Chupacabra
+# "El" = "The".
+#: Source/monstdat.cpp:369
+msgctxt "monster"
+msgid "El Chupacabras"
+msgstr "Чупакабра"
+
+#: Source/monstdat.cpp:370
+msgctxt "monster"
+msgid "Skullfire"
+msgstr "Огнечереп"
+
+#: Source/monstdat.cpp:371
+msgctxt "monster"
+msgid "Warpskull"
+msgstr "Кривочереп"
+
+#: Source/monstdat.cpp:372
+msgctxt "monster"
+msgid "Goretongue"
+msgstr "Кровояз"
+
+#: Source/monstdat.cpp:373
+msgctxt "monster"
+msgid "Pulsecrawler"
+msgstr "Ползопульс"
+
+#: Source/monstdat.cpp:374
+msgctxt "monster"
+msgid "Moonbender"
+msgstr "Луногиб"
+
+#: Source/monstdat.cpp:375
+msgctxt "monster"
+msgid "Wrathraven"
+msgstr "Гневный Ворон"
+
+#: Source/monstdat.cpp:376
+msgctxt "monster"
+msgid "Spineeater"
+msgstr "Спиногрыз"
+
+#: Source/monstdat.cpp:377
+msgctxt "monster"
+msgid "Blackash the Burning"
+msgstr "Чернострел Пылающий"
+
+#: Source/monstdat.cpp:378
+msgctxt "monster"
+msgid "Shadowcrow"
+msgstr "Крикун Тьмы"
+
+#: Source/monstdat.cpp:379
+msgctxt "monster"
+msgid "Blightstone the Weak"
+msgstr "Гнилостень Cлабак"
+
+#: Source/monstdat.cpp:380
+msgctxt "monster"
+msgid "Bilefroth the Pit Master"
+msgstr "Желчелей Распорядитель"
+
+#: Source/monstdat.cpp:381
+msgctxt "monster"
+msgid "Bloodskin Darkbow"
+msgstr "Кровошкур Темнолук"
+
+#: Source/monstdat.cpp:382
+msgctxt "monster"
+msgid "Foulwing"
+msgstr "Злокрыл"
+
+#: Source/monstdat.cpp:383
+msgctxt "monster"
+msgid "Shadowdrinker"
+msgstr "Тенеглот"
+
+#: Source/monstdat.cpp:384
+msgctxt "monster"
+msgid "Hazeshifter"
+msgstr "Дымовёртыш"
+
+#: Source/monstdat.cpp:385
+msgctxt "monster"
+msgid "Deathspit"
+msgstr "Смертеплюй"
+
+#: Source/monstdat.cpp:386
+msgctxt "monster"
+msgid "Bloodgutter"
+msgstr "Кроводёр"
+
+# Переводить такое - безумие.
+#: Source/monstdat.cpp:387
+msgctxt "monster"
+msgid "Deathshade Fleshmaul"
+msgstr "Смертоносный Свежеватель"
+
+#: Source/monstdat.cpp:388
+msgctxt "monster"
+msgid "Warmaggot the Mad"
+msgstr "Военоличинка Безумец"
+
+#: Source/monstdat.cpp:389
+msgctxt "monster"
+msgid "Glasskull the Jagged"
+msgstr "Зубастый Стеклочереп"
+
+#: Source/monstdat.cpp:390
+msgctxt "monster"
+msgid "Blightfire"
+msgstr "Отравленный Огонь"
+
+#: Source/monstdat.cpp:391
+msgctxt "monster"
+msgid "Nightwing the Cold"
+msgstr "Леденящий Мрачнокрыл"
+
+#: Source/monstdat.cpp:392
+msgctxt "monster"
+msgid "Gorestone"
+msgstr "Камнемяс"
+
+# Родственник Deathshade Fleshmaul
+#: Source/monstdat.cpp:393
+msgctxt "monster"
+msgid "Bronzefist Firestone"
+msgstr "Бронзокулакий Огнекам"
+
+#: Source/monstdat.cpp:394
+msgctxt "monster"
+msgid "Wrathfire the Doomed"
+msgstr "Огнегнев Обречённый"
+
+#: Source/monstdat.cpp:395
+msgctxt "monster"
+msgid "Firewound the Grim"
+msgstr "Огнежёг Беспощадный"
+
+#: Source/monstdat.cpp:396
+msgctxt "monster"
+msgid "Baron Sludge"
+msgstr "Барон Гнус"
+
+# Ещё один родственник Deathshade Fleshmaul
+#: Source/monstdat.cpp:397
+msgctxt "monster"
+msgid "Blighthorn Steelmace"
+msgstr "Тленорог Сталебулавный"
+
+#: Source/monstdat.cpp:398
+msgctxt "monster"
+msgid "Chaoshowler"
+msgstr "Ревун Хаоса"
+
+#: Source/monstdat.cpp:399
+msgctxt "monster"
+msgid "Doomgrin the Rotting"
+msgstr "Судьбоскал Гниющий"
+
+#: Source/monstdat.cpp:400
+msgctxt "monster"
+msgid "Madburner"
+msgstr "Безумный Сжигатель"
+
+#: Source/monstdat.cpp:401
+msgctxt "monster"
+msgid "Bonesaw the Litch"
+msgstr "Пилокост Лич"
+
+#: Source/monstdat.cpp:402
+msgctxt "monster"
+msgid "Breakspine"
+msgstr "Спинолом"
+
+#: Source/monstdat.cpp:403
+msgctxt "monster"
+msgid "Devilskull Sharpbone"
+msgstr "Череподьявол Острокост"
+
+#: Source/monstdat.cpp:404
+msgctxt "monster"
+msgid "Brokenstorm"
+msgstr "Бурелом"
+
+#: Source/monstdat.cpp:405
+msgctxt "monster"
+msgid "Stormbane"
+msgstr "Гиблешторм"
+
+#: Source/monstdat.cpp:406
+msgctxt "monster"
+msgid "Oozedrool"
+msgstr "Слюнослиз"
+
+#: Source/monstdat.cpp:407
+msgctxt "monster"
+msgid "Goldblight of the Flame"
+msgstr "Златомор Пламенный"
+
+#: Source/monstdat.cpp:408
+msgctxt "monster"
+msgid "Blackstorm"
+msgstr "Черношторм"
+
+#: Source/monstdat.cpp:409
+msgctxt "monster"
+msgid "Plaguewrath"
+msgstr "Чумогнев"
+
+#: Source/monstdat.cpp:410
+msgctxt "monster"
+msgid "The Flayer"
+msgstr "Живодёр"
+
+#: Source/monstdat.cpp:411
+msgctxt "monster"
+msgid "Bluehorn"
+msgstr "Синерог"
+
+#: Source/monstdat.cpp:412
+msgctxt "monster"
+msgid "Warpfire Hellspawn"
+msgstr "Отродье Искажённого Огня"
+
+#: Source/monstdat.cpp:413
+msgctxt "monster"
+msgid "Fangspeir"
+msgstr "Клыкатор"
+
+#: Source/monstdat.cpp:414
+msgctxt "monster"
+msgid "Festerskull"
+msgstr "Гноечереп"
+
+#: Source/monstdat.cpp:415
+msgctxt "monster"
+msgid "Lionskull the Bent"
+msgstr "Львочереп"
+
+#: Source/monstdat.cpp:416
+msgctxt "monster"
+msgid "Blacktongue"
+msgstr "Чернояз"
+
+#: Source/monstdat.cpp:417
+msgctxt "monster"
+msgid "Viletouch"
+msgstr "Гнилотрог"
+
+#: Source/monstdat.cpp:418
+msgctxt "monster"
+msgid "Viperflame"
+msgstr "Пламений"
+
+#: Source/monstdat.cpp:419
+msgctxt "monster"
+msgid "Fangskin"
+msgstr "Клыкошкур"
+
+#: Source/monstdat.cpp:420
+msgctxt "monster"
+msgid "Witchfire the Unholy"
+msgstr "Огневедьм Нечестивый"
+
+#: Source/monstdat.cpp:421
+msgctxt "monster"
+msgid "Blackskull"
+msgstr "Черночереп"
+
+#: Source/monstdat.cpp:422
+msgctxt "monster"
+msgid "Soulslash"
+msgstr "Душерез"
+
+#: Source/monstdat.cpp:423
+msgctxt "monster"
+msgid "Windspawn"
+msgstr "Ветрородье"
+
+#: Source/monstdat.cpp:424
+msgctxt "monster"
+msgid "Lord of the Pit"
+msgstr "Повелитель Ямы"
+
+#: Source/monstdat.cpp:425
+msgctxt "monster"
+msgid "Rustweaver"
+msgstr "Ржавокрут"
+
+#: Source/monstdat.cpp:426
+msgctxt "monster"
+msgid "Howlingire the Shade"
+msgstr "Ревущая Тень"
+
+#: Source/monstdat.cpp:427
+msgctxt "monster"
+msgid "Doomcloud"
+msgstr "Судьбокров"
+
+#: Source/monstdat.cpp:428
+msgctxt "monster"
+msgid "Bloodmoon Soulfire"
+msgstr "Кровелун Огнедуш"
+
+#: Source/monstdat.cpp:429
+msgctxt "monster"
+msgid "Witchmoon"
+msgstr "Луноведьма"
+
+#: Source/monstdat.cpp:430
+msgctxt "monster"
+msgid "Gorefeast"
+msgstr "Кровепир"
+
+#: Source/monstdat.cpp:431
+msgctxt "monster"
+msgid "Graywar the Slayer"
+msgstr "Блеклобой Палач"
+
+#: Source/monstdat.cpp:432
+msgctxt "monster"
+msgid "Dreadjudge"
+msgstr "Ужасносуд"
+
+#: Source/monstdat.cpp:433
+msgctxt "monster"
+msgid "Stareye the Witch"
+msgstr "Ведьма Звездоглаз"
+
+#: Source/monstdat.cpp:434
+msgctxt "monster"
+msgid "Steelskull the Hunter"
+msgstr "Сталеглав Охотник"
+
+#: Source/monstdat.cpp:435
+msgctxt "monster"
+msgid "Sir Gorash"
+msgstr "Сэр Гораш"
+
+#: Source/monstdat.cpp:436
+msgctxt "monster"
+msgid "The Vizier"
+msgstr "Визирь"
+
+#: Source/monstdat.cpp:437
+msgctxt "monster"
+msgid "Zamphir"
+msgstr "Замфир"
+
+#: Source/monstdat.cpp:438
+msgctxt "monster"
+msgid "Bloodlust"
+msgstr "Кровожадина"
+
+#: Source/monstdat.cpp:439
+msgctxt "monster"
+msgid "Webwidow"
+msgstr "Вдовопут"
+
+#: Source/monstdat.cpp:440
+msgctxt "monster"
+msgid "Fleshdancer"
+msgstr "Плотетанцовщица"
+
+#: Source/monstdat.cpp:441
+msgctxt "monster"
+msgid "Grimspike"
+msgstr "Мрачношип"
+
+#. TRANSLATORS: Unique Monster Block end
+#: Source/monstdat.cpp:443
+msgctxt "monster"
+msgid "Doomlock"
+msgstr "Судьбожим"
+
+#: Source/monster.cpp:2972
 msgid "Animal"
 msgstr "Зверь"
 
-#: Source/monster.cpp:2942
+#: Source/monster.cpp:2974
 msgid "Demon"
 msgstr "Демон"
 
-#: Source/monster.cpp:2944
+#: Source/monster.cpp:2976
 msgid "Undead"
 msgstr "Нежить"
 
-#: Source/monster.cpp:4318
+#: Source/monster.cpp:4230
 #, c++-format
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Тип: {:s}  Убито: {:d}"
 
-#: Source/monster.cpp:4320
+#: Source/monster.cpp:4232
 #, c++-format
 msgid "Total kills: {:d}"
 msgstr "Убито: {:d}"
 
-#: Source/monster.cpp:4352
+#: Source/monster.cpp:4264
 #, c++-format
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Здоровье: {:d}-{:d}"
 
-#: Source/monster.cpp:4357
+#: Source/monster.cpp:4269
 msgid "No magic resistance"
 msgstr "Нет сопротивления"
 
-#: Source/monster.cpp:4360
+#: Source/monster.cpp:4272
 msgid "Resists:"
 msgstr "Сопротивления:"
 
-#: Source/monster.cpp:4362 Source/monster.cpp:4372
+#: Source/monster.cpp:4274 Source/monster.cpp:4284
 msgid " Magic"
 msgstr " Магия"
 
-#: Source/monster.cpp:4364 Source/monster.cpp:4374
+#: Source/monster.cpp:4276 Source/monster.cpp:4286
 msgid " Fire"
 msgstr " Огонь"
 
-#: Source/monster.cpp:4366 Source/monster.cpp:4376
+#: Source/monster.cpp:4278 Source/monster.cpp:4288
 msgid " Lightning"
 msgstr " Молния"
 
-#: Source/monster.cpp:4370
+#: Source/monster.cpp:4282
 msgid "Immune:"
 msgstr "Иммунитет:"
 
-#: Source/monster.cpp:4387
+#: Source/monster.cpp:4299
 #, c++-format
 msgid "Type: {:s}"
 msgstr "Тип: {:s}"
 
-#: Source/monster.cpp:4392 Source/monster.cpp:4398
+#: Source/monster.cpp:4304 Source/monster.cpp:4310
 msgid "No resistances"
 msgstr "Без сопротивлений"
 
-#: Source/monster.cpp:4393 Source/monster.cpp:4402
+#: Source/monster.cpp:4305 Source/monster.cpp:4314
 msgid "No Immunities"
 msgstr "Без иммунитета"
 
-#: Source/monster.cpp:4396
+#: Source/monster.cpp:4308
 msgid "Some Magic Resistances"
 msgstr "Малое сопротивление магии"
 
-#: Source/monster.cpp:4400
+#: Source/monster.cpp:4312
 msgid "Some Magic Immunities"
 msgstr "Малый магический иммунитет"
 
-#: Source/mpq/mpq_writer.cpp:162
+#: Source/mpq/mpq_writer.cpp:171
 msgid "Failed to open archive for writing."
 msgstr "Не удалось открыть архив для записи."
 
-#: Source/msg.cpp:857
+#: Source/msg.cpp:807
 msgid "Trying to drop a floor item?"
 msgstr "Пытаетесь выкинуть предмет, лежащий на полу?"
 
-#: Source/msg.cpp:1459
+#: Source/msg.cpp:1431
 #, c++-format
 msgid "{:s} has cast an invalid spell."
 msgstr "{:s} применил несуществующее заклинание."
 
-#: Source/msg.cpp:1463
+#: Source/msg.cpp:1435
 #, c++-format
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s} применил запрещённое заклинание."
 
-#: Source/msg.cpp:2094 Source/multi.cpp:830 Source/multi.cpp:880
+#: Source/msg.cpp:2087 Source/multi.cpp:817 Source/multi.cpp:868
 #, c++-format
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "Игрок '{:s}' (уровень {:d}) присоединился к игре"
 
-#: Source/msg.cpp:2481
+#: Source/msg.cpp:2454
 msgid "The game ended"
 msgstr "Игра окончена"
 
-#: Source/msg.cpp:2487
+#: Source/msg.cpp:2460
 msgid "Unable to get level data"
 msgstr "Невозможно получить данные уровня"
 
-#: Source/multi.cpp:277
+#: Source/multi.cpp:270
 #, c++-format
 msgid "Player '{:s}' just left the game"
 msgstr "Игрок '{:s}' покинул игру"
 
-#: Source/multi.cpp:280
+#: Source/multi.cpp:273
 #, c++-format
 msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr "Игрок '{:s}' убил Диабло и покинул игру!"
 
-#: Source/multi.cpp:284
+#: Source/multi.cpp:277
 #, c++-format
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "Игрок '{:s}' исключён из-за времени ожидания"
 
-#: Source/multi.cpp:882
+#: Source/multi.cpp:870
 #, c++-format
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "Игрок '{:s}' (уровень {:d}) уже в игре"
 
 #. TRANSLATORS: Shrine Name Block
-#: Source/objects.cpp:126
+#: Source/objects.cpp:121
 msgid "Mysterious"
 msgstr "Таинственный"
 
-#: Source/objects.cpp:127
+#: Source/objects.cpp:122
 msgid "Hidden"
 msgstr "Скрытый"
 
-#: Source/objects.cpp:128
+#: Source/objects.cpp:123
 msgid "Gloomy"
 msgstr "Хмурый"
 
-#: Source/objects.cpp:129 Source/translation_dummy.cpp:606
-msgid "Weird"
-msgstr "Причудливый"
-
-#: Source/objects.cpp:130 Source/objects.cpp:137
+#: Source/objects.cpp:125 Source/objects.cpp:132
 msgid "Magical"
 msgstr "Магический"
 
-#: Source/objects.cpp:131
+#: Source/objects.cpp:126
 msgid "Stone"
 msgstr "Каменный"
 
-#: Source/objects.cpp:132
+#: Source/objects.cpp:127
 msgid "Religious"
 msgstr "Религиозный"
 
-#: Source/objects.cpp:133
+#: Source/objects.cpp:128
 msgid "Enchanted"
 msgstr "Заколдованный"
 
-#: Source/objects.cpp:134
+#: Source/objects.cpp:129
 msgid "Thaumaturgic"
 msgstr "Чудотворный"
 
-#: Source/objects.cpp:135
+#: Source/objects.cpp:130
 msgid "Fascinating"
 msgstr "Обворожительный"
 
-#: Source/objects.cpp:136
+#: Source/objects.cpp:131
 msgid "Cryptic"
 msgstr "Загадочный"
 
-#: Source/objects.cpp:138
+#: Source/objects.cpp:133
 msgid "Eldritch"
 msgstr "Сверхъестественный"
 
-#: Source/objects.cpp:139
+#: Source/objects.cpp:134
 msgid "Eerie"
 msgstr "Жуткий"
 
-#: Source/objects.cpp:140
+#: Source/objects.cpp:135
 msgid "Divine"
 msgstr "Божественный"
 
-#: Source/objects.cpp:141 Source/translation_dummy.cpp:641
-msgid "Holy"
-msgstr "Святой"
-
-#: Source/objects.cpp:142
+#: Source/objects.cpp:137
 msgid "Sacred"
 msgstr "Священный"
 
-#: Source/objects.cpp:143
+#: Source/objects.cpp:138
 msgid "Spiritual"
 msgstr "Духовный"
 
-#: Source/objects.cpp:144
+#: Source/objects.cpp:139
 msgid "Spooky"
 msgstr "Пугающий"
 
-#: Source/objects.cpp:145
+#: Source/objects.cpp:140
 msgid "Abandoned"
 msgstr "Заброшенный"
 
-#: Source/objects.cpp:146
+#: Source/objects.cpp:141
 msgid "Creepy"
 msgstr "Страшный"
 
-#: Source/objects.cpp:147
+#: Source/objects.cpp:142
 msgid "Quiet"
 msgstr "Тихий"
 
-#: Source/objects.cpp:148
+#: Source/objects.cpp:143
 msgid "Secluded"
 msgstr "Уединённый"
 
-#: Source/objects.cpp:149
+#: Source/objects.cpp:144
 msgid "Ornate"
 msgstr "Украшенный"
 
-#: Source/objects.cpp:150
+#: Source/objects.cpp:145
 msgid "Glimmering"
 msgstr "Блестящий"
 
-#: Source/objects.cpp:151
+#: Source/objects.cpp:146
 msgid "Tainted"
 msgstr "Испорченный"
 
-#: Source/objects.cpp:152
+#: Source/objects.cpp:147
 msgid "Oily"
 msgstr "Маслянистый"
 
-#: Source/objects.cpp:153
+#: Source/objects.cpp:148
 msgid "Glowing"
 msgstr "Светящийся"
 
-#: Source/objects.cpp:154
+#: Source/objects.cpp:149
 msgid "Mendicant's"
 msgstr "Нищенский"
 
-#: Source/objects.cpp:155
+#: Source/objects.cpp:150
 msgid "Sparkling"
 msgstr "Сверкающий"
 
-#: Source/objects.cpp:157
+#: Source/objects.cpp:152
 msgid "Shimmering"
 msgstr "Мерцающий"
 
-#: Source/objects.cpp:158
+#: Source/objects.cpp:153
 msgid "Solar"
 msgstr "Солнечный"
 
 #. TRANSLATORS: Shrine Name Block end
-#: Source/objects.cpp:160
+#: Source/objects.cpp:155
 msgid "Murphy's"
 msgstr "Мёрфи"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:213
+#: Source/objects.cpp:285
 msgid "The Great Conflict"
 msgstr "Великий Конфликт"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:214
+#: Source/objects.cpp:286
 msgid "The Wages of Sin are War"
 msgstr "Возмездие за Грех - Война"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:215
+#: Source/objects.cpp:287
 msgid "The Tale of the Horadrim"
 msgstr "Сказ Хорадримов"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:216
+#: Source/objects.cpp:288
 msgid "The Dark Exile"
 msgstr "Тёмное Изгнание"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:217
+#: Source/objects.cpp:289
 msgid "The Sin War"
 msgstr "Война Грехов"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:218
+#: Source/objects.cpp:290
 msgid "The Binding of the Three"
 msgstr "Связь Трёх"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:219
+#: Source/objects.cpp:291
 msgid "The Realms Beyond"
 msgstr "Царства за Гранью"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:220
+#: Source/objects.cpp:292
 msgid "Tale of the Three"
 msgstr "Сказ Трёх"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:221
+#: Source/objects.cpp:293
 msgid "The Black King"
 msgstr "Чёрный Король"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:222
+#: Source/objects.cpp:294
 msgid "Journal: The Ensorcellment"
 msgstr "Журнал: Волшебство"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:223
+#: Source/objects.cpp:295
 msgid "Journal: The Meeting"
 msgstr "Журнал: Встреча"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:224
+#: Source/objects.cpp:296
 msgid "Journal: The Tirade"
 msgstr "Журнал: Тирада"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:225
+#: Source/objects.cpp:297
 msgid "Journal: His Power Grows"
 msgstr "Журнал: Его Сила Растёт"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:226
+#: Source/objects.cpp:298
 msgid "Journal: NA-KRUL"
 msgstr "Журнал: НА-КРУЛ"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:227
+#: Source/objects.cpp:299
 msgid "Journal: The End"
 msgstr "Журнал: Конец"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:228
+#: Source/objects.cpp:300
 msgid "A Spellbook"
 msgstr "Книга Заклинаний"
 
-#: Source/objects.cpp:4779
+#: Source/objects.cpp:4885
 msgid "Crucified Skeleton"
 msgstr "Распятый скелет"
 
-#: Source/objects.cpp:4783
+#: Source/objects.cpp:4889
 msgid "Lever"
 msgstr "Рычаг"
 
-#: Source/objects.cpp:4793
+#: Source/objects.cpp:4899
 msgid "Open Door"
 msgstr "Открытая дверь"
 
-#: Source/objects.cpp:4795
+#: Source/objects.cpp:4901
 msgid "Closed Door"
 msgstr "Закрытая дверь"
 
-#: Source/objects.cpp:4797
+#: Source/objects.cpp:4903
 msgid "Blocked Door"
 msgstr "Заблокированная дверь"
 
-#: Source/objects.cpp:4802
+#: Source/objects.cpp:4908
 msgid "Ancient Tome"
 msgstr "Древний фолиант"
 
-#: Source/objects.cpp:4804
+#: Source/objects.cpp:4910
 msgid "Book of Vileness"
 msgstr "Книга подлости"
 
-#: Source/objects.cpp:4809
+#: Source/objects.cpp:4915
 msgid "Skull Lever"
 msgstr "Череп-рычаг"
 
-#: Source/objects.cpp:4811
+#: Source/objects.cpp:4917
 msgid "Mythical Book"
 msgstr "Мифическая книга"
 
-#: Source/objects.cpp:4814
+#: Source/objects.cpp:4920
 msgid "Small Chest"
 msgstr "Маленький сундук"
 
-#: Source/objects.cpp:4817
+#: Source/objects.cpp:4923
 msgid "Chest"
 msgstr "Сундук"
 
-#: Source/objects.cpp:4821
+#: Source/objects.cpp:4927
 msgid "Large Chest"
 msgstr "Большой сундук"
 
-#: Source/objects.cpp:4824
+#: Source/objects.cpp:4930
 msgid "Sarcophagus"
 msgstr "Саркофаг"
 
-#: Source/objects.cpp:4826
+#: Source/objects.cpp:4932
 msgid "Bookshelf"
 msgstr "Книжная полка"
 
-#: Source/objects.cpp:4829
+#: Source/objects.cpp:4935
 msgid "Bookcase"
 msgstr "Книжный шкаф"
 
-#: Source/objects.cpp:4832
+#: Source/objects.cpp:4938
 msgid "Barrel"
 msgstr "Бочка"
 
-#: Source/objects.cpp:4835
+#: Source/objects.cpp:4941
 msgid "Pod"
 msgstr "Кокон"
 
-#: Source/objects.cpp:4838
+#: Source/objects.cpp:4944
 msgid "Urn"
 msgstr "Урна"
 
 # Взял из Diablo 3.
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:4841
+#: Source/objects.cpp:4947
 #, c++-format
 msgid "{:s} Shrine"
 msgstr "{:s} святилище"
 
-#: Source/objects.cpp:4843
+#: Source/objects.cpp:4949
 msgid "Skeleton Tome"
 msgstr "Фолиант скелетов"
 
-#: Source/objects.cpp:4845
+#: Source/objects.cpp:4951
 msgid "Library Book"
 msgstr "Библиотечная книга"
 
-#: Source/objects.cpp:4847
+#: Source/objects.cpp:4953
 msgid "Blood Fountain"
 msgstr "Кровавый фонтан"
 
-#: Source/objects.cpp:4849
+#: Source/objects.cpp:4955
 msgid "Decapitated Body"
 msgstr "Обезглавленное тело"
 
-#: Source/objects.cpp:4851
+#: Source/objects.cpp:4957
 msgid "Book of the Blind"
 msgstr "Книга Слепцов"
 
-#: Source/objects.cpp:4853
+#: Source/objects.cpp:4959
 msgid "Book of Blood"
 msgstr "Книга Крови"
 
-#: Source/objects.cpp:4855
+#: Source/objects.cpp:4961
 msgid "Purifying Spring"
 msgstr "Очищающий источник"
 
-#: Source/objects.cpp:4858 Source/translation_dummy.cpp:316
-#: Source/translation_dummy.cpp:318 Source/translation_dummy.cpp:320
-#: Source/translation_dummy.cpp:322
-msgid "Armor"
-msgstr "Доспехи"
-
-#: Source/objects.cpp:4860 Source/objects.cpp:4877
+#: Source/objects.cpp:4966 Source/objects.cpp:4983
 msgid "Weapon Rack"
 msgstr "Стойка с оружием"
 
 # Взял из Diablo 3.
-#: Source/objects.cpp:4862
+#: Source/objects.cpp:4968
 msgid "Goat Shrine"
 msgstr "Козье святилище"
 
-#: Source/objects.cpp:4864
+#: Source/objects.cpp:4970
 msgid "Cauldron"
 msgstr "Котёл"
 
-#: Source/objects.cpp:4866
+#: Source/objects.cpp:4972
 msgid "Murky Pool"
 msgstr "Тёмный бассейн"
 
-#: Source/objects.cpp:4868
+#: Source/objects.cpp:4974
 msgid "Fountain of Tears"
 msgstr "Фонтан слёз"
 
-#: Source/objects.cpp:4870
+#: Source/objects.cpp:4976
 msgid "Steel Tome"
 msgstr "Стальной фолиант"
 
-#: Source/objects.cpp:4872
+#: Source/objects.cpp:4978
 msgid "Pedestal of Blood"
 msgstr "Пьедестал крови"
 
-#: Source/objects.cpp:4879
+#: Source/objects.cpp:4985
 msgid "Mushroom Patch"
 msgstr "Грибы"
 
-#: Source/objects.cpp:4881
+#: Source/objects.cpp:4987
 msgid "Vile Stand"
 msgstr "Мерзкий стенд"
 
-#: Source/objects.cpp:4883
+#: Source/objects.cpp:4989
 msgid "Slain Hero"
 msgstr "Убитый герой"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:4895
+#: Source/objects.cpp:5001
 #, c++-format
 msgid "Trapped {:s}"
 msgstr "{:s} с ловушкой"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls lever
-#: Source/objects.cpp:4900
+#: Source/objects.cpp:5006
 #, c++-format
 msgid "{:s} (disabled)"
 msgstr "{:s} (отключено)"
 
-#: Source/options.cpp:272 Source/options.cpp:409 Source/options.cpp:415
+#: Source/options.cpp:450 Source/options.cpp:590 Source/options.cpp:596
 msgid "ON"
 msgstr "ВКЛ"
 
-#: Source/options.cpp:272 Source/options.cpp:407 Source/options.cpp:413
+#: Source/options.cpp:450 Source/options.cpp:588 Source/options.cpp:594
 msgid "OFF"
 msgstr "ВЫКЛ"
 
-#: Source/options.cpp:384 Source/options.cpp:385
+#: Source/options.cpp:563 Source/options.cpp:564
 msgid "Game Mode"
 msgstr "Режим игры"
 
-#: Source/options.cpp:384
+#: Source/options.cpp:563
 msgid "Game Mode Settings"
 msgstr "Настройки игрового процесса"
 
-#: Source/options.cpp:385
+#: Source/options.cpp:564
 msgid "Play Diablo or Hellfire."
 msgstr "Играть в Diablo или Hellfire."
 
-#: Source/options.cpp:391
+#: Source/options.cpp:570
 msgid "Restrict to Shareware"
 msgstr "Ограничить до Shareware"
 
-#: Source/options.cpp:391
+#: Source/options.cpp:570
 msgid ""
 "Makes the game compatible with the demo. Enables multiplayer with friends "
 "who don't own a full copy of Diablo."
@@ -3999,114 +6735,118 @@ msgstr ""
 "Делает игру совместимой с демоверсией. Позволяет играть в сетевую игру с "
 "друзьями, у которых нет полной версии Diablo."
 
-#: Source/options.cpp:404
+#: Source/options.cpp:585
 msgid "Start Up"
 msgstr "Запустить"
 
-#: Source/options.cpp:404
+#: Source/options.cpp:585
 msgid "Start Up Settings"
 msgstr "Параметры запуска"
 
-#: Source/options.cpp:405 Source/options.cpp:411
+#: Source/options.cpp:586 Source/options.cpp:592
 msgid "Intro"
 msgstr "Интро"
 
-#: Source/options.cpp:405 Source/options.cpp:411
+#: Source/options.cpp:586 Source/options.cpp:592
 msgid "Shown Intro cinematic."
 msgstr "Показываемый ролик."
 
-#: Source/options.cpp:417
+#: Source/options.cpp:598
 msgid "Splash"
 msgstr "Заставка"
 
-#: Source/options.cpp:417
+#: Source/options.cpp:598
 msgid "Shown splash screen."
 msgstr "Показываемая заставка."
 
-#: Source/options.cpp:419
+#: Source/options.cpp:600
 msgid "Logo and Title Screen"
 msgstr "Логотип и титульный экран"
 
-#: Source/options.cpp:420
+#: Source/options.cpp:601
 msgid "Title Screen"
 msgstr "Титульный экран"
 
-#: Source/options.cpp:435
+#: Source/options.cpp:616
 msgid "Diablo specific Settings"
 msgstr "Специальные настройки Diablo"
 
-#: Source/options.cpp:449
+#: Source/options.cpp:630
 msgid "Hellfire specific Settings"
 msgstr "Специальные настройки Hellfire"
 
-#: Source/options.cpp:463
+#: Source/options.cpp:644
 msgid "Audio"
 msgstr "Звук"
 
-#: Source/options.cpp:463
+#: Source/options.cpp:644
 msgid "Audio Settings"
 msgstr "Настройки звука"
 
-#: Source/options.cpp:466
+#: Source/options.cpp:647
 msgid "Walking Sound"
 msgstr "Звук ходьбы"
 
 # Player? Maybe the player character? Or hero?
 # (The original phrase is formulated in a quite, ahem, specific way. Might need to update the English translation itself.)
-#: Source/options.cpp:466
+#: Source/options.cpp:647
 msgid "Player emits sound when walking."
 msgstr "Персонаж издает звук при ходьбе."
 
-#: Source/options.cpp:467
+#: Source/options.cpp:648
 msgid "Auto Equip Sound"
 msgstr "Звук автоэкипирования"
 
-#: Source/options.cpp:467
+#: Source/options.cpp:648
 msgid "Automatically equipping items on pickup emits the equipment sound."
 msgstr "При автоматическом экипировании предметов издаётся звук."
 
-#: Source/options.cpp:468
+#: Source/options.cpp:649
 msgid "Item Pickup Sound"
 msgstr "Звук сбора предметов"
 
-#: Source/options.cpp:468
+#: Source/options.cpp:649
 msgid "Picking up items emits the items pickup sound."
 msgstr "При сборе предметов издаётся звук."
 
-#: Source/options.cpp:469
+#: Source/options.cpp:650
 msgid "Sample Rate"
 msgstr "Частота дискретизации"
 
-#: Source/options.cpp:469
+#: Source/options.cpp:650
 msgid "Output sample rate (Hz)."
 msgstr "Выходная частота дискретизации (Гц)"
 
-#: Source/options.cpp:470
+#: Source/options.cpp:651
 msgid "Channels"
 msgstr "Каналы"
 
-#: Source/options.cpp:470
+#: Source/options.cpp:651
 msgid "Number of output channels."
 msgstr "Количество выходных каналов."
 
-#: Source/options.cpp:471
+#: Source/options.cpp:652
 msgid "Buffer Size"
 msgstr "Размер буфера"
 
-#: Source/options.cpp:471
+#: Source/options.cpp:652
 msgid "Buffer size (number of frames per channel)."
 msgstr "Размер буфера (количество кадров на канал)."
 
-#: Source/options.cpp:472
+#: Source/options.cpp:653
 msgid "Resampling Quality"
 msgstr "Качество передискретизации"
 
-#: Source/options.cpp:472
+#: Source/options.cpp:653
 msgid "Quality of the resampler, from 0 (lowest) to 10 (highest)."
 msgstr "Качество передискретизации, от 0 (самое низкое) до 10 (самое высокое)."
 
+#: Source/options.cpp:684
+msgid "Resolution"
+msgstr "Разрешение"
+
 # Полный корректный перевод не влазит в 3 строки.
-#: Source/options.cpp:497
+#: Source/options.cpp:684
 msgid ""
 "Affect the game's internal resolution and determine your view area. Note: "
 "This can differ from screen resolution, when Upscaling, Integer Scaling or "
@@ -4116,43 +6856,43 @@ msgstr ""
 "Примечание: зависит от использованного типа масштабирования (Upscaling, "
 "Integer Scaling или Fit to Screen)."
 
-#: Source/options.cpp:643
+#: Source/options.cpp:831
 msgid "Resampler"
 msgstr "Ресемплер"
 
-#: Source/options.cpp:643
+#: Source/options.cpp:831
 msgid "Audio resampler"
 msgstr "Авто ресемплер"
 
-#: Source/options.cpp:700
+#: Source/options.cpp:888
 msgid "Device"
 msgstr "Устройство"
 
-#: Source/options.cpp:700
+#: Source/options.cpp:888
 msgid "Audio device"
 msgstr "Аудио устройство"
 
-#: Source/options.cpp:757
+#: Source/options.cpp:956
 msgid "Graphics"
 msgstr "Графика"
 
-#: Source/options.cpp:757
+#: Source/options.cpp:956
 msgid "Graphics Settings"
 msgstr "Настройки графики"
 
-#: Source/options.cpp:758
+#: Source/options.cpp:957
 msgid "Fullscreen"
 msgstr "На весь экран"
 
-#: Source/options.cpp:758
+#: Source/options.cpp:957
 msgid "Display the game in windowed or fullscreen mode."
 msgstr "Отображение игры в оконном или полноэкранном режиме."
 
-#: Source/options.cpp:760
+#: Source/options.cpp:959
 msgid "Fit to Screen"
 msgstr "По размеру экрана"
 
-#: Source/options.cpp:760
+#: Source/options.cpp:959
 msgid ""
 "Automatically adjust the game window to your current desktop screen aspect "
 "ratio and resolution."
@@ -4160,11 +6900,11 @@ msgstr ""
 "Автоматически настраивает окно игры в соответствии с текущим соотношением "
 "сторон и разрешением экрана рабочего стола."
 
-#: Source/options.cpp:763
+#: Source/options.cpp:962
 msgid "Upscale"
 msgstr "Масштабирование"
 
-#: Source/options.cpp:763
+#: Source/options.cpp:962
 msgid ""
 "Enables image scaling from the game resolution to your monitor resolution. "
 "Prevents changing the monitor resolution and allows window resizing."
@@ -4173,104 +6913,104 @@ msgstr ""
 "монитора. Предотвращает изменение разрешения монитора и позволяет изменять "
 "размер окна."
 
-#: Source/options.cpp:770
+#: Source/options.cpp:969
 msgid "Scaling Quality"
 msgstr "Качество масштабирования"
 
-#: Source/options.cpp:770
+#: Source/options.cpp:969
 msgid "Enables optional filters to the output image when upscaling."
 msgstr ""
 "Включает дополнительные фильтры для выходного изображения при "
 "масштабировании."
 
-#: Source/options.cpp:772
+#: Source/options.cpp:971
 msgid "Nearest Pixel"
 msgstr "Ближайший пиксель"
 
-#: Source/options.cpp:773
+#: Source/options.cpp:972
 msgid "Bilinear"
 msgstr "Билинейная"
 
-#: Source/options.cpp:774
+#: Source/options.cpp:973
 msgid "Anisotropic"
 msgstr "Анизотропная"
 
-#: Source/options.cpp:776
+#: Source/options.cpp:975
 msgid "Integer Scaling"
 msgstr "Целочисленное масштабирование"
 
-#: Source/options.cpp:776
+#: Source/options.cpp:975
 msgid "Scales the image using whole number pixel ratio."
 msgstr ""
 "Масштабирует изображение с использованием целочисленного соотношения "
 "пикселей."
 
-#: Source/options.cpp:784
+#: Source/options.cpp:983
 msgid "Frame Rate Control"
 msgstr "Управление Частотой Кадров"
 
-#: Source/options.cpp:785
+#: Source/options.cpp:984
 msgid ""
 "Manages frame rate to balance performance, reduce tearing, or save power."
 msgstr ""
 "Управление частотой кадров для сбалансирования производительности, "
 "уменьшения разрывов или экономии электроэнергии."
 
-#: Source/options.cpp:795
+#: Source/options.cpp:994
 msgid "Vertical Sync"
 msgstr "Вертикальная синхронизация"
 
-#: Source/options.cpp:797
+#: Source/options.cpp:996
 msgid "Limit FPS"
 msgstr "Ограничение FPS"
 
-#: Source/options.cpp:800
+#: Source/options.cpp:999
 msgid "Zoom on when enabled."
 msgstr "Приближает, если включено."
 
-#: Source/options.cpp:801
+#: Source/options.cpp:1000
 msgid "Color Cycling"
 msgstr "Цветовой цикл"
 
-#: Source/options.cpp:801
+#: Source/options.cpp:1000
 msgid "Color cycling effect used for water, lava, and acid animation."
 msgstr ""
 "Эффект циклического изменения цвета, используемый для анимации воды, лавы и "
 "кислоты."
 
-#: Source/options.cpp:802
+#: Source/options.cpp:1001
 msgid "Alternate nest art"
 msgstr "Альтернативное оформление Гнезда"
 
-#: Source/options.cpp:802
+#: Source/options.cpp:1001
 msgid "The game will use an alternative palette for Hellfire’s nest tileset."
 msgstr ""
 "В игре будет использована альтернативная палитра для тайлов Гнезда в "
 "Hellfire."
 
-#: Source/options.cpp:804
+#: Source/options.cpp:1003
 msgid "Hardware Cursor"
 msgstr "Аппаратный курсор"
 
-#: Source/options.cpp:804
+#: Source/options.cpp:1003
 msgid "Use a hardware cursor"
 msgstr "Использовать аппаратный курсор"
 
-#: Source/options.cpp:805
+#: Source/options.cpp:1004
 msgid "Hardware Cursor For Items"
 msgstr "Аппаратный курсор для предметов"
 
-#: Source/options.cpp:805
+#: Source/options.cpp:1004
 msgid "Use a hardware cursor for items."
 msgstr "Использовать аппаратный курсор для предметов."
 
 # Если оставить слово "максимальный", то не влезает в границы интерфейса (2 символа).
-#: Source/options.cpp:806
+#: Source/options.cpp:1005
 msgid "Hardware Cursor Maximum Size"
 msgstr "Предельный размер аппаратного курсора"
 
 # "Максимальный" на "предельный" менять не стал..
-#: Source/options.cpp:806
+#: Source/options.cpp:1005
 msgid ""
 "Maximum width / height for the hardware cursor. Larger cursors fall back to "
 "software."
@@ -4278,23 +7018,27 @@ msgstr ""
 "Максимальная ширина/высота аппаратного курсора. Курсоры большого размера "
 "откатываются к программным."
 
-#: Source/options.cpp:808
+#: Source/options.cpp:1007
 msgid "Show FPS"
 msgstr "Показать FPS"
 
-#: Source/options.cpp:808
+#: Source/options.cpp:1007
 msgid "Displays the FPS in the upper left corner of the screen."
 msgstr "Отображать FPS в верхнем левом углу экрана."
 
-#: Source/options.cpp:843
+#: Source/options.cpp:1053
 msgid "Gameplay"
 msgstr "Геймплей"
 
-#: Source/options.cpp:843
+#: Source/options.cpp:1053
 msgid "Gameplay Settings"
 msgstr "Настройки игрового процесса"
 
-#: Source/options.cpp:845
+#: Source/options.cpp:1055
+msgid "Run in Town"
+msgstr "Бег в городе"
+
+#: Source/options.cpp:1055
 msgid ""
 "Enable jogging/fast walking in town for Diablo and Hellfire. This option was "
 "introduced in the expansion."
@@ -4302,38 +7046,36 @@ msgstr ""
 "Включить бег трусцой/быструю ходьбу в городе для Diablo и Hellfire. Эта "
 "опция была введена в дополнении."
 
-#: Source/options.cpp:846
+#: Source/options.cpp:1056
 msgid "Grab Input"
 msgstr "Захват ввода"
 
-#: Source/options.cpp:846
+#: Source/options.cpp:1056
 msgid "When enabled mouse is locked to the game window."
 msgstr "Если включено, мышь фиксируется в окне игры."
 
-#: Source/options.cpp:847
-msgid "Pause Game When Window Loses Focus"
-msgstr "Пауза если окно теряет фокус"
+#: Source/options.cpp:1057
+msgid "Theo Quest"
+msgstr "Задание Тео"
 
-#: Source/options.cpp:847
-msgid "When enabled, the game will pause when focus is lost."
-msgstr ""
-"Если включено, игра встанет на паузу при потере фокуса (переключении на "
-"другое окно)."
-
-#: Source/options.cpp:848
+#: Source/options.cpp:1057
 msgid "Enable Little Girl quest."
 msgstr "Включает задание Малышки."
 
-#: Source/options.cpp:849
+#: Source/options.cpp:1058
+msgid "Cow Quest"
+msgstr "Коровье задание"
+
+#: Source/options.cpp:1058
 msgid ""
 "Enable Jersey's quest. Lester the farmer is replaced by the Complete Nut."
 msgstr "Включает задание Джерси. Фермер Лестер заменяется на Полного психа."
 
-#: Source/options.cpp:850
+#: Source/options.cpp:1059
 msgid "Friendly Fire"
 msgstr "Дружественный огонь"
 
-#: Source/options.cpp:850
+#: Source/options.cpp:1059
 msgid ""
 "Allow arrow/spell damage between players in multiplayer even when the "
 "friendly mode is on."
@@ -4341,139 +7083,183 @@ msgstr ""
 "Разрешить урон от стрел/заклинаний между игроками в сетевой игре, даже если "
 "включен дружественный режим."
 
-#: Source/options.cpp:851
+#: Source/options.cpp:1060
 msgid "Full quests in Multiplayer"
 msgstr "Полные квесты в сетевой игре"
 
-#: Source/options.cpp:851
+#: Source/options.cpp:1060
 msgid "Enables the full/uncut singleplayer version of quests."
 msgstr "Включает полную/не обрезанную версию квестов."
 
-#: Source/options.cpp:852
+#: Source/options.cpp:1061
 msgid "Test Bard"
 msgstr "Тестировать Барда"
 
-#: Source/options.cpp:852
+#: Source/options.cpp:1061
 msgid "Force the Bard character type to appear in the hero selection menu."
 msgstr "Даёт возможность выбора вырезанного персонажа Барда."
 
-#: Source/options.cpp:853
+#: Source/options.cpp:1062
 msgid "Test Barbarian"
 msgstr "Тестировать варвара"
 
-#: Source/options.cpp:853
+#: Source/options.cpp:1062
 msgid ""
 "Force the Barbarian character type to appear in the hero selection menu."
 msgstr "Даёт возможность выбора вырезанного персонажа Варвара."
 
-#: Source/options.cpp:854
+#: Source/options.cpp:1063
 msgid "Experience Bar"
 msgstr "Полоса опыта"
 
 # UI как "пользовательский интерфейс" – слишком длинно. Адаптировал.
-#: Source/options.cpp:854
+#: Source/options.cpp:1063
 msgid "Experience Bar is added to the UI at the bottom of the screen."
 msgstr "Полоса опыта добавлена в нижнюю часть панели интерфейса игрока."
 
-#: Source/options.cpp:855
+#: Source/options.cpp:1064
 msgid "Show Item Graphics in Stores"
 msgstr "Отобразить вид товара в магазине"
 
-#: Source/options.cpp:855
+#: Source/options.cpp:1064
 msgid "Show item graphics to the left of item descriptions in store menus."
 msgstr "Отображает то, как выглядит продаваемый предмет слева от текста."
 
-#: Source/options.cpp:856
+#: Source/options.cpp:1065
 msgid "Show health values"
 msgstr "Показать значение здоровья"
 
 # Здесь и ниже – приведение к единообразию во всём меню.
-#: Source/options.cpp:856
+#: Source/options.cpp:1065
 msgid "Displays current / max health value on health globe."
 msgstr "Отображает текущее/максимальное значение здоровья на шаре здоровья."
 
-#: Source/options.cpp:857
+#: Source/options.cpp:1066
 msgid "Show mana values"
 msgstr "Показать значение маны"
 
-#: Source/options.cpp:857
+#: Source/options.cpp:1066
 msgid "Displays current / max mana value on mana globe."
 msgstr "Отображает текущее/максимальное значение маны на шаре маны."
 
-#: Source/options.cpp:858
+#: Source/options.cpp:1067
 msgid "Enemy Health Bar"
 msgstr "Индикатор здоровья врага"
 
-#: Source/options.cpp:858
+#: Source/options.cpp:1067
 msgid "Enemy Health Bar is displayed at the top of the screen."
 msgstr "Полоса здоровья врага отображается в верхней части экрана."
 
-#: Source/options.cpp:859
+#: Source/options.cpp:1068
+msgid "Auto Gold Pickup"
+msgstr "Автоподбор золота"
+
+#: Source/options.cpp:1068
 msgid "Gold is automatically collected when in close proximity to the player."
 msgstr ""
 "Золото автоматически подбирается, когда персонаж находится в "
 "непосредственной близости от него."
 
-#: Source/options.cpp:860
+#: Source/options.cpp:1069
+msgid "Auto Elixir Pickup"
+msgstr "Автоподбор элексиров"
+
+#: Source/options.cpp:1069
 msgid ""
 "Elixirs are automatically collected when in close proximity to the player."
 msgstr ""
 "Эликсиры автоматически подбираются, когда персонаж находится в "
 "непосредственной близости от них."
 
-#: Source/options.cpp:861
+#: Source/options.cpp:1070
+msgid "Auto Oil Pickup"
+msgstr "Автоподбор масел"
+
+#: Source/options.cpp:1070
 msgid "Oils are automatically collected when in close proximity to the player."
 msgstr ""
 "Масла автоматически подбираются, когда персонаж находится в непосредственной "
 "близости от них."
 
-#: Source/options.cpp:862
+#: Source/options.cpp:1071
+msgid "Auto Pickup in Town"
+msgstr "Автоподбор в городе"
+
+#: Source/options.cpp:1071
 msgid "Automatically pickup items in town."
 msgstr "Автоподбор предметов в городе."
 
-#: Source/options.cpp:863
+#: Source/options.cpp:1072
+msgid "Adria Refills Mana"
+msgstr "Адрия восполняет ману"
+
+#: Source/options.cpp:1072
 msgid "Adria will refill your mana when you visit her shop."
 msgstr "Адрия пополнит вашу ману, когда вы посетите её магазин."
 
-#: Source/options.cpp:864
+#: Source/options.cpp:1073
+msgid "Auto Equip Weapons"
+msgstr "Автоэкипирование оружия"
+
+#: Source/options.cpp:1073
 msgid ""
 "Weapons will be automatically equipped on pickup or purchase if enabled."
 msgstr ""
 "Оружие будет автоматически экипировано при подборе или покупке, если "
 "включено."
 
-#: Source/options.cpp:865
+#: Source/options.cpp:1074
+msgid "Auto Equip Armor"
+msgstr "Автоэкипирование брони"
+
+#: Source/options.cpp:1074
 msgid "Armor will be automatically equipped on pickup or purchase if enabled."
 msgstr ""
 "Броня будет автоматически экипирована при подборе или покупке, если включено."
 
-#: Source/options.cpp:866
+#: Source/options.cpp:1075
+msgid "Auto Equip Helms"
+msgstr "Автоэкипирование шлемов"
+
+#: Source/options.cpp:1075
 msgid "Helms will be automatically equipped on pickup or purchase if enabled."
 msgstr ""
 "Шлемы будут автоматически экипированы при подборе или покупке, если включено."
 
-#: Source/options.cpp:867
+#: Source/options.cpp:1076
+msgid "Auto Equip Shields"
+msgstr "Автоэкипирование щитов"
+
+#: Source/options.cpp:1076
 msgid ""
 "Shields will be automatically equipped on pickup or purchase if enabled."
 msgstr ""
 "Щиты будут автоматически экипированы при подборе или покупке, если включено."
 
-#: Source/options.cpp:868
+#: Source/options.cpp:1077
+msgid "Auto Equip Jewelry"
+msgstr "Автоэкипирование украшений"
+
+#: Source/options.cpp:1077
 msgid ""
 "Jewelry will be automatically equipped on pickup or purchase if enabled."
 msgstr ""
 "Украшения будут автоматически экипированы при подборе или покупке, если "
 "включено."
 
-#: Source/options.cpp:869
+#: Source/options.cpp:1078
+msgid "Randomize Quests"
+msgstr "Рандомизировать задания"
+
+#: Source/options.cpp:1078
 msgid "Randomly selecting available quests for new games."
 msgstr "Случайный выбор доступных заданий для новых игр."
 
-#: Source/options.cpp:870
+#: Source/options.cpp:1079
 msgid "Show Monster Type"
 msgstr "Показать тип монстра"
 
-#: Source/options.cpp:870
+#: Source/options.cpp:1079
 msgid ""
 "Hovering over a monster will display the type of monster in the description "
 "box in the UI."
@@ -4481,29 +7267,41 @@ msgstr ""
 "При наведении курсора на монстра, тип монстра будет отображаться в поле "
 "описания панели интерфейса игрока."
 
-#: Source/options.cpp:871
+#: Source/options.cpp:1080
+msgid "Show Item Labels"
+msgstr "Показать имя предметов"
+
+#: Source/options.cpp:1080
 msgid "Show labels for items on the ground when enabled."
 msgstr "Отображает название лежащих на земле предметов, если включено."
 
-#: Source/options.cpp:872
+#: Source/options.cpp:1081
+msgid "Auto Refill Belt"
+msgstr "Автопополнение пояса"
+
+#: Source/options.cpp:1081
 msgid "Refill belt from inventory when belt item is consumed."
 msgstr "Пополнить пояс из инвентаря, если предмет на поясе израсходован."
 
-#: Source/options.cpp:873
+#: Source/options.cpp:1082
+msgid "Disable Crippling Shrines"
+msgstr "Отключить калечащие святилища"
+
+#: Source/options.cpp:1082
 msgid ""
-"When enabled Cauldrons, Fascinating Shrines, Goat Shrines, Ornate Shrines, "
-"Sacred Shrines and Murphy's Shrines are not able to be clicked on and "
+"When enabled Cauldrons, Fascinating Shrines, Goat Shrines, Ornate Shrines "
+"and Sacred Shrines are not able to be clicked on and "
 "labeled as disabled."
 msgstr ""
 "Если включено, святилища со случайным эффектом не будут доступны к "
 "применению. Будут доступны лишь фонтаны и бассейны."
 
 # Что-то лучше не подобрал. Заменить, если будет найдено что-то лучше.
-#: Source/options.cpp:874
+#: Source/options.cpp:1083
 msgid "Quick Cast"
 msgstr "Быстрое заклинание"
 
-#: Source/options.cpp:874
+#: Source/options.cpp:1083
 msgid ""
 "Spell hotkeys instantly cast the spell, rather than switching the readied "
 "spell."
@@ -4511,258 +7309,249 @@ msgstr ""
 "Горячие клавиши заклинаний мгновенно применяют заклинание, а не переключают "
 "их."
 
-#: Source/options.cpp:875
+# Пункт здесь и ниже находится в меню перед числом, так что.. так будет логичнее.
+#: Source/options.cpp:1084
+msgid "Heal Potion Pickup"
+msgstr "Подбор Зелий Исцеления"
+
+#: Source/options.cpp:1084
 msgid "Number of Healing potions to pick up automatically."
 msgstr "Количество Зелий Исцеления, которое нужно подобрать автоматически."
 
-#: Source/options.cpp:876
+#: Source/options.cpp:1085
+msgid "Full Heal Potion Pickup"
+msgstr "Подбор Зелий Полного Исцеления"
+
+#: Source/options.cpp:1085
 msgid "Number of Full Healing potions to pick up automatically."
 msgstr ""
 "Количество Зелий Полного Исцеления, которое нужно подобрать автоматически."
 
-#: Source/options.cpp:877
+#: Source/options.cpp:1086
+msgid "Mana Potion Pickup"
+msgstr "Подбор Зелий Маны"
+
+#: Source/options.cpp:1086
 msgid "Number of Mana potions to pick up automatically."
 msgstr "Количество Зелий Маны, которое нужно подобрать автоматически."
 
-#: Source/options.cpp:878
+#: Source/options.cpp:1087
+msgid "Full Mana Potion Pickup"
+msgstr "Подбор Зелий Полной Маны"
+
+#: Source/options.cpp:1087
 msgid "Number of Full Mana potions to pick up automatically."
 msgstr "Количество Зелий Полной Маны, которое нужно подобрать автоматически."
 
-#: Source/options.cpp:879
+#: Source/options.cpp:1088
+msgid "Rejuvenation Potion Pickup"
+msgstr "Подбор Зелий Омоложения"
+
+#: Source/options.cpp:1088
 msgid "Number of Rejuvenation potions to pick up automatically."
 msgstr "Количество Зелий Омоложения, которое нужно подобрать автоматически."
 
-#: Source/options.cpp:880
+#: Source/options.cpp:1089
+msgid "Full Rejuvenation Potion Pickup"
+msgstr "Подбор Зелий Полного Омоложения"
+
+#: Source/options.cpp:1089
 msgid "Number of Full Rejuvenation potions to pick up automatically."
 msgstr ""
 "Количество Зелий Полного Омоложения, которое нужно подобрать автоматически."
 
-#: Source/options.cpp:881
+#: Source/options.cpp:1090
 msgid "Enable floating numbers"
 msgstr "Включить парящие числа урона"
 
-#: Source/options.cpp:881
+#: Source/options.cpp:1090
 msgid "Enables floating numbers on gaining XP / dealing damage etc."
 msgstr "Выводит числа полученного и нанесённого урона над целью."
 
-#: Source/options.cpp:883
+#: Source/options.cpp:1092
 msgid "Off"
 msgstr "Выключено"
 
-#: Source/options.cpp:884
+#: Source/options.cpp:1093
 msgid "Random Angles"
 msgstr "Разные направления"
 
-#: Source/options.cpp:885
+#: Source/options.cpp:1094
 msgid "Vertical Only"
 msgstr "Вертикальное направление"
 
-#: Source/options.cpp:937
+#: Source/options.cpp:1145
 msgid "Controller"
 msgstr "Контроллер"
 
-#: Source/options.cpp:937
+#: Source/options.cpp:1145
 msgid "Controller Settings"
 msgstr "Настройки контроллера"
 
-#: Source/options.cpp:946
+#: Source/options.cpp:1154
 msgid "Network"
 msgstr "Сеть"
 
-#: Source/options.cpp:946
+#: Source/options.cpp:1154
 msgid "Network Settings"
 msgstr "Настройки сети"
 
-#: Source/options.cpp:958
+#: Source/options.cpp:1166
 msgid "Chat"
 msgstr "Чат"
 
-#: Source/options.cpp:958
+#: Source/options.cpp:1166
 msgid "Chat Settings"
 msgstr "Настройки чата"
 
-#: Source/options.cpp:967 Source/options.cpp:1085
+#: Source/options.cpp:1175 Source/options.cpp:1293
 msgid "Language"
 msgstr "Язык"
 
-#: Source/options.cpp:967
+#: Source/options.cpp:1175
 msgid "Define what language to use in game."
 msgstr "Определите, какой язык использовать в игре."
 
-#: Source/options.cpp:1085
+#: Source/options.cpp:1293
 msgid "Language Settings"
 msgstr "Настройки языка"
 
-#: Source/options.cpp:1096
+#: Source/options.cpp:1305
 msgid "Keymapping"
 msgstr "Клавиатура"
 
-#: Source/options.cpp:1096
+#: Source/options.cpp:1305
 msgid "Keymapping Settings"
 msgstr "Настройка привязки клавиш клавиатуры"
 
-#: Source/options.cpp:1358
+#: Source/options.cpp:1561
 msgid "Padmapping"
 msgstr "Геймпад"
 
-#: Source/options.cpp:1358
+#: Source/options.cpp:1561
 msgid "Padmapping Settings"
 msgstr "Настройка привязки кнопок геймпада"
 
-#: Source/options.cpp:1695
-msgid "Mods"
-msgstr "Моды"
-
-#: Source/options.cpp:1695
-msgid "Mod Settings"
-msgstr "Настройки модов"
-
-#: Source/panels/charpanel.cpp:133
+#: Source/panels/charpanel.cpp:127
 msgid "Level"
 msgstr "Уровень"
 
-#: Source/panels/charpanel.cpp:135
+#: Source/panels/charpanel.cpp:129
 msgid "Experience"
 msgstr "Опыт"
 
-#: Source/panels/charpanel.cpp:140
+#: Source/panels/charpanel.cpp:134
 msgid "Next level"
 msgstr ""
 "След.\n"
 "уровень"
 
-#: Source/panels/charpanel.cpp:150
+#: Source/panels/charpanel.cpp:143
 msgid "Base"
 msgstr "База"
 
-#: Source/panels/charpanel.cpp:151
+#: Source/panels/charpanel.cpp:144
 msgid "Now"
 msgstr "Сейчас"
 
-#: Source/panels/charpanel.cpp:152
+#: Source/panels/charpanel.cpp:145
 msgid "Strength"
 msgstr "Сила"
 
-#: Source/panels/charpanel.cpp:156
+#: Source/panels/charpanel.cpp:149
 msgid "Magic"
 msgstr "Магия"
 
-#: Source/panels/charpanel.cpp:160
+#: Source/panels/charpanel.cpp:153
 msgid "Dexterity"
 msgstr "Ловкость"
 
-#: Source/panels/charpanel.cpp:163
+#: Source/panels/charpanel.cpp:156
 msgid "Vitality"
 msgstr "Живучесть"
 
 # Всё-таки поменял на более логиный перевод...
-#: Source/panels/charpanel.cpp:166
+#: Source/panels/charpanel.cpp:159
 msgid "Points to distribute"
 msgstr ""
 "Всего\n"
 "очков"
 
-#: Source/panels/charpanel.cpp:172 Source/translation_dummy.cpp:247
-#: Source/translation_dummy.cpp:602
-msgid "Gold"
-msgstr "Золото"
-
-#: Source/panels/charpanel.cpp:176
+#: Source/panels/charpanel.cpp:169
 msgid "Armor class"
 msgstr "Класс брони"
 
-#: Source/panels/charpanel.cpp:178
+#: Source/panels/charpanel.cpp:171
 msgid "To hit"
 msgstr "Меткость"
 
-#: Source/panels/charpanel.cpp:180
+#: Source/panels/charpanel.cpp:173
 msgid "Damage"
 msgstr "Урон"
 
-#: Source/panels/charpanel.cpp:187
+#: Source/panels/charpanel.cpp:180
 msgid "Life"
 msgstr "Здоровье"
 
-#: Source/panels/charpanel.cpp:191
+#: Source/panels/charpanel.cpp:184
 msgid "Mana"
 msgstr "Мана"
 
 # "Сопротивление" не помещается в панель персонажа
-#: Source/panels/charpanel.cpp:196
+#: Source/panels/charpanel.cpp:189
 msgid "Resist magic"
 msgstr "Сопр. магии"
 
 # "Сопротивление" не помещается в панель персонажа
-#: Source/panels/charpanel.cpp:198
+#: Source/panels/charpanel.cpp:191
 msgid "Resist fire"
 msgstr "Сопр. огню"
 
 # "Сопротивление" не помещается в панель персонажа
-#: Source/panels/charpanel.cpp:200
+#: Source/panels/charpanel.cpp:193
 msgid "Resist lightning"
 msgstr "Сопр. молнии"
 
-#: Source/panels/mainpanel.cpp:91
+#: Source/panels/mainpanel.cpp:85
 msgid "char"
 msgstr "перс"
 
-#: Source/panels/mainpanel.cpp:92
+#: Source/panels/mainpanel.cpp:86
 msgid "quests"
 msgstr "задания"
 
-#: Source/panels/mainpanel.cpp:93
+#: Source/panels/mainpanel.cpp:87
 msgid "map"
 msgstr "карта"
 
-#: Source/panels/mainpanel.cpp:94
+#: Source/panels/mainpanel.cpp:88
 msgid "menu"
 msgstr "меню"
 
-#: Source/panels/mainpanel.cpp:95
+#: Source/panels/mainpanel.cpp:89
 msgid "inv"
 msgstr "инв"
 
-#: Source/panels/mainpanel.cpp:96
+#: Source/panels/mainpanel.cpp:90
 msgid "spells"
 msgstr "закл"
 
-#: Source/panels/mainpanel.cpp:106 Source/panels/mainpanel.cpp:132
-#: Source/panels/mainpanel.cpp:134
+#: Source/panels/mainpanel.cpp:100 Source/panels/mainpanel.cpp:126
+#: Source/panels/mainpanel.cpp:128
 msgid "voice"
 msgstr "голос"
 
-#: Source/panels/mainpanel.cpp:127 Source/panels/mainpanel.cpp:129
-#: Source/panels/mainpanel.cpp:131
+#: Source/panels/mainpanel.cpp:121 Source/panels/mainpanel.cpp:123
+#: Source/panels/mainpanel.cpp:125
 msgid "mute"
 msgstr "мут"
 
-#: Source/panels/spell_book.cpp:119
-msgid "Unusable"
-msgstr "Неиспользовано"
-
-#. TRANSLATORS: UI constraints, keep short please.
-#: Source/panels/spell_book.cpp:122
-msgid "Dmg: 1/3 target hp"
-msgstr "Урн: 1/3 здр цели"
-
-#. TRANSLATORS: UI constraints, keep short please.
-#: Source/panels/spell_book.cpp:129
-#, c++-format
-msgid "Heals: {:d} - {:d}"
-msgstr "Лечение: {:d} - {:d}"
-
-#. TRANSLATORS: UI constraints, keep short please.
-#: Source/panels/spell_book.cpp:131
-#, c++-format
-msgid "Damage: {:d} - {:d}"
-msgstr "Урон: {:d} - {:d}"
-
 # Why "умение", but "навык"?
-#: Source/panels/spell_book.cpp:186 Source/panels/spell_list.cpp:151
+#: Source/panels/spell_book.cpp:158 Source/panels/spell_list.cpp:150
 msgid "Skill"
 msgstr "Умение"
 
-#: Source/panels/spell_book.cpp:190
+#: Source/panels/spell_book.cpp:162
 #, c++-format
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
@@ -4771,340 +7560,567 @@ msgstr[1] "Посох ({:d} заряда)"
 msgstr[2] "Посох ({:d} зарядов)"
 
 #. TRANSLATORS: UI constraints, keep short please.
-#: Source/panels/spell_book.cpp:195
+#: Source/panels/spell_book.cpp:167
 #, c++-format
 msgctxt "spellbook"
 msgid "Level {:d}"
 msgstr "Уровень {:d}"
 
+#: Source/panels/spell_book.cpp:169
+msgid "Unusable"
+msgstr "Неиспользовано"
+
 #. TRANSLATORS: UI constraints, keep short please.
-#: Source/panels/spell_book.cpp:199
+#: Source/panels/spell_book.cpp:177
+#, c++-format
+msgid "Heals: {:d} - {:d}"
+msgstr "Лечение: {:d} - {:d}"
+
+#. TRANSLATORS: UI constraints, keep short please.
+#: Source/panels/spell_book.cpp:179
+#, c++-format
+msgid "Damage: {:d} - {:d}"
+msgstr "Урон: {:d} - {:d}"
+
+#. TRANSLATORS: UI constraints, keep short please.
+#: Source/panels/spell_book.cpp:183
+msgid "Dmg: 1/3 target hp"
+msgstr "Урн: 1/3 здр цели"
+
+#. TRANSLATORS: UI constraints, keep short please.
+#: Source/panels/spell_book.cpp:185
 #, c++-format
 msgctxt "spellbook"
 msgid "Mana: {:d}"
 msgstr "Мана: {:d}"
 
 # Why "чары", but "заклинание"?
-#: Source/panels/spell_list.cpp:158
+#: Source/panels/spell_list.cpp:157
 msgid "Spell"
 msgstr "Чары"
 
-#: Source/panels/spell_list.cpp:161
+#: Source/panels/spell_list.cpp:160
 msgid "Damages undead only"
 msgstr "Наносит урон только нежити"
 
-#: Source/panels/spell_list.cpp:172
+#: Source/panels/spell_list.cpp:171
 msgid "Scroll"
 msgstr "Свиток"
-
-#: Source/panels/spell_list.cpp:183 Source/translation_dummy.cpp:455
-#: Source/translation_dummy.cpp:457 Source/translation_dummy.cpp:459
-#: Source/translation_dummy.cpp:461 Source/translation_dummy.cpp:463
-msgid "Staff"
-msgstr "Посох"
 
 #: Source/panels/spell_list.cpp:193
 #, c++-format
 msgid "Spell Hotkey {:s}"
 msgstr "Горячая клавиша заклинания {:s}"
 
-#: Source/pfile.cpp:761
+#: Source/pfile.cpp:734
 msgid "Unable to open archive"
 msgstr "Невозможно открыть архив"
 
-#: Source/pfile.cpp:763
+#: Source/pfile.cpp:736
 msgid "Unable to load character"
 msgstr "Невозможно загрузить персонажа"
 
-#: Source/plrmsg.cpp:78 Source/qol/chatlog.cpp:128
+#: Source/plrmsg.cpp:84 Source/qol/chatlog.cpp:131
 #, c++-format
 msgid "{:s} (lvl {:d}): "
 msgstr "{:s} (урвн {:d}): "
 
-#: Source/qol/chatlog.cpp:168
+#: Source/qol/chatlog.cpp:160
 #, c++-format
 msgid "Chat History (Messages: {:d})"
 msgstr "История чата (Сообщения: {:d})"
 
-#: Source/qol/itemlabels.cpp:113
+#: Source/qol/itemlabels.cpp:110
 #, c++-format
 msgid "{:s} gold"
 msgstr "{:s} золота"
 
-#: Source/qol/stash.cpp:651
+#: Source/qol/stash.cpp:640
 msgid "How many gold pieces do you want to withdraw?"
 msgstr "Сколько золотых монет вы хотите взять?"
 
-#: Source/qol/xpbar.cpp:138
+#: Source/qol/xpbar.cpp:125
 #, c++-format
 msgid "Level {:d}"
 msgstr "Уровень {:d}"
 
-#: Source/qol/xpbar.cpp:144 Source/qol/xpbar.cpp:152
+#: Source/qol/xpbar.cpp:131 Source/qol/xpbar.cpp:139
 #, c++-format
 msgid "Experience: {:s}"
 msgstr "Опыт: {:s}"
 
-#: Source/qol/xpbar.cpp:145
+#: Source/qol/xpbar.cpp:132
 msgid "Maximum Level"
 msgstr "Максимальный уровень"
 
-#: Source/qol/xpbar.cpp:154
+#: Source/qol/xpbar.cpp:140
 #, c++-format
 msgid "Next Level: {:s}"
 msgstr "Следующий уровень: {:s}"
 
-#: Source/qol/xpbar.cpp:155
+#: Source/qol/xpbar.cpp:141
 #, c++-format
 msgid "{:s} to Level {:d}"
 msgstr "{:s} до уровня {:d}"
 
 #. TRANSLATORS: Quest Name Block
-#: Source/quests.cpp:53
+#: Source/quests.cpp:48
 msgid "The Magic Rock"
 msgstr "Небесный Камень"
 
-#: Source/quests.cpp:54 Source/translation_dummy.cpp:264
-msgid "Black Mushroom"
-msgstr "Чёрный Гриб"
-
-#: Source/quests.cpp:55
+#: Source/quests.cpp:50
 msgid "Gharbad The Weak"
 msgstr "Гарбад Слабый"
 
-#: Source/quests.cpp:56
+#: Source/quests.cpp:51
 msgid "Zhar the Mad"
 msgstr "Зар Безумец"
 
-#: Source/quests.cpp:57
+#: Source/quests.cpp:52
 msgid "Lachdanan"
 msgstr "Лахданан"
 
-#: Source/quests.cpp:59
+#: Source/quests.cpp:54
 msgid "The Butcher"
 msgstr "Мясник"
 
-#: Source/quests.cpp:60
+#: Source/quests.cpp:55
 msgid "Ogden's Sign"
 msgstr "Вывеска Огдена"
 
-#: Source/quests.cpp:61
+#: Source/quests.cpp:56
 msgid "Halls of the Blind"
 msgstr "Залы Слепцов"
 
-#: Source/quests.cpp:62
+#: Source/quests.cpp:57
 msgid "Valor"
 msgstr "Доблесть"
 
-#: Source/quests.cpp:63 Source/translation_dummy.cpp:263
-msgid "Anvil of Fury"
-msgstr "Дьявольская Наковальня"
-
-#: Source/quests.cpp:64
+#: Source/quests.cpp:59
 msgid "Warlord of Blood"
 msgstr "Кровавый Генерал"
 
-#: Source/quests.cpp:65
+#: Source/quests.cpp:60
 msgid "The Curse of King Leoric"
 msgstr "Проклятье Короля Леорика"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:67 Source/quests.cpp:103
+#: Source/quests.cpp:62 Source/quests.cpp:98
 msgid "The Chamber of Bone"
 msgstr "Палата Костей"
 
-#: Source/quests.cpp:68
+#: Source/quests.cpp:63
 msgid "Archbishop Lazarus"
 msgstr "Архиепископ Лазарь"
 
-#: Source/quests.cpp:69
+#: Source/quests.cpp:64
 msgid "Grave Matters"
 msgstr "Серьёзные Вопросы"
 
-#: Source/quests.cpp:70
+#: Source/quests.cpp:65
 msgid "Farmer's Orchard"
 msgstr "Фермерский Сад"
 
-#: Source/quests.cpp:71
+#: Source/quests.cpp:66
 msgid "Little Girl"
 msgstr "Малышка"
 
-#: Source/quests.cpp:72
+#: Source/quests.cpp:67
 msgid "Wandering Trader"
 msgstr "Странствующий Торговец"
 
-#: Source/quests.cpp:73
+#: Source/quests.cpp:68
 msgid "The Defiler"
 msgstr "Осквернитель"
 
-#: Source/quests.cpp:74
+#: Source/quests.cpp:69
 msgid "Na-Krul"
 msgstr "На-Крул"
 
 #. TRANSLATORS: Quest Name Block end
-#: Source/quests.cpp:76
+#: Source/quests.cpp:71
 msgid "The Jersey's Jersey"
 msgstr "Джерси Джерси"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:102
+#: Source/quests.cpp:97
 msgid "King Leoric's Tomb"
 msgstr "Могила Короля Леорика"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:105
+#: Source/quests.cpp:100
 msgid "A Dark Passage"
 msgstr "Тёмный Проход"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:106
+#: Source/quests.cpp:101
 msgid "Unholy Altar"
 msgstr "Нечестивый Алтарь"
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
-#: Source/quests.cpp:379
+#: Source/quests.cpp:401
 #, c++-format
 msgid "To {:s}"
 msgstr "К {:s}"
 
-#: Source/quick_messages.cpp:10
-msgid "I need help! Come here!"
-msgstr "Мне нужна помощь! Ко мне!"
+#: Source/spelldat.cpp:24
+msgctxt "spell"
+msgid "Firebolt"
+msgstr "Огненная Стрела"
 
-#: Source/quick_messages.cpp:11
-msgid "Follow me."
-msgstr "Иди за мной."
+#: Source/spelldat.cpp:25
+msgctxt "spell"
+msgid "Healing"
+msgstr "Исцеление"
 
-#: Source/quick_messages.cpp:12
-msgid "Here's something for you."
-msgstr "Вот кое-что для тебя."
+#: Source/spelldat.cpp:26
+msgctxt "spell"
+msgid "Lightning"
+msgstr "Молния"
 
-#: Source/quick_messages.cpp:13
-msgid "Now you DIE!"
-msgstr "Сейчас ты СДОХНЕШЬ!"
+#: Source/spelldat.cpp:27
+msgctxt "spell"
+msgid "Flash"
+msgstr "Вспышка"
 
-#: Source/quick_messages.cpp:14
-msgid "Heal yourself!"
-msgstr "Лечи себя!"
+#: Source/spelldat.cpp:28
+msgctxt "spell"
+msgid "Identify"
+msgstr "Идентификация"
 
-#: Source/quick_messages.cpp:15
-msgid "Watch out!"
-msgstr "Берегись!"
+#: Source/spelldat.cpp:29
+msgctxt "spell"
+msgid "Fire Wall"
+msgstr "Стена Огня"
 
-#: Source/quick_messages.cpp:16
-msgid "Thanks."
-msgstr "Спасибо."
+#: Source/spelldat.cpp:30
+msgctxt "spell"
+msgid "Town Portal"
+msgstr "Городской Портал"
 
-#: Source/quick_messages.cpp:17
-msgid "Retreat!"
-msgstr "Отступай!"
+#: Source/spelldat.cpp:31
+msgctxt "spell"
+msgid "Stone Curse"
+msgstr "Окаменение"
 
-#: Source/quick_messages.cpp:18
-msgid "Sorry."
-msgstr "Извини."
+#: Source/spelldat.cpp:32
+msgctxt "spell"
+msgid "Infravision"
+msgstr "Инфразрение"
 
-#: Source/quick_messages.cpp:19
-msgid "I'm waiting."
-msgstr "Я жду."
+#: Source/spelldat.cpp:33
+msgctxt "spell"
+msgid "Phasing"
+msgstr "Перемещение"
 
-#: Source/stores.cpp:130
+#: Source/spelldat.cpp:34
+msgctxt "spell"
+msgid "Mana Shield"
+msgstr "Щит Маны"
+
+#: Source/spelldat.cpp:35
+msgctxt "spell"
+msgid "Fireball"
+msgstr "Огненный Шар"
+
+#: Source/spelldat.cpp:36
+msgctxt "spell"
+msgid "Guardian"
+msgstr "Хранитель"
+
+#: Source/spelldat.cpp:37
+msgctxt "spell"
+msgid "Chain Lightning"
+msgstr "Цепная Молния"
+
+#: Source/spelldat.cpp:38
+msgctxt "spell"
+msgid "Flame Wave"
+msgstr "Волна Огня"
+
+#: Source/spelldat.cpp:39
+msgctxt "spell"
+msgid "Doom Serpents"
+msgstr "Роковые Змеи"
+
+#: Source/spelldat.cpp:40
+msgctxt "spell"
+msgid "Blood Ritual"
+msgstr "Кровавый Ритуал"
+
+#: Source/spelldat.cpp:41
+msgctxt "spell"
+msgid "Nova"
+msgstr "Нова"
+
+#: Source/spelldat.cpp:42
+msgctxt "spell"
+msgid "Invisibility"
+msgstr "Невидимость"
+
+#: Source/spelldat.cpp:43
+msgctxt "spell"
+msgid "Inferno"
+msgstr "Преисподняя"
+
+#: Source/spelldat.cpp:44
+msgctxt "spell"
+msgid "Golem"
+msgstr "Голем"
+
+#: Source/spelldat.cpp:45
+msgctxt "spell"
+msgid "Rage"
+msgstr "Ярость"
+
+#: Source/spelldat.cpp:46
+msgctxt "spell"
+msgid "Teleport"
+msgstr "Телепорт"
+
+#: Source/spelldat.cpp:47
+msgctxt "spell"
+msgid "Apocalypse"
+msgstr "Апокалипсис"
+
+#: Source/spelldat.cpp:48
+msgctxt "spell"
+msgid "Etherealize"
+msgstr "Эфиризация"
+
+#: Source/spelldat.cpp:49
+msgctxt "spell"
+msgid "Item Repair"
+msgstr "Ремонт Предмета"
+
+#: Source/spelldat.cpp:50
+msgctxt "spell"
+msgid "Staff Recharge"
+msgstr "Перезарядка Посоха"
+
+#: Source/spelldat.cpp:51
+msgctxt "spell"
+msgid "Trap Disarm"
+msgstr "Обезвредить Ловушку"
+
+#: Source/spelldat.cpp:52
+msgctxt "spell"
+msgid "Elemental"
+msgstr "Элементаль"
+
+#: Source/spelldat.cpp:53
+msgctxt "spell"
+msgid "Charged Bolt"
+msgstr "Заряженная Стрела"
+
+#: Source/spelldat.cpp:54
+msgctxt "spell"
+msgid "Holy Bolt"
+msgstr "Святая Стрела"
+
+#: Source/spelldat.cpp:55
+msgctxt "spell"
+msgid "Resurrect"
+msgstr "Воскрешение"
+
+#: Source/spelldat.cpp:56
+msgctxt "spell"
+msgid "Telekinesis"
+msgstr "Телекинез"
+
+#: Source/spelldat.cpp:57
+msgctxt "spell"
+msgid "Heal Other"
+msgstr "Лечение Другого"
+
+#: Source/spelldat.cpp:58
+msgctxt "spell"
+msgid "Blood Star"
+msgstr "Кровавая Звезда"
+
+#: Source/spelldat.cpp:59
+msgctxt "spell"
+msgid "Bone Spirit"
+msgstr "Костяной Дух"
+
+#: Source/spelldat.cpp:60
+msgctxt "spell"
+msgid "Mana"
+msgstr "Мана"
+
+#: Source/spelldat.cpp:61
+msgctxt "spell"
+msgid "the Magi"
+msgstr "Маги"
+
+#: Source/spelldat.cpp:62
+msgctxt "spell"
+msgid "the Jester"
+msgstr "Шут"
+
+#: Source/spelldat.cpp:63
+msgctxt "spell"
+msgid "Lightning Wall"
+msgstr "Стена Молний"
+
+#: Source/spelldat.cpp:64
+msgctxt "spell"
+msgid "Immolation"
+msgstr "Жертвоприношение"
+
+#: Source/spelldat.cpp:65
+msgctxt "spell"
+msgid "Warp"
+msgstr "Искривление"
+
+#: Source/spelldat.cpp:66
+msgctxt "spell"
+msgid "Reflect"
+msgstr "Отражение"
+
+#: Source/spelldat.cpp:67
+msgctxt "spell"
+msgid "Berserk"
+msgstr "Берсерк"
+
+#: Source/spelldat.cpp:68
+msgctxt "spell"
+msgid "Ring of Fire"
+msgstr "Кольцо Огня"
+
+#: Source/spelldat.cpp:69
+msgctxt "spell"
+msgid "Search"
+msgstr "Поиск"
+
+#: Source/spelldat.cpp:70
+msgctxt "spell"
+msgid "Rune of Fire"
+msgstr "Руна Огня"
+
+#: Source/spelldat.cpp:71
+msgctxt "spell"
+msgid "Rune of Light"
+msgstr "Руна Света"
+
+#: Source/spelldat.cpp:72
+msgctxt "spell"
+msgid "Rune of Nova"
+msgstr "Руна Новы"
+
+#: Source/spelldat.cpp:73
+msgctxt "spell"
+msgid "Rune of Immolation"
+msgstr "Руна Жертвоприношения"
+
+#: Source/spelldat.cpp:74
+msgctxt "spell"
+msgid "Rune of Stone"
+msgstr "Руна Камня"
+
+#: Source/stores.cpp:129
 msgid "Griswold"
 msgstr "Гризвольд"
 
-#: Source/stores.cpp:131
+#: Source/stores.cpp:130
 msgid "Pepin"
 msgstr "Пепин"
 
-#: Source/stores.cpp:133
+#: Source/stores.cpp:132
 msgid "Ogden"
 msgstr "Огден"
 
-#: Source/stores.cpp:134
+#: Source/stores.cpp:133
 msgid "Cain"
 msgstr "Каин"
 
-#: Source/stores.cpp:135
+#: Source/stores.cpp:134
 msgid "Farnham"
 msgstr "Фарнам"
 
-#: Source/stores.cpp:136
+#: Source/stores.cpp:135
 msgid "Adria"
 msgstr "Адрия"
 
-#: Source/stores.cpp:137 Source/stores.cpp:1266
+#: Source/stores.cpp:136 Source/stores.cpp:1315
 msgid "Gillian"
 msgstr "Джиллиан"
 
-#: Source/stores.cpp:138
+#: Source/stores.cpp:137
 msgid "Wirt"
 msgstr "Вирт"
 
-#: Source/stores.cpp:264 Source/stores.cpp:271
+#: Source/stores.cpp:263 Source/stores.cpp:270
 msgid "Back"
 msgstr "Назад"
 
-#: Source/stores.cpp:293 Source/stores.cpp:299 Source/stores.cpp:325
+#: Source/stores.cpp:292 Source/stores.cpp:298
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:310
+#: Source/stores.cpp:309
 #, c++-format
 msgid "Damage: {:d}-{:d}  "
 msgstr "Урон: {:d}-{:d}  "
 
-#: Source/stores.cpp:312
+#: Source/stores.cpp:311
 #, c++-format
 msgid "Armor: {:d}  "
 msgstr "Броня: {:d}  "
 
-#: Source/stores.cpp:314
-#, c++-format
-msgid "Dur: {:d}/{:d}"
+#: Source/stores.cpp:313
+#, fuzzy, c++-format
+#| msgid "Dur: {:d}/{:d}"
+msgid "Dur: {:d}/{:d},  "
 msgstr "Прчн: {:d}/{:d}"
 
-#: Source/stores.cpp:316
-msgid "Indestructible"
-msgstr "Неразрушимое"
+#: Source/stores.cpp:315
+msgid "Indestructible,  "
+msgstr "Неразрушимое,  "
 
-#: Source/stores.cpp:386 Source/stores.cpp:1034 Source/stores.cpp:1253
+#: Source/stores.cpp:323
+msgid "No required attributes"
+msgstr "Нет обязательных атрибутов"
+
+#: Source/stores.cpp:355 Source/stores.cpp:1069 Source/stores.cpp:1302
 msgid "Welcome to the"
 msgstr "Добро пожаловать в"
 
-#: Source/stores.cpp:387
+#: Source/stores.cpp:356
 msgid "Blacksmith's shop"
 msgstr "Магазин кузнеца"
 
-#: Source/stores.cpp:388 Source/stores.cpp:685 Source/stores.cpp:1036
-#: Source/stores.cpp:1079 Source/stores.cpp:1255 Source/stores.cpp:1267
-#: Source/stores.cpp:1280
+#: Source/stores.cpp:357 Source/stores.cpp:705 Source/stores.cpp:1071
+#: Source/stores.cpp:1128 Source/stores.cpp:1304 Source/stores.cpp:1316
+#: Source/stores.cpp:1329
 msgid "Would you like to:"
 msgstr "Вы хотите:"
 
-#: Source/stores.cpp:389
+#: Source/stores.cpp:358
 msgid "Talk to Griswold"
 msgstr "Поговорить с Гризвольдом"
 
-#: Source/stores.cpp:390
+#: Source/stores.cpp:359
 msgid "Buy basic items"
 msgstr "Купить базовые предметы"
 
-#: Source/stores.cpp:391
+#: Source/stores.cpp:360
 msgid "Buy premium items"
 msgstr "Купить премиальные предметы"
 
-#: Source/stores.cpp:392 Source/stores.cpp:688
+#: Source/stores.cpp:361 Source/stores.cpp:708
 msgid "Sell items"
 msgstr "Продать предметы"
 
-#: Source/stores.cpp:393
+#: Source/stores.cpp:362
 msgid "Repair items"
 msgstr "Починить предметы"
 
-#: Source/stores.cpp:394
+#: Source/stores.cpp:363
 msgid "Leave the shop"
 msgstr "Покинуть магазин"
 
-#: Source/stores.cpp:422 Source/stores.cpp:724 Source/stores.cpp:1056
+#: Source/stores.cpp:406 Source/stores.cpp:759 Source/stores.cpp:1105
 msgid "I have these items for sale:"
 msgstr "У меня есть на продажу:"
 
@@ -5113,219 +8129,219 @@ msgstr "У меня есть на продажу:"
 msgid "I have these premium items for sale:"
 msgstr "У меня есть на продажу:"
 
-#: Source/stores.cpp:567 Source/stores.cpp:817
+#: Source/stores.cpp:590 Source/stores.cpp:852
 msgid "You have nothing I want."
 msgstr "У вас нет ничего нужного мне."
 
-#: Source/stores.cpp:578 Source/stores.cpp:829
+#: Source/stores.cpp:601 Source/stores.cpp:864
 msgid "Which item is for sale?"
 msgstr "Какой предмет продать?"
 
-#: Source/stores.cpp:646
+#: Source/stores.cpp:666
 msgid "You have nothing to repair."
 msgstr "У вас нечего чинить."
 
-#: Source/stores.cpp:657
+#: Source/stores.cpp:677
 msgid "Repair which item?"
 msgstr "Какой предмет починить?"
 
-#: Source/stores.cpp:684
+#: Source/stores.cpp:704
 msgid "Witch's shack"
 msgstr "Хижина ведьмы"
 
-#: Source/stores.cpp:686
+#: Source/stores.cpp:706
 msgid "Talk to Adria"
 msgstr "Поговорить с Адрией"
 
-#: Source/stores.cpp:687 Source/stores.cpp:1038
+#: Source/stores.cpp:707 Source/stores.cpp:1073
 msgid "Buy items"
 msgstr "Купить предметы"
 
-#: Source/stores.cpp:689
+#: Source/stores.cpp:709
 msgid "Recharge staves"
 msgstr "Зарядить посохи"
 
-#: Source/stores.cpp:690
+#: Source/stores.cpp:710
 msgid "Leave the shack"
 msgstr "Покинуть хижину"
 
-#: Source/stores.cpp:891
+#: Source/stores.cpp:926
 msgid "You have nothing to recharge."
 msgstr "У вас нечего заряжать."
 
-#: Source/stores.cpp:902
+#: Source/stores.cpp:937
 msgid "Recharge which item?"
 msgstr "Какой предмет зарядить?"
 
-#: Source/stores.cpp:915
+#: Source/stores.cpp:950
 msgid "You do not have enough gold"
 msgstr "Нужно больше золота"
 
-#: Source/stores.cpp:923
+#: Source/stores.cpp:958
 msgid "You do not have enough room in inventory"
 msgstr "У вас недостаточно места в инвентаре"
 
-#: Source/stores.cpp:941
+#: Source/stores.cpp:976
 msgid "Do we have a deal?"
 msgstr "По рукам?"
 
-#: Source/stores.cpp:944
+#: Source/stores.cpp:979
 msgid "Are you sure you want to identify this item?"
 msgstr "Вы уверены, что хотите идентифицировать этот предмет?"
 
-#: Source/stores.cpp:950
+#: Source/stores.cpp:985
 msgid "Are you sure you want to buy this item?"
 msgstr "Вы уверены, что хотите купить этот предмет?"
 
-#: Source/stores.cpp:953
+#: Source/stores.cpp:988
 msgid "Are you sure you want to recharge this item?"
 msgstr "Вы уверены, что хотите зарядить этот предмет?"
 
-#: Source/stores.cpp:957
+#: Source/stores.cpp:992
 msgid "Are you sure you want to sell this item?"
 msgstr "Вы уверены, что хотите продать этот предмет?"
 
-#: Source/stores.cpp:960
+#: Source/stores.cpp:995
 msgid "Are you sure you want to repair this item?"
 msgstr "Вы уверены, что хотите починить этот предмет?"
 
-#: Source/stores.cpp:974 Source/towners.cpp:154
+#: Source/stores.cpp:1009 Source/towners.cpp:158
 msgid "Wirt the Peg-legged boy"
 msgstr "Одноногий мальчик Вирт"
 
-#: Source/stores.cpp:977 Source/stores.cpp:984
+#: Source/stores.cpp:1012 Source/stores.cpp:1019
 msgid "Talk to Wirt"
 msgstr "Поговорить с Виртом"
 
 # Перефразировал весь диалог с Виртом. Точный перевод хреново выглядит в игре.
-#: Source/stores.cpp:978
+#: Source/stores.cpp:1013
 msgid "I have something for sale,"
 msgstr "У меня есть кое-что на продажу,"
 
-#: Source/stores.cpp:979
+#: Source/stores.cpp:1014
 msgid "but it will cost 50 gold"
 msgstr "но ты должен дать 50 золота"
 
-#: Source/stores.cpp:980
+#: Source/stores.cpp:1015
 msgid "just to take a look. "
 msgstr "чтобы увидеть это. "
 
-#: Source/stores.cpp:981
+#: Source/stores.cpp:1016
 msgid "What have you got?"
 msgstr "Что у тебя есть?"
 
-#: Source/stores.cpp:982 Source/stores.cpp:985 Source/stores.cpp:1082
-#: Source/stores.cpp:1270
+#: Source/stores.cpp:1017 Source/stores.cpp:1020 Source/stores.cpp:1131
+#: Source/stores.cpp:1319
 msgid "Say goodbye"
 msgstr "Попрощаться"
 
-#: Source/stores.cpp:995
+#: Source/stores.cpp:1030
 msgid "I have this item for sale:"
 msgstr "У меня есть на продажу:"
 
-#: Source/stores.cpp:1012
+#: Source/stores.cpp:1047
 msgid "Leave"
 msgstr "Уйти"
 
-#: Source/stores.cpp:1035
+#: Source/stores.cpp:1070
 msgid "Healer's home"
 msgstr "Дом целителя"
 
-#: Source/stores.cpp:1037
+#: Source/stores.cpp:1072
 msgid "Talk to Pepin"
 msgstr "Поговорить с Пепином"
 
-#: Source/stores.cpp:1039
+#: Source/stores.cpp:1074
 msgid "Leave Healer's home"
 msgstr "Покинуть дом целителя"
 
-#: Source/stores.cpp:1078
+#: Source/stores.cpp:1127
 msgid "The Town Elder"
 msgstr "Городской Старейшина"
 
-#: Source/stores.cpp:1080
+#: Source/stores.cpp:1129
 msgid "Talk to Cain"
 msgstr "Поговорить с Каином"
 
-#: Source/stores.cpp:1081
+#: Source/stores.cpp:1130
 msgid "Identify an item"
 msgstr "Идентифицировать предмет"
 
-#: Source/stores.cpp:1174
+#: Source/stores.cpp:1223
 msgid "You have nothing to identify."
 msgstr "У вас нечего идентифицировать."
 
-#: Source/stores.cpp:1185
+#: Source/stores.cpp:1234
 msgid "Identify which item?"
 msgstr "Какой предмет идентифицировать?"
 
-#: Source/stores.cpp:1200
+#: Source/stores.cpp:1249
 msgid "This item is:"
 msgstr "Этот предмет:"
 
-#: Source/stores.cpp:1203
+#: Source/stores.cpp:1252
 msgid "Done"
 msgstr "Готово"
 
-#: Source/stores.cpp:1212
+#: Source/stores.cpp:1261
 #, c++-format
 msgid "Talk to {:s}"
 msgstr "Поговорить с {:s}"
 
-#: Source/stores.cpp:1215
+#: Source/stores.cpp:1264
 #, c++-format
 msgid "Talking to {:s}"
 msgstr "Разговор с {:s}"
 
-#: Source/stores.cpp:1216
+#: Source/stores.cpp:1265
 msgid "is not available"
 msgstr "не доступен"
 
-#: Source/stores.cpp:1217
+#: Source/stores.cpp:1266
 msgid "in the shareware"
 msgstr "в shareware"
 
-#: Source/stores.cpp:1218
+#: Source/stores.cpp:1267
 msgid "version"
 msgstr "версии"
 
-#: Source/stores.cpp:1245
+#: Source/stores.cpp:1294
 msgid "Gossip"
 msgstr "Сплетни"
 
-#: Source/stores.cpp:1254
+#: Source/stores.cpp:1303
 msgid "Rising Sun"
 msgstr "таверну \"Восход\""
 
-#: Source/stores.cpp:1256
+#: Source/stores.cpp:1305
 msgid "Talk to Ogden"
 msgstr "Поговорить с Огденом"
 
-#: Source/stores.cpp:1257
+#: Source/stores.cpp:1306
 msgid "Leave the tavern"
 msgstr "Покинуть таверну"
 
-#: Source/stores.cpp:1268
+#: Source/stores.cpp:1317
 msgid "Talk to Gillian"
 msgstr "Поговорить с Джиллиан"
 
-#: Source/stores.cpp:1269
+#: Source/stores.cpp:1318
 msgid "Access Storage"
 msgstr "Доступ к хранилищу"
 
-#: Source/stores.cpp:1279 Source/towners.cpp:209
+#: Source/stores.cpp:1328 Source/towners.cpp:216
 msgid "Farnham the Drunk"
 msgstr "Пьяница Фарнам"
 
-#: Source/stores.cpp:1281
+#: Source/stores.cpp:1330
 msgid "Talk to Farnham"
 msgstr "Поговорить с Фарнамом"
 
-#: Source/stores.cpp:1282
+#: Source/stores.cpp:1331
 msgid "Say Goodbye"
 msgstr "Попрощаться"
 
-#: Source/stores.cpp:2412
+#: Source/stores.cpp:2463
 #, c++-format
 msgid "Your gold: {:s}"
 msgstr "Ваше золото: {:s}"
@@ -6281,7 +9297,7 @@ msgstr ""
 "Я никогда раньше не слышала о Лахданане. К сожалению, тут я ничем не могу "
 "тебе помочь."
 
-#. TRANSLATORS: Quest dialog spoken by Griswold
+#. TRANSLATORS: Quest dialog spoken by Ogden
 #: Source/textdat.cpp:164
 msgid ""
 "If it is actually Lachdanan that you have met, then I would advise that you "
@@ -7924,9 +10940,15 @@ msgstr ""
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:425
+#, fuzzy
+#| msgid ""
+#| "If I was you... and I ain't... but if I was, I'd sell all that stuff you "
+#| "got and get out of here. That boy out there... He's always got somethin' "
+#| "good, but you gotta give him some gold or he won't even show you what "
+#| "he's got."
 msgid ""
 "If I was you... and I ain't... but if I was, I'd sell all that stuff you got "
-"and get out of here. That boy out there... He's always got somethin' good, "
+"and get out of here. That boy out there... He's always got somethin good, "
 "but you gotta give him some gold or he won't even show you what he's got."
 msgstr ""
 "Если б я был ты... а я не ты... но если б я был, я бы продал все свои вещи и "
@@ -8229,7 +11251,7 @@ msgstr ""
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:471 Source/textdat.cpp:479 Source/textdat.cpp:487
-#: Source/textdat.cpp:517 Source/textdat.cpp:525
+#: Source/textdat.cpp:525 Source/textdat.cpp:533
 msgid ""
 "Beyond the Hall of Heroes lies the Chamber of Bone. Eternal death awaits any "
 "who would seek to steal the treasures secured within this room. So speaks "
@@ -8241,7 +11263,7 @@ msgstr ""
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:473 Source/textdat.cpp:481 Source/textdat.cpp:489
-#: Source/textdat.cpp:519 Source/textdat.cpp:527
+#: Source/textdat.cpp:527 Source/textdat.cpp:535
 msgid ""
 "...and so, locked beyond the Gateway of Blood and past the Hall of Fire, "
 "Valor awaits for the Hero of Light to awaken..."
@@ -8250,7 +11272,7 @@ msgstr ""
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:475 Source/textdat.cpp:483 Source/textdat.cpp:491
-#: Source/textdat.cpp:521 Source/textdat.cpp:529
+#: Source/textdat.cpp:529 Source/textdat.cpp:537
 msgid ""
 "I can see what you see not.\n"
 "Vision milky then eyes rot.\n"
@@ -8272,7 +11294,7 @@ msgstr ""
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:477 Source/textdat.cpp:485 Source/textdat.cpp:493
-#: Source/textdat.cpp:523 Source/textdat.cpp:531
+#: Source/textdat.cpp:531 Source/textdat.cpp:539
 msgid ""
 "The armories of Hell are home to the Warlord of Blood. In his wake lay the "
 "mutilated bodies of thousands. Angels and men alike have been cut down to "
@@ -8285,7 +11307,7 @@ msgstr ""
 "крови."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:497
+#: Source/textdat.cpp:505
 msgid ""
 "Take heed and bear witness to the truths that lie herein, for they are the "
 "last legacy of the Horadrim. There is a war that rages on even now, beyond "
@@ -8303,7 +11325,7 @@ msgstr ""
 "за контроль над вселенной."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:499
+#: Source/textdat.cpp:507
 msgid ""
 "Take heed and bear witness to the truths that lie herein, for they are the "
 "last legacy of the Horadrim. When the Eternal Conflict between the High "
@@ -8321,7 +11343,7 @@ msgstr ""
 "в союз с одной из сторон и смогли повлиять на ход Войны Грехов."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:501
+#: Source/textdat.cpp:509
 msgid ""
 "Take heed and bear witness to the truths that lie herein, for they are the "
 "last legacy of the Horadrim. Nearly three hundred years ago, it came to be "
@@ -8361,7 +11383,7 @@ msgstr ""
 "человека, которым легко завладеть, - возможно, старика или ребёнка."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:503
+#: Source/textdat.cpp:511
 msgid ""
 "So it came to be that there was a great revolution within the Burning Hells "
 "known as The Dark Exile. The Lesser Evils overthrew the Three Prime Evils "
@@ -8379,7 +11401,7 @@ msgstr ""
 "Вратам Ада."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:505
+#: Source/textdat.cpp:513
 msgid ""
 "Many demons traveled to the mortal realm in search of the Three Brothers. "
 "These demons were followed to the mortal plane by Angels who hunted them "
@@ -8394,7 +11416,7 @@ msgstr ""
 "также он нажил себе множество врагов в подземном мире."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:507
+#: Source/textdat.cpp:515
 msgid ""
 "So it came to be that the Three Prime Evils were banished in spirit form to "
 "the mortal realm and after sewing chaos across the East for decades, they "
@@ -8424,7 +11446,7 @@ msgstr ""
 "вызволить своих Братьев и вновь разжечь пламя Войны Грехов..."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:509
+#: Source/textdat.cpp:517
 msgid ""
 "All praises to Diablo - Lord of Terror and Survivor of The Dark Exile. When "
 "he awakened from his long slumber, my Lord and Master spoke to me of secrets "
@@ -8440,7 +11462,7 @@ msgstr ""
 "людей. Мой повелитель называет это Войной Грехов."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:511
+#: Source/textdat.cpp:519
 msgid ""
 "Glory and Approbation to Diablo - Lord of Terror and Leader of the Three. My "
 "Lord spoke to me of his two Brothers, Mephisto and Baal, who were banished "
@@ -8457,7 +11479,7 @@ msgstr ""
 "ярость Троих."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:513
+#: Source/textdat.cpp:521
 msgid ""
 "Hail and Sacrifice to Diablo - Lord of Terror and Destroyer of Souls. When I "
 "awoke my Master from his sleep, he attempted to possess a mortal's form. "
@@ -8479,7 +11501,7 @@ msgstr ""
 "молюсь, что он вознаградит меня, когда станет Повелителем этого мира."
 
 #. TRANSLATORS: Neutral Text spoken by Ogden
-#: Source/textdat.cpp:515
+#: Source/textdat.cpp:523
 msgid ""
 "Thank goodness you've returned!\n"
 "Much has changed since you lived here, my friend. All was peaceful until the "
@@ -8505,7 +11527,7 @@ msgstr ""
 "Буду рад поговорить с тобой ещё раз. Желаю удачи."
 
 #. TRANSLATORS: Quest text spoken by Adria
-#: Source/textdat.cpp:533
+#: Source/textdat.cpp:541
 msgid ""
 "Maintain your quest.  Finding a treasure that is lost is not easy.  Finding "
 "a treasure that is hidden less so.  I will leave you with this.  Do not let "
@@ -8516,7 +11538,7 @@ msgstr ""
 "мешать вашим поискам."
 
 #. TRANSLATORS: Quest text spoken by Griswold
-#: Source/textdat.cpp:535
+#: Source/textdat.cpp:543
 msgid ""
 "A what?!  This is foolishness.  There's no treasure buried here in "
 "Tristram.  Let me see that!!  Ah, Look these drawings are inaccurate.  They "
@@ -8529,7 +11551,7 @@ msgstr ""
 "а не под нашими огородами."
 
 #. TRANSLATORS: Quest text spoken by Pepin
-#: Source/textdat.cpp:537
+#: Source/textdat.cpp:545
 msgid ""
 "I really don't have time to discuss some map you are looking for.  I have "
 "many sick people that require my help and yours as well."
@@ -8538,7 +11560,7 @@ msgstr ""
 "людей нуждается в моей помощи, да и в твоей тоже."
 
 #. TRANSLATORS: Quest text spoken by Adria
-#: Source/textdat.cpp:539 Source/textdat.cpp:551
+#: Source/textdat.cpp:547 Source/textdat.cpp:559
 msgid ""
 "The once proud Iswall is trapped deep beneath the surface of this world.  "
 "His honor stripped and his visage altered.  He is trapped in immortal "
@@ -8549,7 +11571,7 @@ msgstr ""
 "скрывать то, что могло его освободить."
 
 #. TRANSLATORS: Quest text spoken by Ogden
-#: Source/textdat.cpp:541
+#: Source/textdat.cpp:549
 msgid ""
 "I'll bet that Wirt saw you coming and put on an act just so he could laugh "
 "at you later when you were running around the town with your nose in the "
@@ -8560,7 +11582,7 @@ msgstr ""
 "придавать значение."
 
 #. TRANSLATORS: Quest text spoken by Cain
-#: Source/textdat.cpp:543
+#: Source/textdat.cpp:551
 msgid ""
 "There was a time when this town was a frequent stop for travelers from far "
 "and wide.  Much has changed since then.  But hidden caves and buried "
@@ -8573,7 +11595,7 @@ msgstr ""
 "просто выдумал всё это."
 
 #. TRANSLATORS: Quest text spoken by Farnham
-#: Source/textdat.cpp:545
+#: Source/textdat.cpp:553
 msgid ""
 "Listen here.  Come close.  I don't know if you know what I know, but you've "
 "have really got something here.  That's a map."
@@ -8582,12 +11604,21 @@ msgstr ""
 "действительно кое-что есть. Эта карта."
 
 #. TRANSLATORS: Quest text spoken by Gillian
-#: Source/textdat.cpp:547
+#: Source/textdat.cpp:555
+#, fuzzy
+#| msgid ""
+#| "My grandmother often tells me stories about the strange forces that "
+#| "inhabit the graveyard outside of the church.  And it may well interest "
+#| "you to hear one of them.  She said that if you were to leave the proper "
+#| "offering in the cemetery, enter the cathedral to pray for the dead, and "
+#| "then return, the offering would be altered in some strange way.  I don't "
+#| "know if this is just the talk of an old sick woman, but anything seems "
+#| "possible these days."
 msgid ""
 "My grandmother often tells me stories about the strange forces that inhabit "
 "the graveyard outside of the church.  And it may well interest you to hear "
 "one of them.  She said that if you were to leave the proper offering in the "
-"cemetery, enter the cathedral to pray for the dead, and then return, the "
+"cemetary, enter the cathedral to pray for the dead, and then return, the "
 "offering would be altered in some strange way.  I don't know if this is just "
 "the talk of an old sick woman, but anything seems possible these days."
 msgstr ""
@@ -8599,7 +11630,7 @@ msgstr ""
 "но теперь настало такое время, что всякое может произойти."
 
 #. TRANSLATORS: Quest text spoken by Wirt
-#: Source/textdat.cpp:549
+#: Source/textdat.cpp:557
 msgid ""
 "Hmmm.  A vast and mysterious treasure you say.  Mmmm.  Maybe I could be "
 "interested in picking up a few things from you.  Or better yet, don't you "
@@ -8610,7 +11641,7 @@ msgstr ""
 "редкие и дорогие припасы, чтобы пройти через это испытание?"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
-#: Source/textdat.cpp:553
+#: Source/textdat.cpp:561
 msgid ""
 "So, you're the hero everyone's been talking about. Perhaps you could help a "
 "poor, simple farmer out of a terrible mess? At the edge of my orchard, just "
@@ -8629,7 +11660,7 @@ msgstr ""
 "но я должен присматривать за коровами..."
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
-#: Source/textdat.cpp:555
+#: Source/textdat.cpp:563
 msgid ""
 "I knew that it couldn't be as simple as that witch made it sound. It's a sad "
 "world when you can't even trust your neighbors."
@@ -8638,7 +11669,7 @@ msgstr ""
 "мир, если нельзя доверять даже соседям."
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
-#: Source/textdat.cpp:557
+#: Source/textdat.cpp:565
 msgid ""
 "Is it gone? Did you send it back to the dark recesses of Hades that spawned "
 "it? You what? Oh, don't tell me you lost it! Those things don't come cheap, "
@@ -8649,7 +11680,7 @@ msgstr ""
 "дёшево. Найди эту вещь, а потом взорви эту ужасную штуковину."
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
-#: Source/textdat.cpp:559
+#: Source/textdat.cpp:567
 msgid ""
 "I heard the explosion from here! Many thanks to you, kind stranger. What "
 "with all these things comin' out of the ground, monsters taking over the "
@@ -8661,7 +11692,7 @@ msgstr ""
 "бедный фермер, но вот, ну вот - прими это вместе с моей благодарностью."
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
-#: Source/textdat.cpp:561
+#: Source/textdat.cpp:569
 msgid ""
 "Oh, such a trouble I have...maybe...No, I couldn't impose on you, what with "
 "all the other troubles. Maybe after you've cleansed the church of some of "
@@ -8673,12 +11704,12 @@ msgstr ""
 "церковь от тварей, ты придёшь снова... и немного поможешь бедному фермеру?"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
-#: Source/textdat.cpp:563
+#: Source/textdat.cpp:571
 msgid "Waaaah! (sniff) Waaaah! (sniff)"
 msgstr "Уааааа! (хлюп) Уааааа! (хлюп)"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
-#: Source/textdat.cpp:564
+#: Source/textdat.cpp:572
 msgid ""
 "I lost Theo!  I lost my best friend!  We were playing over by the river, and "
 "Theo said he wanted to go look at the big green thing.  I said we shouldn't, "
@@ -8691,7 +11722,7 @@ msgstr ""
 "жук СХВАТИЛ его и утащил!"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
-#: Source/textdat.cpp:566
+#: Source/textdat.cpp:574
 msgid ""
 "Didja find him?  You gotta find Theodore, please!  He's just little.  He "
 "can't take care of himself!  Please!"
@@ -8700,7 +11731,7 @@ msgstr ""
 "о себе позаботиться!  Прошу тебя!"
 
 #. TRANSLATORS: Quest text spoken by Little Girl (Quest End)
-#: Source/textdat.cpp:568
+#: Source/textdat.cpp:576
 msgid ""
 "You found him!  You found him!  Thank you!  Oh Theo, did those nasty bugs "
 "scare you?  Hey!  Ugh!  There's something stuck to your fur!  Ick!  Come on, "
@@ -8711,7 +11742,7 @@ msgstr ""
 "домой!"
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
-#: Source/textdat.cpp:570
+#: Source/textdat.cpp:578
 msgid ""
 "We have long lain dormant, and the time to awaken has come.  After our long "
 "sleep, we are filled with great hunger.  Soon, now, we shall feed..."
@@ -8720,7 +11751,7 @@ msgstr ""
 "проголодались. Очень скоро мы утолим свой голод..."
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
-#: Source/textdat.cpp:572
+#: Source/textdat.cpp:580
 msgid ""
 "Have you been enjoying yourself, little mammal?  How pathetic. Your little "
 "world will be no challenge at all."
@@ -8729,7 +11760,7 @@ msgstr ""
 "не будет проблемой."
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
-#: Source/textdat.cpp:574
+#: Source/textdat.cpp:582
 msgid ""
 "These lands shall be defiled, and our brood shall overrun the fields that "
 "men call home.  Our tendrils shall envelop this world, and we will feast on "
@@ -8740,14 +11771,14 @@ msgstr ""
 "Люди будут нашей собственностью и пищей."
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
-#: Source/textdat.cpp:576
+#: Source/textdat.cpp:584
 msgid ""
 "Ah, I can smell you...you are close! Close! Ssss...the scent of blood and "
 "fear...how enticing..."
 msgstr "Ближе, сладость моя! Я чую твой страх, и я голоден..."
 
 #. TRANSLATORS: Quest text spoken by Narrator
-#: Source/textdat.cpp:584
+#: Source/textdat.cpp:592
 msgid ""
 "And in the year of the Golden Light, it was so decreed that a great "
 "Cathedral be raised.  The cornerstone of this holy place was to be carved "
@@ -8777,22 +11808,22 @@ msgstr ""
 "фундамента - целостность стремлений и целостность характера."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:586
+#: Source/textdat.cpp:594
 msgid "Moo."
 msgstr "Му."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:587
+#: Source/textdat.cpp:595
 msgid "I said, Moo."
 msgstr "А я говорю Муу."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:588
+#: Source/textdat.cpp:596
 msgid "Look I'm just a cow, OK?"
 msgstr "Да я просто корова."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:589
+#: Source/textdat.cpp:597
 msgid ""
 "All right, all right.  I'm not really a cow.  I don't normally go around "
 "like this; but, I was sitting at home minding my own business and all of a "
@@ -8816,7 +11847,7 @@ msgstr ""
 "от развилки реки... ну, знаешь... тот, с неухоженным садом."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:591
+#: Source/textdat.cpp:599
 msgid ""
 "What are you wasting time for?  Go get my suit!  And hurry!  That Holstein "
 "over there keeps winking at me!"
@@ -8825,14 +11856,14 @@ msgstr ""
 "меня!"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:593
+#: Source/textdat.cpp:601
 msgid ""
 "Hey, have you got my suit there?  Quick, pass it over!  These ears itch like "
 "you wouldn't believe!"
 msgstr "Эй, ты принёс мой костюм? Быстрее давай его сюда!"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:595
+#: Source/textdat.cpp:603
 msgid ""
 "No no no no!  This is my GRAY suit!  It's for evening wear!  Formal "
 "occasions!  I can't wear THIS.  What are you, some kind of weirdo?  I need "
@@ -8842,7 +11873,7 @@ msgstr ""
 "случаев!  Я не могу надеть ЕГО.  Ты что, идиот?  Мне нужен КОРИЧНЕВЫЙ костюм."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:597
+#: Source/textdat.cpp:605
 msgid ""
 "Ahh, that's MUCH better.  Whew!  At last, some dignity!  Are my antlers on "
 "straight?  Good.  Look, thanks a lot for helping me out.  Here, take this as "
@@ -8857,7 +11888,7 @@ msgstr ""
 "Маленький совет, а? Чао."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:599
+#: Source/textdat.cpp:607
 msgid ""
 "Look.  I'm a cow.  And you, you're monster bait. Get some experience under "
 "your belt!  We'll talk..."
@@ -8866,7 +11897,7 @@ msgstr ""
 "плечами! Тогда поговорим..."
 
 #. TRANSLATORS: Quest text spoken by Farmer
-#: Source/textdat.cpp:602
+#: Source/textdat.cpp:610
 msgid ""
 "It must truly be a fearsome task I've set before you. If there was just some "
 "way that I could... would a flagon of some nice, fresh milk help?"
@@ -8875,7 +11906,7 @@ msgstr ""
 "тебе... может быть фляжка свежего молока придаст тебе сил?"
 
 #. TRANSLATORS: Quest text spoken by Farmer
-#: Source/textdat.cpp:604
+#: Source/textdat.cpp:612
 msgid ""
 "Oh, I could use your help, but perhaps after you've saved the catacombs from "
 "the desecration of those beasts."
@@ -8884,7 +11915,7 @@ msgstr ""
 "катакомбы от этих чудовищ."
 
 #. TRANSLATORS: Quest text spoken by Farmer
-#: Source/textdat.cpp:606
+#: Source/textdat.cpp:614
 msgid ""
 "I need something done, but I couldn't impose on a perfect stranger. Perhaps "
 "after you've been here a while I might feel more comfortable asking a favor."
@@ -8893,7 +11924,7 @@ msgstr ""
 "незнакомого человека. Может быть, немного позже попрошу тебя и о помощи."
 
 #. TRANSLATORS: Quest text spoken by Farmer
-#: Source/textdat.cpp:608
+#: Source/textdat.cpp:616
 msgid ""
 "I see in you the potential for greatness.  Perhaps sometime while you are "
 "fulfilling your destiny, you could stop by and do a little favor for me?"
@@ -8902,7 +11933,7 @@ msgstr ""
 "между подвигами, ты навесишь меня и окажешь мне небольшую услугу?"
 
 #. TRANSLATORS: Quest text spoken by Farmer
-#: Source/textdat.cpp:610
+#: Source/textdat.cpp:618
 msgid ""
 "I think you could probably help me, but perhaps after you've gotten a little "
 "more powerful. I wouldn't want to injure the village's only chance to "
@@ -8913,7 +11944,7 @@ msgstr ""
 "поселившееся в церкви!"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:612
+#: Source/textdat.cpp:620
 msgid ""
 "Me, I'm a self-made cow.  Make something of yourself, and... then we'll talk."
 msgstr ""
@@ -8921,7 +11952,7 @@ msgstr ""
 "поговорим."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:614
+#: Source/textdat.cpp:622
 msgid ""
 "I don't have to explain myself to every tourist that walks by!  Don't you "
 "have some monsters to kill?  Maybe we'll talk later.  If you live..."
@@ -8931,7 +11962,7 @@ msgstr ""
 "Если выживешь..."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:616
+#: Source/textdat.cpp:624
 msgid ""
 "Quit bugging me.  I'm looking for someone really heroic.  And you're not "
 "it.  I can't trust you, you're going to get eaten by monsters any day now... "
@@ -8942,7 +11973,7 @@ msgstr ""
 "нужен опытный герой."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:618
+#: Source/textdat.cpp:626
 msgid ""
 "All right, I'll cut the bull.  I didn't mean to steer you wrong.  I was "
 "sitting at home, feeling moo-dy, when things got really un-stable; a whole "
@@ -8967,8 +11998,21 @@ msgstr ""
 "мимо моего дома, он к югу от развилки реки... ну, знаете... тот, что с "
 "неухоженным садом."
 
+#. TRANSLATORS: Quest text spoken by Unknown, Maybe Farmer
+#: Source/textdat.cpp:628
+msgid ""
+"Cloudy and cooler today.  Casting the nets of necromancy across the void "
+"landed two new subspecies of flying horror; a good day's work.  Must "
+"remember to order some more bat guano and black candles from Adria; I'm "
+"running a bit low."
+msgstr ""
+"Сегодня пасмурно и прохладнее. Забросив сети некромантии через пустоту, мы "
+"получили два новых подвида летающего ужаса; хороший рабочий день. Надо не "
+"забыть заказать у Адрии ещё немного гуано летучих мышей и чёрных свечей; у "
+"меня уже на исходе."
+
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:621
+#: Source/textdat.cpp:630
 msgid ""
 "I have tried spells, threats, abjuration and bargaining with this foul "
 "creature -- to no avail.  My methods of enslaving lesser demons seem to have "
@@ -8979,7 +12023,7 @@ msgstr ""
 "бесстрашное существо."
 
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:623
+#: Source/textdat.cpp:632
 msgid ""
 "My home is slowly becoming corrupted by the vileness of this unwanted "
 "prisoner.  The crypts are full of shadows that move just beyond the corners "
@@ -8992,7 +12036,7 @@ msgstr ""
 "хотят найти этот дневник."
 
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:625
+#: Source/textdat.cpp:634
 msgid ""
 "In its ranting, the creature has let slip its name -- Na-Krul.  I have "
 "attempted to research the name, but the smaller demons have somehow "
@@ -9005,7 +12049,7 @@ msgstr ""
 "меня ужас.  Я предпочитаю называть его Существом, чем говорить это имя."
 
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:627
+#: Source/textdat.cpp:636
 msgid ""
 "The entrapped creature's howls of fury keep me from gaining much needed "
 "sleep.  It rages against the one who sent it to the Void, and it calls foul "
@@ -9018,7 +12062,7 @@ msgstr ""
 "поделать, чтобы не слышать их."
 
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:629
+#: Source/textdat.cpp:638
 msgid ""
 "My time is quickly running out.  I must record the ways to weaken the demon, "
 "and then conceal that text, lest his minions find some way to use my "
@@ -9031,7 +12075,7 @@ msgstr ""
 "искать и знания."
 
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:631
+#: Source/textdat.cpp:640
 msgid ""
 "Whoever finds this scroll is charged with stopping the demonic creature that "
 "lies within these walls.  My time is over. Even now, its hellish minions "
@@ -9060,24 +12104,24 @@ msgstr ""
 "вырвется на волю!  Используй только эти заклинания, иначе погибнешь."
 
 #. TRANSLATORS: Quest text read aloud from book by player
-#: Source/textdat.cpp:633 Source/textdat.cpp:636 Source/textdat.cpp:639
-#: Source/textdat.cpp:642 Source/textdat.cpp:645
+#: Source/textdat.cpp:642 Source/textdat.cpp:645 Source/textdat.cpp:648
+#: Source/textdat.cpp:651 Source/textdat.cpp:654
 msgid "In Spiritu Sanctum."
 msgstr "In Spiritu Sanctum."
 
 #. TRANSLATORS: Quest text read aloud from book by player
-#: Source/textdat.cpp:634 Source/textdat.cpp:637 Source/textdat.cpp:640
-#: Source/textdat.cpp:643 Source/textdat.cpp:646
+#: Source/textdat.cpp:643 Source/textdat.cpp:646 Source/textdat.cpp:649
+#: Source/textdat.cpp:652 Source/textdat.cpp:655
 msgid "Praedictum Otium."
 msgstr "Praedictum Otium."
 
 #. TRANSLATORS: Quest text read aloud from book by player
-#: Source/textdat.cpp:635 Source/textdat.cpp:638 Source/textdat.cpp:641
-#: Source/textdat.cpp:644 Source/textdat.cpp:647
+#: Source/textdat.cpp:644 Source/textdat.cpp:647 Source/textdat.cpp:650
+#: Source/textdat.cpp:653 Source/textdat.cpp:656
 msgid "Efficio Obitus Ut Inimicus."
 msgstr "Efficio Obitus Ut Inimicus."
 
-#: Source/towners.cpp:84
+#: Source/towners.cpp:83
 msgid "Griswold the Blacksmith"
 msgstr "Кузнец Гризвольд"
 
@@ -9085,3177 +12129,160 @@ msgstr "Кузнец Гризвольд"
 msgid "Ogden the Tavern owner"
 msgstr "Владелец таверны Огден"
 
-#: Source/towners.cpp:115
+#: Source/towners.cpp:116
 msgid "Wounded Townsman"
 msgstr "Раненый горожанин"
 
-#: Source/towners.cpp:136
+#: Source/towners.cpp:138
 msgid "Adria the Witch"
 msgstr "Ведьма Адрия"
 
-#: Source/towners.cpp:145
+#: Source/towners.cpp:148
 msgid "Gillian the Barmaid"
 msgstr "Барменша Джиллиан"
 
-#: Source/towners.cpp:176
+#: Source/towners.cpp:181
 msgid "Pepin the Healer"
 msgstr "Целитель Пепин"
 
-#: Source/towners.cpp:193
+#: Source/towners.cpp:199
 msgid "Cain the Elder"
 msgstr "Старейшина Каин"
 
-#: Source/towners.cpp:220
+#: Source/towners.cpp:228
 msgid "Cow"
 msgstr "Корова"
 
-#: Source/towners.cpp:243
+#: Source/towners.cpp:252
 msgid "Lester the farmer"
 msgstr "Фермер Лестер"
 
-#: Source/towners.cpp:255
+#: Source/towners.cpp:265
 msgid "Complete Nut"
 msgstr "Полный псих"
 
-#: Source/towners.cpp:263
+#: Source/towners.cpp:274
 msgid "Celia"
 msgstr "Селия"
 
-#: Source/towners.cpp:276
+#: Source/towners.cpp:287
 msgid "Slain Townsman"
 msgstr "Убитый горожанин"
 
-#: Source/translation_dummy.cpp:9
-msgctxt "monster"
-msgid "Zombie"
-msgstr "Зомби"
-
-#: Source/translation_dummy.cpp:10
-msgctxt "monster"
-msgid "Ghoul"
-msgstr "Упырь"
-
-#: Source/translation_dummy.cpp:11
-msgctxt "monster"
-msgid "Rotting Carcass"
-msgstr "Гниющая Туша"
-
-#: Source/translation_dummy.cpp:12
-msgctxt "monster"
-msgid "Black Death"
-msgstr "Чёрная Смерть"
-
-#: Source/translation_dummy.cpp:13 Source/translation_dummy.cpp:21
-msgctxt "monster"
-msgid "Fallen One"
-msgstr "Падший"
-
-#: Source/translation_dummy.cpp:14 Source/translation_dummy.cpp:22
-msgctxt "monster"
-msgid "Carver"
-msgstr "Резчик"
-
-#: Source/translation_dummy.cpp:15 Source/translation_dummy.cpp:23
-msgctxt "monster"
-msgid "Devil Kin"
-msgstr "Дьяволёнок"
-
-#: Source/translation_dummy.cpp:16 Source/translation_dummy.cpp:24
-msgctxt "monster"
-msgid "Dark One"
-msgstr "Тёмный"
-
-#: Source/translation_dummy.cpp:17 Source/translation_dummy.cpp:29
-msgctxt "monster"
-msgid "Skeleton"
-msgstr "Скелет"
-
-#: Source/translation_dummy.cpp:18
-msgctxt "monster"
-msgid "Corpse Axe"
-msgstr "Мертвец с Топором"
-
-#: Source/translation_dummy.cpp:19 Source/translation_dummy.cpp:31
-msgctxt "monster"
-msgid "Burning Dead"
-msgstr "Горящий Мертвец"
-
-#: Source/translation_dummy.cpp:20 Source/translation_dummy.cpp:32
-msgctxt "monster"
-msgid "Horror"
-msgstr "Ужас"
-
-#: Source/translation_dummy.cpp:25
-msgctxt "monster"
-msgid "Scavenger"
-msgstr "Мусорщик"
-
-#: Source/translation_dummy.cpp:26
-msgctxt "monster"
-msgid "Plague Eater"
-msgstr "Пожиратель Душ"
-
-#: Source/translation_dummy.cpp:27
-msgctxt "monster"
-msgid "Shadow Beast"
-msgstr "Теневой Зверь"
-
-#: Source/translation_dummy.cpp:28
-msgctxt "monster"
-msgid "Bone Gasher"
-msgstr "Костепил"
-
-#: Source/translation_dummy.cpp:30
-msgctxt "monster"
-msgid "Corpse Bow"
-msgstr "Мертвец с Луком"
-
-#: Source/translation_dummy.cpp:33
-msgctxt "monster"
-msgid "Skeleton Captain"
-msgstr "Капитан Скелетов"
-
-#: Source/translation_dummy.cpp:34
-msgctxt "monster"
-msgid "Corpse Captain"
-msgstr "Капитан Мертвецов"
-
-#: Source/translation_dummy.cpp:35
-msgctxt "monster"
-msgid "Burning Dead Captain"
-msgstr "Капитан Горящих Мертвецов"
-
-#: Source/translation_dummy.cpp:36
-msgctxt "monster"
-msgid "Horror Captain"
-msgstr "Капитан Ужасов"
-
-#: Source/translation_dummy.cpp:37
-msgctxt "monster"
-msgid "Invisible Lord"
-msgstr "Невидимый Лорд"
-
-#: Source/translation_dummy.cpp:38
-msgctxt "monster"
-msgid "Hidden"
-msgstr "Скрытый"
-
-#: Source/translation_dummy.cpp:39
-msgctxt "monster"
-msgid "Stalker"
-msgstr "Преследователь"
-
-#: Source/translation_dummy.cpp:40
-msgctxt "monster"
-msgid "Unseen"
-msgstr "Незримый"
-
-#: Source/translation_dummy.cpp:41
-msgctxt "monster"
-msgid "Illusion Weaver"
-msgstr "Ткач Иллюзий"
-
-#: Source/translation_dummy.cpp:42
-msgctxt "monster"
-msgid "Satyr Lord"
-msgstr "Лорд Сатиров"
-
-#: Source/translation_dummy.cpp:43 Source/translation_dummy.cpp:51
-msgctxt "monster"
-msgid "Flesh Clan"
-msgstr "Клан Плоти"
-
-#: Source/translation_dummy.cpp:44 Source/translation_dummy.cpp:52
-msgctxt "monster"
-msgid "Stone Clan"
-msgstr "Клан Камня"
-
-#: Source/translation_dummy.cpp:45 Source/translation_dummy.cpp:53
-msgctxt "monster"
-msgid "Fire Clan"
-msgstr "Клан Огня"
-
-#: Source/translation_dummy.cpp:46 Source/translation_dummy.cpp:54
-msgctxt "monster"
-msgid "Night Clan"
-msgstr "Клан Ночи"
-
-# это летучая мышь
-#: Source/translation_dummy.cpp:47
-msgctxt "monster"
-msgid "Fiend"
-msgstr "Изверг"
-
-#: Source/translation_dummy.cpp:48
-msgctxt "monster"
-msgid "Blink"
-msgstr "Мерцающий"
-
-#: Source/translation_dummy.cpp:49
-msgctxt "monster"
-msgid "Gloom"
-msgstr "Мрак"
-
-#: Source/translation_dummy.cpp:50
-msgctxt "monster"
-msgid "Familiar"
-msgstr "Фамильяр"
-
-#: Source/translation_dummy.cpp:55
-msgctxt "monster"
-msgid "Acid Beast"
-msgstr "Кислотный Зверь"
-
-#: Source/translation_dummy.cpp:56
-msgctxt "monster"
-msgid "Poison Spitter"
-msgstr "Ядовитый Плеватель"
-
-#: Source/translation_dummy.cpp:57
-msgctxt "monster"
-msgid "Pit Beast"
-msgstr "Зверь Преисподней"
-
-#: Source/translation_dummy.cpp:58
-msgctxt "monster"
-msgid "Lava Maw"
-msgstr "Лавовая Пасть"
-
-#: Source/translation_dummy.cpp:59 Source/translation_dummy.cpp:148
-msgctxt "monster"
-msgid "Skeleton King"
-msgstr "Король-Скелет"
-
-#: Source/translation_dummy.cpp:60 Source/translation_dummy.cpp:156
-msgctxt "monster"
-msgid "The Butcher"
-msgstr "Мясник"
-
-#: Source/translation_dummy.cpp:61
-msgctxt "monster"
-msgid "Overlord"
-msgstr "Владыка"
-
-#: Source/translation_dummy.cpp:62
-msgctxt "monster"
-msgid "Mud Man"
-msgstr "Грязевой Человек"
-
-#: Source/translation_dummy.cpp:63
-msgctxt "monster"
-msgid "Toad Demon"
-msgstr "Лягушачий Демон"
-
-#: Source/translation_dummy.cpp:64
-msgctxt "monster"
-msgid "Flayed One"
-msgstr "Ободранный"
-
-#: Source/translation_dummy.cpp:65
-msgctxt "monster"
-msgid "Wyrm"
-msgstr "Змей"
-
-#: Source/translation_dummy.cpp:66
-msgctxt "monster"
-msgid "Cave Slug"
-msgstr "Пещерный Слизень"
-
-#: Source/translation_dummy.cpp:67
-msgctxt "monster"
-msgid "Devil Wyrm"
-msgstr "Дьявольский Змей"
-
-#: Source/translation_dummy.cpp:68
-msgctxt "monster"
-msgid "Devourer"
-msgstr "Пожиратель"
-
-#: Source/translation_dummy.cpp:69
-msgctxt "monster"
-msgid "Magma Demon"
-msgstr "Демон Магмы"
-
-#: Source/translation_dummy.cpp:70
-msgctxt "monster"
-msgid "Blood Stone"
-msgstr "Кровавый Камень"
-
-#: Source/translation_dummy.cpp:71
-msgctxt "monster"
-msgid "Hell Stone"
-msgstr "Адский Камень"
-
-#: Source/translation_dummy.cpp:72
-msgctxt "monster"
-msgid "Lava Lord"
-msgstr "Лавовый Лорд"
-
-#: Source/translation_dummy.cpp:73
-msgctxt "monster"
-msgid "Horned Demon"
-msgstr "Рогатый Демон"
-
-#: Source/translation_dummy.cpp:74
-msgctxt "monster"
-msgid "Mud Runner"
-msgstr "Грязевой Бегун"
-
-#: Source/translation_dummy.cpp:75
-msgctxt "monster"
-msgid "Frost Charger"
-msgstr "Морозный Бегун"
-
-#: Source/translation_dummy.cpp:76
-msgctxt "monster"
-msgid "Obsidian Lord"
-msgstr "Обсидиановый Лорд"
-
-#: Source/translation_dummy.cpp:77
-msgctxt "monster"
-msgid "oldboned"
-msgstr "старокостный"
-
-#: Source/translation_dummy.cpp:78
-msgctxt "monster"
-msgid "Red Death"
-msgstr "Красная Смерть"
-
-# "Li_t_ch", not "Licht".
-# (Also, see the translation of "The Arch-Litch Malignus" below.)
-#: Source/translation_dummy.cpp:79
-msgctxt "monster"
-msgid "Litch Demon"
-msgstr "Демон-Лич"
-
-#: Source/translation_dummy.cpp:80
-msgctxt "monster"
-msgid "Undead Balrog"
-msgstr "Балрог-Нежить"
-
-#: Source/translation_dummy.cpp:81
-msgctxt "monster"
-msgid "Incinerator"
-msgstr "Сжигатель"
-
-#: Source/translation_dummy.cpp:82
-msgctxt "monster"
-msgid "Flame Lord"
-msgstr "Пламенный Лорд"
-
-#: Source/translation_dummy.cpp:83
-msgctxt "monster"
-msgid "Doom Fire"
-msgstr "Роковой Огонь"
-
-#: Source/translation_dummy.cpp:84
-msgctxt "monster"
-msgid "Hell Burner"
-msgstr "Адский Сжигатель"
-
-#: Source/translation_dummy.cpp:85
-msgctxt "monster"
-msgid "Red Storm"
-msgstr "Красная Буря"
-
-#: Source/translation_dummy.cpp:86
-msgctxt "monster"
-msgid "Storm Rider"
-msgstr "Штормовой Всадник"
-
-#: Source/translation_dummy.cpp:87
-msgctxt "monster"
-msgid "Storm Lord"
-msgstr "Повелитель Бури"
-
-#: Source/translation_dummy.cpp:88
-msgctxt "monster"
-msgid "Maelstrom"
-msgstr "Вихрь"
-
-#: Source/translation_dummy.cpp:89
-msgctxt "monster"
-msgid "Devil Kin Brute"
-msgstr "Дьяволёнок-Громила"
-
-#: Source/translation_dummy.cpp:90
-msgctxt "monster"
-msgid "Winged-Demon"
-msgstr "Крылатый Демон"
-
-#: Source/translation_dummy.cpp:91
-msgctxt "monster"
-msgid "Gargoyle"
-msgstr "Горгулья"
-
-#: Source/translation_dummy.cpp:92
-msgctxt "monster"
-msgid "Blood Claw"
-msgstr "Кровавый Коготь"
-
-#: Source/translation_dummy.cpp:93
-msgctxt "monster"
-msgid "Death Wing"
-msgstr "Крыло Смерти"
-
-#: Source/translation_dummy.cpp:94
-msgctxt "monster"
-msgid "Slayer"
-msgstr "Убийца"
-
-#: Source/translation_dummy.cpp:95
-msgctxt "monster"
-msgid "Guardian"
-msgstr "Хранитель"
-
-#: Source/translation_dummy.cpp:96
-msgctxt "monster"
-msgid "Vortex Lord"
-msgstr "Лорд Вихря"
-
-#: Source/translation_dummy.cpp:97
-msgctxt "monster"
-msgid "Balrog"
-msgstr "Балрог"
-
-#: Source/translation_dummy.cpp:98
-msgctxt "monster"
-msgid "Cave Viper"
-msgstr "Пещерная Гадюка"
-
-#: Source/translation_dummy.cpp:99
-msgctxt "monster"
-msgid "Fire Drake"
-msgstr "Огненный Дракон"
-
-#: Source/translation_dummy.cpp:100
-msgctxt "monster"
-msgid "Gold Viper"
-msgstr "Золотая Гадюка"
-
-#: Source/translation_dummy.cpp:101
-msgctxt "monster"
-msgid "Azure Drake"
-msgstr "Лазурный Дракон"
-
-#: Source/translation_dummy.cpp:102
-msgctxt "monster"
-msgid "Black Knight"
-msgstr "Чёрный Рыцарь"
-
-#: Source/translation_dummy.cpp:103
-msgctxt "monster"
-msgid "Doom Guard"
-msgstr "Страж Рока"
-
-#: Source/translation_dummy.cpp:104
-msgctxt "monster"
-msgid "Steel Lord"
-msgstr "Лорд Стали"
-
-#: Source/translation_dummy.cpp:105
-msgctxt "monster"
-msgid "Blood Knight"
-msgstr "Рыцарь Крови"
-
-# Adjective.
-#: Source/translation_dummy.cpp:106
-msgctxt "monster"
-msgid "The Shredded"
-msgstr "Дроблёный"
-
-# Пустой?
-#: Source/translation_dummy.cpp:107
-msgctxt "monster"
-msgid "Hollow One"
-msgstr "Полый"
-
-# Можно "Мастер боли", но хозяин как-то жутче.
-#: Source/translation_dummy.cpp:108
-msgctxt "monster"
-msgid "Pain Master"
-msgstr "Хозяин Боли"
-
-#: Source/translation_dummy.cpp:109
-msgctxt "monster"
-msgid "Reality Weaver"
-msgstr "Ткач Реальности"
-
-#: Source/translation_dummy.cpp:110
-msgctxt "monster"
-msgid "Succubus"
-msgstr "Суккуб"
-
-#: Source/translation_dummy.cpp:111
-msgctxt "monster"
-msgid "Snow Witch"
-msgstr "Снежная Ведьма"
-
-#: Source/translation_dummy.cpp:112
-msgctxt "monster"
-msgid "Hell Spawn"
-msgstr "Адское Отродье"
-
-#: Source/translation_dummy.cpp:113
-msgctxt "monster"
-msgid "Soul Burner"
-msgstr "Сжигатель Душ"
-
-#: Source/translation_dummy.cpp:114
-msgctxt "monster"
-msgid "Counselor"
-msgstr "Советник"
-
-#: Source/translation_dummy.cpp:115
-msgctxt "monster"
-msgid "Magistrate"
-msgstr "Магистрат"
-
-#: Source/translation_dummy.cpp:116
-msgctxt "monster"
-msgid "Cabalist"
-msgstr "Заговорщик"
-
-#: Source/translation_dummy.cpp:117
-msgctxt "monster"
-msgid "Advocate"
-msgstr "Заступник"
-
-#: Source/translation_dummy.cpp:118
-msgctxt "monster"
-msgid "Golem"
-msgstr "Голем"
-
-#: Source/translation_dummy.cpp:119
-msgctxt "monster"
-msgid "The Dark Lord"
-msgstr "Тёмный Лорд"
-
-#: Source/translation_dummy.cpp:120
-msgctxt "monster"
-msgid "The Arch-Litch Malignus"
-msgstr "Архилич Малигнус"
-
-#: Source/translation_dummy.cpp:121
-msgctxt "monster"
-msgid "Hellboar"
-msgstr "Адский Вепрь"
-
-#: Source/translation_dummy.cpp:122
-msgctxt "monster"
-msgid "Stinger"
-msgstr "Жалитель"
-
-#: Source/translation_dummy.cpp:123
-msgctxt "monster"
-msgid "Psychorb"
-msgstr "Психорб"
-
-# FIXME: This creature is not a simple spider, so it might need a different translation.
-# "Арахнон"?
-# ---------------------------------------------
-# Да
-#: Source/translation_dummy.cpp:124
-msgctxt "monster"
-msgid "Arachnon"
-msgstr "Арахнон"
-
-#: Source/translation_dummy.cpp:125
-msgctxt "monster"
-msgid "Felltwin"
-msgstr "Падшие Близнецы"
-
-#: Source/translation_dummy.cpp:126
-msgctxt "monster"
-msgid "Hork Spawn"
-msgstr "Блюющее Отродье"
-
-#: Source/translation_dummy.cpp:127
-msgctxt "monster"
-msgid "Venomtail"
-msgstr "Скорпион"
-
-#: Source/translation_dummy.cpp:128
-msgctxt "monster"
-msgid "Necromorb"
-msgstr "Некроморб"
-
-#: Source/translation_dummy.cpp:129
-msgctxt "monster"
-msgid "Spider Lord"
-msgstr "Лорд Пауков"
-
-#: Source/translation_dummy.cpp:130
-msgctxt "monster"
-msgid "Lashworm"
-msgstr "Плёточный Червь"
-
-#: Source/translation_dummy.cpp:131
-msgctxt "monster"
-msgid "Torchant"
-msgstr "Огненный Муравей"
-
-#: Source/translation_dummy.cpp:132 Source/translation_dummy.cpp:157
-msgctxt "monster"
-msgid "Hork Demon"
-msgstr "Блюющий Демон"
-
-#: Source/translation_dummy.cpp:133
-msgctxt "monster"
-msgid "Hell Bug"
-msgstr "Адский Жук"
-
-#: Source/translation_dummy.cpp:134
-msgctxt "monster"
-msgid "Gravedigger"
-msgstr "Могилокопатель"
-
-#: Source/translation_dummy.cpp:135
-msgctxt "monster"
-msgid "Tomb Rat"
-msgstr "Крыса Подземелья"
-
-#: Source/translation_dummy.cpp:136
-msgctxt "monster"
-msgid "Firebat"
-msgstr "Огненная Летучая Мышь"
-
-#: Source/translation_dummy.cpp:137
-msgctxt "monster"
-msgid "Skullwing"
-msgstr "Черепокрыл"
-
-#: Source/translation_dummy.cpp:138
-msgctxt "monster"
-msgid "Lich"
-msgstr "Лич"
-
-#: Source/translation_dummy.cpp:139
-msgctxt "monster"
-msgid "Crypt Demon"
-msgstr "Демон Склепа"
-
-#: Source/translation_dummy.cpp:140
-msgctxt "monster"
-msgid "Hellbat"
-msgstr "Адская Летучая Мышь"
-
-#: Source/translation_dummy.cpp:141
-msgctxt "monster"
-msgid "Bone Demon"
-msgstr "Костяной Демон"
-
-#: Source/translation_dummy.cpp:142
-msgctxt "monster"
-msgid "Arch Lich"
-msgstr "Архилич"
-
-#: Source/translation_dummy.cpp:143
-msgctxt "monster"
-msgid "Biclops"
-msgstr "Биклоп"
-
-#: Source/translation_dummy.cpp:144
-msgctxt "monster"
-msgid "Flesh Thing"
-msgstr "Плоть"
-
-#: Source/translation_dummy.cpp:145
-msgctxt "monster"
-msgid "Reaper"
-msgstr "Жнец"
-
-#: Source/translation_dummy.cpp:146 Source/translation_dummy.cpp:159
-msgctxt "monster"
-msgid "Na-Krul"
-msgstr "На-Крул"
-
-#: Source/translation_dummy.cpp:147
-msgctxt "monster"
-msgid "Gharbad the Weak"
-msgstr "Гарбад Слабый"
-
-#: Source/translation_dummy.cpp:149
-msgctxt "monster"
-msgid "Zhar the Mad"
-msgstr "Зар Безумец"
-
-#: Source/translation_dummy.cpp:150
-msgctxt "monster"
-msgid "Snotspill"
-msgstr "Сморкун"
-
-#: Source/translation_dummy.cpp:151
-msgctxt "monster"
-msgid "Arch-Bishop Lazarus"
-msgstr "Архиепископ Лазарь"
-
-#: Source/translation_dummy.cpp:152
-msgctxt "monster"
-msgid "Red Vex"
-msgstr "Красная Ворожея"
-
-#: Source/translation_dummy.cpp:153
-msgctxt "monster"
-msgid "Black Jade"
-msgstr "Чернодейка"
-
-#: Source/translation_dummy.cpp:154
-msgctxt "monster"
-msgid "Lachdanan"
-msgstr "Лахданан"
-
-#: Source/translation_dummy.cpp:155
-msgctxt "monster"
-msgid "Warlord of Blood"
-msgstr "Кровавый Генерал"
-
-#: Source/translation_dummy.cpp:158
-msgctxt "monster"
-msgid "The Defiler"
-msgstr "Осквернитель"
-
-#: Source/translation_dummy.cpp:160
-msgctxt "monster"
-msgid "Bonehead Keenaxe"
-msgstr "Костеголовый Кинакс"
-
-#: Source/translation_dummy.cpp:161
-msgctxt "monster"
-msgid "Bladeskin the Slasher"
-msgstr "Лезвий Полосователь"
-
-#: Source/translation_dummy.cpp:162
-msgctxt "monster"
-msgid "Soulpus"
-msgstr "Душегной"
-
-#: Source/translation_dummy.cpp:163
-msgctxt "monster"
-msgid "Pukerat the Unclean"
-msgstr "Нечистый Блевокрыс"
-
-#: Source/translation_dummy.cpp:164
-msgctxt "monster"
-msgid "Boneripper"
-msgstr "Костедёр"
-
-#: Source/translation_dummy.cpp:165
-msgctxt "monster"
-msgid "Rotfeast the Hungry"
-msgstr "Гнилоед Голодный"
-
-# FIXME: "Guts" and "hank".
-# "Моток кишок"?
-# ---------------------------------------------
-# Есть перевод из WoW, там "Gutshank" переведён как "Потрошмяк". Оставил свой вариант.
-#: Source/translation_dummy.cpp:166
-msgctxt "monster"
-msgid "Gutshank the Quick"
-msgstr "Кишкокрут Быстрый"
-
-#: Source/translation_dummy.cpp:167
-msgctxt "monster"
-msgid "Brokenhead Bangshield"
-msgstr "Пусточереп Крепкощит"
-
-#: Source/translation_dummy.cpp:168
-msgctxt "monster"
-msgid "Bongo"
-msgstr "Бонго"
-
-#: Source/translation_dummy.cpp:169
-msgctxt "monster"
-msgid "Rotcarnage"
-msgstr "Гнилобой"
-
-#: Source/translation_dummy.cpp:170
-msgctxt "monster"
-msgid "Shadowbite"
-msgstr "Тенекус"
-
-#: Source/translation_dummy.cpp:171
-msgctxt "monster"
-msgid "Deadeye"
-msgstr "Мертвоглаз"
-
-#: Source/translation_dummy.cpp:172
-msgctxt "monster"
-msgid "Madeye the Dead"
-msgstr "Бесоглаз Мертвец"
-
-# https://en.wikipedia.org/wiki/Chupacabra
-# "El" = "The".
-#: Source/translation_dummy.cpp:173
-msgctxt "monster"
-msgid "El Chupacabras"
-msgstr "Чупакабра"
-
-#: Source/translation_dummy.cpp:174
-msgctxt "monster"
-msgid "Skullfire"
-msgstr "Огнечереп"
-
-#: Source/translation_dummy.cpp:175
-msgctxt "monster"
-msgid "Warpskull"
-msgstr "Кривочереп"
-
-#: Source/translation_dummy.cpp:176
-msgctxt "monster"
-msgid "Goretongue"
-msgstr "Кровояз"
-
-#: Source/translation_dummy.cpp:177
-msgctxt "monster"
-msgid "Pulsecrawler"
-msgstr "Ползопульс"
-
-#: Source/translation_dummy.cpp:178
-msgctxt "monster"
-msgid "Moonbender"
-msgstr "Луногиб"
-
-#: Source/translation_dummy.cpp:179
-msgctxt "monster"
-msgid "Wrathraven"
-msgstr "Гневный Ворон"
-
-#: Source/translation_dummy.cpp:180
-msgctxt "monster"
-msgid "Spineeater"
-msgstr "Спиногрыз"
-
-#: Source/translation_dummy.cpp:181
-msgctxt "monster"
-msgid "Blackash the Burning"
-msgstr "Чернострел Пылающий"
-
-#: Source/translation_dummy.cpp:182
-msgctxt "monster"
-msgid "Shadowcrow"
-msgstr "Крикун Тьмы"
-
-#: Source/translation_dummy.cpp:183
-msgctxt "monster"
-msgid "Blightstone the Weak"
-msgstr "Гнилостень Cлабак"
-
-#: Source/translation_dummy.cpp:184
-msgctxt "monster"
-msgid "Bilefroth the Pit Master"
-msgstr "Желчелей Распорядитель"
-
-#: Source/translation_dummy.cpp:185
-msgctxt "monster"
-msgid "Bloodskin Darkbow"
-msgstr "Кровошкур Темнолук"
-
-#: Source/translation_dummy.cpp:186
-msgctxt "monster"
-msgid "Foulwing"
-msgstr "Злокрыл"
-
-#: Source/translation_dummy.cpp:187
-msgctxt "monster"
-msgid "Shadowdrinker"
-msgstr "Тенеглот"
-
-#: Source/translation_dummy.cpp:188
-msgctxt "monster"
-msgid "Hazeshifter"
-msgstr "Дымовёртыш"
-
-#: Source/translation_dummy.cpp:189
-msgctxt "monster"
-msgid "Deathspit"
-msgstr "Смертеплюй"
-
-#: Source/translation_dummy.cpp:190
-msgctxt "monster"
-msgid "Bloodgutter"
-msgstr "Кроводёр"
-
-# Переводить такое - безумие.
-#: Source/translation_dummy.cpp:191
-msgctxt "monster"
-msgid "Deathshade Fleshmaul"
-msgstr "Смертоносный Свежеватель"
-
-#: Source/translation_dummy.cpp:192
-msgctxt "monster"
-msgid "Warmaggot the Mad"
-msgstr "Военоличинка Безумец"
-
-#: Source/translation_dummy.cpp:193
-msgctxt "monster"
-msgid "Glasskull the Jagged"
-msgstr "Зубастый Стеклочереп"
-
-#: Source/translation_dummy.cpp:194
-msgctxt "monster"
-msgid "Blightfire"
-msgstr "Отравленный Огонь"
-
-#: Source/translation_dummy.cpp:195
-msgctxt "monster"
-msgid "Nightwing the Cold"
-msgstr "Леденящий Мрачнокрыл"
-
-#: Source/translation_dummy.cpp:196
-msgctxt "monster"
-msgid "Gorestone"
-msgstr "Камнемяс"
-
-# Родственник Deathshade Fleshmaul
-#: Source/translation_dummy.cpp:197
-msgctxt "monster"
-msgid "Bronzefist Firestone"
-msgstr "Бронзокулакий Огнекам"
-
-#: Source/translation_dummy.cpp:198
-msgctxt "monster"
-msgid "Wrathfire the Doomed"
-msgstr "Огнегнев Обречённый"
-
-#: Source/translation_dummy.cpp:199
-msgctxt "monster"
-msgid "Firewound the Grim"
-msgstr "Огнежёг Беспощадный"
-
-#: Source/translation_dummy.cpp:200
-msgctxt "monster"
-msgid "Baron Sludge"
-msgstr "Барон Гнус"
-
-# Ещё один родственник Deathshade Fleshmaul
-#: Source/translation_dummy.cpp:201
-msgctxt "monster"
-msgid "Blighthorn Steelmace"
-msgstr "Тленорог Сталебулавный"
-
-#: Source/translation_dummy.cpp:202
-msgctxt "monster"
-msgid "Chaoshowler"
-msgstr "Ревун Хаоса"
-
-#: Source/translation_dummy.cpp:203
-msgctxt "monster"
-msgid "Doomgrin the Rotting"
-msgstr "Судьбоскал Гниющий"
-
-#: Source/translation_dummy.cpp:204
-msgctxt "monster"
-msgid "Madburner"
-msgstr "Безумный Сжигатель"
-
-#: Source/translation_dummy.cpp:205
-msgctxt "monster"
-msgid "Bonesaw the Litch"
-msgstr "Пилокост Лич"
-
-#: Source/translation_dummy.cpp:206
-msgctxt "monster"
-msgid "Breakspine"
-msgstr "Спинолом"
-
-#: Source/translation_dummy.cpp:207
-msgctxt "monster"
-msgid "Devilskull Sharpbone"
-msgstr "Череподьявол Острокост"
-
-#: Source/translation_dummy.cpp:208
-msgctxt "monster"
-msgid "Brokenstorm"
-msgstr "Бурелом"
-
-#: Source/translation_dummy.cpp:209
-msgctxt "monster"
-msgid "Stormbane"
-msgstr "Гиблешторм"
-
-#: Source/translation_dummy.cpp:210
-msgctxt "monster"
-msgid "Oozedrool"
-msgstr "Слюнослиз"
-
-#: Source/translation_dummy.cpp:211
-msgctxt "monster"
-msgid "Goldblight of the Flame"
-msgstr "Златомор Пламенный"
-
-#: Source/translation_dummy.cpp:212
-msgctxt "monster"
-msgid "Blackstorm"
-msgstr "Черношторм"
-
-#: Source/translation_dummy.cpp:213
-msgctxt "monster"
-msgid "Plaguewrath"
-msgstr "Чумогнев"
-
-#: Source/translation_dummy.cpp:214
-msgctxt "monster"
-msgid "The Flayer"
-msgstr "Живодёр"
-
-#: Source/translation_dummy.cpp:215
-msgctxt "monster"
-msgid "Bluehorn"
-msgstr "Синерог"
-
-#: Source/translation_dummy.cpp:216
-msgctxt "monster"
-msgid "Warpfire Hellspawn"
-msgstr "Отродье Искажённого Огня"
-
-#: Source/translation_dummy.cpp:217
-msgctxt "monster"
-msgid "Fangspeir"
-msgstr "Клыкатор"
-
-#: Source/translation_dummy.cpp:218
-msgctxt "monster"
-msgid "Festerskull"
-msgstr "Гноечереп"
-
-#: Source/translation_dummy.cpp:219
-msgctxt "monster"
-msgid "Lionskull the Bent"
-msgstr "Львочереп"
-
-#: Source/translation_dummy.cpp:220
-msgctxt "monster"
-msgid "Blacktongue"
-msgstr "Чернояз"
-
-#: Source/translation_dummy.cpp:221
-msgctxt "monster"
-msgid "Viletouch"
-msgstr "Гнилотрог"
-
-#: Source/translation_dummy.cpp:222
-msgctxt "monster"
-msgid "Viperflame"
-msgstr "Пламений"
-
-#: Source/translation_dummy.cpp:223
-msgctxt "monster"
-msgid "Fangskin"
-msgstr "Клыкошкур"
-
-#: Source/translation_dummy.cpp:224
-msgctxt "monster"
-msgid "Witchfire the Unholy"
-msgstr "Огневедьм Нечестивый"
-
-#: Source/translation_dummy.cpp:225
-msgctxt "monster"
-msgid "Blackskull"
-msgstr "Черночереп"
-
-#: Source/translation_dummy.cpp:226
-msgctxt "monster"
-msgid "Soulslash"
-msgstr "Душерез"
-
-#: Source/translation_dummy.cpp:227
-msgctxt "monster"
-msgid "Windspawn"
-msgstr "Ветрородье"
-
-#: Source/translation_dummy.cpp:228
-msgctxt "monster"
-msgid "Lord of the Pit"
-msgstr "Повелитель Ямы"
-
-#: Source/translation_dummy.cpp:229
-msgctxt "monster"
-msgid "Rustweaver"
-msgstr "Ржавокрут"
-
-#: Source/translation_dummy.cpp:230
-msgctxt "monster"
-msgid "Howlingire the Shade"
-msgstr "Ревущая Тень"
-
-#: Source/translation_dummy.cpp:231
-msgctxt "monster"
-msgid "Doomcloud"
-msgstr "Судьбокров"
-
-#: Source/translation_dummy.cpp:232
-msgctxt "monster"
-msgid "Bloodmoon Soulfire"
-msgstr "Кровелун Огнедуш"
-
-#: Source/translation_dummy.cpp:233
-msgctxt "monster"
-msgid "Witchmoon"
-msgstr "Луноведьма"
-
-#: Source/translation_dummy.cpp:234
-msgctxt "monster"
-msgid "Gorefeast"
-msgstr "Кровепир"
-
-#: Source/translation_dummy.cpp:235
-msgctxt "monster"
-msgid "Graywar the Slayer"
-msgstr "Блеклобой Палач"
-
-#: Source/translation_dummy.cpp:236
-msgctxt "monster"
-msgid "Dreadjudge"
-msgstr "Ужасносуд"
-
-#: Source/translation_dummy.cpp:237
-msgctxt "monster"
-msgid "Stareye the Witch"
-msgstr "Ведьма Звездоглаз"
-
-#: Source/translation_dummy.cpp:238
-msgctxt "monster"
-msgid "Steelskull the Hunter"
-msgstr "Сталеглав Охотник"
-
-#: Source/translation_dummy.cpp:239
-msgctxt "monster"
-msgid "Sir Gorash"
-msgstr "Сэр Гораш"
-
-#: Source/translation_dummy.cpp:240
-msgctxt "monster"
-msgid "The Vizier"
-msgstr "Визирь"
-
-#: Source/translation_dummy.cpp:241
-msgctxt "monster"
-msgid "Zamphir"
-msgstr "Замфир"
-
-#: Source/translation_dummy.cpp:242
-msgctxt "monster"
-msgid "Bloodlust"
-msgstr "Кровожадина"
-
-#: Source/translation_dummy.cpp:243
-msgctxt "monster"
-msgid "Webwidow"
-msgstr "Вдовопут"
-
-#: Source/translation_dummy.cpp:244
-msgctxt "monster"
-msgid "Fleshdancer"
-msgstr "Плотетанцовщица"
-
-#: Source/translation_dummy.cpp:245
-msgctxt "monster"
-msgid "Grimspike"
-msgstr "Мрачношип"
-
-#: Source/translation_dummy.cpp:246
-msgctxt "monster"
-msgid "Doomlock"
-msgstr "Судьбожим"
-
-#: Source/translation_dummy.cpp:248 Source/translation_dummy.cpp:390
-msgid "Short Sword"
-msgstr "Короткий Меч"
-
-#: Source/translation_dummy.cpp:249 Source/translation_dummy.cpp:341
-msgid "Buckler"
-msgstr "Круглый Щит"
-
-#: Source/translation_dummy.cpp:250 Source/translation_dummy.cpp:431
-#: Source/translation_dummy.cpp:432 Source/translation_dummy.cpp:433
-msgid "Club"
-msgstr "Дубина"
-
-#: Source/translation_dummy.cpp:251 Source/translation_dummy.cpp:438
-msgid "Short Bow"
-msgstr "Короткий Лук"
-
-#: Source/translation_dummy.cpp:252
-msgid "Short Staff of Mana"
-msgstr "Короткий Посох Маны"
-
-#: Source/translation_dummy.cpp:253
-msgid "Cleaver"
-msgstr "Тесак"
-
-#: Source/translation_dummy.cpp:254 Source/translation_dummy.cpp:487
-msgid "The Undead Crown"
-msgstr "Корона Нежити"
-
-#: Source/translation_dummy.cpp:255 Source/translation_dummy.cpp:488
-msgid "Empyrean Band"
-msgstr "Эмпирейское Кольцо"
-
-#: Source/translation_dummy.cpp:256
-msgid "Magic Rock"
-msgstr "Волшебный Камень"
-
-#: Source/translation_dummy.cpp:257 Source/translation_dummy.cpp:489
-msgid "Optic Amulet"
-msgstr "Оптический Амулет"
-
-#: Source/translation_dummy.cpp:258 Source/translation_dummy.cpp:490
-msgid "Ring of Truth"
-msgstr "Кольцо Истины"
-
-#: Source/translation_dummy.cpp:259
-msgid "Tavern Sign"
-msgstr "Вывеска Таверны"
-
-# Или просто шапка/шлем
-#: Source/translation_dummy.cpp:260 Source/translation_dummy.cpp:491
-msgid "Harlequin Crest"
-msgstr "Гребень Арлекина"
-
-#: Source/translation_dummy.cpp:261 Source/translation_dummy.cpp:492
-msgid "Veil of Steel"
-msgstr "Стальная Завеса"
-
-#: Source/translation_dummy.cpp:262
-msgid "Golden Elixir"
-msgstr "Золотой Эликсир"
-
-#: Source/translation_dummy.cpp:265
-msgid "Brain"
-msgstr "Мозг"
-
-#: Source/translation_dummy.cpp:266
-msgid "Fungal Tome"
-msgstr "Грибной Фолиант"
-
-#: Source/translation_dummy.cpp:267
-msgid "Spectral Elixir"
-msgstr "Призрачный Эликсир"
-
-#: Source/translation_dummy.cpp:268
-msgid "Blood Stone"
-msgstr "Кровавый Камень"
-
-#: Source/translation_dummy.cpp:269
-msgid "Cathedral Map"
-msgstr "Карта Собора"
-
-#: Source/translation_dummy.cpp:270
-msgid "Heart"
-msgstr "Сердце"
-
-#: Source/translation_dummy.cpp:271 Source/translation_dummy.cpp:353
-msgid "Potion of Healing"
-msgstr "Зелье Исцеления"
-
-#: Source/translation_dummy.cpp:272 Source/translation_dummy.cpp:355
-msgid "Potion of Mana"
-msgstr "Зелье Маны"
-
-#: Source/translation_dummy.cpp:273 Source/translation_dummy.cpp:370
-msgid "Scroll of Identify"
-msgstr "Свиток Идентификации"
-
-#: Source/translation_dummy.cpp:274 Source/translation_dummy.cpp:374
-msgid "Scroll of Town Portal"
-msgstr "Свиток Портала в Город"
-
-#: Source/translation_dummy.cpp:275 Source/translation_dummy.cpp:493
-msgid "Arkaine's Valor"
-msgstr "Отвага Аркейна"
-
-#: Source/translation_dummy.cpp:276 Source/translation_dummy.cpp:354
-msgid "Potion of Full Healing"
-msgstr "Зелье Полного Исцеления"
-
-#: Source/translation_dummy.cpp:277 Source/translation_dummy.cpp:356
-msgid "Potion of Full Mana"
-msgstr "Зелье Полной Маны"
-
-#: Source/translation_dummy.cpp:278 Source/translation_dummy.cpp:494
-msgid "Griswold's Edge"
-msgstr "Лезвие Гризвольда"
-
-#: Source/translation_dummy.cpp:279 Source/translation_dummy.cpp:495
-msgid "Bovine Plate"
-msgstr "Бычьи Доспехи"
-
-#: Source/translation_dummy.cpp:280
-msgid "Staff of Lazarus"
-msgstr "Посох Лазаря"
-
-#: Source/translation_dummy.cpp:281 Source/translation_dummy.cpp:371
-msgid "Scroll of Resurrect"
-msgstr "Свиток Воскрешения"
-
-#: Source/translation_dummy.cpp:283 Source/translation_dummy.cpp:454
-msgid "Short Staff"
-msgstr "Короткий Посох"
-
-#: Source/translation_dummy.cpp:284 Source/translation_dummy.cpp:391
-#: Source/translation_dummy.cpp:393 Source/translation_dummy.cpp:395
-#: Source/translation_dummy.cpp:397 Source/translation_dummy.cpp:403
-#: Source/translation_dummy.cpp:405 Source/translation_dummy.cpp:407
-#: Source/translation_dummy.cpp:409 Source/translation_dummy.cpp:411
-msgid "Sword"
-msgstr "Меч"
-
-#: Source/translation_dummy.cpp:285 Source/translation_dummy.cpp:388
-#: Source/translation_dummy.cpp:389
-msgid "Dagger"
-msgstr "Кинжал"
-
-#: Source/translation_dummy.cpp:286
-msgid "Rune Bomb"
-msgstr "Рунная Бомба"
-
-#: Source/translation_dummy.cpp:287
-msgid "Theodore"
-msgstr "Теодор"
-
-#: Source/translation_dummy.cpp:288
-msgid "Auric Amulet"
-msgstr "Золотой Амулет"
-
-#: Source/translation_dummy.cpp:289
-msgid "Torn Note 1"
-msgstr "Обрывок Записки 1"
-
-#: Source/translation_dummy.cpp:290
-msgid "Torn Note 2"
-msgstr "Обрывок Записки 2"
-
-#: Source/translation_dummy.cpp:291
-msgid "Torn Note 3"
-msgstr "Обрывок Записки 3"
-
-#: Source/translation_dummy.cpp:292
-msgid "Reconstructed Note"
-msgstr "Восстановленная Записка"
-
-#: Source/translation_dummy.cpp:293
-msgid "Brown Suit"
-msgstr "Коричневый Костюм"
-
-#: Source/translation_dummy.cpp:294
-msgid "Grey Suit"
-msgstr "Серый Костюм"
-
-#: Source/translation_dummy.cpp:295 Source/translation_dummy.cpp:296
-#: Source/translation_dummy.cpp:298
-msgid "Cap"
-msgstr "Шапка"
-
-#: Source/translation_dummy.cpp:297
-msgid "Skull Cap"
-msgstr "Тюбетейка"
-
-#: Source/translation_dummy.cpp:299 Source/translation_dummy.cpp:300
-#: Source/translation_dummy.cpp:302 Source/translation_dummy.cpp:306
-msgid "Helm"
-msgstr "Шлем"
-
-#: Source/translation_dummy.cpp:301
-msgid "Full Helm"
-msgstr "Закрытый Шлем"
-
-#: Source/translation_dummy.cpp:303 Source/translation_dummy.cpp:304
-msgid "Crown"
-msgstr "Корона"
-
-#: Source/translation_dummy.cpp:305
-msgid "Great Helm"
-msgstr "Большой Шлем"
-
-#: Source/translation_dummy.cpp:307 Source/translation_dummy.cpp:308
-msgid "Cape"
-msgstr "Плащ"
-
-#: Source/translation_dummy.cpp:309 Source/translation_dummy.cpp:310
-msgid "Rags"
-msgstr "Тряпьё"
-
-#: Source/translation_dummy.cpp:311 Source/translation_dummy.cpp:312
-msgid "Cloak"
-msgstr "Мантия"
-
-#: Source/translation_dummy.cpp:313 Source/translation_dummy.cpp:314
-msgid "Robe"
-msgstr "Роба"
-
-#: Source/translation_dummy.cpp:315
-msgid "Quilted Armor"
-msgstr "Стёганые Доспехи"
-
-#: Source/translation_dummy.cpp:317
-msgid "Leather Armor"
-msgstr "Кожаная Броня"
-
-#: Source/translation_dummy.cpp:319
-msgid "Hard Leather Armor"
-msgstr "Дублёная Кожаная Броня"
-
-#: Source/translation_dummy.cpp:321
-msgid "Studded Leather Armor"
-msgstr "Клёпаный Кожаный Доспех"
-
-#: Source/translation_dummy.cpp:323
-msgid "Ring Mail"
-msgstr "Кольцевая Кольчуга"
-
-#: Source/translation_dummy.cpp:324 Source/translation_dummy.cpp:326
-#: Source/translation_dummy.cpp:328 Source/translation_dummy.cpp:332
-msgid "Mail"
-msgstr "Кольчуга"
-
-#: Source/translation_dummy.cpp:325
-msgid "Chain Mail"
-msgstr "Кольчатая Кольчуга"
-
-#: Source/translation_dummy.cpp:327
-msgid "Scale Mail"
-msgstr "Чешуйчатая Кольчуга"
-
-#: Source/translation_dummy.cpp:329
-msgid "Breast Plate"
-msgstr "Нагрудник"
-
-#: Source/translation_dummy.cpp:330 Source/translation_dummy.cpp:334
-#: Source/translation_dummy.cpp:336 Source/translation_dummy.cpp:338
-#: Source/translation_dummy.cpp:340
-msgid "Plate"
-msgstr "Латы"
-
-#: Source/translation_dummy.cpp:331
-msgid "Splint Mail"
-msgstr "Шинная Кольчуга"
-
-#: Source/translation_dummy.cpp:333
-msgid "Plate Mail"
-msgstr "Пластинчатый Доспех"
-
-#: Source/translation_dummy.cpp:335
-msgid "Field Plate"
-msgstr "Полевая Пластина"
-
-#: Source/translation_dummy.cpp:337
-msgid "Gothic Plate"
-msgstr "Готическая Пластина"
-
-#: Source/translation_dummy.cpp:339
-msgid "Full Plate Mail"
-msgstr "Полная Пластинчатая Кольчуга"
-
-#: Source/translation_dummy.cpp:342 Source/translation_dummy.cpp:344
-#: Source/translation_dummy.cpp:346 Source/translation_dummy.cpp:348
-#: Source/translation_dummy.cpp:350 Source/translation_dummy.cpp:352
-msgid "Shield"
-msgstr "Щит"
-
-#: Source/translation_dummy.cpp:343
-msgid "Small Shield"
-msgstr "Маленький Щит"
-
-#: Source/translation_dummy.cpp:345
-msgid "Large Shield"
-msgstr "Большой Щит"
-
-#: Source/translation_dummy.cpp:347
-msgid "Kite Shield"
-msgstr "Треугольный Щит"
-
-#: Source/translation_dummy.cpp:349
-msgid "Tower Shield"
-msgstr "Башенный Щит"
-
-#: Source/translation_dummy.cpp:351
-msgid "Gothic Shield"
-msgstr "Готический Щит"
-
-#: Source/translation_dummy.cpp:357
-msgid "Potion of Rejuvenation"
-msgstr "Зелье Омоложения"
-
-#: Source/translation_dummy.cpp:358
-msgid "Potion of Full Rejuvenation"
-msgstr "Зелье Полного Омоложения"
-
-#: Source/translation_dummy.cpp:362
-msgid "Oil"
-msgstr "Масло"
-
-#: Source/translation_dummy.cpp:363
-msgid "Elixir of Strength"
-msgstr "Эликсир Силы"
-
-#: Source/translation_dummy.cpp:364
-msgid "Elixir of Magic"
-msgstr "Эликсир Магии"
-
-#: Source/translation_dummy.cpp:365
-msgid "Elixir of Dexterity"
-msgstr "Эликсир Ловкости"
-
-#: Source/translation_dummy.cpp:366
-msgid "Elixir of Vitality"
-msgstr "Эликсир Живучести"
-
-#: Source/translation_dummy.cpp:367
-msgid "Scroll of Healing"
-msgstr "Свиток Исцеления"
-
-#: Source/translation_dummy.cpp:368
-msgid "Scroll of Search"
-msgstr "Свиток Поиска"
-
-#: Source/translation_dummy.cpp:369
-msgid "Scroll of Lightning"
-msgstr "Свиток Молнии"
-
-#: Source/translation_dummy.cpp:372
-msgid "Scroll of Fire Wall"
-msgstr "Свиток Стены Огня"
-
-#: Source/translation_dummy.cpp:373
-msgid "Scroll of Inferno"
-msgstr "Свиток Преисподней"
-
-#: Source/translation_dummy.cpp:375
-msgid "Scroll of Flash"
-msgstr "Свиток Вспышки"
-
-#: Source/translation_dummy.cpp:376
-msgid "Scroll of Infravision"
-msgstr "Свиток Инфразрения"
-
-#: Source/translation_dummy.cpp:377
-msgid "Scroll of Phasing"
-msgstr "Свиток Перемещения"
-
-#: Source/translation_dummy.cpp:378
-msgid "Scroll of Mana Shield"
-msgstr "Свиток Щита Маны"
-
-#: Source/translation_dummy.cpp:379
-msgid "Scroll of Flame Wave"
-msgstr "Свиток Волны Огня"
-
-#: Source/translation_dummy.cpp:380
-msgid "Scroll of Fireball"
-msgstr "Свиток Огненного Шара"
-
-#: Source/translation_dummy.cpp:381
-msgid "Scroll of Stone Curse"
-msgstr "Свиток Окаменения"
-
-#: Source/translation_dummy.cpp:382
-msgid "Scroll of Chain Lightning"
-msgstr "Свиток Цепной Молнии"
-
-#: Source/translation_dummy.cpp:383
-msgid "Scroll of Guardian"
-msgstr "Свиток Защитника"
-
-#: Source/translation_dummy.cpp:384
-msgid "Scroll of Nova"
-msgstr "Свиток Новы"
-
-#: Source/translation_dummy.cpp:385
-msgid "Scroll of Golem"
-msgstr "Свиток Голема"
-
-#: Source/translation_dummy.cpp:386
-msgid "Scroll of Teleport"
-msgstr "Свиток Телепорта"
-
-#: Source/translation_dummy.cpp:387
-msgid "Scroll of Apocalypse"
-msgstr "Свиток Апокалипсиса"
-
-#: Source/translation_dummy.cpp:392
-msgid "Falchion"
-msgstr "Фальшион"
-
-#: Source/translation_dummy.cpp:394
-msgid "Scimitar"
-msgstr "Ятаган"
-
-#: Source/translation_dummy.cpp:396
-msgid "Claymore"
-msgstr "Клеймор"
-
-#: Source/translation_dummy.cpp:398 Source/translation_dummy.cpp:399
-msgid "Blade"
-msgstr "Клинок"
-
-#: Source/translation_dummy.cpp:400 Source/translation_dummy.cpp:401
-msgid "Sabre"
-msgstr "Сабля"
-
-#: Source/translation_dummy.cpp:402
-msgid "Long Sword"
-msgstr "Длинный Меч"
-
-#: Source/translation_dummy.cpp:404
-msgid "Broad Sword"
-msgstr "Широкий Меч"
-
-#: Source/translation_dummy.cpp:406
-msgid "Bastard Sword"
-msgstr "Полуторный Меч"
-
-#: Source/translation_dummy.cpp:408
-msgid "Two-Handed Sword"
-msgstr "Двуручный Меч"
-
-#: Source/translation_dummy.cpp:410
-msgid "Great Sword"
-msgstr "Великий Меч"
-
-#: Source/translation_dummy.cpp:412
-msgid "Small Axe"
-msgstr "Маленький Топор"
-
-#: Source/translation_dummy.cpp:413 Source/translation_dummy.cpp:414
-#: Source/translation_dummy.cpp:415 Source/translation_dummy.cpp:417
-#: Source/translation_dummy.cpp:419 Source/translation_dummy.cpp:421
-#: Source/translation_dummy.cpp:423
-msgid "Axe"
-msgstr "Топор"
-
-#: Source/translation_dummy.cpp:416
-msgid "Large Axe"
-msgstr "Большой Топор"
-
-#: Source/translation_dummy.cpp:418
-msgid "Broad Axe"
-msgstr "Широкий Топор"
-
-#: Source/translation_dummy.cpp:420
-msgid "Battle Axe"
-msgstr "Боевой Топор"
-
-#: Source/translation_dummy.cpp:422
-msgid "Great Axe"
-msgstr "Двуручный Топор"
-
-#: Source/translation_dummy.cpp:424 Source/translation_dummy.cpp:425
-#: Source/translation_dummy.cpp:427
-msgid "Mace"
-msgstr "Булава"
-
-#: Source/translation_dummy.cpp:426
-msgid "Morning Star"
-msgstr "Моргенштерн"
-
-#: Source/translation_dummy.cpp:428
-msgid "War Hammer"
-msgstr "Боевой Молот"
-
-#: Source/translation_dummy.cpp:429
-msgid "Hammer"
-msgstr "Молот"
-
-#: Source/translation_dummy.cpp:430
-msgid "Spiked Club"
-msgstr "Шипованная Дубина"
-
-#: Source/translation_dummy.cpp:434 Source/translation_dummy.cpp:435
-msgid "Flail"
-msgstr "Цеп"
-
-#: Source/translation_dummy.cpp:436 Source/translation_dummy.cpp:437
-msgid "Maul"
-msgstr "Кувалда"
-
-#: Source/translation_dummy.cpp:439 Source/translation_dummy.cpp:441
-#: Source/translation_dummy.cpp:443 Source/translation_dummy.cpp:445
-#: Source/translation_dummy.cpp:447 Source/translation_dummy.cpp:449
-#: Source/translation_dummy.cpp:451 Source/translation_dummy.cpp:453
-msgid "Bow"
-msgstr "Лук"
-
-#: Source/translation_dummy.cpp:440
-msgid "Hunter's Bow"
-msgstr "Охотничий Лук"
-
-#: Source/translation_dummy.cpp:442
-msgid "Long Bow"
-msgstr "Длинный Лук"
-
-#: Source/translation_dummy.cpp:444
-msgid "Composite Bow"
-msgstr "Композитный Лук"
-
-#: Source/translation_dummy.cpp:446
-msgid "Short Battle Bow"
-msgstr "Короткий Боевой Лук"
-
-#: Source/translation_dummy.cpp:448
-msgid "Long Battle Bow"
-msgstr "Длинный Боевой Лук"
-
-#: Source/translation_dummy.cpp:450
-msgid "Short War Bow"
-msgstr "Короткий Военный Лук"
-
-#: Source/translation_dummy.cpp:452
-msgid "Long War Bow"
-msgstr "Длинный Военный Лук"
-
-#: Source/translation_dummy.cpp:456
-msgid "Long Staff"
-msgstr "Длинный Посох"
-
-#: Source/translation_dummy.cpp:458
-msgid "Composite Staff"
-msgstr "Композитный Посох"
-
-#: Source/translation_dummy.cpp:460
-msgid "Quarter Staff"
-msgstr "Короткий Посох"
-
-#: Source/translation_dummy.cpp:462
-msgid "War Staff"
-msgstr "Военный Посох"
-
-#: Source/translation_dummy.cpp:464 Source/translation_dummy.cpp:465
-#: Source/translation_dummy.cpp:466 Source/translation_dummy.cpp:467
-#: Source/translation_dummy.cpp:468 Source/translation_dummy.cpp:469
-msgid "Ring"
-msgstr "Кольцо"
-
-#: Source/translation_dummy.cpp:470 Source/translation_dummy.cpp:471
-#: Source/translation_dummy.cpp:472 Source/translation_dummy.cpp:473
-msgid "Amulet"
-msgstr "Амулет"
-
-#: Source/translation_dummy.cpp:474
-msgid "Rune of Fire"
-msgstr "Руна Огня"
-
-#: Source/translation_dummy.cpp:475 Source/translation_dummy.cpp:477
-#: Source/translation_dummy.cpp:479 Source/translation_dummy.cpp:481
-#: Source/translation_dummy.cpp:483
-msgid "Rune"
-msgstr "Руна"
-
-#: Source/translation_dummy.cpp:476
-msgid "Rune of Lightning"
-msgstr "Руна Молнии"
-
-#: Source/translation_dummy.cpp:478
-msgid "Greater Rune of Fire"
-msgstr "Великая Руна Огня"
-
-#: Source/translation_dummy.cpp:480
-msgid "Greater Rune of Lightning"
-msgstr "Великая Руна Молнии"
-
-#: Source/translation_dummy.cpp:482
-msgid "Rune of Stone"
-msgstr "Руна Камня"
-
-#: Source/translation_dummy.cpp:484
-msgid "Short Staff of Charged Bolt"
-msgstr "Короткий Посох Заряженной Стрелы"
-
-#: Source/translation_dummy.cpp:485
-msgid "Arena Potion"
-msgstr "Зелье Арены"
-
-#: Source/translation_dummy.cpp:486
-msgid "The Butcher's Cleaver"
-msgstr "Тесак Мясника"
-
-#: Source/translation_dummy.cpp:496
-msgid "The Rift Bow"
-msgstr "Лук Разлома"
-
-#: Source/translation_dummy.cpp:497
-msgid "The Needler"
-msgstr "Игольщик"
-
-#: Source/translation_dummy.cpp:498
-msgid "The Celestial Bow"
-msgstr "Небесный Лук"
-
-#: Source/translation_dummy.cpp:499
-msgid "Deadly Hunter"
-msgstr "Смертоносный Охотник"
-
-#: Source/translation_dummy.cpp:500
-msgid "Bow of the Dead"
-msgstr "Лук Мёртвых"
-
-#: Source/translation_dummy.cpp:501
-msgid "The Blackoak Bow"
-msgstr "Лук из Чёрного Дуба"
-
-#: Source/translation_dummy.cpp:502
-msgid "Flamedart"
-msgstr "Пламенный Дротик"
-
-#: Source/translation_dummy.cpp:503
-msgid "Fleshstinger"
-msgstr "Жало Плоти"
-
-#: Source/translation_dummy.cpp:504
-msgid "Windforce"
-msgstr "Сила Ветра"
-
-#: Source/translation_dummy.cpp:505
-msgid "Eaglehorn"
-msgstr "Орлиный Рог"
-
-#: Source/translation_dummy.cpp:506
-msgid "Gonnagal's Dirk"
-msgstr "Кортик Гоннагала"
-
-#: Source/translation_dummy.cpp:507
-msgid "The Defender"
-msgstr "Защитник"
-
-#: Source/translation_dummy.cpp:508
-msgid "Gryphon's Claw"
-msgstr "Коготь Грифона"
-
-#: Source/translation_dummy.cpp:509
-msgid "Black Razor"
-msgstr "Чёрная Бритва"
-
-#: Source/translation_dummy.cpp:510
-msgid "Gibbous Moon"
-msgstr "Лучезарная Луна"
-
-#: Source/translation_dummy.cpp:511
-msgid "Ice Shank"
-msgstr "Ледяной Хвостовик"
-
-#: Source/translation_dummy.cpp:512
-msgid "The Executioner's Blade"
-msgstr "Клинок Палача"
-
-#: Source/translation_dummy.cpp:513
-msgid "The Bonesaw"
-msgstr "Костепил"
-
-#: Source/translation_dummy.cpp:514
-msgid "Shadowhawk"
-msgstr "Теневой Ястреб"
-
-#: Source/translation_dummy.cpp:515
-msgid "Wizardspike"
-msgstr "Волшебный Шип"
-
-#: Source/translation_dummy.cpp:516
-msgid "Lightsabre"
-msgstr "Световой Меч"
-
-#: Source/translation_dummy.cpp:517
-msgid "The Falcon's Talon"
-msgstr "Коготь Сокола"
-
-#: Source/translation_dummy.cpp:518
-msgid "Inferno"
-msgstr "Преисподняя"
-
-#: Source/translation_dummy.cpp:519
-msgid "Doombringer"
-msgstr "Несущий Гибель"
-
-#: Source/translation_dummy.cpp:520
-msgid "The Grizzly"
-msgstr "Гризли"
-
-#: Source/translation_dummy.cpp:521
-msgid "The Grandfather"
-msgstr "Дедушка"
-
-#: Source/translation_dummy.cpp:522
-msgid "The Mangler"
-msgstr "Увечитель"
-
-#: Source/translation_dummy.cpp:523
-msgid "Sharp Beak"
-msgstr "Острый Клюв"
-
-#: Source/translation_dummy.cpp:524
-msgid "BloodSlayer"
-msgstr "Кровоубийца"
-
-#: Source/translation_dummy.cpp:525
-msgid "The Celestial Axe"
-msgstr "Небесный Топор"
-
-#: Source/translation_dummy.cpp:526
-msgid "Wicked Axe"
-msgstr "Злой Топор"
-
-#: Source/translation_dummy.cpp:527
-msgid "Stonecleaver"
-msgstr "Каменный Тесак"
-
-# I'm pretty sure it pronounced as "Агинара", not "Агуинара".
-# ---------------------------------------------
-# Так и есть.
-#: Source/translation_dummy.cpp:528
-msgid "Aguinara's Hatchet"
-msgstr "Топор Агинары"
-
-#: Source/translation_dummy.cpp:529
-msgid "Hellslayer"
-msgstr "Адский Убийца"
-
-#: Source/translation_dummy.cpp:530
-msgid "Messerschmidt's Reaver"
-msgstr "Разоритель Мессершмидта"
-
-#: Source/translation_dummy.cpp:531
-msgid "Crackrust"
-msgstr "Трещины Ржавчины"
-
-#: Source/translation_dummy.cpp:532
-msgid "Hammer of Jholm"
-msgstr "Молот Джхольма"
-
-#: Source/translation_dummy.cpp:533
-msgid "Civerb's Cudgel"
-msgstr "Дубинка Сиверба"
-
-#: Source/translation_dummy.cpp:534
-msgid "The Celestial Star"
-msgstr "Небесная Звезда"
-
-#: Source/translation_dummy.cpp:535
-msgid "Baranar's Star"
-msgstr "Звезда Баранара"
-
-#: Source/translation_dummy.cpp:536
-msgid "Gnarled Root"
-msgstr "Корявый Корень"
-
-#: Source/translation_dummy.cpp:537
-msgid "The Cranium Basher"
-msgstr "Черепобойник"
-
-#: Source/translation_dummy.cpp:538
-msgid "Schaefer's Hammer"
-msgstr "Молот Шефера"
-
-#: Source/translation_dummy.cpp:539
-msgid "Dreamflange"
-msgstr "Кромка Грёз"
-
-#: Source/translation_dummy.cpp:540
-msgid "Staff of Shadows"
-msgstr "Посох Теней"
-
-#: Source/translation_dummy.cpp:541
-msgid "Immolator"
-msgstr "Поджигатель"
-
-#: Source/translation_dummy.cpp:542
-msgid "Storm Spire"
-msgstr "Острие Бури"
-
-#: Source/translation_dummy.cpp:543
-msgid "Gleamsong"
-msgstr "Мерцающая Песнь"
-
-#: Source/translation_dummy.cpp:544
-msgid "Thundercall"
-msgstr "Громовой Зов"
-
-#: Source/translation_dummy.cpp:545
-msgid "The Protector"
-msgstr "Защитник"
-
-#: Source/translation_dummy.cpp:546
-msgid "Naj's Puzzler"
-msgstr "Головоломка Наджа"
-
-#: Source/translation_dummy.cpp:547
-msgid "Mindcry"
-msgstr "Крик Разума"
-
-#: Source/translation_dummy.cpp:548
-msgid "Rod of Onan"
-msgstr "Жезл Онана"
-
-#: Source/translation_dummy.cpp:549
-msgid "Helm of Spirits"
-msgstr "Шлем Духов"
-
-#: Source/translation_dummy.cpp:550
-msgid "Thinking Cap"
-msgstr "Шапка Размышлений"
-
-#: Source/translation_dummy.cpp:551
-msgid "OverLord's Helm"
-msgstr "Шлем Владыки"
-
-#: Source/translation_dummy.cpp:552
-msgid "Fool's Crest"
-msgstr "Гребень Дурака"
-
-#: Source/translation_dummy.cpp:553
-msgid "Gotterdamerung"
-msgstr "Гибель Богов"
-
-#: Source/translation_dummy.cpp:554
-msgid "Royal Circlet"
-msgstr "Королевский Венец"
-
-#: Source/translation_dummy.cpp:555
-msgid "Torn Flesh of Souls"
-msgstr "Разорванная Плоть Душ"
-
-#: Source/translation_dummy.cpp:556
-msgid "The Gladiator's Bane"
-msgstr "Проклятие Гладиатора"
-
-#: Source/translation_dummy.cpp:557
-msgid "The Rainbow Cloak"
-msgstr "Плащ Радуги"
-
-#: Source/translation_dummy.cpp:558
-msgid "Leather of Aut"
-msgstr "Кожа Аута"
-
-#: Source/translation_dummy.cpp:559
-msgid "Wisdom's Wrap"
-msgstr "Накидка Мудрости"
-
-#: Source/translation_dummy.cpp:560
-msgid "Sparking Mail"
-msgstr "Сверкающая Кольчуга"
-
-#: Source/translation_dummy.cpp:561
-msgid "Scavenger Carapace"
-msgstr "Панцирь Мусорщика"
-
-#: Source/translation_dummy.cpp:562
-msgid "Nightscape"
-msgstr "Ночной Пейзаж"
-
-#: Source/translation_dummy.cpp:563
-msgid "Naj's Light Plate"
-msgstr "Лёгкая Пластина Наджа"
-
-#: Source/translation_dummy.cpp:564
-msgid "Demonspike Coat"
-msgstr "Покров Демонских Шипов"
-
-#: Source/translation_dummy.cpp:565
-msgid "The Deflector"
-msgstr "Отражатель"
-
-#: Source/translation_dummy.cpp:566
-msgid "Split Skull Shield"
-msgstr "Щит из Расколотого Черепа"
-
-#: Source/translation_dummy.cpp:567
-msgid "Dragon's Breach"
-msgstr "Разлом Дракона"
-
-#: Source/translation_dummy.cpp:568
-msgid "Blackoak Shield"
-msgstr "Щит из Чёрного Дуба"
-
-#: Source/translation_dummy.cpp:569
-msgid "Holy Defender"
-msgstr "Святой Защитник"
-
-#: Source/translation_dummy.cpp:570
-msgid "Stormshield"
-msgstr "Грозовой Щит"
-
-#: Source/translation_dummy.cpp:571
-msgid "Bramble"
-msgstr "Ежевика"
-
-#: Source/translation_dummy.cpp:572
-msgid "Ring of Regha"
-msgstr "Кольцо Регхи"
-
-#: Source/translation_dummy.cpp:573
-msgid "The Bleeder"
-msgstr "Проливатель Крови"
-
-#: Source/translation_dummy.cpp:574
-msgid "Constricting Ring"
-msgstr "Сужающее Кольцо"
-
-#: Source/translation_dummy.cpp:575
-msgid "Ring of Engagement"
-msgstr "Обручальное Кольцо"
-
-#: Source/translation_dummy.cpp:576
-msgid "Giant's Knuckle"
-msgstr "Кастет Гиганта"
-
-#: Source/translation_dummy.cpp:577
-msgid "Mercurial Ring"
-msgstr "Ртутное Кольцо"
-
-#: Source/translation_dummy.cpp:578
-msgid "Xorine's Ring"
-msgstr "Кольцо Ксорин"
-
-#: Source/translation_dummy.cpp:579
-msgid "Karik's Ring"
-msgstr "Кольцо Карика"
-
-#: Source/translation_dummy.cpp:580
-msgid "Ring of Magma"
-msgstr "Кольцо Магмы"
-
-#: Source/translation_dummy.cpp:581
-msgid "Ring of the Mystics"
-msgstr "Кольцо Мистики"
-
-#: Source/translation_dummy.cpp:582
-msgid "Ring of Thunder"
-msgstr "Кольцо Грома"
-
-#: Source/translation_dummy.cpp:583
-msgid "Amulet of Warding"
-msgstr "Защитный Амулет"
-
-#: Source/translation_dummy.cpp:584
-msgid "Gnat Sting"
-msgstr "Жало Комара"
-
-#: Source/translation_dummy.cpp:585
-msgid "Flambeau"
-msgstr "Факел"
-
-#: Source/translation_dummy.cpp:586
-msgid "Armor of Gloom"
-msgstr "Доспех Мрака"
-
-#: Source/translation_dummy.cpp:587
-msgid "Blitzen"
-msgstr "Блитцен"
-
-#: Source/translation_dummy.cpp:588
-msgid "Thunderclap"
-msgstr "Удар Грома"
-
-#: Source/translation_dummy.cpp:589
-msgid "Shirotachi"
-msgstr "Широтачи"
-
-#: Source/translation_dummy.cpp:590
-msgid "Eater of Souls"
-msgstr "Пожиратель Душ"
-
-#: Source/translation_dummy.cpp:591
-msgid "Diamondedge"
-msgstr "Кромка Алмаза"
-
-#: Source/translation_dummy.cpp:592
-msgid "Bone Chain Armor"
-msgstr "Костяная Броня"
-
-#: Source/translation_dummy.cpp:593
-msgid "Demon Plate Armor"
-msgstr "Демонический Доспех"
-
-#: Source/translation_dummy.cpp:594
-msgid "Acolyte's Amulet"
-msgstr "Амулет Приспешника"
-
-#: Source/translation_dummy.cpp:595
-msgid "Gladiator's Ring"
-msgstr "Кольцо Гладиатора"
-
-# Хотелось бы как-то добавить средний и женский род для всех последующих слов до Doppelganger's включительно. Оловянный дубина/кольцо
-#: Source/translation_dummy.cpp:596
-msgid "Tin"
-msgstr "Оловянный"
-
-#: Source/translation_dummy.cpp:597
-msgid "Brass"
-msgstr "Латунный"
-
-#: Source/translation_dummy.cpp:598
-msgid "Bronze"
-msgstr "Бронзовый"
-
-#: Source/translation_dummy.cpp:599
-msgid "Iron"
-msgstr "Железный"
-
-#: Source/translation_dummy.cpp:600
-msgid "Steel"
-msgstr "Стальной"
-
-#: Source/translation_dummy.cpp:601
-msgid "Silver"
-msgstr "Серебряный"
-
-#: Source/translation_dummy.cpp:603
-msgid "Platinum"
-msgstr "Платиновый"
-
-#: Source/translation_dummy.cpp:604
-msgid "Mithril"
-msgstr "Мифриловый"
-
-#: Source/translation_dummy.cpp:605
-msgid "Meteoric"
-msgstr "Метеоритный"
-
-#: Source/translation_dummy.cpp:607
-msgid "Strange"
-msgstr "Странный"
-
-#: Source/translation_dummy.cpp:608
-msgid "Useless"
-msgstr "Бесполезный"
-
-#: Source/translation_dummy.cpp:609
-msgid "Bent"
-msgstr "Согнутый"
-
-#: Source/translation_dummy.cpp:610
-msgid "Weak"
-msgstr "Хлипкий"
-
-#: Source/translation_dummy.cpp:611
-msgid "Jagged"
-msgstr "Зубчатый"
-
-#: Source/translation_dummy.cpp:612
-msgid "Deadly"
-msgstr "Смертоносный"
-
-#: Source/translation_dummy.cpp:613
-msgid "Heavy"
-msgstr "Тяжелый"
-
-#: Source/translation_dummy.cpp:614
-msgid "Vicious"
-msgstr "Порочный"
-
-#: Source/translation_dummy.cpp:615
-msgid "Brutal"
-msgstr "Жестокий"
-
-#: Source/translation_dummy.cpp:616
-msgid "Massive"
-msgstr "Массивный"
-
-#: Source/translation_dummy.cpp:617
-msgid "Savage"
-msgstr "Дикий"
-
-#: Source/translation_dummy.cpp:618
-msgid "Ruthless"
-msgstr "Беспощадный"
-
-#: Source/translation_dummy.cpp:619
-msgid "Merciless"
-msgstr "Безжалостный"
-
-#: Source/translation_dummy.cpp:620
-msgid "Clumsy"
-msgstr "Неуклюжий"
-
-#: Source/translation_dummy.cpp:621
-msgid "Dull"
-msgstr "Тупой"
-
-#: Source/translation_dummy.cpp:622
-msgid "Sharp"
-msgstr "Острый"
-
-#: Source/translation_dummy.cpp:623 Source/translation_dummy.cpp:633
-msgid "Fine"
-msgstr "Изящный"
-
-#: Source/translation_dummy.cpp:624
-msgid "Warrior's"
-msgstr "Воинский"
-
-#: Source/translation_dummy.cpp:625
-msgid "Soldier's"
-msgstr "Солдатский"
-
-# Лордский...
-# ---------------------------------------------
-# Тут либо "господский", либо "властелинский".
-#: Source/translation_dummy.cpp:626
-msgid "Lord's"
-msgstr "Господский"
-
-#: Source/translation_dummy.cpp:627
-msgid "Knight's"
-msgstr "Рыцарский"
-
-#: Source/translation_dummy.cpp:628
-msgid "Master's"
-msgstr "Мастерский"
-
-#: Source/translation_dummy.cpp:629
-msgid "Champion's"
-msgstr "Чемпионский"
-
-#: Source/translation_dummy.cpp:630
-msgid "King's"
-msgstr "Королевский"
-
-#: Source/translation_dummy.cpp:631
-msgid "Vulnerable"
-msgstr "Уязвимый"
-
-#: Source/translation_dummy.cpp:632
-msgid "Rusted"
-msgstr "Ржавый"
-
-#: Source/translation_dummy.cpp:634
-msgid "Strong"
-msgstr "Сильный"
-
-#: Source/translation_dummy.cpp:635
-msgid "Grand"
-msgstr "Великий"
-
-#: Source/translation_dummy.cpp:636
-msgid "Valiant"
-msgstr "Доблестный"
-
-#: Source/translation_dummy.cpp:637
-msgid "Glorious"
-msgstr "Великолепный"
-
-#: Source/translation_dummy.cpp:638
-msgid "Blessed"
-msgstr "Благославенный"
-
-#: Source/translation_dummy.cpp:639
-msgid "Saintly"
-msgstr "Освящённый"
-
-#: Source/translation_dummy.cpp:640
-msgid "Awesome"
-msgstr "Устрашающий"
-
-#: Source/translation_dummy.cpp:642
-msgid "Godly"
-msgstr "Благочестивый"
-
-#: Source/translation_dummy.cpp:643
-msgid "Red"
-msgstr "Красный"
-
-#: Source/translation_dummy.cpp:644 Source/translation_dummy.cpp:645
-msgid "Crimson"
-msgstr "Багровый"
-
-#: Source/translation_dummy.cpp:646
-msgid "Garnet"
-msgstr "Гранатовый"
-
-#: Source/translation_dummy.cpp:647
-msgid "Ruby"
-msgstr "Рубиновый"
-
-#: Source/translation_dummy.cpp:648
-msgid "Blue"
-msgstr "Голубой"
-
-#: Source/translation_dummy.cpp:649
-msgid "Azure"
-msgstr "Лазурный"
-
-#: Source/translation_dummy.cpp:650
-msgid "Lapis"
-msgstr "Лазуритовый"
-
-#: Source/translation_dummy.cpp:651
-msgid "Cobalt"
-msgstr "Кобальтовый"
-
-#: Source/translation_dummy.cpp:652
-msgid "Sapphire"
-msgstr "Сапфировый"
-
-#: Source/translation_dummy.cpp:653
-msgid "White"
-msgstr "Белый"
-
-#: Source/translation_dummy.cpp:654
-msgid "Pearl"
-msgstr "Жемчужный"
-
-#: Source/translation_dummy.cpp:655
-msgid "Ivory"
-msgstr "Слоновой Кости"
-
-#: Source/translation_dummy.cpp:656
-msgid "Crystal"
-msgstr "Кристальный"
-
-#: Source/translation_dummy.cpp:657
-msgid "Diamond"
-msgstr "Алмазный"
-
-#: Source/translation_dummy.cpp:658
-msgid "Topaz"
-msgstr "Топазовый"
-
-#: Source/translation_dummy.cpp:659
-msgid "Amber"
-msgstr "Янтарный"
-
-#: Source/translation_dummy.cpp:660
-msgid "Jade"
-msgstr "Нефритовый"
-
-#: Source/translation_dummy.cpp:661
-msgid "Obsidian"
-msgstr "Обсидиановый"
-
-#: Source/translation_dummy.cpp:662
-msgid "Emerald"
-msgstr "Изумрудный"
-
-#: Source/translation_dummy.cpp:663
-msgid "Hyena's"
-msgstr "Гиений"
-
-#: Source/translation_dummy.cpp:664
-msgid "Frog's"
-msgstr "Лягушачий"
-
-#: Source/translation_dummy.cpp:665
-msgid "Spider's"
-msgstr "Паучий"
-
-#: Source/translation_dummy.cpp:666
-msgid "Raven's"
-msgstr "Вороний"
-
-#: Source/translation_dummy.cpp:667
-msgid "Snake's"
-msgstr "Змеиный"
-
-#: Source/translation_dummy.cpp:668
-msgid "Serpent's"
-msgstr "Гадючий"
-
-#: Source/translation_dummy.cpp:669
-msgid "Drake's"
-msgstr "Змиевый"
-
-#: Source/translation_dummy.cpp:670
-msgid "Dragon's"
-msgstr "Драконий"
-
-#: Source/translation_dummy.cpp:671
-msgid "Wyrm's"
-msgstr "Змеевой"
-
-#: Source/translation_dummy.cpp:672
-msgid "Hydra's"
-msgstr "Гидры"
-
-#: Source/translation_dummy.cpp:673
-msgid "Angel's"
-msgstr "Ангельский"
-
-#: Source/translation_dummy.cpp:674
-msgid "Arch-Angel's"
-msgstr "Архангельский"
-
-#: Source/translation_dummy.cpp:675
-msgid "Plentiful"
-msgstr "Богатый"
-
-#: Source/translation_dummy.cpp:676
-msgid "Bountiful"
-msgstr "Щедрый"
-
-#: Source/translation_dummy.cpp:677
-msgid "Flaming"
-msgstr "Пылающий"
-
-#: Source/translation_dummy.cpp:678
-msgid "Lightning"
-msgstr "Светящийся"
-
-#: Source/translation_dummy.cpp:679
-msgid "Jester's"
-msgstr "Шутовской"
-
-#: Source/translation_dummy.cpp:680
-msgid "Crystalline"
-msgstr "Кристаллический"
-
-#: Source/translation_dummy.cpp:681
-msgid "Doppelganger's"
-msgstr "Двойникский"
-
-#: Source/translation_dummy.cpp:682
-msgid "quality"
-msgstr "качества"
-
-#: Source/translation_dummy.cpp:683
-msgid "maiming"
-msgstr "увеличения"
-
-#: Source/translation_dummy.cpp:684
-msgid "slaying"
-msgstr "убийства"
-
-# крови уже есть, если есть адекватный перевод, меняйте немедленно
-# ---------------------------------------------
-# Научное название запёкшейся крови – струп.
-#: Source/translation_dummy.cpp:685
-msgid "gore"
-msgstr "струпа"
-
-#: Source/translation_dummy.cpp:686
-msgid "carnage"
-msgstr "бойни"
-
-#: Source/translation_dummy.cpp:687
-msgid "slaughter"
-msgstr "резни"
-
-#: Source/translation_dummy.cpp:688
-msgid "pain"
-msgstr "боли"
-
-#: Source/translation_dummy.cpp:689
-msgid "tears"
-msgstr "слёз"
-
-#: Source/translation_dummy.cpp:690
-msgid "health"
-msgstr "здоровья"
-
-#: Source/translation_dummy.cpp:691
-msgid "protection"
-msgstr "защиты"
-
-#: Source/translation_dummy.cpp:692
-msgid "absorption"
-msgstr "поглощения"
-
-#: Source/translation_dummy.cpp:693
-msgid "deflection"
-msgstr "отклонения"
-
-#: Source/translation_dummy.cpp:694
-msgid "osmosis"
-msgstr "осмоса"
-
-#: Source/translation_dummy.cpp:695
-msgid "frailty"
-msgstr "хрупкости"
-
-#: Source/translation_dummy.cpp:696
-msgid "weakness"
-msgstr "слабости"
-
-#: Source/translation_dummy.cpp:697
-msgid "strength"
-msgstr "силы"
-
-#: Source/translation_dummy.cpp:698
-msgid "might"
-msgstr "мощи"
-
-#: Source/translation_dummy.cpp:699
-msgid "power"
-msgstr "могущества"
-
-#: Source/translation_dummy.cpp:700
-msgid "giants"
-msgstr "гигантов"
-
-#: Source/translation_dummy.cpp:701
-msgid "titans"
-msgstr "титанов"
-
-#: Source/translation_dummy.cpp:702
-msgid "paralysis"
-msgstr "паралича"
-
-#: Source/translation_dummy.cpp:703
-msgid "atrophy"
-msgstr "атрофии"
-
-#: Source/translation_dummy.cpp:704
-msgid "dexterity"
-msgstr "ловкости"
-
-#: Source/translation_dummy.cpp:705
-msgid "skill"
-msgstr "умения"
-
-#: Source/translation_dummy.cpp:706
-msgid "accuracy"
-msgstr "меткости"
-
-#: Source/translation_dummy.cpp:707
-msgid "precision"
-msgstr "точности"
-
-#: Source/translation_dummy.cpp:708
-msgid "perfection"
-msgstr "совершенства"
-
-#: Source/translation_dummy.cpp:709
-msgid "the fool"
-msgstr "дурака"
-
-#: Source/translation_dummy.cpp:710
-msgid "dyslexia"
-msgstr "дислексии"
-
-#: Source/translation_dummy.cpp:711
-msgid "magic"
-msgstr "магии"
-
-#: Source/translation_dummy.cpp:712
-msgid "the mind"
-msgstr "разума"
-
-#: Source/translation_dummy.cpp:713
-msgid "brilliance"
-msgstr "блеска"
-
-#: Source/translation_dummy.cpp:714
-msgid "sorcery"
-msgstr "колдовства"
-
-#: Source/translation_dummy.cpp:715
-msgid "wizardry"
-msgstr "волшебства"
-
-#: Source/translation_dummy.cpp:716
-msgid "illness"
-msgstr "хвори"
-
-#: Source/translation_dummy.cpp:717
-msgid "disease"
-msgstr "болезни"
-
-#: Source/translation_dummy.cpp:718
-msgid "vitality"
-msgstr "живучести"
-
-# Change at will
-#: Source/translation_dummy.cpp:719
-msgid "zest"
-msgstr "жара"
-
-#: Source/translation_dummy.cpp:720
-msgid "vim"
-msgstr "напора"
-
-#: Source/translation_dummy.cpp:721
-msgid "vigor"
-msgstr "силы"
-
-#: Source/translation_dummy.cpp:722
-msgid "life"
-msgstr "жизни"
-
-#: Source/translation_dummy.cpp:723
-msgid "trouble"
-msgstr "неприятности"
-
-#: Source/translation_dummy.cpp:724
-msgid "the pit"
-msgstr "ямы"
-
-#: Source/translation_dummy.cpp:725
-msgid "the sky"
-msgstr "небес"
-
-#: Source/translation_dummy.cpp:726
-msgid "the moon"
-msgstr "луны"
-
-#: Source/translation_dummy.cpp:727
-msgid "the stars"
-msgstr "звёзд"
-
-#: Source/translation_dummy.cpp:728
-msgid "the heavens"
-msgstr "небес"
-
-#: Source/translation_dummy.cpp:729
-msgid "the zodiac"
-msgstr "зодиака"
-
-#: Source/translation_dummy.cpp:730
-msgid "the vulture"
-msgstr "стервятника"
-
-#: Source/translation_dummy.cpp:731
-msgid "the jackal"
-msgstr "шакала"
-
-#: Source/translation_dummy.cpp:732
-msgid "the fox"
-msgstr "лисы"
-
-#: Source/translation_dummy.cpp:733
-msgid "the jaguar"
-msgstr "ягуара"
-
-#: Source/translation_dummy.cpp:734
-msgid "the eagle"
-msgstr "орла"
-
-#: Source/translation_dummy.cpp:735
-msgid "the wolf"
-msgstr "волка"
-
-#: Source/translation_dummy.cpp:736
-msgid "the tiger"
-msgstr "тигра"
-
-#: Source/translation_dummy.cpp:737
-msgid "the lion"
-msgstr "льва"
-
-#: Source/translation_dummy.cpp:738
-msgid "the mammoth"
-msgstr "мамонта"
-
-#: Source/translation_dummy.cpp:739
-msgid "the whale"
-msgstr "кита"
-
-#: Source/translation_dummy.cpp:740
-msgid "fragility"
-msgstr "хрупкости"
-
-#: Source/translation_dummy.cpp:741
-msgid "brittleness"
-msgstr "ломкости"
-
-#: Source/translation_dummy.cpp:742
-msgid "sturdiness"
-msgstr "прочности"
-
-#: Source/translation_dummy.cpp:743
-msgid "craftsmanship"
-msgstr "мастерства"
-
-#: Source/translation_dummy.cpp:744
-msgid "structure"
-msgstr "структуры"
-
-#: Source/translation_dummy.cpp:745
-msgid "the ages"
-msgstr "веков"
-
-#: Source/translation_dummy.cpp:746
-msgid "the dark"
-msgstr "тьмы"
-
-#: Source/translation_dummy.cpp:747
-msgid "the night"
-msgstr "ночи"
-
-#: Source/translation_dummy.cpp:748
-msgid "light"
-msgstr "света"
-
-#: Source/translation_dummy.cpp:749
-msgid "radiance"
-msgstr "сияния"
-
-#: Source/translation_dummy.cpp:750
-msgid "flame"
-msgstr "пламени"
-
-#: Source/translation_dummy.cpp:751
-msgid "fire"
-msgstr "огня"
-
-#: Source/translation_dummy.cpp:752
-msgid "burning"
-msgstr "горения"
-
-#: Source/translation_dummy.cpp:753
-msgid "shock"
-msgstr "шока"
-
-#: Source/translation_dummy.cpp:754
-msgid "lightning"
-msgstr "молнии"
-
-#: Source/translation_dummy.cpp:755
-msgid "thunder"
-msgstr "грома"
-
-#: Source/translation_dummy.cpp:756
-msgid "many"
-msgstr "множества"
-
-#: Source/translation_dummy.cpp:757
-msgid "plenty"
-msgstr "достатка"
-
-#: Source/translation_dummy.cpp:758
-msgid "thorns"
-msgstr "шипов"
-
-# коррупции - слишком в духе уголовного кодекса
-#: Source/translation_dummy.cpp:759
-msgid "corruption"
-msgstr "разложения"
-
-#: Source/translation_dummy.cpp:760
-msgid "thieves"
-msgstr "воров"
-
-#: Source/translation_dummy.cpp:761
-msgid "the bear"
-msgstr "медведя"
-
-#: Source/translation_dummy.cpp:762
-msgid "the bat"
-msgstr "летучей мыши"
-
-#: Source/translation_dummy.cpp:763
-msgid "vampires"
-msgstr "вампиров"
-
-#: Source/translation_dummy.cpp:764
-msgid "the leech"
-msgstr "пиявки"
-
-#: Source/translation_dummy.cpp:765
-msgid "blood"
-msgstr "крови"
-
-#: Source/translation_dummy.cpp:766
-msgid "piercing"
-msgstr "протыкания"
-
-#: Source/translation_dummy.cpp:767
-msgid "puncturing"
-msgstr "прокалывания"
-
-#: Source/translation_dummy.cpp:768
-msgid "bashing"
-msgstr "избиения"
-
-#: Source/translation_dummy.cpp:769
-msgid "readiness"
-msgstr "готовности"
-
-#: Source/translation_dummy.cpp:770
-msgid "swiftness"
-msgstr "стремительности"
-
-#: Source/translation_dummy.cpp:771
-msgid "speed"
-msgstr "скорости"
-
-#: Source/translation_dummy.cpp:772
-msgid "haste"
-msgstr "спешки"
-
-#: Source/translation_dummy.cpp:773
-msgid "balance"
-msgstr "баланса"
-
-#: Source/translation_dummy.cpp:774
-msgid "stability"
-msgstr "стабильности"
-
-#: Source/translation_dummy.cpp:775
-msgid "harmony"
-msgstr "гармонии"
-
-#: Source/translation_dummy.cpp:776
-msgid "blocking"
-msgstr "блокирования"
-
-#: Source/translation_dummy.cpp:777
-msgid "devastation"
-msgstr "опустошения"
-
-#: Source/translation_dummy.cpp:778
-msgid "decay"
-msgstr "разложения"
-
-#: Source/translation_dummy.cpp:779
-msgid "peril"
-msgstr "опасности"
-
-#: Source/translation_dummy.cpp:780
-msgctxt "spell"
-msgid "Firebolt"
-msgstr "Огненная Стрела"
-
-#: Source/translation_dummy.cpp:781
-msgctxt "spell"
-msgid "Healing"
-msgstr "Исцеление"
-
-#: Source/translation_dummy.cpp:782
-msgctxt "spell"
-msgid "Lightning"
-msgstr "Молния"
-
-#: Source/translation_dummy.cpp:783
-msgctxt "spell"
-msgid "Flash"
-msgstr "Вспышка"
-
-#: Source/translation_dummy.cpp:784
-msgctxt "spell"
-msgid "Identify"
-msgstr "Идентификация"
-
-#: Source/translation_dummy.cpp:785
-msgctxt "spell"
-msgid "Fire Wall"
-msgstr "Стена Огня"
-
-#: Source/translation_dummy.cpp:786
-msgctxt "spell"
-msgid "Town Portal"
-msgstr "Городской Портал"
-
-#: Source/translation_dummy.cpp:787
-msgctxt "spell"
-msgid "Stone Curse"
-msgstr "Окаменение"
-
-#: Source/translation_dummy.cpp:788
-msgctxt "spell"
-msgid "Infravision"
-msgstr "Инфразрение"
-
-#: Source/translation_dummy.cpp:789
-msgctxt "spell"
-msgid "Phasing"
-msgstr "Перемещение"
-
-#: Source/translation_dummy.cpp:790
-msgctxt "spell"
-msgid "Mana Shield"
-msgstr "Щит Маны"
-
-#: Source/translation_dummy.cpp:791
-msgctxt "spell"
-msgid "Fireball"
-msgstr "Огненный Шар"
-
-#: Source/translation_dummy.cpp:792
-msgctxt "spell"
-msgid "Guardian"
-msgstr "Хранитель"
-
-#: Source/translation_dummy.cpp:793
-msgctxt "spell"
-msgid "Chain Lightning"
-msgstr "Цепная Молния"
-
-#: Source/translation_dummy.cpp:794
-msgctxt "spell"
-msgid "Flame Wave"
-msgstr "Волна Огня"
-
-#: Source/translation_dummy.cpp:795
-msgctxt "spell"
-msgid "Doom Serpents"
-msgstr "Роковые Змеи"
-
-#: Source/translation_dummy.cpp:796
-msgctxt "spell"
-msgid "Blood Ritual"
-msgstr "Кровавый Ритуал"
-
-#: Source/translation_dummy.cpp:797
-msgctxt "spell"
-msgid "Nova"
-msgstr "Нова"
-
-#: Source/translation_dummy.cpp:798
-msgctxt "spell"
-msgid "Invisibility"
-msgstr "Невидимость"
-
-#: Source/translation_dummy.cpp:799
-msgctxt "spell"
-msgid "Inferno"
-msgstr "Преисподняя"
-
-#: Source/translation_dummy.cpp:800
-msgctxt "spell"
-msgid "Golem"
-msgstr "Голем"
-
-#: Source/translation_dummy.cpp:801
-msgctxt "spell"
-msgid "Rage"
-msgstr "Ярость"
-
-#: Source/translation_dummy.cpp:802
-msgctxt "spell"
-msgid "Teleport"
-msgstr "Телепорт"
-
-#: Source/translation_dummy.cpp:803
-msgctxt "spell"
-msgid "Apocalypse"
-msgstr "Апокалипсис"
-
-#: Source/translation_dummy.cpp:804
-msgctxt "spell"
-msgid "Etherealize"
-msgstr "Эфиризация"
-
-#: Source/translation_dummy.cpp:805
-msgctxt "spell"
-msgid "Item Repair"
-msgstr "Ремонт Предмета"
-
-#: Source/translation_dummy.cpp:806
-msgctxt "spell"
-msgid "Staff Recharge"
-msgstr "Перезарядка Посоха"
-
-#: Source/translation_dummy.cpp:807
-msgctxt "spell"
-msgid "Trap Disarm"
-msgstr "Обезвредить Ловушку"
-
-#: Source/translation_dummy.cpp:808
-msgctxt "spell"
-msgid "Elemental"
-msgstr "Элементаль"
-
-#: Source/translation_dummy.cpp:809
-msgctxt "spell"
-msgid "Charged Bolt"
-msgstr "Заряженная Стрела"
-
-#: Source/translation_dummy.cpp:810
-msgctxt "spell"
-msgid "Holy Bolt"
-msgstr "Святая Стрела"
-
-#: Source/translation_dummy.cpp:811
-msgctxt "spell"
-msgid "Resurrect"
-msgstr "Воскрешение"
-
-#: Source/translation_dummy.cpp:812
-msgctxt "spell"
-msgid "Telekinesis"
-msgstr "Телекинез"
-
-#: Source/translation_dummy.cpp:813
-msgctxt "spell"
-msgid "Heal Other"
-msgstr "Лечение Другого"
-
-#: Source/translation_dummy.cpp:814
-msgctxt "spell"
-msgid "Blood Star"
-msgstr "Кровавая Звезда"
-
-#: Source/translation_dummy.cpp:815
-msgctxt "spell"
-msgid "Bone Spirit"
-msgstr "Костяной Дух"
-
-#: Source/translation_dummy.cpp:816
-msgctxt "spell"
-msgid "Mana"
-msgstr "Мана"
-
-#: Source/translation_dummy.cpp:817
-msgctxt "spell"
-msgid "the Magi"
-msgstr "Маги"
-
-#: Source/translation_dummy.cpp:818
-msgctxt "spell"
-msgid "the Jester"
-msgstr "Шут"
-
-#: Source/translation_dummy.cpp:819
-msgctxt "spell"
-msgid "Lightning Wall"
-msgstr "Стена Молний"
-
-#: Source/translation_dummy.cpp:820
-msgctxt "spell"
-msgid "Immolation"
-msgstr "Жертвоприношение"
-
-#: Source/translation_dummy.cpp:821
-msgctxt "spell"
-msgid "Warp"
-msgstr "Искривление"
-
-#: Source/translation_dummy.cpp:822
-msgctxt "spell"
-msgid "Reflect"
-msgstr "Отражение"
-
-#: Source/translation_dummy.cpp:823
-msgctxt "spell"
-msgid "Berserk"
-msgstr "Берсерк"
-
-#: Source/translation_dummy.cpp:824
-msgctxt "spell"
-msgid "Ring of Fire"
-msgstr "Кольцо Огня"
-
-#: Source/translation_dummy.cpp:825
-msgctxt "spell"
-msgid "Search"
-msgstr "Поиск"
-
-#: Source/translation_dummy.cpp:826
-msgctxt "spell"
-msgid "Rune of Fire"
-msgstr "Руна Огня"
-
-#: Source/translation_dummy.cpp:827
-msgctxt "spell"
-msgid "Rune of Light"
-msgstr "Руна Света"
-
-#: Source/translation_dummy.cpp:828
-msgctxt "spell"
-msgid "Rune of Nova"
-msgstr "Руна Новы"
-
-#: Source/translation_dummy.cpp:829
-msgctxt "spell"
-msgid "Rune of Immolation"
-msgstr "Руна Жертвоприношения"
-
-#: Source/translation_dummy.cpp:830
-msgctxt "spell"
-msgid "Rune of Stone"
-msgstr "Руна Камня"
-
 #. TRANSLATORS: Thousands separator
-#: Source/utils/format_int.cpp:27
+#: Source/utils/format_int.cpp:26
 msgid ","
 msgstr ","
+
+#, c++-format
+#~ msgid "Unable to load data from file {0}"
+#~ msgstr "Не удаётся загрузить данные из файла {0}"
+
+#, c++-format
+#~ msgid "{0} is incomplete, please check the file contents."
+#~ msgstr "{0} является неполным, пожалуйста, проверьте содержимое файла."
+
+#, c++-format
+#~ msgid ""
+#~ "Your {0} file doesn't have the expected columns, please make sure it "
+#~ "matches the documented format."
+#~ msgstr ""
+#~ "В вашем файле {0} нет нужных столбцов, пожалуйста, убедитесь, что он "
+#~ "соответствует документированному формату."
+
+#, c++-format
+#~ msgid "Non-numeric value {0} for {1} in {2} at row {3} and column {4}"
+#~ msgstr "Нечисловое значение {0} для {1} в {2} в строке {3} и столбце {4}"
+
+#, c++-format
+#~ msgid "Out of range value {0} for {1} in {2} at row {3} and column {4}"
+#~ msgstr "Значение вне диапазона {0} для {1} в {2} в строке {3} и столбце {4}"
+
+#, c++-format
+#~ msgid "Invalid value {0} for {1} in {2} at row {3} and column {4}"
+#~ msgstr "Недопустимое значение {0} для {1} в {2} в строке {3} и столбце {4}"
+
+#~ msgid "Previous quick spell"
+#~ msgstr "Предыдущее заклинание"
+
+#~ msgid "Selects the previous quick spell (cycles)."
+#~ msgstr "Выбрать предыдущее заклинание (циклично)."
+
+#~ msgid "Next quick spell"
+#~ msgstr "Следующее заклинание"
+
+#~ msgid "Selects the next quick spell (cycles)."
+#~ msgstr "Выбрать следующее заклинание (циклично)."
+
+#~ msgid "Cycle map type"
+#~ msgstr "Тип цикла карты"
+
+#~ msgid "Opaque -> Transparent -> Minimap -> None"
+#~ msgstr "Непрозрачный -> Прозрачный -> Миникарта -> Нет"
+
+#~ msgid "Sort Inventory"
+#~ msgstr "Сортировка инвентаря"
+
+#~ msgid "Sorts the inventory."
+#~ msgstr "Сортирует инвентарь."
+
+#~ msgid "Console"
+#~ msgstr "Консоль"
+
+#~ msgid "Opens Lua console."
+#~ msgstr "Открывает консоль Lua."
+
+#, c++-format
+#~ msgid ""
+#~ "Failed to open file:\n"
+#~ "{:s}\n"
+#~ "\n"
+#~ "{:s}\n"
+#~ "\n"
+#~ "The MPQ file(s) might be damaged. Please check the file integrity."
+#~ msgstr ""
+#~ "Не удалось открыть файл:\n"
+#~ "{:s}\n"
+#~ "\n"
+#~ "{:s}\n"
+#~ "\n"
+#~ "Возможно, файл(ы) MPQ поврежден(ы). Пожалуйста, проверьте целостность "
+#~ "файла."
+
+#~ msgid "Pause Game When Window Loses Focus"
+#~ msgstr "Пауза если окно теряет фокус"
+
+#~ msgid "When enabled, the game will pause when focus is lost."
+#~ msgstr ""
+#~ "Если включено, игра встанет на паузу при потере фокуса (переключении на "
+#~ "другое окно)."
+
+#~ msgid "Mods"
+#~ msgstr "Моды"
+
+#~ msgid "Mod Settings"
+#~ msgstr "Настройки модов"
+
+#~ msgid "Heal yourself!"
+#~ msgstr "Лечи себя!"
+
+#~ msgid "Watch out!"
+#~ msgstr "Берегись!"
+
+#~ msgid "Thanks."
+#~ msgstr "Спасибо."
+
+#~ msgid "Retreat!"
+#~ msgstr "Отступай!"
+
+#~ msgid "Sorry."
+#~ msgstr "Извини."
+
+#~ msgid "I'm waiting."
+#~ msgstr "Я жду."
+
+#~ msgid "Indestructible"
+#~ msgstr "Неразрушимое"
 
 #~ msgid ""
 #~ "Forces waiting for Vertical Sync. Prevents tearing effect when drawing a "
@@ -12272,12 +12299,6 @@ msgstr ","
 #~ msgstr ""
 #~ "Ограничить FPS во избежание нагрузки на процессор. Учитывается частота "
 #~ "обновления."
-
-#~ msgid "Indestructible,  "
-#~ msgstr "Неразрушимое,  "
-
-#~ msgid "No required attributes"
-#~ msgstr "Нет обязательных атрибутов"
 
 #~ msgid "Options:"
 #~ msgstr "Параметры:"
@@ -12343,14 +12364,3 @@ msgstr ","
 #~ "изуродованные тела тысяч людей. Ангелы и люди были вырезаны для "
 #~ "исполнения его бесконечных жертвоприношений Тёмным, требующим одного: "
 #~ "крови."
-
-#~ msgid ""
-#~ "Cloudy and cooler today.  Casting the nets of necromancy across the void "
-#~ "landed two new subspecies of flying horror; a good day's work.  Must "
-#~ "remember to order some more bat guano and black candles from Adria; I'm "
-#~ "running a bit low."
-#~ msgstr ""
-#~ "Сегодня пасмурно и прохладнее. Забросив сети некромантии через пустоту, "
-#~ "мы получили два новых подвида летающего ужаса; хороший рабочий день. Надо "
-#~ "не забыть заказать у Адрии ещё немного гуано летучих мышей и чёрных "
-#~ "свечей; у меня уже на исходе."

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -720,7 +720,7 @@ msgid ""
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
 "Нормальная сложность\n"
-"Отсюда новичкам стоит начинать путь к победы над Диабло."
+"Отсюда новичкам стоит начинать путь к победе над Диабло."
 
 # Подобрано под размер меню.
 #: Source/DiabloUI/multi/selgame.cpp:394
@@ -783,7 +783,7 @@ msgid ""
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
 "Нормальная скорость\n"
-"Отсюда новичкам стоит начинать путь к победы над Диабло."
+"Отсюда новичкам стоит начинать путь к победе над Диабло."
 
 # Подобрано под размер меню.
 #: Source/DiabloUI/multi/selgame.cpp:520
@@ -1053,8 +1053,6 @@ msgid "Command "
 msgstr "Команда "
 
 #: Source/control.cpp:356
-#, fuzzy
-#| msgid " is unknown."
 msgid " is unkown."
 msgstr " неизвестна."
 
@@ -1112,7 +1110,7 @@ msgstr "Игрок с таким именем не найден"
 
 #: Source/control.cpp:524
 msgid "/help"
-msgstr ""
+msgstr "/help"
 
 #: Source/control.cpp:524
 msgid "Prints help overview or help for a specific command."
@@ -1124,7 +1122,7 @@ msgstr "[command]"
 
 #: Source/control.cpp:525
 msgid "/arena"
-msgstr ""
+msgstr "/arena"
 
 #: Source/control.cpp:525
 msgid "Enter a PvP Arena."
@@ -1136,7 +1134,7 @@ msgstr "<arena-number>"
 
 #: Source/control.cpp:526
 msgid "/arenapot"
-msgstr ""
+msgstr "/arenapot"
 
 #: Source/control.cpp:526
 msgid "Gives Arena Potions."
@@ -1148,7 +1146,7 @@ msgstr "<number>"
 
 #: Source/control.cpp:527
 msgid "/inspect"
-msgstr ""
+msgstr "/inspect"
 
 #: Source/control.cpp:527
 msgid "Inspects stats and equipment of another player."
@@ -1160,17 +1158,15 @@ msgstr "<player name>"
 
 #: Source/control.cpp:528
 msgid "/seedinfo"
-msgstr ""
+msgstr "/seedinfo"
 
 #: Source/control.cpp:528
 msgid "Show seed infos for current level."
 msgstr "Показать информацию о сиде для этого уровня."
 
 #: Source/control.cpp:538
-#, fuzzy
-#| msgid "Command "
 msgid "Command \""
-msgstr "Команда "
+msgstr "Команда \""
 
 #: Source/control.cpp:1013
 msgid "Player friendly"
@@ -1296,8 +1292,6 @@ msgid "level 15"
 msgstr "уровень 15"
 
 #: Source/diablo.cpp:126
-#, fuzzy
-#| msgid "I need help! Come here!"
 msgid "I need help! Come Here!"
 msgstr "Мне нужна помощь! Ко мне!"
 
@@ -2728,11 +2722,11 @@ msgstr "Пластинчатый Доспех"
 
 #: Source/itemdat.cpp:121
 msgid "Field Plate"
-msgstr "Полевая Пластина"
+msgstr "Латный Доспех"
 
 #: Source/itemdat.cpp:122
 msgid "Gothic Plate"
-msgstr "Готическая Пластина"
+msgstr "Готические Латы"
 
 #: Source/itemdat.cpp:123
 msgid "Full Plate Mail"
@@ -2873,10 +2867,8 @@ msgstr "Свиток Апокалипсиса"
 
 #: Source/itemdat.cpp:167 Source/itemdat.cpp:168 Source/itemdat.cpp:169
 #: Source/itemdat.cpp:170
-#, fuzzy
-#| msgid "Book of {:s}"
 msgid "Book of "
-msgstr "Книга {:s}"
+msgstr "Книга "
 
 #: Source/itemdat.cpp:173
 msgid "Falchion"
@@ -4083,7 +4075,7 @@ msgstr "Ночной Пейзаж"
 
 #: Source/itemdat.cpp:511
 msgid "Naj's Light Plate"
-msgstr "Лёгкая Пластина Наджа"
+msgstr "Лёгкие Латы Наджа"
 
 #: Source/itemdat.cpp:512
 msgid "Demonspike Coat"
@@ -4794,17 +4786,17 @@ msgstr "Другая способность (NW)"
 # Сократил восстановление до восст., т.к. текст любит вылезать за рамки
 #: Source/items.cpp:3866
 msgid "fast hit recovery"
-msgstr "быстрое восст. от удара"
+msgstr "быстрое восстановление от удара"
 
 # Сократил восстановление до восст., т.к. текст любит вылезать за рамки
 #: Source/items.cpp:3868
 msgid "faster hit recovery"
-msgstr "более быстрое восст. от удара"
+msgstr "более быстрое восстановление от удара"
 
 # Сократил восстановление до восст., т.к. текст любит вылезать за рамки
 #: Source/items.cpp:3870
 msgid "fastest hit recovery"
-msgstr "наибыстрейшее восст. от удара"
+msgstr "наибыстрейшее восстановление от удара"
 
 #: Source/items.cpp:3873
 msgid "fast block"
@@ -4814,9 +4806,9 @@ msgstr "быстрый блок"
 #, c++-format
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
-msgstr[0] "добавляет {:d} очко к урону"
-msgstr[1] "добавляет {:d} очка к урону"
-msgstr[2] "добавляет {:d} очков к урону"
+msgstr[0] "+{:d} очко к урону"
+msgstr[1] "+{:d} очка к урону"
+msgstr[2] "+{:d} очков к урону"
 
 #: Source/items.cpp:3877
 msgid "fires random speed arrows"
@@ -7290,8 +7282,7 @@ msgstr "Отключить калечащие святилища"
 #: Source/options.cpp:1082
 msgid ""
 "When enabled Cauldrons, Fascinating Shrines, Goat Shrines, Ornate Shrines "
-"and Sacred Shrines are not able to be clicked on and "
-"labeled as disabled."
+"and Sacred Shrines are not able to be clicked on and labeled as disabled."
 msgstr ""
 "Если включено, святилища со случайным эффектом не будут доступны к "
 "применению. Будут доступны лишь фонтаны и бассейны."
@@ -8069,10 +8060,9 @@ msgid "Armor: {:d}  "
 msgstr "Броня: {:d}  "
 
 #: Source/stores.cpp:313
-#, fuzzy, c++-format
-#| msgid "Dur: {:d}/{:d}"
+#, c++-format
 msgid "Dur: {:d}/{:d},  "
-msgstr "Прчн: {:d}/{:d}"
+msgstr "Прчн: {:d}/{:d}, "
 
 #: Source/stores.cpp:315
 msgid "Indestructible,  "
@@ -10940,12 +10930,6 @@ msgstr ""
 
 #. TRANSLATORS: Neutral dialog spoken by Farnham (Gossip)
 #: Source/textdat.cpp:425
-#, fuzzy
-#| msgid ""
-#| "If I was you... and I ain't... but if I was, I'd sell all that stuff you "
-#| "got and get out of here. That boy out there... He's always got somethin' "
-#| "good, but you gotta give him some gold or he won't even show you what "
-#| "he's got."
 msgid ""
 "If I was you... and I ain't... but if I was, I'd sell all that stuff you got "
 "and get out of here. That boy out there... He's always got somethin good, "
@@ -11605,15 +11589,6 @@ msgstr ""
 
 #. TRANSLATORS: Quest text spoken by Gillian
 #: Source/textdat.cpp:555
-#, fuzzy
-#| msgid ""
-#| "My grandmother often tells me stories about the strange forces that "
-#| "inhabit the graveyard outside of the church.  And it may well interest "
-#| "you to hear one of them.  She said that if you were to leave the proper "
-#| "offering in the cemetery, enter the cathedral to pray for the dead, and "
-#| "then return, the offering would be altered in some strange way.  I don't "
-#| "know if this is just the talk of an old sick woman, but anything seems "
-#| "possible these days."
 msgid ""
 "My grandmother often tells me stories about the strange forces that inhabit "
 "the graveyard outside of the church.  And it may well interest you to hear "
@@ -11623,11 +11598,11 @@ msgid ""
 "the talk of an old sick woman, but anything seems possible these days."
 msgstr ""
 "Моя бабушка часто рассказывает мне о странных духах, обитающих на кладбище "
-"возле церкви. Тебе, наверное, будет интересно послушать об этом. Она "
+"возле церкви.  Тебе, наверное, будет интересно послушать об этом.  Она "
 "говорит, что если оставить на кладбище подобающий дар, зайти в Собор и "
 "помолиться за мёртвых, а затем вернуться, то дар странным образом "
-"измениться. Я не знаю, возможно, это просто фантазия старой больной женщины, "
-"но теперь настало такое время, что всякое может произойти."
+"измениться.  Я не знаю, возможно, это просто фантазия старой больной "
+"женщины, но теперь настало такое время, что всякое может произойти."
 
 #. TRANSLATORS: Quest text spoken by Wirt
 #: Source/textdat.cpp:557


### PR DESCRIPTION
Fixed the display of translations "Dur: {:d}/{:d},  " and "No required attributes"
Fixed the display of the translation of the description of the "Disable Crippling Shrines" setting
Fixed minor issues with the translation of the name of some types of plate armor have been
Other fixes