### PR TITLE
Android: Bump NDK to 28.0.13004108

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -44,8 +44,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: android-project/app/.cxx
-        key: ${{ github.workflow }}-v4-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v4-
+        key: ${{ github.workflow }}-v5-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v5-
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -7,7 +7,7 @@ if (buildAsApplication) {
 }
 
 android {
-	ndkVersion '27.2.12479018'
+	ndkVersion '28.0.13004108'
 	compileSdk 35
 	defaultConfig {
 		if (buildAsApplication) {


### PR DESCRIPTION
R28 was released 3 weeks ago and is now preinstalled on GitHub CI runners.

https://github.com/android/ndk/releases/tag/r28