### PR TITLE
Don't assume output surface pitch is the same as width

### DIFF
--- a/Source/engine/render/light_render.cpp
+++ b/Source/engine/render/light_render.cpp
@@ -450,10 +450,11 @@ Lightmap::Lightmap(const uint8_t *outBuffer, uint16_t outPitch,
 
 Lightmap Lightmap::build(Point tilePosition, Point targetBufferPosition,
     int viewportWidth, int viewportHeight, int rows, int columns,
-    const uint8_t *outBuffer, const uint8_t *lightTables, size_t lightTableSize)
+    const uint8_t *outBuffer, uint16_t outPitch,
+    const uint8_t *lightTables, size_t lightTableSize)
 {
 	BuildLightmap(tilePosition, targetBufferPosition, viewportWidth, viewportHeight, rows, columns);
-	return Lightmap(outBuffer, LightmapBuffer, gnScreenWidth, lightTables, lightTableSize);
+	return Lightmap(outBuffer, outPitch, LightmapBuffer, gnScreenWidth, lightTables, lightTableSize);
 }
 
 Lightmap Lightmap::bleedUp(const Lightmap &source, Point targetBufferPosition, std::span<uint8_t> lightmapBuffer)
@@ -466,7 +467,7 @@ Lightmap Lightmap::bleedUp(const Lightmap &source, Point targetBufferPosition, s
 	const int sourceHeight = static_cast<int>(source.lightmapBuffer.size() / source.lightmapPitch);
 	const int clipLeft = std::max(0, -targetBufferPosition.x);
 	const int clipTop = std::max(0, -(targetBufferPosition.y - TILE_HEIGHT + 1));
-	const int clipRight = std::max(0, targetBufferPosition.x + TILE_WIDTH - source.outPitch);
+	const int clipRight = std::max(0, targetBufferPosition.x + TILE_WIDTH - source.lightmapPitch);
 	const int clipBottom = std::max(0, targetBufferPosition.y - sourceHeight + 1);
 
 	// Nothing we can do if the tile is completely outside the bounds of the lightmap
@@ -499,7 +500,7 @@ Lightmap Lightmap::bleedUp(const Lightmap &source, Point targetBufferPosition, s
 
 		// Copy data from the source lightmap between the top edge of the base diamond
 		assert(dst + lightOffset + lightLength <= lightmapBuffer.data() + TILE_WIDTH * TILE_HEIGHT);
-		assert(src + lightOffset + lightLength <= LightmapBuffer.data() + LightmapBuffer.size());
+		assert(src + lightOffset + lightLength <= source.lightmapBuffer.data() + source.lightmapBuffer.size());
 		memcpy(dst + lightOffset, src + lightOffset, lightLength);
 
 		src -= source.lightmapPitch;

--- a/Source/engine/render/light_render.hpp
+++ b/Source/engine/render/light_render.hpp
@@ -41,7 +41,8 @@ public:
 
 	static Lightmap build(Point tilePosition, Point targetBufferPosition,
 	    int viewportWidth, int viewportHeight, int rows, int columns,
-	    const uint8_t *outBuffer, const uint8_t *lightTables, size_t lightTableSize);
+	    const uint8_t *outBuffer, uint16_t outPitch,
+	    const uint8_t *lightTables, size_t lightTableSize);
 
 	static Lightmap bleedUp(const Lightmap &source, Point targetBufferPosition, std::span<uint8_t> lightmapBuffer);
 

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1133,7 +1133,7 @@ void DrawGame(const Surface &fullOut, Point position, Displacement offset)
 
 	Lightmap lightmap = Lightmap::build(position, Point {} + offset,
 	    gnScreenWidth, gnViewportHeight, rows, columns,
-	    out.at(0, 0), LightTables[0].data(), LightTables[0].size());
+	    out.at(0, 0), out.pitch(), LightTables[0].data(), LightTables[0].size());
 
 	DrawFloor(out, lightmap, position, Point {} + offset, rows, columns);
 	DrawTileContent(out, lightmap, position, Point {} + offset, rows, columns);


### PR DESCRIPTION
Fixes OOB errors that occur at 1146x480 resolution. The pitch of the output surface is 1148, not 1146.