### PR TITLE
Per-pixel lighting using software renderer

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -90,6 +90,7 @@ set(libdevilutionx_SRCS
 
   engine/render/automap_render.cpp
   engine/render/dun_render.cpp
+  engine/render/light_render.cpp
   engine/render/primitive_render.cpp
   engine/render/scrollrt.cpp
   engine/render/text_render.cpp

--- a/Source/engine/render/blit_impl.hpp
+++ b/Source/engine/render/blit_impl.hpp
@@ -6,6 +6,7 @@
 #include <version>
 
 #include "engine/palette.h"
+#include "engine/render/light_render.hpp"
 #include "utils/attributes.h"
 
 namespace devilution {
@@ -64,6 +65,31 @@ struct BlitWithMap {
 	}
 };
 
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillWithLightmap(uint8_t *dst, unsigned length, uint8_t color)
+{
+	DVL_ASSUME(length != 0);
+	const uint8_t *lightmap = GetLightmapAt(dst);
+	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY lightmap, lightmap + length, dst, [color](uint8_t lightLevel) { return AdjustColor(color, lightLevel); });
+}
+
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsWithLightmap(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, unsigned length)
+{
+	DVL_ASSUME(length != 0);
+	const uint8_t *lightmap = GetLightmapAt(dst);
+	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY src, src + length, lightmap, dst, AdjustColor);
+}
+
+struct BlitWithLightmap {
+	DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void operator()(unsigned length, uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src) const
+	{
+		BlitPixelsWithLightmap(dst, src, length);
+	}
+	DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void operator()(unsigned length, uint8_t color, uint8_t *DVL_RESTRICT dst) const
+	{
+		BlitFillWithLightmap(dst, length, color);
+	}
+};
+
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillBlended(uint8_t *dst, unsigned length, uint8_t color)
 {
 	DVL_ASSUME(length != 0);
@@ -109,6 +135,50 @@ struct BlitBlendedWithMap {
 	DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void operator()(unsigned length, uint8_t color, uint8_t *DVL_RESTRICT dst) const
 	{
 		BlitFillBlended(dst, length, colorMap[color]);
+	}
+};
+
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillBlendedWithLightmap(uint8_t *dst, unsigned length, uint8_t color)
+{
+	DVL_ASSUME(length != 0);
+	const uint8_t *lightmap = GetLightmapAt(dst);
+	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY lightmap, lightmap + length, dst, dst, [color, pal = paletteTransparencyLookup](uint8_t lightLevel, uint8_t dstColor) {
+		uint8_t srcColor = AdjustColor(color, lightLevel);
+		return pal[srcColor][dstColor];
+	});
+}
+
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsBlendedWithLightmap(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, unsigned length)
+{
+	DVL_ASSUME(length != 0);
+	const uint8_t *lightmap = GetLightmapAt(dst);
+
+	if (length < 1024) {
+		uint8_t litSrc[1024];
+		std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY src, src + length, lightmap, litSrc, AdjustColor);
+		std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY litSrc, litSrc + length, dst, dst, [pal = paletteTransparencyLookup](uint8_t srcColor, uint8_t dstColor) {
+			return pal[dstColor][srcColor];
+		});
+		return;
+	}
+
+	for (size_t i = 0; i < length; i++) {
+		uint8_t srcColor = src[i];
+		uint8_t dstColor = dst[i];
+		uint8_t lightLevel = lightmap[i];
+		uint8_t litColor = AdjustColor(srcColor, lightLevel);
+		dst[i] = paletteTransparencyLookup[dstColor][litColor];
+	}
+}
+
+struct BlitBlendedWithLightmap {
+	DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void operator()(unsigned length, uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src) const
+	{
+		BlitPixelsBlendedWithLightmap(dst, src, length);
+	}
+	DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void operator()(unsigned length, uint8_t color, uint8_t *DVL_RESTRICT dst) const
+	{
+		BlitFillBlendedWithLightmap(dst, length, color);
 	}
 };
 

--- a/Source/engine/render/blit_impl.hpp
+++ b/Source/engine/render/blit_impl.hpp
@@ -65,26 +65,26 @@ struct BlitWithMap {
 	}
 };
 
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillWithLightmap(uint8_t *dst, unsigned length, uint8_t color, const Lightmap *lightmap)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillWithLightmap(uint8_t *dst, unsigned length, uint8_t color, const Lightmap &lightmap)
 {
 	DVL_ASSUME(length != 0);
-	const uint8_t *light = lightmap->getLightingAt(dst);
-	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY light, light + length, dst, [color, lightmap](uint8_t lightLevel) {
-		return lightmap->adjustColor(color, lightLevel);
+	const uint8_t *light = lightmap.getLightingAt(dst);
+	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY light, light + length, dst, [color, &lightmap](uint8_t lightLevel) {
+		return lightmap.adjustColor(color, lightLevel);
 	});
 }
 
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsWithLightmap(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, unsigned length, const Lightmap *lightmap)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsWithLightmap(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, unsigned length, const Lightmap &lightmap)
 {
 	DVL_ASSUME(length != 0);
-	const uint8_t *light = lightmap->getLightingAt(dst);
-	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY src, src + length, light, dst, [lightmap](uint8_t srcColor, uint8_t lightLevel) {
-		return lightmap->adjustColor(srcColor, lightLevel);
+	const uint8_t *light = lightmap.getLightingAt(dst);
+	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY src, src + length, light, dst, [&lightmap](uint8_t srcColor, uint8_t lightLevel) {
+		return lightmap.adjustColor(srcColor, lightLevel);
 	});
 }
 
 struct BlitWithLightmap {
-	const Lightmap *lightmap;
+	const Lightmap &lightmap;
 
 	DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void operator()(unsigned length, uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src) const
 	{
@@ -144,25 +144,25 @@ struct BlitBlendedWithMap {
 	}
 };
 
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillBlendedWithLightmap(uint8_t *dst, unsigned length, uint8_t color, const Lightmap *lightmap)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitFillBlendedWithLightmap(uint8_t *dst, unsigned length, uint8_t color, const Lightmap &lightmap)
 {
 	DVL_ASSUME(length != 0);
-	const uint8_t *light = lightmap->getLightingAt(dst);
-	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY light, light + length, dst, dst, [color, lightmap, pal = paletteTransparencyLookup](uint8_t lightLevel, uint8_t dstColor) {
-		uint8_t srcColor = lightmap->adjustColor(color, lightLevel);
+	const uint8_t *light = lightmap.getLightingAt(dst);
+	std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY light, light + length, dst, dst, [color, &lightmap, pal = paletteTransparencyLookup](uint8_t lightLevel, uint8_t dstColor) {
+		uint8_t srcColor = lightmap.adjustColor(color, lightLevel);
 		return pal[srcColor][dstColor];
 	});
 }
 
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsBlendedWithLightmap(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, unsigned length, const Lightmap *lightmap)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsBlendedWithLightmap(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, unsigned length, const Lightmap &lightmap)
 {
 	DVL_ASSUME(length != 0);
-	const uint8_t *light = lightmap->getLightingAt(dst);
+	const uint8_t *light = lightmap.getLightingAt(dst);
 
 	if (length < 1024) {
 		uint8_t litSrc[1024];
-		std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY src, src + length, light, litSrc, [lightmap](uint8_t srcColor, uint8_t lightLevel) {
-			return lightmap->adjustColor(srcColor, lightLevel);
+		std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY src, src + length, light, litSrc, [&lightmap](uint8_t srcColor, uint8_t lightLevel) {
+			return lightmap.adjustColor(srcColor, lightLevel);
 		});
 		std::transform(DEVILUTIONX_BLIT_EXECUTION_POLICY litSrc, litSrc + length, dst, dst, [pal = paletteTransparencyLookup](uint8_t srcColor, uint8_t dstColor) {
 			return pal[dstColor][srcColor];
@@ -174,13 +174,13 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void BlitPixelsBlendedWithLightmap(uint8_t *
 		uint8_t srcColor = src[i];
 		uint8_t dstColor = dst[i];
 		uint8_t lightLevel = light[i];
-		uint8_t litColor = lightmap->adjustColor(srcColor, lightLevel);
+		uint8_t litColor = lightmap.adjustColor(srcColor, lightLevel);
 		dst[i] = paletteTransparencyLookup[dstColor][litColor];
 	}
 }
 
 struct BlitBlendedWithLightmap {
-	const Lightmap *lightmap;
+	const Lightmap &lightmap;
 
 	DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void operator()(unsigned length, uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src) const
 	{

--- a/Source/engine/render/clx_render.cpp
+++ b/Source/engine/render/clx_render.cpp
@@ -588,6 +588,11 @@ void ClxDrawTRN(const Surface &out, Point position, ClxSprite clx, const uint8_t
 	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitWithMap { trn });
 }
 
+void ClxDrawWithLightmap(const Surface &out, Point position, ClxSprite clx)
+{
+	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitWithLightmap {});
+}
+
 void ClxDrawBlended(const Surface &out, Point position, ClxSprite clx)
 {
 	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitBlended {});
@@ -596,6 +601,11 @@ void ClxDrawBlended(const Surface &out, Point position, ClxSprite clx)
 void ClxDrawBlendedTRN(const Surface &out, Point position, ClxSprite clx, const uint8_t *trn)
 {
 	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitBlendedWithMap { trn });
+}
+
+void ClxDrawBlendedWithLightmap(const Surface &out, Point position, ClxSprite clx)
+{
+	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitBlendedWithLightmap {});
 }
 
 void ClxDrawOutline(const Surface &out, uint8_t col, Point position, ClxSprite clx)

--- a/Source/engine/render/clx_render.cpp
+++ b/Source/engine/render/clx_render.cpp
@@ -590,7 +590,7 @@ void ClxDrawTRN(const Surface &out, Point position, ClxSprite clx, const uint8_t
 
 void ClxDrawWithLightmap(const Surface &out, Point position, ClxSprite clx, const Lightmap &lightmap)
 {
-	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitWithLightmap { &lightmap });
+	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitWithLightmap { lightmap });
 }
 
 void ClxDrawBlended(const Surface &out, Point position, ClxSprite clx)
@@ -605,7 +605,7 @@ void ClxDrawBlendedTRN(const Surface &out, Point position, ClxSprite clx, const 
 
 void ClxDrawBlendedWithLightmap(const Surface &out, Point position, ClxSprite clx, const Lightmap &lightmap)
 {
-	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitBlendedWithLightmap { &lightmap });
+	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitBlendedWithLightmap { lightmap });
 }
 
 void ClxDrawOutline(const Surface &out, uint8_t col, Point position, ClxSprite clx)

--- a/Source/engine/render/clx_render.cpp
+++ b/Source/engine/render/clx_render.cpp
@@ -588,9 +588,9 @@ void ClxDrawTRN(const Surface &out, Point position, ClxSprite clx, const uint8_t
 	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitWithMap { trn });
 }
 
-void ClxDrawWithLightmap(const Surface &out, Point position, ClxSprite clx)
+void ClxDrawWithLightmap(const Surface &out, Point position, ClxSprite clx, const Lightmap &lightmap)
 {
-	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitWithLightmap {});
+	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitWithLightmap { &lightmap });
 }
 
 void ClxDrawBlended(const Surface &out, Point position, ClxSprite clx)
@@ -603,9 +603,9 @@ void ClxDrawBlendedTRN(const Surface &out, Point position, ClxSprite clx, const 
 	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitBlendedWithMap { trn });
 }
 
