### PR TITLE
Adjust x-start with UiFlags::KerningFitSpacing

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -416,9 +416,14 @@ uint32_t DoDrawString(const Surface &out, std::string_view text, Rectangle rect,
     TextRenderOptions &opts)
 {
 	CurrentFont currentFont;
-	int curSpacing = HasAnyOf(opts.flags, UiFlags::KerningFitSpacing)
-	    ? AdjustSpacingToFitHorizontally(lineWidth, opts.spacing, charactersInLine, rect.size.width)
-	    : opts.spacing;
+	int curSpacing = opts.spacing;
+	if (HasAnyOf(opts.flags, UiFlags::KerningFitSpacing)) {
+		curSpacing = AdjustSpacingToFitHorizontally(lineWidth, opts.spacing, charactersInLine, rect.size.width);
+		if (curSpacing != opts.spacing && HasAnyOf(opts.flags, UiFlags::AlignCenter | UiFlags::AlignRight)) {
+			const int adjustedLineWidth = GetLineWidth(text, size, curSpacing, &charactersInLine);
+			characterPosition.x = GetLineStartX(opts.flags, rect, adjustedLineWidth);
+		}
+	}
 
 	char32_t next;
 	std::string_view remaining = text;
@@ -467,7 +472,7 @@ uint32_t DoDrawString(const Surface &out, std::string_view text, Rectangle rect,
 				curSpacing = AdjustSpacingToFitHorizontally(nextLineWidth, opts.spacing, charactersInLine, rect.size.width);
 			}
 
-			if (HasAnyOf(opts.flags, (UiFlags::AlignCenter | UiFlags::AlignRight))) {
+			if (HasAnyOf(opts.flags, UiFlags::AlignCenter | UiFlags::AlignRight)) {
 				lineWidth = width;
 				if (remaining.size() > cpLen)
 					lineWidth += curSpacing + GetLineWidth(remaining.substr(cpLen), size, curSpacing);
@@ -776,9 +781,14 @@ void DrawStringWithColors(const Surface &out, std::string_view fmt, DrawStringFo
 	const Surface clippedOut = ClipSurface(out, rect);
 
 	CurrentFont currentFont;
-	int curSpacing = HasAnyOf(opts.flags, UiFlags::KerningFitSpacing)
-	    ? AdjustSpacingToFitHorizontally(lineWidth, opts.spacing, charactersInLine, rect.size.width)
-	    : opts.spacing;
+	int curSpacing = opts.spacing;
+	if (HasAnyOf(opts.flags, UiFlags::KerningFitSpacing)) {
+		curSpacing = AdjustSpacingToFitHorizontally(lineWidth, opts.spacing, charactersInLine, rect.size.width);
+		if (curSpacing != opts.spacing && HasAnyOf(opts.flags, UiFlags::AlignCenter | UiFlags::AlignRight)) {
+			const int adjustedLineWidth = GetLineWidth(fmt, args, argsLen, 0, size, curSpacing, &charactersInLine);
+			characterPosition.x = GetLineStartX(opts.flags, rect, adjustedLineWidth);
+		}
+	}
 
 	char32_t prev = U'\0';
 	char32_t next;


### PR DESCRIPTION
When using KerningFitSpacing with centered or right-aligned text, adjust the horizontal start position after changing the spacing.

Supersedes #7705 by @kphoenix137 