### PR TITLE
Bump CI to Ubuntu 22.04 and minimum CMake to 3.22

### DIFF
--- a/.github/workflows/3ds.yml
+++ b/.github/workflows/3ds.yml
@@ -33,7 +33,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+          tee /etc/apt/sources.list.d/bullseye-backports.list <<LIST
+          deb http://deb.debian.org/debian bullseye-backports main
+          LIST
           apt-get update
+          apt-get install -y -t bullseye-backports cmake
           apt-get install -y \
             ffmpeg \
             gettext
@@ -87,4 +91,3 @@ jobs:
           asset_name: devilutionx-3ds.cia
           file: ./build/devilutionx.cia
           overwrite: true
-...

--- a/.github/workflows/Linux_aarch64.yml
+++ b/.github/workflows/Linux_aarch64.yml
@@ -25,47 +25,23 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    # Work around the somewhat broken packages in the GitHub Actions Ubuntu 20.04 image.
-    # https://github.com/actions/runner-images/issues/4620#issuecomment-981333260
-    - name: Work around broken packages
-      run: sudo apt-get -y install --allow-downgrades libpcre2-8-0=10.34-7
-
-    - name: Add clang repo
-      run: |
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-        sudo tee /etc/apt/sources.list.d/clang.list <<LIST
-        deb [arch=amd64,arm64] http://apt.llvm.org/focal/ llvm-toolchain-focal-18 main
-        deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-18 main
-        LIST
-
     # Installs dependencies, including arm64 libraries (runs `sudo apt-get update` as part of it)
     - name: Install dependencies
-      run: Packaging/nix/debian-cross-aarch64-prep.sh --no-gcc
-
-    - name: Install clang-18
-      run: |
-        sudo apt-get install -yq --no-install-recommends clang-18 lld-18 libc++-18-dev:arm64 \
-          libgcc-10-dev-arm64-cross binutils-aarch64-linux-gnu libc++1-18:arm64 libc++abi1-18:arm64 && \
-        sudo update-alternatives --install \
-          /usr/bin/clang++ clang++ /usr/bin/clang++-18 200 && \
-        sudo update-alternatives --install \
-          /usr/bin/clang clang /usr/bin/clang-18 200 \
-          --slave /usr/bin/lld lld /usr/bin/lld-18 \
-          --slave /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-18
+      run: Packaging/nix/debian-cross-aarch64-prep.sh
 
     - name: Cache CMake build folder
       uses: actions/cache@v4
       with:
         path: build
-        key: ${{ github.workflow }}-v7-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v7-
+        key: ${{ github.workflow }}-v8-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v8-
 
     - name: Build
       working-directory: ${{github.workspace}}
@@ -76,7 +52,7 @@ jobs:
       # We set DEVILUTIONX_SYSTEM_LIBSODIUM=OFF because its soversion changes frequently.
       # We set DEVILUTIONX_SYSTEM_BZIP2=OFF because Fedora and Debian do not agree on how to link it.
       run: |
