### PR TITLE
Check for MonsterMode::Death in isPossibleToHit()

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4785,7 +4785,7 @@ bool Monster::isPossibleToHit() const
 	return !(hitPoints >> 6 <= 0
 	    || talkMsg != TEXT_NONE
 	    || (type().type == MT_ILLWEAV && goal == MonsterGoal::Retreat)
-	    || mode == MonsterMode::Charge
+	    || (IsAnyOf(mode, MonsterMode::Charge, MonsterMode::Death))
 	    || (IsAnyOf(type().type, MT_COUNSLR, MT_MAGISTR, MT_CABALIST, MT_ADVOCATE) && goal != MonsterGoal::Normal));
 }
 


### PR DESCRIPTION
Recently a team of four reported on Discord there was a Blood Knight in their game that was still alive after Diablo was eliminated.

![image](https://github.com/user-attachments/assets/f0b3980b-43ba-421a-9625-75ca49630e5a)

`DiabloDeath()` only updates the monster's animation and mode, but not hitpoints. The game stops calling `ProcessPlayers()`, but `ProcessMissiles()` should still be active. So my theory is that if a stray missile happens to hit the Blood Knight while Diablo is bleeding out, it could engage hit recovery which would override the animation and mode of the monster.

It seems reasonable to include `MonsterMode::Death` in the `isPossibleToHit()` function to prevent missiles from hitting monsters that were killed by `DiabloDeath()`. Monsters that were killed by other means should probably also not be possible to hit.