### PR TITLE
Stores - Unhardcode shop values

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4391,10 +4391,10 @@ void SpawnSmith(int lvl)
 	constexpr int PinnedItemCount = 0;
 
 	int maxValue = MaxVendorValue;
-	int maxItems = 19;
+	int maxItems = NumSmithBasicItems;
 	if (gbIsHellfire) {
 		maxValue = MaxVendorValueHf;
-		maxItems = 24;
+		maxItems = NumSmithBasicItemsHf;
 	}
 
 	int iCnt = RandomIntBetween(10, maxItems);
@@ -4412,7 +4412,7 @@ void SpawnSmith(int lvl)
 		newItem._iCreateInfo = lvl | CF_SMITH;
 		newItem._iIdentified = true;
 	}
-	for (int i = iCnt; i < SMITH_ITEMS; i++)
+	for (int i = iCnt; i < NumSmithBasicItemsHf; i++)
 		SmithItems[i].clear();
 
 	SortVendor(SmithItems + PinnedItemCount);
@@ -4421,7 +4421,7 @@ void SpawnSmith(int lvl)
 void SpawnPremium(const Player &player)
 {
 	int lvl = player.getCharacterLevel();
-	int maxItems = gbIsHellfire ? SMITH_PREMIUM_ITEMS : 6;
+	int maxItems = gbIsHellfire ? NumSmithItemsHf : NumSmithItems;
 	if (PremiumItemCount < maxItems) {
 		for (int i = 0; i < maxItems; i++) {
 			if (PremiumItems[i].isEmpty()) {
@@ -4453,17 +4453,17 @@ void SpawnPremium(const Player &player)
 
 void SpawnWitch(int lvl)
 {
-	constexpr int PinnedItemCount = 3;
+	constexpr int PinnedItemCount = NumWitchPinnedItems;
 	constexpr std::array<_item_indexes, PinnedItemCount> PinnedItemTypes = { IDI_MANA, IDI_FULLMANA, IDI_PORTAL };
 	constexpr int MaxPinnedBookCount = 4;
 	constexpr std::array<_item_indexes, MaxPinnedBookCount> PinnedBookTypes = { IDI_BOOK1, IDI_BOOK2, IDI_BOOK3, IDI_BOOK4 };
 
 	int bookCount = 0;
 	const int pinnedBookCount = gbIsHellfire ? RandomIntLessThan(MaxPinnedBookCount) : 0;
-	const int itemCount = RandomIntBetween(10, gbIsHellfire ? 24 : 17);
+	const int itemCount = RandomIntBetween(10, gbIsHellfire ? NumWitchItemsHf : NumWitchItems);
 	const int maxValue = gbIsHellfire ? MaxVendorValueHf : MaxVendorValue;
 
-	for (int i = 0; i < WITCH_ITEMS; i++) {
+	for (int i = 0; i < NumWitchItemsHf; i++) {
 		Item &item = WitchItems[i];
 		item = {};
 
@@ -4634,15 +4634,15 @@ void SpawnBoy(int lvl)
 
 void SpawnHealer(int lvl)
 {
-	constexpr size_t PinnedItemCount = 2;
+	constexpr size_t PinnedItemCount = NumHealerPinnedItems;
 	constexpr std::array<_item_indexes, PinnedItemCount + 1> PinnedItemTypes = { IDI_HEAL, IDI_FULLHEAL, IDI_RESURRECT };
-	const auto itemCount = static_cast<size_t>(RandomIntBetween(10, gbIsHellfire ? 19 : 17));
+	const auto itemCount = static_cast<size_t>(RandomIntBetween(10, gbIsHellfire ? NumHealerItemsHf : NumHealerItems));
 
 	for (size_t i = 0; i < sizeof(HealerItems) / sizeof(HealerItems[0]); ++i) {
 		Item &item = HealerItems[i];
 		item = {};
 
-		if (i < PinnedItemCount || (gbIsMultiplayer && i == PinnedItemCount)) {
+		if (i < PinnedItemCount || (gbIsMultiplayer && i < NumHealerPinnedItemsMp)) {
 			item._iSeed = AdvanceRndSeed();
 			GetItemAttrs(item, PinnedItemTypes[i], 1);
 			item._iCreateInfo = lvl;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -40,14 +40,14 @@ int CurrentItemIndex;
 int8_t PlayerItemIndexes[48];
 Item PlayerItems[48];
 
-Item SmithItems[SMITH_ITEMS];
+Item SmithItems[NumSmithBasicItemsHf];
 int PremiumItemCount;
 int PremiumItemLevel;
-Item PremiumItems[SMITH_PREMIUM_ITEMS];
+Item PremiumItems[NumSmithItemsHf];
 
 Item HealerItems[20];
 
-Item WitchItems[WITCH_ITEMS];
+Item WitchItems[NumWitchItemsHf];
 
 int BoyItemLevel;
 Item BoyItem;
@@ -100,7 +100,7 @@ struct STextStruct {
 };
 
 /** Text lines */
-STextStruct TextLine[STORE_LINES];
+STextStruct TextLine[NumStoreLines];
 
 /** Whether to render the player's gold amount in the top left */
 bool RenderGold;
@@ -180,7 +180,7 @@ void CalculateLineHeights()
 {
 	TextLine[0].y = 0;
 	if (IsSmallFontTall()) {
-		for (int i = 1; i < STORE_LINES; ++i) {
+		for (int i = 1; i < NumStoreLines; ++i) {
 			// Space out consecutive text lines, unless they are both selectable (never the case currently).
 			if (TextLine[i].hasText() && TextLine[i - 1].hasText() && !(TextLine[i].isSelectable() && TextLine[i - 1].isSelectable())) {
 				TextLine[i].y = TextLine[i - 1].y + LargeTextHeight;
@@ -189,7 +189,7 @@ void CalculateLineHeights()
 			}
 		}
 	} else {
-		for (int i = 1; i < STORE_LINES; ++i) {
+		for (int i = 1; i < NumStoreLines; ++i) {
 			TextLine[i].y = i * SmallLineHeight;
 		}
 	}
@@ -1322,8 +1322,8 @@ void SmithBuyItem(Item &item)
 		item._iIdentified = false;
 	StoreAutoPlace(item, true);
 	int idx = OldScrollPos + ((OldTextLine - PreviousScrollPos) / 4);
-	if (idx == SMITH_ITEMS - 1) {
-		SmithItems[SMITH_ITEMS - 1].clear();
+	if (idx == NumSmithBasicItemsHf - 1) {
+		SmithItems[NumSmithBasicItemsHf - 1].clear();
 	} else {
 		for (; !SmithItems[idx + 1].isEmpty(); idx++) {
 			SmithItems[idx] = std::move(SmithItems[idx + 1]);
@@ -1574,8 +1574,8 @@ void WitchBuyItem(Item &item)
 	StoreAutoPlace(item, true);
 
 	if (idx >= 3) {
-		if (idx == WITCH_ITEMS - 1) {
-			WitchItems[WITCH_ITEMS - 1].clear();
+		if (idx == NumWitchItemsHf - 1) {
+			WitchItems[NumWitchItemsHf - 1].clear();
 		} else {
 			for (; !WitchItems[idx + 1].isEmpty(); idx++) {
 				WitchItems[idx] = std::move(WitchItems[idx + 1]);
@@ -2114,7 +2114,7 @@ void AddStoreHoldRepair(Item *itm, int8_t i)
 
 void InitStores()
 {
-	ClearSText(0, STORE_LINES);
+	ClearSText(0, NumStoreLines);
 	ActiveStore = TalkID::None;
 	IsTextFullSize = false;
 	HasScrollbar = false;
@@ -2264,7 +2264,7 @@ void StartStore(TalkID s)
 	RenderGold = false;
 	QuestLogIsOpen = false;
 	CloseGoldDrop();
-	ClearSText(0, STORE_LINES);
+	ClearSText(0, NumStoreLines);
 	ReleaseStoreBtn();
 	switch (s) {
 	case TalkID::Smith:
@@ -2357,7 +2357,7 @@ void StartStore(TalkID s)
 	}
 
 	CurrentTextLine = -1;
-	for (int i = 0; i < STORE_LINES; i++) {
+	for (int i = 0; i < NumStoreLines; i++) {
 		if (TextLine[i].isSelectable()) {
 			CurrentTextLine = i;
 			break;
@@ -2402,7 +2402,7 @@ void DrawSText(const Surface &out)
 
 	CalculateLineHeights();
 	const Point uiPosition = GetUIRectangle().position;
-	for (int i = 0; i < STORE_LINES; i++) {
+	for (int i = 0; i < NumStoreLines; i++) {
 		if (TextLine[i].isDivider())
 			DrawSLine(out, uiPosition.y + PaddingTop + TextLine[i].y + TextHeight() / 2);
 		else if (TextLine[i].hasText())
@@ -2510,7 +2510,7 @@ void StoreUp()
 		CurrentTextLine--;
 		while (!TextLine[CurrentTextLine].isSelectable()) {
 			if (CurrentTextLine == 0)
-				CurrentTextLine = STORE_LINES - 1;
+				CurrentTextLine = NumStoreLines - 1;
 			else
 				CurrentTextLine--;
 		}
@@ -2518,13 +2518,13 @@ void StoreUp()
 	}
 
 	if (CurrentTextLine == 0)
-		CurrentTextLine = STORE_LINES - 1;
+		CurrentTextLine = NumStoreLines - 1;
 	else
 		CurrentTextLine--;
 
 	while (!TextLine[CurrentTextLine].isSelectable()) {
 		if (CurrentTextLine == 0)
-			CurrentTextLine = STORE_LINES - 1;
+			CurrentTextLine = NumStoreLines - 1;
 		else
 			CurrentTextLine--;
 	}
@@ -2546,7 +2546,7 @@ void StoreDown()
 
 		CurrentTextLine++;
 		while (!TextLine[CurrentTextLine].isSelectable()) {
-			if (CurrentTextLine == STORE_LINES - 1)
+			if (CurrentTextLine == NumStoreLines - 1)
 				CurrentTextLine = 0;
 			else
 				CurrentTextLine++;
@@ -2554,13 +2554,13 @@ void StoreDown()
 		return;
 	}
 
-	if (CurrentTextLine == STORE_LINES - 1)
+	if (CurrentTextLine == NumStoreLines - 1)
 		CurrentTextLine = 0;
 	else
 		CurrentTextLine++;
 
 	while (!TextLine[CurrentTextLine].isSelectable()) {
-		if (CurrentTextLine == STORE_LINES - 1)
+		if (CurrentTextLine == NumStoreLines - 1)
 			CurrentTextLine = 0;
 		else
 			CurrentTextLine++;
@@ -2745,7 +2745,7 @@ void CheckStoreBtn()
 		int y = relativeY / LineHeight();
 
 		// Large small fonts draw beyond LineHeight. Check if the click was on the overflow text.
-		if (IsSmallFontTall() && y > 0 && y < STORE_LINES
+		if (IsSmallFontTall() && y > 0 && y < NumStoreLines
 		    && TextLine[y - 1].hasText() && !TextLine[y].hasText()
 		    && relativeY < TextLine[y - 1].y + LargeTextHeight) {
 			--y;

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -17,10 +17,22 @@
 
 namespace devilution {
 
-#define WITCH_ITEMS 25
-#define SMITH_ITEMS 25
-#define SMITH_PREMIUM_ITEMS 15
-#define STORE_LINES 104
+constexpr int NumSmithBasicItems = 19;
+constexpr int NumSmithBasicItemsHf = 24;
+
+constexpr int NumSmithItems = 6;
+constexpr int NumSmithItemsHf = 15;
+
+constexpr int NumHealerItems = 17;
+constexpr int NumHealerItemsHf = 19;
+constexpr int NumHealerPinnedItems = 2;
+constexpr int NumHealerPinnedItemsMp = 3;
+
+constexpr int NumWitchItems = 17;
+constexpr int NumWitchItemsHf = 24;
+constexpr int NumWitchPinnedItems = 3;
+
+constexpr int NumStoreLines = 104;
 
 enum class TalkID : uint8_t {
 	None,
@@ -60,19 +72,19 @@ extern int8_t PlayerItemIndexes[48];
 extern DVL_API_FOR_TEST Item PlayerItems[48];
 
 /** Items sold by Griswold */
-extern Item SmithItems[SMITH_ITEMS];
+extern Item SmithItems[NumSmithBasicItemsHf];
 /** Number of premium items for sale by Griswold */
 extern int PremiumItemCount;
 /** Base level of current premium items sold by Griswold */
 extern int PremiumItemLevel;
 /** Premium items sold by Griswold */
-extern Item PremiumItems[SMITH_PREMIUM_ITEMS];
+extern Item PremiumItems[NumSmithItemsHf];
 
 /** Items sold by Pepin */
 extern Item HealerItems[20];
 
 /** Items sold by Adria */
-extern Item WitchItems[WITCH_ITEMS];
+extern Item WitchItems[NumWitchItemsHf];
 
 /** Current level of the item sold by Wirt */
 extern int BoyItemLevel;


### PR DESCRIPTION
Use constexpr instead of #define, and unhardcode values used in towner stores.

Note: You may notice that the some define's numbers don't match (e.g. 24 instead of 25), however the game used the hardcoded integer values as rules for how many items end up populating for the player, making the values of the respective defines pointless when exceeding the hardcoded values. (Look at how the witch will attempt to spawn a 25th item, but then immediately discard it)