### PR TITLE
Bleed per-pixel light up when rendering walls

### DIFF
--- a/Source/engine/render/light_render.cpp
+++ b/Source/engine/render/light_render.cpp
@@ -1,10 +1,13 @@
 #include "engine/render/light_render.hpp"
 
+#include <cassert>
+#include <span>
 #include <vector>
 
 #include "engine/displacement.hpp"
 #include "engine/point.hpp"
 #include "levels/dun_tile.hpp"
+#include "levels/gendung.h"
 #include "lighting.h"
 #include "options.h"
 
@@ -365,7 +368,12 @@ void BuildLightmap(Point tilePosition, Point targetBufferPosition, uint16_t view
 	if (!*GetOptions().Graphics.perPixelLighting)
 		return;
 
-	const size_t totalPixels = static_cast<size_t>(viewportWidth) * viewportHeight;
+	// Since light may need to bleed up to the top of wall tiles,
+	// expand the buffer space to include the full base diamond of the tallest tile graphics
+	const uint16_t bufferHeight = viewportHeight + TILE_HEIGHT * (MicroTileLen / 2 + 1);
+	rows += MicroTileLen + 2;
+
+	const size_t totalPixels = static_cast<size_t>(viewportWidth) * bufferHeight;
 	LightmapBuffer.resize(totalPixels);
 
 	// Since rendering occurs in cells between quads,
@@ -402,7 +410,7 @@ void BuildLightmap(Point tilePosition, Point targetBufferPosition, uint16_t view
 					continue;
 				if (lightLevel < minLight)
 					break;
-				RenderCell(quad, center0, lightLevel, lightmap, viewportWidth, viewportHeight);
+				RenderCell(quad, center0, lightLevel, lightmap, viewportWidth, bufferHeight);
 			}
 		}
 
@@ -426,9 +434,13 @@ void BuildLightmap(Point tilePosition, Point targetBufferPosition, uint16_t view
 
 } // namespace
 
-Lightmap::Lightmap(const uint8_t *outBuffer, const uint8_t *lightmapBuffer, const uint8_t *lightTables, size_t lightTableSize)
+Lightmap::Lightmap(const uint8_t *outBuffer, uint16_t outPitch,
+    std::span<const uint8_t> lightmapBuffer, uint16_t lightmapPitch,
+    const uint8_t *lightTables, size_t lightTableSize)
     : outBuffer(outBuffer)
+    , outPitch(outPitch)
     , lightmapBuffer(lightmapBuffer)
+    , lightmapPitch(lightmapPitch)
     , lightTables(lightTables)
     , lightTableSize(lightTableSize)
 {
@@ -439,7 +451,63 @@ Lightmap Lightmap::build(Point tilePosition, Point targetBufferPosition,
     const uint8_t *outBuffer, const uint8_t *lightTables, size_t lightTableSize)
 {
 	BuildLightmap(tilePosition, targetBufferPosition, viewportWidth, viewportHeight, rows, columns);
-	return Lightmap(outBuffer, LightmapBuffer.data(), lightTables, lightTableSize);
+	return Lightmap(outBuffer, LightmapBuffer, gnScreenWidth, lightTables, lightTableSize);
+}
+
+Lightmap Lightmap::bleedUp(const Lightmap &source, Point targetBufferPosition, std::span<uint8_t> lightmapBuffer)
+{
+	assert(lightmapBuffer.size() >= TILE_WIDTH * TILE_HEIGHT);
+
+	if (!*GetOptions().Graphics.perPixelLighting)
+		return source;
+
+	const int sourceHeight = static_cast<int>(source.lightmapBuffer.size() / source.lightmapPitch);
+	const int clipLeft = std::max(0, -targetBufferPosition.x);
+	const int clipTop = std::max(0, -(targetBufferPosition.y - TILE_HEIGHT + 1));
+	const int clipRight = std::max(0, targetBufferPosition.x + TILE_WIDTH - source.outPitch);
+	const int clipBottom = std::max(0, targetBufferPosition.y - sourceHeight + 1);
+
+	// Nothing we can do if the tile is completely outside the bounds of the lightmap
+	if (clipLeft + clipRight >= TILE_WIDTH)
+		return source;
+	if (clipTop + clipBottom >= TILE_HEIGHT)
+		return source;
+
+	const uint16_t lightmapPitch = std::max(0, TILE_WIDTH - clipLeft - clipRight);
+	const uint16_t lightmapHeight = TILE_HEIGHT - clipTop - clipBottom;
+
+	// Find the left edge of the last row in the tile
+	const int outOffset = std::max(0, (targetBufferPosition.y - clipBottom) * source.outPitch + targetBufferPosition.x + clipLeft);
+	const uint8_t *outLoc = source.outBuffer + outOffset;
+	const uint8_t *outBuffer = outLoc - (lightmapHeight - 1) * source.outPitch;
+
+	// Start copying bytes from the bottom row of the tile
+	const uint8_t *src = source.getLightingAt(outLoc);
+	uint8_t *dst = lightmapBuffer.data() + (lightmapHeight - 1) * lightmapPitch;
+
+	int rowCount = clipBottom;
+	while (src >= source.lightmapBuffer.data() && dst >= lightmapBuffer.data()) {
+		const int bleed = std::max(0, (rowCount - TILE_HEIGHT / 2) * 2);
+		const int lightOffset = std::max(bleed, clipLeft) - clipLeft;
+		const int lightLength = std::max(0, TILE_WIDTH - clipLeft - std::max(bleed, clipRight) - lightOffset);
+
+		// Bleed pixels up by copying data from the row below this one
+		if (rowCount > clipBottom && lightLength < lightmapPitch)
+			memcpy(dst, dst + lightmapPitch, lightmapPitch);
+
+		// Copy data from the source lightmap between the top edge of the base diamond
+		assert(dst + lightOffset + lightLength <= lightmapBuffer.data() + TILE_WIDTH * TILE_HEIGHT);
+		assert(src + lightOffset + lightLength <= LightmapBuffer.data() + LightmapBuffer.size());
+		memcpy(dst + lightOffset, src + lightOffset, lightLength);
+
+		src -= source.lightmapPitch;
+		dst -= lightmapPitch;
+		rowCount++;
+	}
+
+	return Lightmap(outBuffer, source.outPitch,
+	    lightmapBuffer, lightmapPitch,
+	    source.lightTables, source.lightTableSize);
 }
 
 } // namespace devilution

