### PR TITLE
Don't darken flame wave after it reaches full brightness

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3384,7 +3384,8 @@ void ProcessFlashTop(Missile &missile)
 
 void ProcessFlameWave(Missile &missile)
 {
-	constexpr int ExpLight[14] = { 2, 3, 4, 5, 5, 6, 7, 8, 9, 10, 11, 12, 12 };
+	constexpr int ExpLightLen = 12;
+	constexpr int ExpLight[ExpLightLen] = { 2, 3, 4, 5, 5, 6, 7, 8, 9, 10, 11, 12 };
 
 	// Adjust missile's position for processing
 	missile.position.tile += Direction::North;
@@ -3402,18 +3403,12 @@ void ProcessFlameWave(Missile &missile)
 	if (missile.duration == 0) {
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
-	}
-	if (missile._mimfnum != 0 || missile.duration == 0) {
-		if (missile.position.tile != Point { missile.var3, missile.var4 }) {
-			missile.var3 = missile.position.tile.x;
-			missile.var4 = missile.position.tile.y;
-			ChangeLight(missile._mlid, missile.position.tile, 8);
-		}
 	} else {
 		if (missile.var2 == 0)
 			missile._mlid = AddLight(missile.position.tile, ExpLight[0]);
 		ChangeLight(missile._mlid, missile.position.tile, ExpLight[missile.var2]);
-		missile.var2++;
+		if (missile.var2 < ExpLightLen - 1)
+			missile.var2++;
 	}
 	// Adjust missile's position for rendering
 	missile.position.tile += Direction::South;


### PR DESCRIPTION
This PR fixes the light radius of Flame Wave missiles which was inexplicably hardcoded to 8 despite the missile having already reached a light radius of 12. I also removed the logic that uses `var3` and `var4` to limit the frequency at which Flame Wave lights update their position, since I don't think we need it anymore now that the light jitter was fixed.

The following video, shared by @FitzRoyX on Discord, demonstrates how the wall gets darker in the middle of the spell despite the wall of flame continuously moving closer to the wall.

https://github.com/user-attachments/assets/ddb31cc7-fa72-47de-83fb-31506d6c5bd7