### PR TITLE
Cap Resolution

### DIFF
--- a/Source/options.h
+++ b/Source/options.h
@@ -351,10 +351,7 @@ public:
 	[[nodiscard]] size_t GetActiveListIndex() const override;
 	void SetActiveListIndex(size_t index) override;
 
-	void setAvailableResolutions(std::vector<std::pair<Size, std::string>> &&resolutions)
-	{
-		resolutions_ = std::move(resolutions);
-	}
+	void setAvailableResolutions(std::vector<std::pair<Size, std::string>> &&resolutions);
 
 	Size operator*() const { return size_; }
 


### PR DESCRIPTION
Cap screen resolution so that width cannot exceed 1280 and height cannot exceed 720 in order to prevent players from utilizing resolution as a meta gameplay strategy.