### PR TITLE
codecov.yml: Pass CODECOV_TOKEN

### DIFF
--- a/.github/workflows/Linux_x86_64_test.yml
+++ b/.github/workflows/Linux_x86_64_test.yml
@@ -53,4 +53,4 @@ jobs:
     - name: Upload results
       uses: codecov/codecov-action@v5
       with:
-        gcov: true
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
A token is required to upload coverage for protected branches.

Hopefully fixes #7805 

Note that `gcov: true` argument was unnecessary and isn't actually recognized by codecov-action.