### PR TITLE
Swap offsets in distance formula for light cones

### DIFF
--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -361,8 +361,8 @@ void MakeLightTable()
 		for (int offsetX = 0; offsetX < 8; offsetX++) {
 			for (int y = 0; y < 16; y++) {
 				for (int x = 0; x < 16; x++) {
-					int a = (8 * x - offsetY);
-					int b = (8 * y - offsetX);
+					int a = (8 * x - offsetX);
+					int b = (8 * y - offsetY);
 					LightConeInterpolations[offsetX][offsetY][x][y] = static_cast<uint8_t>(sqrt(a * a + b * b));
 				}
 			}


### PR DESCRIPTION
Compare the lighting for the Sarcophagus between these two videos.

Before:

https://github.com/user-attachments/assets/002564c0-0ddb-45c8-9328-edf3f3c3fbc0

After:

https://github.com/user-attachments/assets/5148b890-7e15-4760-b97d-6f6281fd7f71