### PR TITLE
More consistent gamepad context sensitivity

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2044,7 +2044,7 @@ void InitPadmapActions()
 				    QuickCast(i);
 		    },
 		    nullptr,
-		    CanPlayerTakeAction,
+		    []() { return CanPlayerTakeAction() && !InGameMenu(); },
 		    i + 1);
 	}
 	options.Padmapper.AddAction(
@@ -2091,7 +2091,7 @@ void InitPadmapActions()
 		    ControllerActionHeld = GameActionType_NONE;
 		    LastMouseButtonAction = MouseActionType::None;
 	    },
-	    CanPlayerTakeAction);
+	    []() { return CanPlayerTakeAction() && !InGameMenu(); });
 	options.Padmapper.AddAction(
 	    "CancelAction",
 	    N_("Cancel action"),
@@ -2179,7 +2179,9 @@ void InitPadmapActions()
 	    ControllerButton_AXIS_TRIGGERLEFT,
 	    [] {
 		    ProcessGameAction(GameAction { GameActionType_TOGGLE_CHARACTER_INFO });
-	    });
+	    },
+	    nullptr,
+	    []() { return CanPlayerTakeAction() && !InGameMenu(); });
 	options.Padmapper.AddAction(
 	    "Inventory",
 	    N_("Inventory"),
@@ -2189,7 +2191,7 @@ void InitPadmapActions()
 		    ProcessGameAction(GameAction { GameActionType_TOGGLE_INVENTORY });
 	    },
 	    nullptr,
-	    CanPlayerTakeAction);
+	    []() { return CanPlayerTakeAction() && !InGameMenu(); });
 	options.Padmapper.AddAction(
 	    "QuestLog",
 	    N_("Quest log"),
@@ -2199,7 +2201,7 @@ void InitPadmapActions()
 		    ProcessGameAction(GameAction { GameActionType_TOGGLE_QUEST_LOG });
 	    },
 	    nullptr,
-	    CanPlayerTakeAction);
+	    []() { return CanPlayerTakeAction() && !InGameMenu(); });
 	options.Padmapper.AddAction(
 	    "SpellBook",
 	    N_("Spellbook"),
@@ -2209,7 +2211,7 @@ void InitPadmapActions()
 		    ProcessGameAction(GameAction { GameActionType_TOGGLE_SPELL_BOOK });
 	    },
 	    nullptr,
-	    CanPlayerTakeAction);
+	    []() { return CanPlayerTakeAction() && !InGameMenu(); });
 	options.Padmapper.AddAction(
 	    "DisplaySpells",
 	    N_("Speedbook"),
@@ -2219,7 +2221,7 @@ void InitPadmapActions()
 		    ProcessGameAction(GameAction { GameActionType_TOGGLE_QUICK_SPELL_MENU });
 	    },
 	    nullptr,
-	    CanPlayerTakeAction);
+	    []() { return CanPlayerTakeAction() && !InGameMenu(); });
 	options.Padmapper.AddAction(
 	    "Toggle Automap",
 	    N_("Toggle automap"),


### PR DESCRIPTION
This PR aligns the order of operations between `GetLeftStickOrDPadGameUIHandler()`, `PerformPrimaryAction()`, `PerformSecondaryAction()`, and `PerformSpellAction()` so that menu interactions work more consistently when multiple menus are open. As an example, if you managed to get the inventory and the speedbook open at the same time, gamepad would interact with the inventory but the info panel would only show the spell from the speedbook you happened to be hovering over. As another example, if you managed to get the char panel and speedbook open at the same time with stat points to distribute, the d-pad and analog stick would prioritize the char panel whereas the primary action button would prioritize the speedbook.

The PR also disables various padmapper actions when game menus are open. For example, you can no longer open and close the inventory while browsing a towner's store menus.