### PR TITLE
Use signed integers for interpolation in marching squares algorithm

### DIFF
--- a/Source/engine/render/light_render.cpp
+++ b/Source/engine/render/light_render.cpp
@@ -85,11 +85,13 @@ void RenderTriangle(Point p1, Point p2, Point p3, uint8_t lightLevel, uint8_t *l
 	}
 }
 
-uint8_t Interpolate(uint8_t q1, uint8_t q2, uint8_t lightLevel)
+uint8_t Interpolate(int q1, int q2, int lightLevel)
 {
 	// Result will be 28.4 fixed-point
-	uint8_t numerator = (lightLevel - q1) << 4;
-	return (numerator + 0x8) / (q2 - q1);
+	int numerator = (lightLevel - q1) << 4;
+	int result = (numerator + 0x8) / (q2 - q1);
+	assert(result >= 0);
+	return static_cast<uint8_t>(result);
 }
 
 void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *lightmap, uint16_t pitch, uint16_t scanLines)


### PR DESCRIPTION
Fixes aberrations in the light data around the saddle points in cases 5 and 10 of the marching squares algorithm. You can see it most clearly by casting Flame Wave, where the following visual effect will flicker onto the screen.

![image](https://github.com/user-attachments/assets/3678952f-eff0-4d49-b590-0f6f8c749b2d)

And in this image, you can see the `dLight` data that causes it. The light data goes a bit crazy around the saddle points (the space between tiles with with values 0 east/west and 5 north/south).

![image](https://github.com/user-attachments/assets/f4fb9ed1-ca32-4dd6-bfea-05b46508be15)