--- a/Source/engine/render/light_render.hpp
+++ b/Source/engine/render/light_render.hpp
@@ -1,12 +1,21 @@
 #pragma once
 
+#include <span>
+
 #include "engine/point.hpp"
 
 namespace devilution {
 
 class Lightmap {
 public:
-	explicit Lightmap(const uint8_t *outBuffer, const uint8_t *lightmapBuffer, const uint8_t *lightTables, size_t lightTableSize);
+	explicit Lightmap(const uint8_t *outBuffer, std::span<const uint8_t> lightmapBuffer, uint16_t pitch, const uint8_t *lightTables, size_t lightTableSize)
+	    : Lightmap(outBuffer, pitch, lightmapBuffer, pitch, lightTables, lightTableSize)
+	{
+	}
+
+	explicit Lightmap(const uint8_t *outBuffer, uint16_t outPitch,
+	    std::span<const uint8_t> lightmapBuffer, uint16_t lightmapPitch,
+	    const uint8_t *lightTables, size_t lightTableSize);
 
 	uint8_t adjustColor(uint8_t color, uint8_t lightLevel) const
 	{
@@ -16,16 +25,33 @@ public:
 
 	const uint8_t *getLightingAt(const uint8_t *outLoc) const
 	{
-		return lightmapBuffer + (outLoc - outBuffer);
+		const ptrdiff_t outDist = outLoc - outBuffer;
+		const ptrdiff_t rowOffset = outDist % outPitch;
+
+		if (outDist < 0) {
+			// In order to support "bleed up" for wall tiles,
+			// reuse the first row whenever outLoc is out of bounds
+			const int modOffset = rowOffset < 0 ? outPitch : 0;
+			return lightmapBuffer.data() + rowOffset + modOffset;
+		}
+
+		const ptrdiff_t row = outDist / outPitch;
+		return lightmapBuffer.data() + row * lightmapPitch + rowOffset;
 	}
 
 	static Lightmap build(Point tilePosition, Point targetBufferPosition,
 	    int viewportWidth, int viewportHeight, int rows, int columns,
 	    const uint8_t *outBuffer, const uint8_t *lightTables, size_t lightTableSize);
 
+	static Lightmap bleedUp(const Lightmap &source, Point targetBufferPosition, std::span<uint8_t> lightmapBuffer);
+
 private:
 	const uint8_t *outBuffer;
-	const uint8_t *lightmapBuffer;
+	const uint16_t outPitch;
+
+	std::span<const uint8_t> lightmapBuffer;
+	const uint16_t lightmapPitch;
+
 	const uint8_t *lightTables;
 	const size_t lightTableSize;
 };

--- a/test/dun_render_benchmark.cpp
+++ b/test/dun_render_benchmark.cpp
@@ -65,7 +65,7 @@ void InitOnce()
 void RunForTileMaskLight(benchmark::State &state, TileType tileType, MaskType maskType, const uint8_t *lightTable)
 {
 	Surface out = Surface(SdlSurface.get());
-	Lightmap lightmap(nullptr, nullptr, nullptr, 0);
+	Lightmap lightmap(nullptr, {}, 1, nullptr, 0);
 	size_t numItemsProcessed = 0;
 	const std::span<const LevelCelBlock> tiles = Tiles[tileType];
 	for (auto _ : state) {


### PR DESCRIPTION
This PR bleeds light up from the top edge of the base diamond to the top of wall/ceiling tiles, as described in #7809.

For this to work, we first need to copy light data for the base diamond of the wall tile from the per-pixel lightmap into a new 64x32 buffer. As we do this, we also compute where the top edge of the base diamond is so we can bleed data up from there to the top of the buffer. This new buffer becomes the source for light data used when rendering the base diamond. Then, when rendering the rest of the CEL data above the base diamond, we simply reuse the top row of the 64x32 buffer for every rendering instruction, allowing us to apply the same lighting to the rest of the graphic.

This effect really does make the lighting on walls and ceilings look remarkably similar to the tile-based lighting.

https://github.com/user-attachments/assets/ce30a181-f52e-40b6-a805-b1ca206236a8

Unfortunately, it does reintroduce some banding between ceiling tiles. The best way to resolve this is to differentiate between wall tiles and ceiling tiles, which will require some work to add additional tile properties and/or masks for each tile graphic. That will be outside the scope of this PR.

This resolves #7809