-void ClxDrawBlendedWithLightmap(const Surface &out, Point position, ClxSprite clx)
+void ClxDrawBlendedWithLightmap(const Surface &out, Point position, ClxSprite clx, const Lightmap &lightmap)
 {
-	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitBlendedWithLightmap {});
+	DoRenderBackwards(out, position, clx.pixelData(), clx.pixelDataSize(), clx.width(), clx.height(), BlitBlendedWithLightmap { &lightmap });
 }
 
 void ClxDrawOutline(const Surface &out, uint8_t col, Point position, ClxSprite clx)

--- a/Source/engine/render/clx_render.hpp
+++ b/Source/engine/render/clx_render.hpp
@@ -16,6 +16,7 @@
 
 #include "engine/clx_sprite.hpp"
 #include "engine/point.hpp"
+#include "engine/render/light_render.hpp"
 #include "engine/surface.hpp"
 #include "lighting.h"
 
@@ -105,7 +106,14 @@ inline void ClxDrawLight(const Surface &out, Point position, ClxSprite clx, int 
 	}
 }
 
-void ClxDrawWithLightmap(const Surface &out, Point position, ClxSprite clx);
+/**
+ * @brief Blit CL2 sprite, and apply lighting, to the given buffer at the given coordinates
+ * @param out Output buffer
+ * @param position Target buffer coordinate
+ * @param clx CLX frame
+ * @param lightmap Per-pixel light buffer
+ */
+void ClxDrawWithLightmap(const Surface &out, Point position, ClxSprite clx, const Lightmap &lightmap);
 
 /**
  * @brief Blit CL2 sprite, and apply lighting and transparency blending, to the given buffer at the given coordinates
@@ -122,7 +130,14 @@ inline void ClxDrawLightBlended(const Surface &out, Point position, ClxSprite cl
 	}
 }
 
-void ClxDrawBlendedWithLightmap(const Surface &out, Point position, ClxSprite clx);
+/**
+ * @brief Blit CL2 sprite, and apply lighting and transparency blending, to the given buffer at the given coordinates
+ * @param out Output buffer
+ * @param position Target buffer coordinate
+ * @param clx CLX frame
+ * @param lightmap Per-pixel light buffer
+ */
+void ClxDrawBlendedWithLightmap(const Surface &out, Point position, ClxSprite clx, const Lightmap &lightmap);
 
 /**
  * Returns if cursor is within the CLX sprite (ignores shadow)

--- a/Source/engine/render/clx_render.hpp
+++ b/Source/engine/render/clx_render.hpp
@@ -105,6 +105,8 @@ inline void ClxDrawLight(const Surface &out, Point position, ClxSprite clx, int 
 	}
 }
 
+void ClxDrawWithLightmap(const Surface &out, Point position, ClxSprite clx);
+
 /**
  * @brief Blit CL2 sprite, and apply lighting and transparency blending, to the given buffer at the given coordinates
  * @param out Output buffer
@@ -119,6 +121,8 @@ inline void ClxDrawLightBlended(const Surface &out, Point position, ClxSprite cl
 		ClxDrawBlended(out, position, clx);
 	}
 }
+
+void ClxDrawBlendedWithLightmap(const Surface &out, Point position, ClxSprite clx);
 
 /**
  * Returns if cursor is within the CLX sprite (ignores shadow)

--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -118,16 +118,16 @@ enum class LightType : uint8_t {
 };
 
 template <LightType Light>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl);
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap);
 
 template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::FullyDark>(uint8_t *DVL_RESTRICT dst, [[maybe_unused]] const uint8_t *DVL_RESTRICT src, uint_fast8_t n, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::FullyDark>(uint8_t *DVL_RESTRICT dst, [[maybe_unused]] const uint8_t *DVL_RESTRICT src, uint_fast8_t n, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
 	BlitFillDirect(dst, n, 0);
 }
 
 template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::FullyLit>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::FullyLit>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
 #ifndef DEBUG_RENDER_COLOR
 	BlitPixelsDirect(dst, src, n);
@@ -137,7 +137,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::FullyLit>(u
 }
 
 template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::PartiallyLit>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::PartiallyLit>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
 #ifndef DEBUG_RENDER_COLOR
 	BlitPixelsWithMap(dst, src, n, tbl);
@@ -147,45 +147,45 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::PartiallyLi
 }
 
 template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::PerPixel>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::PerPixel>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 #ifndef DEBUG_RENDER_COLOR
-	BlitPixelsWithLightmap(dst, src, n);
+	BlitPixelsWithLightmap(dst, src, n, lightmap);
 #else
-	BlitFillDirect(dst, n, tbl[DBGCOLOR]);
+	BlitFillWithLightmap(dst, n, DBGCOLOR, lightmap);
 #endif
 }
 
 #ifndef DEBUG_RENDER_COLOR
 template <LightType Light>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl);
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap);
 
 template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent<LightType::FullyDark>(uint8_t *DVL_RESTRICT dst, [[maybe_unused]] const uint8_t *DVL_RESTRICT src, uint_fast8_t n, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent<LightType::FullyDark>(uint8_t *DVL_RESTRICT dst, [[maybe_unused]] const uint8_t *DVL_RESTRICT src, uint_fast8_t n, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
 	BlitFillBlended(dst, n, 0);
 }
 
 template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent<LightType::FullyLit>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent<LightType::FullyLit>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
 	BlitPixelsBlended(dst, src, n);
 }
 
 template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent<LightType::PartiallyLit>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent<LightType::PartiallyLit>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
 	BlitPixelsBlendedWithMap(dst, src, n, tbl);
 }
 
 template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent<LightType::PerPixel>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent<LightType::PerPixel>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	BlitPixelsBlendedWithLightmap(dst, src, n);
+	BlitPixelsBlendedWithLightmap(dst, src, n, lightmap);
 }
 #else // DEBUG_RENDER_COLOR
 template <LightType Light>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
 	for (size_t i = 0; i < n; i++) {
 		dst[i] = paletteTransparencyLookup[dst[i]][tbl[DBGCOLOR + 4]];
@@ -194,47 +194,47 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent(uint8_t *DVL_REST
 #endif
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparentOrOpaque(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t width, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparentOrOpaque(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t width, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	if constexpr (Transparent) {
-		RenderLineTransparent<Light>(dst, src, width, tbl);
+		RenderLineTransparent<Light>(dst, src, width, tbl, lightmap);
 	} else {
-		RenderLineOpaque<Light>(dst, src, width, tbl);
+		RenderLineOpaque<Light>(dst, src, width, tbl, lightmap);
 	}
 }
 
 template <LightType Light, bool OpaqueFirst>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparentAndOpaque(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t prefixWidth, uint_fast8_t width, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparentAndOpaque(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t prefixWidth, uint_fast8_t width, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	if constexpr (OpaqueFirst) {
-		RenderLineOpaque<Light>(dst, src, prefixWidth, tbl);
-		RenderLineTransparent<Light>(dst + prefixWidth, src + prefixWidth, width - prefixWidth, tbl);
+		RenderLineOpaque<Light>(dst, src, prefixWidth, tbl, lightmap);
+		RenderLineTransparent<Light>(dst + prefixWidth, src + prefixWidth, width - prefixWidth, tbl, lightmap);
 	} else {
-		RenderLineTransparent<Light>(dst, src, prefixWidth, tbl);
-		RenderLineOpaque<Light>(dst + prefixWidth, src + prefixWidth, width - prefixWidth, tbl);
+		RenderLineTransparent<Light>(dst, src, prefixWidth, tbl, lightmap);
+		RenderLineOpaque<Light>(dst + prefixWidth, src + prefixWidth, width - prefixWidth, tbl, lightmap);
 	}
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLine(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, int8_t prefix)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLine(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, int8_t prefix)
 {
 	if constexpr (Mask == MaskType::Solid || Mask == MaskType::Transparent) {
-		RenderLineTransparentOrOpaque<Light, /*Transparent=*/Mask == MaskType::Transparent>(dst, src, n, tbl);
+		RenderLineTransparentOrOpaque<Light, /*Transparent=*/Mask == MaskType::Transparent>(dst, src, n, tbl, lightmap);
 	} else if (prefix >= static_cast<int8_t>(n)) {
 		// We std::clamp the prefix to (0, n] and avoid calling `RenderLineTransparent/Opaque` with width=0.
 		if constexpr (Mask == MaskType::Right) {
-			RenderLineOpaque<Light>(dst, src, n, tbl);
+			RenderLineOpaque<Light>(dst, src, n, tbl, lightmap);
 		} else {
-			RenderLineTransparent<Light>(dst, src, n, tbl);
+			RenderLineTransparent<Light>(dst, src, n, tbl, lightmap);
 		}
 	} else if (prefix <= 0) {
 		if constexpr (Mask == MaskType::Left) {
-			RenderLineOpaque<Light>(dst, src, n, tbl);
+			RenderLineOpaque<Light>(dst, src, n, tbl, lightmap);
 		} else {
-			RenderLineTransparent<Light>(dst, src, n, tbl);
+			RenderLineTransparent<Light>(dst, src, n, tbl, lightmap);
 		}
 	} else {
-		RenderLineTransparentAndOpaque<Light, /*OpaqueFirst=*/Mask == MaskType::Right>(dst, src, prefix, n, tbl);
+		RenderLineTransparentAndOpaque<Light, /*OpaqueFirst=*/Mask == MaskType::Right>(dst, src, prefix, n, tbl, lightmap);
 	}
 }
 