-        cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/aarch64-linux-gnu-clang-static-libc++.toolchain.cmake \
+        cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/aarch64-linux-gnu.toolchain.cmake \
           -DCMAKE_BUILD_TYPE=${{env.CMAKE_BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=/usr -DCPACK=ON -DDEVILUTIONX_SYSTEM_LIBFMT=OFF \
           -DDEVILUTIONX_SYSTEM_LIBSODIUM=OFF -DDEVILUTIONX_SYSTEM_BZIP2=OFF && \
         cmake --build build -j $(getconf _NPROCESSORS_ONLN) --target package

--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -25,38 +25,23 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    # Work around the somewhat broken packages in the GitHub Actions Ubuntu 20.04 image.
-    # https://github.com/actions/runner-images/issues/4620#issuecomment-981333260
-    - name: Work around broken packages
-      run: sudo apt-get -y install --allow-downgrades libpcre2-8-0=10.34-7
-
-    - name: Add gcc repo
-      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-
     # Installs dependencies, including x86 libraries (runs `sudo apt-get update` as part of it)
     - name: Install dependencies
-      run: Packaging/nix/debian-cross-i386-prep.sh --no-gcc
-
-    - name: Install gcc-13
-      run: |
-        sudo apt-get install -yq --no-install-recommends gcc-13 g++-13 g++-13-multilib && \
-        sudo update-alternatives --install \
-          /usr/bin/gcc gcc /usr/bin/gcc-13 13 \
-          --slave /usr/bin/g++ g++ /usr/bin/g++-13
+      run: Packaging/nix/debian-cross-i386-prep.sh
 
     - name: Cache CMake build folder
       uses: actions/cache@v4
       with:
         path: build
-        key: ${{ github.workflow }}-v6-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v6-
+        key: ${{ github.workflow }}-v7-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v7-
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/.github/workflows/Linux_x86_64.yml
+++ b/.github/workflows/Linux_x86_64.yml
@@ -25,36 +25,23 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    - name: Add gcc repo
-      run: sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-
     # Installs dependencies and runs `sudo apt-get update` as part of it.
     - name: Install dependencies
-      run: Packaging/nix/debian-host-prep.sh --no-gcc
-
-    - name: Install gcc-13
-      run: |
-        sudo apt-get install -yq --no-install-recommends gcc-13 g++-13 && \
-        sudo update-alternatives --install \
-          /usr/bin/gcc gcc /usr/bin/gcc-13 13 \
-          --slave /usr/bin/g++ g++ /usr/bin/g++-13
-
-    - name: Create Build Environment
-      run: Packaging/nix/debian-host-prep.sh --no-gcc
+      run: Packaging/nix/debian-host-prep.sh
 
     - name: Cache CMake build folder
       uses: actions/cache@v4
       with:
         path: build
-        key: ${{ github.workflow }}-v6-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v6-
+        key: ${{ github.workflow }}-v7-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v7-
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/.github/workflows/switch.yml
+++ b/.github/workflows/switch.yml
@@ -33,7 +33,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update && \
+          tee /etc/apt/sources.list.d/bullseye-backports.list <<LIST
+          deb http://deb.debian.org/debian bullseye-backports main
+          LIST
+          apt-get update
+          apt-get install -y -t bullseye-backports cmake
           apt-get install -y --no-install-recommends --no-install-suggests \
             gettext
 

--- a/.github/workflows/xbox_nxdk.yml
+++ b/.github/workflows/xbox_nxdk.yml
@@ -24,7 +24,6 @@ concurrency:
 
 jobs:
   xbox:
-    # `ubuntu-latest` is currently 20.04 but we require a newer clang.
     runs-on: ubuntu-22.04
     env:
       NXDK_DIR: /opt/nxdk

--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -74,10 +74,7 @@ else()
     elseif(TARGET SDL2::SDL2-static)
       # On some distros, such as vitasdk, only the SDL2::SDL2-static target is available.
       # Alias to SDL2::SDL2 because some finder scripts may refer to SDL2::SDL2.
-      if(CMAKE_VERSION VERSION_LESS "3.18")
-        # Aliasing local targets is not supported on CMake < 3.18, so make it global.
-        set_target_properties(SDL2::SDL2-static PROPERTIES IMPORTED_GLOBAL TRUE)
-      endif()
+      add_library(SDL2::SDL2 ALIAS SDL2::SDL2-static)
       if(TARGET SDL2::SDL2main)
         set(SDL2_MAIN SDL2::SDL2main)
       endif()
@@ -260,10 +257,6 @@ if(BUILD_TESTING)
   if(DEVILUTIONX_SYSTEM_GOOGLETEST)
     find_package(GTest REQUIRED)
     if(NOT TARGET GTest::gtest)
-      if(CMAKE_VERSION VERSION_LESS "3.18")
-        # Aliasing local targets is not supported on CMake < 3.18, so make it global.
-        set_target_properties(GTest::GTest PROPERTIES IMPORTED_GLOBAL TRUE)
-      endif()
       add_library(GTest::gtest ALIAS GTest::GTest)
     endif()
   else()

--- a/CMake/finders/FindSDL2_image.cmake
+++ b/CMake/finders/FindSDL2_image.cmake
@@ -1,11 +1,9 @@
 find_package(SDL2_image CONFIG)
 
 if(TARGET SDL2_image::SDL2_image)
-  if(CMAKE_VERSION VERSION_LESS "3.18")
-    # Aliasing local targets is not supported on CMake < 3.18, so make it global.
-    set_target_properties(SDL2_image::SDL2_image PROPERTIES IMPORTED_GLOBAL TRUE)
+  if(NOT TARGET SDL2::SDL2_image)
+    add_library(SDL2::SDL2_image ALIAS SDL2_image::SDL2_image)
   endif()
-  add_library(SDL2::SDL2_image ALIAS SDL2_image::SDL2_image)
 else()
   find_package(PkgConfig)
   pkg_check_modules(PC_SDL2_image QUIET SDL2_image>=2.0.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.22)
 
-foreach(_policy CMP0111 CMP0126 CMP0135 CMP0141)
+foreach(_policy CMP0135 CMP0141)
   if(POLICY ${_policy})
     cmake_policy(SET ${_policy} NEW)
     set(CMAKE_POLICY_DEFAULT_${_policy} NEW)


### PR DESCRIPTION
Ubuntu 20.04 is going EOL in May.
Ubuntu 22.04 CMake is 3.22.
Debian stable CMake is 3.25.
Debian oldstable (EOL in 2026) has CMake 3.25 in bullseye-backports.