### PR TITLE
Fix debug command for talking to towners

### DIFF
--- a/Source/lua/modules/dev/towners.cpp
+++ b/Source/lua/modules/dev/towners.cpp
@@ -76,7 +76,21 @@ std::string DebugCmdVisitTowner(std::string_view name)
 
 std::string DebugCmdTalkToTowner(std::string_view name)
 {
-	if (!DebugTalkToTowner(name)) return StrCat("Towner not found!");
+	if (name.empty()) {
+		std::string ret;
+		ret = StrCat("Please provide the name of a Towner: ");
+		for (const auto &[name, _] : TownerShortNameToTownerId) {
+			ret += ' ';
+			ret.append(name);
+		}
+		return ret;
+	}
+
+	auto it = TownerShortNameToTownerId.find(name);
+	if (it == TownerShortNameToTownerId.end())
+		return StrCat(name, " is invalid!");
+
+	if (!DebugTalkToTowner(it->second)) return StrCat("Towner not found!");
 	return StrCat("Opened ", name, " talk window.");
 }
 

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -93,7 +93,7 @@ void UpdateGirlAnimAfterQuestComplete();
 void UpdateCowFarmerAnimAfterQuestComplete();
 
 #ifdef _DEBUG
-bool DebugTalkToTowner(std::string_view targetName);
+bool DebugTalkToTowner(_talker_id type);
 #endif
 extern _speech_id QuestDialogTable[NUM_TOWNER_TYPES][MAXQUESTS];
 


### PR DESCRIPTION
`DebugTalkToTowner()` is currently no longer able to find any towners at all. This is because it searches by towner name, but `townerData.init()` doesn't populate `towner.name`. It needs to invoke `InitTownerInfo()`, but it can't do that since that function requires us to pass an index to the `Towners` array.

Incidentally, the `DebugCmdVisitTowner()` function uses a lookup table to find towners not only by name, but also by shortened descriptions such as `smith`, `witch`, or `bmaid`. The only downside is that it's not case-insensitive, but I figure someone can add that if they need it.

This PR splits the `InitTownerInfo()` function in two so that `DebugTalkToTowner()` can pass a `Towner` instance that is not a member of the `Towners` array. It also updates `DebugCmdTalkToTowner()` to use the same logic as `DebugCmdVisitTowner()` to make the towner search logic a bit more consistent.