@@ -270,36 +270,36 @@ DVL_ALWAYS_INLINE bool IsFullyLit(const uint8_t *DVL_RESTRICT tbl)
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderSquareFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderSquareFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	for (auto i = 0; i < Height; ++i, dst -= dstPitch) {
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, Width, tbl);
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, Width, tbl, lightmap);
 		src += Width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderSquareClipped(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderSquareClipped(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	src += clip.bottom * Height + clip.left;
 	for (auto i = 0; i < clip.height; ++i, dst -= dstPitch) {
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, clip.width, tbl);
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, clip.width, tbl, lightmap);
 		src += Width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderSquare(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderSquare(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	if (clip.width == Width && clip.height == Height) {
-		RenderSquareFull<Light, Transparent>(dst, dstPitch, src, tbl);
+		RenderSquareFull<Light, Transparent>(dst, dstPitch, src, tbl, lightmap);
 	} else {
-		RenderSquareClipped<Light, Transparent>(dst, dstPitch, src, tbl, clip);
+		RenderSquareClipped<Light, Transparent>(dst, dstPitch, src, tbl, lightmap, clip);
 	}
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquareFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, unsigned height)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquareFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, unsigned height)
 {
 	int8_t prefix = InitialPrefix<Mask>;
 	DVL_ASSUME(height >= 16);
@@ -309,7 +309,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquareFull(uint8_t *DV
 		while (drawWidth > 0) {
 			auto v = static_cast<int8_t>(*src++);
 			if (v > 0) {
-				RenderLine<Light, Mask>(dst, src, v, tbl, prefix - (Width - drawWidth));
+				RenderLine<Light, Mask>(dst, src, v, tbl, lightmap, prefix - (Width - drawWidth));
 				src += v;
 			} else {
 				v = -v;
@@ -323,7 +323,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquareFull(uint8_t *DV
 
 template <LightType Light, MaskType Mask>
 // NOLINTNEXTLINE(readability-function-cognitive-complexity): Actually complex and has to be fast.
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquareClipped(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquareClipped(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const auto skipRestOfTheLine = [&src](int_fast16_t remainingWidth) {
 		while (remainingWidth > 0) {
@@ -355,7 +355,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquareClipped(uint8_t 
 			if (v > 0) {
 				if (v > remainingLeftClip) {
 					const auto overshoot = v - remainingLeftClip;
-					RenderLine<Light, Mask>(dst, src + remainingLeftClip, overshoot, tbl, prefix - (Width - remainingLeftClip));
+					RenderLine<Light, Mask>(dst, src + remainingLeftClip, overshoot, tbl, lightmap, prefix - (Width - remainingLeftClip));
 					dst += overshoot;
 					drawWidth -= overshoot;
 				}
@@ -376,13 +376,13 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquareClipped(uint8_t 
 			auto v = static_cast<int8_t>(*src++);
 			if (v > 0) {
 				if (v > drawWidth) {
-					RenderLine<Light, Mask>(dst, src, drawWidth, tbl, prefix - (Width - drawWidth));
+					RenderLine<Light, Mask>(dst, src, drawWidth, tbl, lightmap, prefix - (Width - drawWidth));
 					src += v;
 					dst += drawWidth;
 					drawWidth -= v;
 					break;
 				}
-				RenderLine<Light, Mask>(dst, src, v, tbl, prefix - (Width - drawWidth));
+				RenderLine<Light, Mask>(dst, src, v, tbl, lightmap, prefix - (Width - drawWidth));
 				src += v;
 			} else {
 				v = -v;
@@ -404,12 +404,12 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquareClipped(uint8_t 
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquare(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTransparentSquare(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	if (clip.width == Width && clip.bottom == 0 && clip.top == 0) {
-		RenderTransparentSquareFull<Light, Mask>(dst, dstPitch, src, tbl, clip.height);
+		RenderTransparentSquareFull<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip.height);
 	} else {
-		RenderTransparentSquareClipped<Light, Mask>(dst, dstPitch, src, tbl, clip);
+		RenderTransparentSquareClipped<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 	}
 }
 
@@ -452,30 +452,30 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT std::size_t CalculateTriangleSourceSkipUpper
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleLower(uint8_t *DVL_RESTRICT &dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleLower(uint8_t *DVL_RESTRICT &dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 0 * dstLineOffset, src + 0, 2, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 1 * dstLineOffset, src + 2, 4, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 2 * dstLineOffset, src + 6, 6, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 3 * dstLineOffset, src + 12, 8, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 4 * dstLineOffset, src + 20, 10, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 5 * dstLineOffset, src + 30, 12, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 6 * dstLineOffset, src + 42, 14, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 7 * dstLineOffset, src + 56, 16, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 8 * dstLineOffset, src + 72, 18, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 9 * dstLineOffset, src + 90, 20, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 10 * dstLineOffset, src + 110, 22, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 11 * dstLineOffset, src + 132, 24, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 12 * dstLineOffset, src + 156, 26, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 13 * dstLineOffset, src + 182, 28, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 14 * dstLineOffset, src + 210, 30, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 15 * dstLineOffset, src + 240, 32, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 0 * dstLineOffset, src + 0, 2, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 1 * dstLineOffset, src + 2, 4, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 2 * dstLineOffset, src + 6, 6, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 3 * dstLineOffset, src + 12, 8, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 4 * dstLineOffset, src + 20, 10, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 5 * dstLineOffset, src + 30, 12, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 6 * dstLineOffset, src + 42, 14, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 7 * dstLineOffset, src + 56, 16, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 8 * dstLineOffset, src + 72, 18, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 9 * dstLineOffset, src + 90, 20, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 10 * dstLineOffset, src + 110, 22, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 11 * dstLineOffset, src + 132, 24, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 12 * dstLineOffset, src + 156, 26, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 13 * dstLineOffset, src + 182, 28, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 14 * dstLineOffset, src + 210, 30, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 15 * dstLineOffset, src + 240, 32, tbl, lightmap);
 	src += 272;
 	dst -= 16 * dstLineOffset;
 }
 
 template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleLower<LightType::FullyDark, /*Transparent=*/false>(uint8_t *DVL_RESTRICT &dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT &src, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleLower<LightType::FullyDark, /*Transparent=*/false>(uint8_t *DVL_RESTRICT &dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT &src, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
 	unsigned width = XStep;
 	for (unsigned i = 0; i < LowerHeight; ++i) {
@@ -487,27 +487,27 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleLower<LightType::FullyDar
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper(uint8_t *DVL_RESTRICT dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper(uint8_t *DVL_RESTRICT dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 0 * dstLineOffset, src + 0, 30, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 1 * dstLineOffset, src + 30, 28, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 2 * dstLineOffset, src + 58, 26, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 3 * dstLineOffset, src + 84, 24, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 4 * dstLineOffset, src + 108, 22, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 5 * dstLineOffset, src + 130, 20, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 6 * dstLineOffset, src + 150, 18, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 7 * dstLineOffset, src + 168, 16, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 8 * dstLineOffset, src + 184, 14, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 9 * dstLineOffset, src + 198, 12, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 10 * dstLineOffset, src + 210, 10, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 11 * dstLineOffset, src + 220, 8, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 12 * dstLineOffset, src + 228, 6, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 13 * dstLineOffset, src + 234, 4, tbl);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 14 * dstLineOffset, src + 238, 2, tbl);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 0 * dstLineOffset, src + 0, 30, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 1 * dstLineOffset, src + 30, 28, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 2 * dstLineOffset, src + 58, 26, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 3 * dstLineOffset, src + 84, 24, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 4 * dstLineOffset, src + 108, 22, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 5 * dstLineOffset, src + 130, 20, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 6 * dstLineOffset, src + 150, 18, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 7 * dstLineOffset, src + 168, 16, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 8 * dstLineOffset, src + 184, 14, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 9 * dstLineOffset, src + 198, 12, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 10 * dstLineOffset, src + 210, 10, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 11 * dstLineOffset, src + 220, 8, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 12 * dstLineOffset, src + 228, 6, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 13 * dstLineOffset, src + 234, 4, tbl, lightmap);
+	RenderLineTransparentOrOpaque<Light, Transparent>(dst - 14 * dstLineOffset, src + 238, 2, tbl, lightmap);
 }
 
 template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper<LightType::FullyDark, /*Transparent=*/false>(uint8_t *DVL_RESTRICT dst, ptrdiff_t dstLineOffset, [[maybe_unused]] const uint8_t *DVL_RESTRICT src, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper<LightType::FullyDark, /*Transparent=*/false>(uint8_t *DVL_RESTRICT dst, ptrdiff_t dstLineOffset, [[maybe_unused]] const uint8_t *DVL_RESTRICT src, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
 	unsigned width = Width - XStep;
 	for (unsigned i = 0; i < TriangleUpperHeight; ++i) {
@@ -518,27 +518,27 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper<LightType::FullyDar
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLower(uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLower(uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	dst += XStep * (LowerHeight - 1);
-	RenderTriangleLower<Light, Transparent>(dst, dstPitch + XStep, src, tbl);
+	RenderTriangleLower<Light, Transparent>(dst, dstPitch + XStep, src, tbl, lightmap);
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLowerClipVertical(const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLowerClipVertical(const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	src += CalculateTriangleSourceSkipLowerBottom(clipY.lowerBottom);
 	dst += XStep * (LowerHeight - clipY.lowerBottom - 1);
 	const auto lowerMax = LowerHeight - clipY.lowerTop;
 	for (auto i = 1 + clipY.lowerBottom; i <= lowerMax; ++i, dst -= dstPitch + XStep) {
 		const auto width = XStep * i;
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl);
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLowerClipLeftAndVertical(int_fast16_t clipLeft, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLowerClipLeftAndVertical(int_fast16_t clipLeft, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	src += CalculateTriangleSourceSkipLowerBottom(clipY.lowerBottom);
 	dst += XStep * (LowerHeight - clipY.lowerBottom - 1) - clipLeft;
@@ -548,13 +548,13 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLowerClipLeftAndVerti
 		const auto startX = Width - XStep * i;
 		const auto skip = startX < clipLeft ? clipLeft - startX : 0;
 		if (width > skip)
-			RenderLineTransparentOrOpaque<Light, Transparent>(dst + skip, src + skip, width - skip, tbl);
+			RenderLineTransparentOrOpaque<Light, Transparent>(dst + skip, src + skip, width - skip, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLowerClipRightAndVertical(int_fast16_t clipRight, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLowerClipRightAndVertical(int_fast16_t clipRight, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	src += CalculateTriangleSourceSkipLowerBottom(clipY.lowerBottom);
 	dst += XStep * (LowerHeight - clipY.lowerBottom - 1);
@@ -562,40 +562,40 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleLowerClipRightAndVert
 	for (auto i = 1 + clipY.lowerBottom; i <= lowerMax; ++i, dst -= dstPitch + XStep) {
 		const auto width = XStep * i;
 		if (width > clipRight)
-			RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width - clipRight, tbl);
+			RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width - clipRight, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	RenderLeftTriangleLower<Light, Transparent>(dst, dstPitch, src, tbl);
+	RenderLeftTriangleLower<Light, Transparent>(dst, dstPitch, src, tbl, lightmap);
 	dst += 2 * XStep;
-	RenderTriangleUpper<Light, Transparent>(dst, dstPitch - XStep, src, tbl);
+	RenderTriangleUpper<Light, Transparent>(dst, dstPitch - XStep, src, tbl, lightmap);
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY(clip);
-	RenderLeftTriangleLowerClipVertical<Light, Transparent>(clipY, dst, dstPitch, src, tbl);
+	RenderLeftTriangleLowerClipVertical<Light, Transparent>(clipY, dst, dstPitch, src, tbl, lightmap);
 	src += CalculateTriangleSourceSkipUpperBottom(clipY.upperBottom);
 	dst += 2 * XStep + XStep * clipY.upperBottom;
 	const auto upperMax = TriangleUpperHeight - clipY.upperTop;
 	for (auto i = 1 + clipY.upperBottom; i <= upperMax; ++i, dst -= dstPitch - XStep) {
 		const auto width = Width - XStep * i;
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl);
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipLeftAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipLeftAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY(clip);
 	const int_fast16_t clipLeft = clip.left;
-	RenderLeftTriangleLowerClipLeftAndVertical<Light, Transparent>(clipLeft, clipY, dst, dstPitch, src, tbl);
+	RenderLeftTriangleLowerClipLeftAndVertical<Light, Transparent>(clipLeft, clipY, dst, dstPitch, src, tbl, lightmap);
 	src += CalculateTriangleSourceSkipUpperBottom(clipY.upperBottom);
 	dst += 2 * XStep + XStep * clipY.upperBottom;
 	const auto upperMax = TriangleUpperHeight - clipY.upperTop;
@@ -603,17 +603,17 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipLeftAndVertical(u
 		const auto width = Width - XStep * i;
 		const auto startX = XStep * i;
 		const auto skip = startX < clipLeft ? clipLeft - startX : 0;
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst + skip, src + skip, width > skip ? width - skip : 0, tbl);
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst + skip, src + skip, width > skip ? width - skip : 0, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipRightAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipRightAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY(clip);
 	const int_fast16_t clipRight = clip.right;
-	RenderLeftTriangleLowerClipRightAndVertical<Light, Transparent>(clipRight, clipY, dst, dstPitch, src, tbl);
+	RenderLeftTriangleLowerClipRightAndVertical<Light, Transparent>(clipRight, clipY, dst, dstPitch, src, tbl, lightmap);
 	src += CalculateTriangleSourceSkipUpperBottom(clipY.upperBottom);
 	dst += 2 * XStep + XStep * clipY.upperBottom;
 	const auto upperMax = TriangleUpperHeight - clipY.upperTop;
@@ -621,60 +621,60 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangleClipRightAndVertical(
 		const auto width = Width - XStep * i;
 		if (width <= clipRight)
 			break;
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width - clipRight, tbl);
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width - clipRight, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangle(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTriangle(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	if (clip.width == Width) {
 		if (clip.height == TriangleHeight) {
-			RenderLeftTriangleFull<Light, Transparent>(dst, dstPitch, src, tbl);
+			RenderLeftTriangleFull<Light, Transparent>(dst, dstPitch, src, tbl, lightmap);
 		} else {
-			RenderLeftTriangleClipVertical<Light, Transparent>(dst, dstPitch, src, tbl, clip);
+			RenderLeftTriangleClipVertical<Light, Transparent>(dst, dstPitch, src, tbl, lightmap, clip);
 		}
 	} else if (clip.right == 0) {
-		RenderLeftTriangleClipLeftAndVertical<Light, Transparent>(dst, dstPitch, src, tbl, clip);
+		RenderLeftTriangleClipLeftAndVertical<Light, Transparent>(dst, dstPitch, src, tbl, lightmap, clip);
 	} else {
-		RenderLeftTriangleClipRightAndVertical<Light, Transparent>(dst, dstPitch, src, tbl, clip);
+		RenderLeftTriangleClipRightAndVertical<Light, Transparent>(dst, dstPitch, src, tbl, lightmap, clip);
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleLower(uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleLower(uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	RenderTriangleLower<Light, Transparent>(dst, dstPitch, src, tbl);
+	RenderTriangleLower<Light, Transparent>(dst, dstPitch, src, tbl, lightmap);
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleLowerClipVertical(const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleLowerClipVertical(const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	src += CalculateTriangleSourceSkipLowerBottom(clipY.lowerBottom);
 	const auto lowerMax = LowerHeight - clipY.lowerTop;
 	for (auto i = 1 + clipY.lowerBottom; i <= lowerMax; ++i, dst -= dstPitch) {
 		const auto width = XStep * i;
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl);
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleLowerClipLeftAndVertical(int_fast16_t clipLeft, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleLowerClipLeftAndVertical(int_fast16_t clipLeft, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	src += CalculateTriangleSourceSkipLowerBottom(clipY.lowerBottom);
 	const auto lowerMax = LowerHeight - clipY.lowerTop;
 	for (auto i = 1 + clipY.lowerBottom; i <= lowerMax; ++i, dst -= dstPitch) {
 		const auto width = XStep * i;
 		if (width > clipLeft)
-			RenderLineTransparentOrOpaque<Light, Transparent>(dst, src + clipLeft, width - clipLeft, tbl);
+			RenderLineTransparentOrOpaque<Light, Transparent>(dst, src + clipLeft, width - clipLeft, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleLowerClipRightAndVertical(int_fast16_t clipRight, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleLowerClipRightAndVertical(int_fast16_t clipRight, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT &dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	src += CalculateTriangleSourceSkipLowerBottom(clipY.lowerBottom);
 	const auto lowerMax = LowerHeight - clipY.lowerTop;
@@ -682,94 +682,94 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleLowerClipRightAndVer
 		const auto width = XStep * i;
 		const auto skip = Width - width < clipRight ? clipRight - (Width - width) : 0;
 		if (width > skip)
-			RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width - skip, tbl);
+			RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width - skip, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	RenderRightTriangleLower<Light, Transparent>(dst, dstPitch, src, tbl);
-	RenderTriangleUpper<Light, Transparent>(dst, dstPitch, src, tbl);
+	RenderRightTriangleLower<Light, Transparent>(dst, dstPitch, src, tbl, lightmap);
+	RenderTriangleUpper<Light, Transparent>(dst, dstPitch, src, tbl, lightmap);
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleClipVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleClipVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY(clip);
-	RenderRightTriangleLowerClipVertical<Light, Transparent>(clipY, dst, dstPitch, src, tbl);
+	RenderRightTriangleLowerClipVertical<Light, Transparent>(clipY, dst, dstPitch, src, tbl, lightmap);
 	src += CalculateTriangleSourceSkipUpperBottom(clipY.upperBottom);
 	const auto upperMax = TriangleUpperHeight - clipY.upperTop;
 	for (auto i = 1 + clipY.upperBottom; i <= upperMax; ++i, dst -= dstPitch) {
 		const auto width = Width - XStep * i;
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl);
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleClipLeftAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleClipLeftAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY(clip);
 	const int_fast16_t clipLeft = clip.left;
-	RenderRightTriangleLowerClipLeftAndVertical<Light, Transparent>(clipLeft, clipY, dst, dstPitch, src, tbl);
+	RenderRightTriangleLowerClipLeftAndVertical<Light, Transparent>(clipLeft, clipY, dst, dstPitch, src, tbl, lightmap);
 	src += CalculateTriangleSourceSkipUpperBottom(clipY.upperBottom);
 	const auto upperMax = TriangleUpperHeight - clipY.upperTop;
 	for (auto i = 1 + clipY.upperBottom; i <= upperMax; ++i, dst -= dstPitch) {
 		const auto width = Width - XStep * i;
 		if (width <= clipLeft)
 			break;
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src + clipLeft, width - clipLeft, tbl);
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src + clipLeft, width - clipLeft, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleClipRightAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangleClipRightAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY(clip);
 	const int_fast16_t clipRight = clip.right;
-	RenderRightTriangleLowerClipRightAndVertical<Light, Transparent>(clipRight, clipY, dst, dstPitch, src, tbl);
+	RenderRightTriangleLowerClipRightAndVertical<Light, Transparent>(clipRight, clipY, dst, dstPitch, src, tbl, lightmap);
 	src += CalculateTriangleSourceSkipUpperBottom(clipY.upperBottom);
 	const auto upperMax = TriangleUpperHeight - clipY.upperTop;
 	for (auto i = 1 + clipY.upperBottom; i <= upperMax; ++i, dst -= dstPitch) {
 		const auto width = Width - XStep * i;
 		const auto skip = Width - width < clipRight ? clipRight - (Width - width) : 0;
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width > skip ? width - skip : 0, tbl);
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, width > skip ? width - skip : 0, tbl, lightmap);
 		src += width;
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangle(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTriangle(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	if (clip.width == Width) {
 		if (clip.height == TriangleHeight) {
-			RenderRightTriangleFull<Light, Transparent>(dst, dstPitch, src, tbl);
+			RenderRightTriangleFull<Light, Transparent>(dst, dstPitch, src, tbl, lightmap);
 		} else {
-			RenderRightTriangleClipVertical<Light, Transparent>(dst, dstPitch, src, tbl, clip);
+			RenderRightTriangleClipVertical<Light, Transparent>(dst, dstPitch, src, tbl, lightmap, clip);
 		}
 	} else if (clip.right == 0) {
-		RenderRightTriangleClipLeftAndVertical<Light, Transparent>(dst, dstPitch, src, tbl, clip);
+		RenderRightTriangleClipLeftAndVertical<Light, Transparent>(dst, dstPitch, src, tbl, lightmap, clip);
 	} else {
-		RenderRightTriangleClipRightAndVertical<Light, Transparent>(dst, dstPitch, src, tbl, clip);
+		RenderRightTriangleClipRightAndVertical<Light, Transparent>(dst, dstPitch, src, tbl, lightmap, clip);
 	}
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalf(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalf(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	if constexpr (Mask == MaskType::Left || Mask == MaskType::Right) {
 		// The first line is always fully opaque.
 		// We handle it specially to avoid calling the blitter with width=0.
 		const uint8_t *srcEnd = src + Width * TrapezoidUpperHeight;
-		RenderLineOpaque<Light>(dst, src, Width, tbl);
+		RenderLineOpaque<Light>(dst, src, Width, tbl, lightmap);
 		src += Width;
 		dst -= dstPitch;
 		uint8_t prefixWidth = (PrefixIncrement<Mask> < 0 ? 32 : 0) + PrefixIncrement<Mask>;
 		do {
-			RenderLineTransparentAndOpaque<Light, /*OpaqueFirst=*/Mask == MaskType::Right>(dst, src, prefixWidth, Width, tbl);
+			RenderLineTransparentAndOpaque<Light, /*OpaqueFirst=*/Mask == MaskType::Right>(dst, src, prefixWidth, Width, tbl, lightmap);
 			prefixWidth += PrefixIncrement<Mask>;
 			src += Width;
 			dst -= dstPitch;
@@ -777,7 +777,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalf(uint8_t *DVL_R
 	} else { // Mask == MaskType::Solid || Mask == MaskType::Transparent
 		const uint8_t *srcEnd = src + Width * TrapezoidUpperHeight;
 		do {
-			RenderLineTransparentOrOpaque<Light, /*Transparent=*/Mask == MaskType::Transparent>(dst, src, Width, tbl);
+			RenderLineTransparentOrOpaque<Light, /*Transparent=*/Mask == MaskType::Transparent>(dst, src, Width, tbl, lightmap);
 			src += Width;
 			dst -= dstPitch;
 		} while (src != srcEnd);
@@ -785,179 +785,179 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalf(uint8_t *DVL_R
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalfClipVertical(const Clip &clip, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalfClipVertical(const Clip &clip, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	const auto upperMax = TrapezoidUpperHeight - clipY.upperTop;
 	int8_t prefix = InitPrefix<Mask>(clip.bottom);
 	for (auto i = 1 + clipY.upperBottom; i <= upperMax; ++i, dst -= dstPitch) {
-		RenderLine<Light, Mask>(dst, src, Width, tbl, prefix);
+		RenderLine<Light, Mask>(dst, src, Width, tbl, lightmap, prefix);
 		src += Width;
 		prefix += PrefixIncrement<Mask>;
 	}
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalfClipLeftAndVertical(const Clip &clip, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalfClipLeftAndVertical(const Clip &clip, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	const auto upperMax = TrapezoidUpperHeight - clipY.upperTop;
 	int8_t prefix = InitPrefix<Mask>(clip.bottom);
 	for (auto i = 1 + clipY.upperBottom; i <= upperMax; ++i, dst -= dstPitch) {
-		RenderLine<Light, Mask>(dst, src, clip.width, tbl, prefix - clip.left);
+		RenderLine<Light, Mask>(dst, src, clip.width, tbl, lightmap, prefix - clip.left);
 		src += Width;
 		prefix += PrefixIncrement<Mask>;
 	}
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalfClipRightAndVertical(const Clip &clip, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalfClipRightAndVertical(const Clip &clip, const DiamondClipY &clipY, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 	const auto upperMax = TrapezoidUpperHeight - clipY.upperTop;
 	int8_t prefix = InitPrefix<Mask>(clip.bottom);
 	for (auto i = 1 + clipY.upperBottom; i <= upperMax; ++i, dst -= dstPitch) {
-		RenderLine<Light, Mask>(dst, src, clip.width, tbl, prefix);
+		RenderLine<Light, Mask>(dst, src, clip.width, tbl, lightmap, prefix);
 		src += Width;
 		prefix += PrefixIncrement<Mask>;
 	}
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	RenderLeftTriangleLower<Light, /*Transparent=*/Mask == MaskType::Transparent>(dst, dstPitch, src, tbl);
+	RenderLeftTriangleLower<Light, /*Transparent=*/Mask == MaskType::Transparent>(dst, dstPitch, src, tbl, lightmap);
 	dst += XStep;
-	RenderTrapezoidUpperHalf<Light, Mask>(dst, dstPitch, src, tbl);
+	RenderTrapezoidUpperHalf<Light, Mask>(dst, dstPitch, src, tbl, lightmap);
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidClipVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidClipVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
-	RenderLeftTriangleLowerClipVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clipY, dst, dstPitch, src, tbl);
+	RenderLeftTriangleLowerClipVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clipY, dst, dstPitch, src, tbl, lightmap);
 	src += clipY.upperBottom * Width;
 	dst += XStep;
-	RenderTrapezoidUpperHalfClipVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl);
+	RenderTrapezoidUpperHalfClipVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl, lightmap);
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidClipLeftAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidClipLeftAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
-	RenderLeftTriangleLowerClipLeftAndVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clip.left, clipY, dst, dstPitch, src, tbl);
+	RenderLeftTriangleLowerClipLeftAndVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clip.left, clipY, dst, dstPitch, src, tbl, lightmap);
 	src += clipY.upperBottom * Width + clip.left;
 	dst += XStep + clip.left;
-	RenderTrapezoidUpperHalfClipLeftAndVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl);
+	RenderTrapezoidUpperHalfClipLeftAndVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl, lightmap);
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidClipRightAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidClipRightAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
-	RenderLeftTriangleLowerClipRightAndVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clip.right, clipY, dst, dstPitch, src, tbl);
+	RenderLeftTriangleLowerClipRightAndVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clip.right, clipY, dst, dstPitch, src, tbl, lightmap);
 	src += clipY.upperBottom * Width;
 	dst += XStep;
-	RenderTrapezoidUpperHalfClipRightAndVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl);
+	RenderTrapezoidUpperHalfClipRightAndVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl, lightmap);
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoid(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoid(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	if (clip.width == Width) {
 		if (clip.height == Height) {
-			RenderLeftTrapezoidFull<Light, Mask>(dst, dstPitch, src, tbl);
+			RenderLeftTrapezoidFull<Light, Mask>(dst, dstPitch, src, tbl, lightmap);
 		} else {
-			RenderLeftTrapezoidClipVertical<Light, Mask>(dst, dstPitch, src, tbl, clip);
+			RenderLeftTrapezoidClipVertical<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 		}
 	} else if (clip.right == 0) {
-		RenderLeftTrapezoidClipLeftAndVertical<Light, Mask>(dst, dstPitch, src, tbl, clip);
+		RenderLeftTrapezoidClipLeftAndVertical<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 	} else {
-		RenderLeftTrapezoidClipRightAndVertical<Light, Mask>(dst, dstPitch, src, tbl, clip);
+		RenderLeftTrapezoidClipRightAndVertical<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 	}
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	RenderRightTriangleLower<Light, /*Transparent=*/Mask == MaskType::Transparent>(dst, dstPitch, src, tbl);
-	RenderTrapezoidUpperHalf<Light, Mask>(dst, dstPitch, src, tbl);
+	RenderRightTriangleLower<Light, /*Transparent=*/Mask == MaskType::Transparent>(dst, dstPitch, src, tbl, lightmap);
+	RenderTrapezoidUpperHalf<Light, Mask>(dst, dstPitch, src, tbl, lightmap);
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidClipVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidClipVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
-	RenderRightTriangleLowerClipVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clipY, dst, dstPitch, src, tbl);
+	RenderRightTriangleLowerClipVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clipY, dst, dstPitch, src, tbl, lightmap);
 	src += clipY.upperBottom * Width;
-	RenderTrapezoidUpperHalfClipVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl);
+	RenderTrapezoidUpperHalfClipVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl, lightmap);
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidClipLeftAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidClipLeftAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
-	RenderRightTriangleLowerClipLeftAndVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clip.left, clipY, dst, dstPitch, src, tbl);
+	RenderRightTriangleLowerClipLeftAndVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clip.left, clipY, dst, dstPitch, src, tbl, lightmap);
 	src += clipY.upperBottom * Width + clip.left;
-	RenderTrapezoidUpperHalfClipLeftAndVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl);
+	RenderTrapezoidUpperHalfClipLeftAndVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl, lightmap);
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidClipRightAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidClipRightAndVertical(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	const DiamondClipY clipY = CalculateDiamondClipY<TrapezoidUpperHeight>(clip);
-	RenderRightTriangleLowerClipRightAndVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clip.right, clipY, dst, dstPitch, src, tbl);
+	RenderRightTriangleLowerClipRightAndVertical<Light, /*Transparent=*/Mask == MaskType::Transparent>(clip.right, clipY, dst, dstPitch, src, tbl, lightmap);
 	src += clipY.upperBottom * Width;
-	RenderTrapezoidUpperHalfClipRightAndVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl);
+	RenderTrapezoidUpperHalfClipRightAndVertical<Light, Mask>(clip, clipY, dst, dstPitch, src, tbl, lightmap);
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoid(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoid(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	if (clip.width == Width) {
 		if (clip.height == Height) {
-			RenderRightTrapezoidFull<Light, Mask>(dst, dstPitch, src, tbl);
+			RenderRightTrapezoidFull<Light, Mask>(dst, dstPitch, src, tbl, lightmap);
 		} else {
-			RenderRightTrapezoidClipVertical<Light, Mask>(dst, dstPitch, src, tbl, clip);
+			RenderRightTrapezoidClipVertical<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 		}
 	} else if (clip.right == 0) {
-		RenderRightTrapezoidClipLeftAndVertical<Light, Mask>(dst, dstPitch, src, tbl, clip);
+		RenderRightTrapezoidClipLeftAndVertical<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 	} else {
-		RenderRightTrapezoidClipRightAndVertical<Light, Mask>(dst, dstPitch, src, tbl, clip);
+		RenderRightTrapezoidClipRightAndVertical<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 	}
 }
 
 template <LightType Light, bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTileType(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTileType(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	switch (tile) {
 	case TileType::Square:
-		RenderSquare<Light, Transparent>(dst, dstPitch, src, tbl, clip);
+		RenderSquare<Light, Transparent>(dst, dstPitch, src, tbl, lightmap, clip);
 		break;
 	case TileType::TransparentSquare:
-		RenderTransparentSquare<Light, Transparent ? MaskType::Transparent : MaskType::Solid>(dst, dstPitch, src, tbl, clip);
+		RenderTransparentSquare<Light, Transparent ? MaskType::Transparent : MaskType::Solid>(dst, dstPitch, src, tbl, lightmap, clip);
 		break;
 	case TileType::LeftTriangle:
-		RenderLeftTriangle<Light, Transparent>(dst, dstPitch, src, tbl, clip);
+		RenderLeftTriangle<Light, Transparent>(dst, dstPitch, src, tbl, lightmap, clip);
 		break;
 	case TileType::RightTriangle:
-		RenderRightTriangle<Light, Transparent>(dst, dstPitch, src, tbl, clip);
+		RenderRightTriangle<Light, Transparent>(dst, dstPitch, src, tbl, lightmap, clip);
 		break;
 	case TileType::LeftTrapezoid:
-		RenderLeftTrapezoid<Light, Transparent ? MaskType::Transparent : MaskType::Solid>(dst, dstPitch, src, tbl, clip);
+		RenderLeftTrapezoid<Light, Transparent ? MaskType::Transparent : MaskType::Solid>(dst, dstPitch, src, tbl, lightmap, clip);
 		break;
 	case TileType::RightTrapezoid:
-		RenderRightTrapezoid<Light, Transparent ? MaskType::Transparent : MaskType::Solid>(dst, dstPitch, src, tbl, clip);
+		RenderRightTrapezoid<Light, Transparent ? MaskType::Transparent : MaskType::Solid>(dst, dstPitch, src, tbl, lightmap, clip);
 		break;
 	}
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidOrTransparentSquare(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidOrTransparentSquare(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	switch (tile) {
 	case TileType::TransparentSquare:
-		RenderTransparentSquare<Light, Mask>(dst, dstPitch, src, tbl, clip);
+		RenderTransparentSquare<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 		break;
 	case TileType::LeftTrapezoid:
-		RenderLeftTrapezoid<Light, Mask>(dst, dstPitch, src, tbl, clip);
+		RenderLeftTrapezoid<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 		break;
 	default:
 		app_fatal("Given mask can only be applied to TransparentSquare or LeftTrapezoid tiles");
@@ -965,14 +965,14 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidOrTransparentSquare(
 }
 
 template <LightType Light, MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidOrTransparentSquare(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidOrTransparentSquare(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	switch (tile) {
 	case TileType::TransparentSquare:
-		RenderTransparentSquare<Light, Mask>(dst, dstPitch, src, tbl, clip);
+		RenderTransparentSquare<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 		break;
 	case TileType::RightTrapezoid:
-		RenderRightTrapezoid<Light, Mask>(dst, dstPitch, src, tbl, clip);
+		RenderRightTrapezoid<Light, Mask>(dst, dstPitch, src, tbl, lightmap, clip);
 		break;
 	default:
 		app_fatal("Given mask can only be applied to TransparentSquare or LeftTrapezoid tiles");
@@ -980,44 +980,44 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidOrTransparentSquare
 }
 
 template <MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidOrTransparentSquareDispatch(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLeftTrapezoidOrTransparentSquareDispatch(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	if (*GetOptions().Graphics.perPixelLighting) {
-		RenderLeftTrapezoidOrTransparentSquare<LightType::PerPixel, Mask>(tile, dst, dstPitch, src, tbl, clip);
+		RenderLeftTrapezoidOrTransparentSquare<LightType::PerPixel, Mask>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	} else if (IsFullyDark(tbl)) {
-		RenderLeftTrapezoidOrTransparentSquare<LightType::FullyDark, Mask>(tile, dst, dstPitch, src, tbl, clip);
+		RenderLeftTrapezoidOrTransparentSquare<LightType::FullyDark, Mask>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	} else if (IsFullyLit(tbl)) {
-		RenderLeftTrapezoidOrTransparentSquare<LightType::FullyLit, Mask>(tile, dst, dstPitch, src, tbl, clip);
+		RenderLeftTrapezoidOrTransparentSquare<LightType::FullyLit, Mask>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	} else {
-		RenderLeftTrapezoidOrTransparentSquare<LightType::PartiallyLit, Mask>(tile, dst, dstPitch, src, tbl, clip);
+		RenderLeftTrapezoidOrTransparentSquare<LightType::PartiallyLit, Mask>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	}
 }
 
 template <MaskType Mask>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidOrTransparentSquareDispatch(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderRightTrapezoidOrTransparentSquareDispatch(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	if (*GetOptions().Graphics.perPixelLighting) {
-		RenderRightTrapezoidOrTransparentSquare<LightType::PerPixel, Mask>(tile, dst, dstPitch, src, tbl, clip);
+		RenderRightTrapezoidOrTransparentSquare<LightType::PerPixel, Mask>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	} else if (IsFullyDark(tbl)) {
-		RenderRightTrapezoidOrTransparentSquare<LightType::FullyDark, Mask>(tile, dst, dstPitch, src, tbl, clip);
+		RenderRightTrapezoidOrTransparentSquare<LightType::FullyDark, Mask>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	} else if (IsFullyLit(tbl)) {
-		RenderRightTrapezoidOrTransparentSquare<LightType::FullyLit, Mask>(tile, dst, dstPitch, src, tbl, clip);
+		RenderRightTrapezoidOrTransparentSquare<LightType::FullyLit, Mask>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	} else {
-		RenderRightTrapezoidOrTransparentSquare<LightType::PartiallyLit, Mask>(tile, dst, dstPitch, src, tbl, clip);
+		RenderRightTrapezoidOrTransparentSquare<LightType::PartiallyLit, Mask>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	}
 }
 
 template <bool Transparent>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTileDispatch(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, Clip clip)
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTileDispatch(TileType tile, uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap, Clip clip)
 {
 	if (*GetOptions().Graphics.perPixelLighting) {
-		RenderTileType<LightType::PerPixel, Transparent>(tile, dst, dstPitch, src, tbl, clip);
+		RenderTileType<LightType::PerPixel, Transparent>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	} else if (IsFullyDark(tbl)) {
-		RenderTileType<LightType::FullyDark, Transparent>(tile, dst, dstPitch, src, tbl, clip);
+		RenderTileType<LightType::FullyDark, Transparent>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	} else if (IsFullyLit(tbl)) {
-		RenderTileType<LightType::FullyLit, Transparent>(tile, dst, dstPitch, src, tbl, clip);
+		RenderTileType<LightType::FullyLit, Transparent>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	} else {
-		RenderTileType<LightType::PartiallyLit, Transparent>(tile, dst, dstPitch, src, tbl, clip);
+		RenderTileType<LightType::PartiallyLit, Transparent>(tile, dst, dstPitch, src, tbl, lightmap, clip);
 	}
 }
 
@@ -1057,7 +1057,7 @@ std::string_view MaskTypeToString(MaskType maskType)
 }
 #endif
 
-DVL_ATTRIBUTE_HOT void RenderTileFrame(const Surface &out, const Point &position, TileType tile, const uint8_t *src, int_fast16_t height,
+DVL_ATTRIBUTE_HOT void RenderTileFrame(const Surface &out, const Lightmap &lightmap, const Point &position, TileType tile, const uint8_t *src, int_fast16_t height,
     MaskType maskType, const uint8_t *tbl)
 {
 #ifdef DEBUG_RENDER_OFFSET_X
@@ -1078,16 +1078,16 @@ DVL_ATTRIBUTE_HOT void RenderTileFrame(const Surface &out, const Point &position
 
 	switch (maskType) {
 	case MaskType::Solid:
-		RenderTileDispatch</*Transparent=*/false>(tile, dst, dstPitch, src, tbl, clip);
+		RenderTileDispatch</*Transparent=*/false>(tile, dst, dstPitch, src, tbl, &lightmap, clip);
 		break;
 	case MaskType::Transparent:
-		RenderTileDispatch</*Transparent=*/true>(tile, dst, dstPitch, src, tbl, clip);
+		RenderTileDispatch</*Transparent=*/true>(tile, dst, dstPitch, src, tbl, &lightmap, clip);
 		break;
 	case MaskType::Left:
-		RenderLeftTrapezoidOrTransparentSquareDispatch<MaskType::Left>(tile, dst, dstPitch, src, tbl, clip);
+		RenderLeftTrapezoidOrTransparentSquareDispatch<MaskType::Left>(tile, dst, dstPitch, src, tbl, &lightmap, clip);
 		break;
 	case MaskType::Right:
-		RenderRightTrapezoidOrTransparentSquareDispatch<MaskType::Right>(tile, dst, dstPitch, src, tbl, clip);
+		RenderRightTrapezoidOrTransparentSquareDispatch<MaskType::Right>(tile, dst, dstPitch, src, tbl, &lightmap, clip);
 		break;
 	}
 
@@ -1118,11 +1118,11 @@ void world_draw_black_tile(const Surface &out, int sx, int sy)
 	const uint16_t dstPitch = out.pitch();
 	if (clipLeft.width > 0) {
 		uint8_t *dst = out.at(static_cast<int>(sx + clipLeft.left), static_cast<int>(sy - clipLeft.bottom));
-		RenderLeftTriangle<LightType::FullyDark, /*Transparent=*/false>(dst, dstPitch, nullptr, nullptr, clipLeft);
+		RenderLeftTriangle<LightType::FullyDark, /*Transparent=*/false>(dst, dstPitch, nullptr, nullptr, nullptr, clipLeft);
 	}
 	if (clipRight.width > 0) {
 		uint8_t *dst = out.at(static_cast<int>(sx + Width + clipRight.left), static_cast<int>(sy - clipRight.bottom));
-		RenderRightTriangle<LightType::FullyDark, /*Transparent=*/false>(dst, dstPitch, nullptr, nullptr, clipRight);
+		RenderRightTriangle<LightType::FullyDark, /*Transparent=*/false>(dst, dstPitch, nullptr, nullptr, nullptr, clipRight);
 	}
 }
 

--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -150,9 +150,9 @@ template <>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::PerPixel>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
 #ifndef DEBUG_RENDER_COLOR
-	BlitPixelsWithLightmap(dst, src, n, lightmap);
+	BlitPixelsWithLightmap(dst, src, n, *lightmap);
 #else
-	BlitFillWithLightmap(dst, n, DBGCOLOR, lightmap);
+	BlitFillWithLightmap(dst, n, DBGCOLOR, *lightmap);
 #endif
 }
 
@@ -181,7 +181,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent<LightType::Partia
 template <>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparent<LightType::PerPixel>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	BlitPixelsBlendedWithLightmap(dst, src, n, lightmap);
+	BlitPixelsBlendedWithLightmap(dst, src, n, *lightmap);
 }
 #else // DEBUG_RENDER_COLOR
 template <LightType Light>

--- a/Source/engine/render/dun_render.hpp
+++ b/Source/engine/render/dun_render.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 
 #include "engine/point.hpp"
+#include "engine/render/light_render.hpp"
 #include "engine/surface.hpp"
 #include "levels/dun_tile.hpp"
 #include "levels/gendung.h"
@@ -112,22 +113,23 @@ std::string_view MaskTypeToString(MaskType maskType);
 /**
  * @brief Low-level tile rendering function.
  */
-void RenderTileFrame(const Surface &out, const Point &position, TileType tile, const uint8_t *src, int_fast16_t height,
+void RenderTileFrame(const Surface &out, const Lightmap &lightmap, const Point &position, TileType tile, const uint8_t *src, int_fast16_t height,
     MaskType maskType, const uint8_t *tbl);
 
 /**
  * @brief Blit current world CEL to the given buffer
  * @param out Target buffer
+ * @param lightmap Per-pixel light buffer
  * @param position Target buffer coordinates
  * @param levelCelBlock The MIN block of the level CEL file.
  * @param maskType The mask to use,
  * @param tbl LightTable or TRN for a tile.
  */
-DVL_ALWAYS_INLINE void RenderTile(const Surface &out, const Point &position,
+DVL_ALWAYS_INLINE void RenderTile(const Surface &out, const Lightmap &lightmap, const Point &position,
     LevelCelBlock levelCelBlock, MaskType maskType, const uint8_t *tbl)
 {
 	const TileType tileType = levelCelBlock.type();
-	RenderTileFrame(out, position, tileType,
+	RenderTileFrame(out, lightmap, position, tileType,
 	    GetDunFrame(levelCelBlock.frame()),
 	    (tileType == TileType::LeftTriangle || tileType == TileType::RightTriangle)
 	        ? DunFrameTriangleHeight
@@ -138,9 +140,9 @@ DVL_ALWAYS_INLINE void RenderTile(const Surface &out, const Point &position,
 /**
  * @brief Renders a floor foliage tile.
  */
-DVL_ALWAYS_INLINE void RenderTileFoliage(const Surface &out, const Point &position, LevelCelBlock levelCelBlock, const uint8_t *tbl)
+DVL_ALWAYS_INLINE void RenderTileFoliage(const Surface &out, const Lightmap &lightmap, const Point &position, LevelCelBlock levelCelBlock, const uint8_t *tbl)
 {
-	RenderTileFrame(out, Point { position.x, position.y - 16 }, TileType::TransparentSquare,
+	RenderTileFrame(out, lightmap, Point { position.x, position.y - 16 }, TileType::TransparentSquare,
 	    GetDunFrameFoliage(levelCelBlock.frame()), /*height=*/16, MaskType::Solid, tbl);
 }
 

--- a/Source/engine/render/light_render.cpp
+++ b/Source/engine/render/light_render.cpp
@@ -1,0 +1,444 @@
+#include "engine/render/light_render.hpp"
+
+#include <vector>
+
+#include "engine/displacement.hpp"
+#include "engine/dx.h"
+#include "engine/point.hpp"
+#include "engine/points_in_rectangle_range.hpp"
+#include "engine/rectangle.hpp"
+#include "levels/dun_tile.hpp"
+#include "lighting.h"
+#include "utils/ui_fwd.h"
+
+namespace devilution {
+
+namespace {
+
+std::vector<uint8_t> Lightmap;
+
+// Half-space method for drawing triangles
+// Points must be provided using counter-clockwise rotation
+// https://web.archive.org/web/20050408192410/http://sw-shader.sourceforge.net/rasterizer.html
+void RenderTriangle(Point p1, Point p2, Point p3, uint8_t lightLevel, uint8_t *lightmap, uint16_t pitch)
+{
+	// Deltas (points are already 28.4 fixed-point)
+	int dx12 = p1.x - p2.x;
+	int dx23 = p2.x - p3.x;
+	int dx31 = p3.x - p1.x;
+
+	int dy12 = p1.y - p2.y;
+	int dy23 = p2.y - p3.y;
+	int dy31 = p3.y - p1.y;
+
+	// 24.8 fixed-point deltas
+	int fdx12 = dx12 << 4;
+	int fdx23 = dx23 << 4;
+	int fdx31 = dx31 << 4;
+
+	int fdy12 = dy12 << 4;
+	int fdy23 = dy23 << 4;
+	int fdy31 = dy31 << 4;
+
+	// Bounding rectangle
+	int minx = (std::min({ p1.x, p2.x, p3.x }) + 0xF) >> 4;
+	int maxx = (std::max({ p1.x, p2.x, p3.x }) + 0xF) >> 4;
+	int miny = (std::min({ p1.y, p2.y, p3.y }) + 0xF) >> 4;
+	int maxy = (std::max({ p1.y, p2.y, p3.y }) + 0xF) >> 4;
+	minx = std::max<int>(minx, 0);
+	maxx = std::min<int>(maxx, gnScreenWidth);
+	miny = std::max<int>(miny, 0);
+	maxy = std::min<int>(maxy, gnViewportHeight);
+
+	uint8_t *dst = lightmap + miny * pitch;
+
+	// Half-edge constants
+	int c1 = dy12 * p1.x - dx12 * p1.y;
+	int c2 = dy23 * p2.x - dx23 * p2.y;
+	int c3 = dy31 * p3.x - dx31 * p3.y;
+
+	// Correct for fill convention
+	if (dy12 < 0 || (dy12 == 0 && dx12 > 0)) c1++;
+	if (dy23 < 0 || (dy23 == 0 && dx23 > 0)) c2++;
+	if (dy31 < 0 || (dy31 == 0 && dx31 > 0)) c3++;
+
+	int cy1 = c1 + dx12 * (miny << 4) - dy12 * (minx << 4);
+	int cy2 = c2 + dx23 * (miny << 4) - dy23 * (minx << 4);
+	int cy3 = c3 + dx31 * (miny << 4) - dy31 * (minx << 4);
+
+	for (int y = miny; y < maxy; y++) {
+		int cx1 = cy1;
+		int cx2 = cy2;
+		int cx3 = cy3;
+
+		for (int x = minx; x < maxx; x++) {
+			if (cx1 > 0 && cx2 > 0 && cx3 > 0)
+				dst[x] = lightLevel;
+
+			cx1 -= fdy12;
+			cx2 -= fdy23;
+			cx3 -= fdy31;
+		}
+
+		cy1 += fdx12;
+		cy2 += fdx23;
+		cy3 += fdx31;
+
+		dst += pitch;
+	}
+}
+
+uint8_t Interpolate(uint8_t q1, uint8_t q2, uint8_t lightLevel)
+{
+	// Result will be 28.4 fixed-point
+	uint8_t numerator = (lightLevel - q1) << 4;
+	return (numerator + 0x8) / (q2 - q1);
+}
+
+void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *lightmap, uint16_t pitch)
+{
+	Point center0 = position;
+	Point center1 = position + Displacement { TILE_WIDTH / 2, TILE_HEIGHT / 2 };
+	Point center2 = position + Displacement { 0, TILE_HEIGHT };
+	Point center3 = position + Displacement { -TILE_WIDTH / 2, TILE_HEIGHT / 2 };
+
+	// 28.4 fixed-point coordinates
+	Point fpCenter0 = center0 * (1 << 4);
+	Point fpCenter1 = center1 * (1 << 4);
+	Point fpCenter2 = center2 * (1 << 4);
+	Point fpCenter3 = center3 * (1 << 4);
+
+	// Marching squares
+	// https://en.wikipedia.org/wiki/Marching_squares
+	uint8_t shape = 0;
+	shape |= quad[0] <= lightLevel ? 8 : 0;
+	shape |= quad[1] <= lightLevel ? 4 : 0;
+	shape |= quad[2] <= lightLevel ? 2 : 0;
+	shape |= quad[3] <= lightLevel ? 1 : 0;
+
+	switch (shape) {
+	// The whole cell is darker than lightLevel
+	case 0: break;
+
+	// Fill in the bottom-left corner of the cell
+	// In isometric view, only the west tile of the quad is lit
+	case 1: {
+		uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
+		uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
+		Point p1 = fpCenter3 + (center2 - center3) * bottomFactor;
+		Point p2 = fpCenter3;
+		Point p3 = fpCenter3 + (center0 - center3) * leftFactor;
+		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in the bottom-right corner of the cell
+	// In isometric view, only the south tile of the quad is lit
+	case 2: {
+		uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
+		uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
+		Point p1 = fpCenter2 + (center1 - center2) * rightFactor;
+		Point p2 = fpCenter2;
+		Point p3 = fpCenter2 + (center3 - center2) * bottomFactor;
+		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in the bottom half of the cell
+	// In isometric view, the south and west tiles of the quad are lit
+	case 3: {
+		uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
+		uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
+		Point p1 = fpCenter2 + (center1 - center2) * rightFactor;
+		Point p2 = fpCenter2;
+		Point p3 = fpCenter3;
+		Point p4 = fpCenter3 + (center1 - center2) * leftFactor;
+		RenderTriangle(p1, p4, p2, lightLevel, lightmap, pitch);
+		RenderTriangle(p2, p4, p3, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in the top-right corner of the cell
+	// In isometric view, only the east tile of the quad is lit
+	case 4: {
+		uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
+		uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
+		Point p1 = fpCenter1 + (center0 - center1) * topFactor;
+		Point p2 = fpCenter1;
+		Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
+		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in the top-right and bottom-left corners of the cell
+	// Use the average of all values in the quad to determine whether to fill in the center
+	// In isometric view, the east and west tiles of the quad are lit
+	case 5: {
+		uint8_t cell = (quad[0] + quad[1] + quad[2] + quad[3] + 2) / 4;
+		uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
+		uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
+		uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
+		uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
+		Point p1 = fpCenter1 + (center0 - center1) * topFactor;
+		Point p2 = fpCenter1;
+		Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
+		Point p4 = fpCenter3 + (center2 - center3) * bottomFactor;
+		Point p5 = fpCenter3;
+		Point p6 = fpCenter3 + (center0 - center3) * leftFactor;
+
+		if (cell <= lightLevel) {
+			uint8_t midFactor0 = Interpolate(quad[0], cell, lightLevel);
+			uint8_t midFactor2 = Interpolate(quad[2], cell, lightLevel);
+			Point p7 = fpCenter0 + (center2 - center0) / 2 * midFactor0;
+			Point p8 = fpCenter2 + (center0 - center2) / 2 * midFactor2;
+			RenderTriangle(p1, p7, p2, lightLevel, lightmap, pitch);
+			RenderTriangle(p2, p7, p8, lightLevel, lightmap, pitch);
+			RenderTriangle(p2, p8, p3, lightLevel, lightmap, pitch);
+			RenderTriangle(p4, p8, p5, lightLevel, lightmap, pitch);
+			RenderTriangle(p5, p8, p7, lightLevel, lightmap, pitch);
+			RenderTriangle(p5, p7, p6, lightLevel, lightmap, pitch);
+		} else {
+			uint8_t midFactor1 = Interpolate(quad[1], cell, lightLevel);
+			uint8_t midFactor3 = Interpolate(quad[3], cell, lightLevel);
+			Point p7 = fpCenter1 + (center3 - center1) / 2 * midFactor1;
+			Point p8 = fpCenter3 + (center1 - center3) / 2 * midFactor3;
+			RenderTriangle(p1, p7, p2, lightLevel, lightmap, pitch);
+			RenderTriangle(p2, p7, p3, lightLevel, lightmap, pitch);
+			RenderTriangle(p4, p8, p5, lightLevel, lightmap, pitch);
+			RenderTriangle(p5, p8, p6, lightLevel, lightmap, pitch);
+		}
+	} break;
+
+	// Fill in the right half of the cell
+	// In isometric view, the south and east tiles of the quad are lit
+	case 6: {
+		uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
+		uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
+		Point p1 = fpCenter1 + (center0 - center1) * topFactor;
+		Point p2 = fpCenter1;
+		Point p3 = fpCenter2;
+		Point p4 = fpCenter2 + (center3 - center2) * bottomFactor;
+		RenderTriangle(p1, p4, p2, lightLevel, lightmap, pitch);
+		RenderTriangle(p2, p4, p3, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in everything except the top-left corner of the cell
+	// In isometric view, the south, east, and west tiles of the quad are lit
+	case 7: {
+		uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
+		uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
+		Point p1 = fpCenter1 + (center0 - center1) * topFactor;
+		Point p2 = fpCenter1;
+		Point p3 = fpCenter2;
+		Point p4 = fpCenter3;
+		Point p5 = fpCenter3 + (center0 - center3) * leftFactor;
+		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch);
+		RenderTriangle(p1, p5, p3, lightLevel, lightmap, pitch);
+		RenderTriangle(p3, p5, p4, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in the top-left corner of the cell
+	// In isometric view, only the north tile of the quad is lit
+	case 8: {
+		uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
+		uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
+		Point p1 = fpCenter0;
+		Point p2 = fpCenter0 + (center1 - center0) * topFactor;
+		Point p3 = fpCenter0 + (center3 - center0) * leftFactor;
+		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in the left half of the cell
+	// In isometric view, the north and west tiles of the quad are lit
+	case 9: {
+		uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
+		uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
+		Point p1 = fpCenter0;
+		Point p2 = fpCenter0 + (center1 - center0) * topFactor;
+		Point p3 = fpCenter3 + (center2 - center3) * bottomFactor;
+		Point p4 = fpCenter3;
+		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch);
+		RenderTriangle(p1, p4, p3, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in the top-left and bottom-right corners of the cell
+	// Use the average of all values in the quad to determine whether to fill in the center
+	// In isometric view, the north and south tiles of the quad are lit
+	case 10: {
+		uint8_t cell = (quad[0] + quad[1] + quad[2] + quad[3] + 2) / 4;
+		uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
+		uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
+		uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
+		uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
+		Point p1 = fpCenter0;
+		Point p2 = fpCenter0 + (center1 - center0) * topFactor;
+		Point p3 = fpCenter2 + (center1 - center2) * rightFactor;
+		Point p4 = fpCenter2;
+		Point p5 = fpCenter2 + (center3 - center2) * bottomFactor;
+		Point p6 = fpCenter0 + (center3 - center0) * leftFactor;
+
+		if (cell <= lightLevel) {
+			uint8_t midFactor1 = Interpolate(quad[1], cell, lightLevel);
+			uint8_t midFactor3 = Interpolate(quad[3], cell, lightLevel);
+			Point p7 = fpCenter1 + (center3 - center1) / 2 * midFactor1;
+			Point p8 = fpCenter3 + (center1 - center3) / 2 * midFactor3;
+			RenderTriangle(p1, p7, p2, lightLevel, lightmap, pitch);
+			RenderTriangle(p1, p6, p8, lightLevel, lightmap, pitch);
+			RenderTriangle(p1, p8, p7, lightLevel, lightmap, pitch);
+			RenderTriangle(p3, p7, p4, lightLevel, lightmap, pitch);
+			RenderTriangle(p4, p8, p5, lightLevel, lightmap, pitch);
+			RenderTriangle(p4, p7, p8, lightLevel, lightmap, pitch);
+		} else {
+			uint8_t midFactor0 = Interpolate(quad[0], cell, lightLevel);
+			uint8_t midFactor2 = Interpolate(quad[2], cell, lightLevel);
+			Point p7 = fpCenter0 + (center2 - center0) / 2 * midFactor0;
+			Point p8 = fpCenter2 + (center0 - center2) / 2 * midFactor2;
+			RenderTriangle(p1, p7, p2, lightLevel, lightmap, pitch);
+			RenderTriangle(p1, p6, p7, lightLevel, lightmap, pitch);
+			RenderTriangle(p3, p8, p4, lightLevel, lightmap, pitch);
+			RenderTriangle(p4, p8, p5, lightLevel, lightmap, pitch);
+		}
+	} break;
+
+	// Fill in everything except the top-right corner of the cell
+	// In isometric view, the north, south, and west tiles of the quad are lit
+	case 11: {
+		uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
+		uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
+		Point p1 = fpCenter0;
+		Point p2 = fpCenter0 + (center1 - center0) * topFactor;
+		Point p3 = fpCenter2 + (center1 - center2) * rightFactor;
+		Point p4 = fpCenter2;
+		Point p5 = fpCenter3;
+		RenderTriangle(p1, p5, p2, lightLevel, lightmap, pitch);
+		RenderTriangle(p2, p5, p3, lightLevel, lightmap, pitch);
+		RenderTriangle(p3, p5, p4, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in the top half of the cell
+	// In isometric view, the north and east tiles of the quad are lit
+	case 12: {
+		uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
+		uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
+		Point p1 = fpCenter0;
+		Point p2 = fpCenter1;
+		Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
+		Point p4 = fpCenter0 + (center3 - center0) * leftFactor;
+		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch);
+		RenderTriangle(p1, p4, p3, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in everything except the bottom-right corner of the cell
+	// In isometric view, the north, east, and west tiles of the quad are lit
+	case 13: {
+		uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
+		uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
+		Point p1 = fpCenter0;
+		Point p2 = fpCenter1;
+		Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
+		Point p4 = fpCenter3 + (center2 - center3) * bottomFactor;
+		Point p5 = fpCenter3;
+		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch);
+		RenderTriangle(p1, p4, p3, lightLevel, lightmap, pitch);
+		RenderTriangle(p2, p5, p4, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in everything except the bottom-left corner of the cell
+	// In isometric view, the north, south, and east tiles of the quad are lit
+	case 14: {
+		uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
+		uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
+		Point p1 = fpCenter0;
+		Point p2 = fpCenter1;
+		Point p3 = fpCenter2;
+		Point p4 = fpCenter2 + (center3 - center2) * bottomFactor;
+		Point p5 = fpCenter0 + (center3 - center0) * leftFactor;
+		RenderTriangle(p1, p5, p2, lightLevel, lightmap, pitch);
+		RenderTriangle(p2, p5, p4, lightLevel, lightmap, pitch);
+		RenderTriangle(p2, p4, p3, lightLevel, lightmap, pitch);
+	} break;
+
+	// Fill in the whole cell
+	// All four tiles in the quad are lit
+	case 15: {
+		RenderTriangle(fpCenter0, fpCenter2, fpCenter1, lightLevel, lightmap, pitch);
+		RenderTriangle(fpCenter0, fpCenter3, fpCenter2, lightLevel, lightmap, pitch);
+	} break;
+	}
+}
+
+} // namespace
+
+void BuildLightmap(Point tilePosition, Point targetBufferPosition, int rows, int columns)
+{
+	const int screenWidth = gnScreenWidth;
+	const size_t totalPixels = static_cast<size_t>(screenWidth) * gnViewportHeight;
+	Lightmap.resize(totalPixels);
+
+	// Since rendering occurs in cells between quads,
+	// expand the rendering space to include tiles outside the viewport
+	tilePosition += Displacement(Direction::NorthWest) * 2;
+	targetBufferPosition -= Displacement { TILE_WIDTH, TILE_HEIGHT };
+	rows += 3;
+	columns++;
+
+	uint8_t *lightmap = Lightmap.data();
+	memset(lightmap, LightsMax, totalPixels);
+	for (int i = 0; i < rows; i++) {
+		for (int j = 0; j < columns; j++, tilePosition += Direction::East, targetBufferPosition.x += TILE_WIDTH) {
+			Point center0 = targetBufferPosition + Displacement { TILE_WIDTH / 2, -TILE_HEIGHT / 2 };
+
+			Point tile0 = tilePosition;
+			Point tile1 = tilePosition + Displacement { 1, 0 };
+			Point tile2 = tilePosition + Displacement { 1, 1 };
+			Point tile3 = tilePosition + Displacement { 0, 1 };
+
+			uint8_t quad[] = {
+				InDungeonBounds(tile0) ? dLight[tile0.x][tile0.y] : static_cast<uint8_t>(LightsMax),
+				InDungeonBounds(tile1) ? dLight[tile1.x][tile1.y] : static_cast<uint8_t>(LightsMax),
+				InDungeonBounds(tile2) ? dLight[tile2.x][tile2.y] : static_cast<uint8_t>(LightsMax),
+				InDungeonBounds(tile3) ? dLight[tile3.x][tile3.y] : static_cast<uint8_t>(LightsMax)
+			};
+
+			uint8_t maxLight = std::max({ quad[0], quad[1], quad[2], quad[3] });
+			uint8_t minLight = std::min({ quad[0], quad[1], quad[2], quad[3] });
+
+			for (uint8_t i = 0; i < LightsMax; i++) {
+				uint8_t lightLevel = LightsMax - i - 1;
+				if (lightLevel > maxLight)
+					continue;
+				if (lightLevel < minLight)
+					break;
+				RenderCell(quad, center0, lightLevel, lightmap, screenWidth);
+			}
+		}
+
+		// Return to start of row
+		tilePosition += Displacement(Direction::West) * columns;
+		targetBufferPosition.x -= columns * TILE_WIDTH;
+
+		// Jump to next row
+		targetBufferPosition.y += TILE_HEIGHT / 2;
+		if ((i & 1) != 0) {
+			tilePosition.x++;
+			columns--;
+			targetBufferPosition.x += TILE_WIDTH / 2;
+		} else {
+			tilePosition.y++;
+			columns++;
+			targetBufferPosition.x -= TILE_WIDTH / 2;
+		}
+	}
+}
+
+uint8_t AdjustColor(uint8_t color, uint8_t lightLevel)
+{
+	return LightTables[lightLevel][color];
+}
+
+const uint8_t *GetLightmapAt(const uint8_t *gbbLoc)
+{
+	// Because the global back buffer is what we use for rendering,
+	// it can be used like this at time of rendering to look up values in the lightmap
+	const Surface &gbb = GlobalBackBuffer();
+	const uint8_t *gbbStart = gbb.at(0, 0);
+	return Lightmap.data() + (gbbLoc - gbbStart);
+}
+
+} // namespace devilution

--- a/Source/engine/render/light_render.hpp
+++ b/Source/engine/render/light_render.hpp
@@ -4,8 +4,28 @@
 
 namespace devilution {
 
+class Lightmap {
+public:
+	Lightmap(uint8_t *outBuffer);
+
+	uint8_t adjustColor(uint8_t color, uint8_t lightLevel) const
+	{
+		size_t offset = lightLevel * lightTableSize + color;
+		return lightTables[offset];
+	}
+
+	const uint8_t *getLightingAt(const uint8_t *outLoc) const
+	{
+		return lightmapBuffer + (outLoc - outBuffer);
+	}
+
+private:
+	uint8_t *outBuffer;
+	uint8_t *lightmapBuffer;
+	uint8_t *lightTables;
+	size_t lightTableSize;
+};
+
 void BuildLightmap(Point tilePosition, Point targetBufferPosition, int rows, int columns);
-uint8_t AdjustColor(uint8_t color, uint8_t lightLevel);
-const uint8_t *GetLightmapAt(const uint8_t *gbbLoc);
 
 } // namespace devilution

--- a/Source/engine/render/light_render.hpp
+++ b/Source/engine/render/light_render.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "engine/point.hpp"
+
+namespace devilution {
+
+void BuildLightmap(Point tilePosition, Point targetBufferPosition, int rows, int columns);
+uint8_t AdjustColor(uint8_t color, uint8_t lightLevel);
+const uint8_t *GetLightmapAt(const uint8_t *gbbLoc);
+
+} // namespace devilution

--- a/Source/engine/render/light_render.hpp
+++ b/Source/engine/render/light_render.hpp
@@ -6,7 +6,7 @@ namespace devilution {
 
 class Lightmap {
 public:
-	Lightmap(uint8_t *outBuffer);
+	explicit Lightmap(const uint8_t *outBuffer, const uint8_t *lightmapBuffer, const uint8_t *lightTables, size_t lightTableSize);
 
 	uint8_t adjustColor(uint8_t color, uint8_t lightLevel) const
 	{
@@ -19,13 +19,15 @@ public:
 		return lightmapBuffer + (outLoc - outBuffer);
 	}
 
-private:
-	uint8_t *outBuffer;
-	uint8_t *lightmapBuffer;
-	uint8_t *lightTables;
-	size_t lightTableSize;
-};
+	static Lightmap build(Point tilePosition, Point targetBufferPosition,
+	    int viewportWidth, int viewportHeight, int rows, int columns,
+	    const uint8_t *outBuffer, const uint8_t *lightTables, size_t lightTableSize);
 
-void BuildLightmap(Point tilePosition, Point targetBufferPosition, int rows, int columns);
+private:
+	const uint8_t *outBuffer;
+	const uint8_t *lightmapBuffer;
+	const uint8_t *lightTables;
+	const size_t lightTableSize;
+};
 
 } // namespace devilution

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1122,9 +1122,10 @@ void DrawGame(const Surface &fullOut, Point position, Displacement offset)
 	DunRenderStats.clear();
 #endif
 
-	BuildLightmap(position, Point {} + offset, rows, columns);
+	Lightmap lightmap = Lightmap::build(position, Point {} + offset,
+	    gnScreenWidth, gnViewportHeight, rows, columns,
+	    out.at(0, 0), LightTables[0].data(), LightTables[0].size());
 
-	Lightmap lightmap(out.at(0, 0));
 	DrawFloor(out, lightmap, position, Point {} + offset, rows, columns);
 	DrawTileContent(out, lightmap, position, Point {} + offset, rows, columns);
 

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -166,7 +166,7 @@ extern DVL_API_FOR_TEST uint8_t currlevel;
 extern bool setlevel;
 /** Specifies the active quest level of the current game. */
 extern _setlevels setlvlnum;
-/** Specifies the player viewpoint X-coordinate of the map. */
+/** Specifies the dungeon type of the active quest level of the current game. */
 extern dungeon_type setlvltype;
 /** Specifies the player viewpoint X,Y-coordinates of the map. */
 extern DVL_API_FOR_TEST Point ViewPosition;

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -674,6 +674,7 @@ GraphicsOptions::GraphicsOptions()
           })
     , brightness("Brightness Correction", OptionEntryFlags::Invisible, "Brightness Correction", "Brightness correction level.", 0)
     , zoom("Zoom", OptionEntryFlags::None, N_("Zoom"), N_("Zoom on when enabled."), false)
+    , perPixelLighting("Per-pixel Lighting", OptionEntryFlags::None, N_("Per-pixel Lighting"), N_("Subtile lighting for smoother light gradients."), true)
     , colorCycling("Color Cycling", OptionEntryFlags::None, N_("Color Cycling"), N_("Color cycling effect used for water, lava, and acid animation."), true)
     , alternateNestArt("Alternate nest art", OptionEntryFlags::OnlyHellfire | OptionEntryFlags::CantChangeInGame, N_("Alternate nest art"), N_("The game will use an alternative palette for Hellfire’s nest tileset."), false)
 #if SDL_VERSION_ATLEAST(2, 0, 0)
@@ -704,6 +705,7 @@ std::vector<OptionEntryBase *> GraphicsOptions::GetEntries()
 		&brightness,
 		&zoom,
 		&showFPS,
+		&perPixelLighting,
 		&colorCycling,
 		&alternateNestArt,
 #if SDL_VERSION_ATLEAST(2, 0, 0)

--- a/Source/options.h
+++ b/Source/options.h
@@ -530,6 +530,8 @@ struct GraphicsOptions : OptionCategoryBase {
 	OptionEntryInt<int> brightness;
 	/** @brief Zoom on start. */
 	OptionEntryBoolean zoom;
+	/** @brief Subtile lighting for smoother light gradients. */
+	OptionEntryBoolean perPixelLighting;
 	/** @brief Enable color cycling animations. */
 	OptionEntryBoolean colorCycling;
 	/** @brief Use alternate nest palette. */

--- a/test/dun_render_benchmark.cpp
+++ b/test/dun_render_benchmark.cpp
@@ -65,7 +65,7 @@ void InitOnce()
 void RunForTileMaskLight(benchmark::State &state, TileType tileType, MaskType maskType, const uint8_t *lightTable)
 {
 	Surface out = Surface(SdlSurface.get());
-	Lightmap lightmap(out.at(0, 0));
+	Lightmap lightmap(nullptr, nullptr, nullptr, 0);
 	size_t numItemsProcessed = 0;
 	const std::span<const LevelCelBlock> tiles = Tiles[tileType];
 	for (auto _ : state) {

--- a/test/dun_render_benchmark.cpp
+++ b/test/dun_render_benchmark.cpp
@@ -65,11 +65,12 @@ void InitOnce()
 void RunForTileMaskLight(benchmark::State &state, TileType tileType, MaskType maskType, const uint8_t *lightTable)
 {
 	Surface out = Surface(SdlSurface.get());
+	Lightmap lightmap(out.at(0, 0));
 	size_t numItemsProcessed = 0;
 	const std::span<const LevelCelBlock> tiles = Tiles[tileType];
 	for (auto _ : state) {
 		for (const LevelCelBlock &levelCelBlock : tiles) {
-			RenderTile(out, Point { 320, 240 }, levelCelBlock, maskType, lightTable);
+			RenderTile(out, lightmap, Point { 320, 240 }, levelCelBlock, maskType, lightTable);
 			uint8_t color = out[Point { 310, 200 }];
 			benchmark::DoNotOptimize(color);
 		}


### PR DESCRIPTION
The idea is to use the marching squares algorithm to create isolines for each of the 16 light levels using the tile-based light data from `dLight`. The contours generated by marching squares are rendered onto a "lightmap" buffer which is used to look up light levels for individual pixels during rendering.

Because this uses the data from `dLight` to generate the isolines, the result should be fundamentally similar to the existing lighting system, just with a more natural gradient. And because the renderer still uses `LightTables` to look up colors in the 8-bit palette, the color banding due to the limited color selection should also be preserved. Furthermore, by hooking into the existing lighting system this way, the code footprint was small enough that I was easily able to provide this as an option in the settings menu.

I would have done some performance testing with 3DS, but I just found out that async loading is broken on that platform so I can't even get in game. :grimacing: 

Anyway, here's a short demonstration of me using `DebugToggle` to switch back and forth on PC.

https://github.com/user-attachments/assets/6321b96a-e2d4-41aa-8677-aae020ad0677