### PR TITLE
Efficiently pack re-encoded level cel blocks

### DIFF
--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -524,11 +524,12 @@ void SetDungeonMicros()
 		uint16_t *pieces = &levelPieces[blocks * levelPieceId];
 		for (uint32_t block = 0; block < blocks; block++) {
 			const LevelCelBlock levelCelBlock { SDL_SwapLE16(pieces[blocks - 2 + (block & 1) - (block & 0xE)]) };
-			DPieceMicros[levelPieceId].mt[block] = levelCelBlock;
+			LevelCelBlock &mt = DPieceMicros[levelPieceId].mt[block];
+			mt = levelCelBlock;
 			if (levelCelBlock.hasValue()) {
 				if (const auto it = frameToTypeMap.find(levelCelBlock.frame()); it == frameToTypeMap.end()) {
 					frameToTypeMap.emplace_hint(it, levelCelBlock.frame(),
-					    DunFrameInfo { static_cast<uint8_t>(block), levelCelBlock.type(), SOLData[levelPieceId] });
+					    DunFrameInfo { static_cast<uint8_t>(block), levelCelBlock.type(), SOLData[levelPieceId], &mt.data });
 				}
 			}
 		}
@@ -538,6 +539,7 @@ void SetDungeonMicros()
 		return a.first < b.first;
 	});
 	ReencodeDungeonCels(pDungeonCels, frameToTypeList);
+	ReindexCelBlocks(frameToTypeList);
 }
 
 void DRLG_InitTrans()

--- a/Source/levels/reencode_dun_cels.hpp
+++ b/Source/levels/reencode_dun_cels.hpp
@@ -17,6 +17,8 @@ struct DunFrameInfo {
 	TileType type;
 	TileProperties properties;
 
+	uint16_t *celBlockData;
+
 	[[nodiscard]] bool isFloor() const
 	{
 		// The BlockMissile check is for stairs in L3 and L4, e.g. tile 46 sub-tile 141 frame 386 in L4.
@@ -35,5 +37,13 @@ struct DunFrameInfo {
  * This reduces memory usage and simplifies the rendering.
  */
 void ReencodeDungeonCels(std::unique_ptr<std::byte[]> &dungeonCels, std::span<std::pair<uint16_t, DunFrameInfo>> frames);
+
+/**
+ * @brief Adjusts frame indexes in cel block data.
+ *
+ * Re-encoding the dungeon cels removes frames that are not referenced.
+ * Indexes must also be adjusted to avoid errors when doing lookups.
+ */
+void ReindexCelBlocks(std::span<std::pair<uint16_t, DunFrameInfo>> frames);
 
 } // namespace devilution


### PR DESCRIPTION
This PR adjusts the logic for re-encoding cel blocks to completely remove all traces of unused frame indexes.

This also resolves errors where data will be reencoded incorrectly when frames are not referenced by the tile data. Consider the following example where I replaced tile 393 in the spritesheet...

> Tile 393 originally referenced frames 0x3ff through 0x402, inclusive. By replacing the tile, I added new frames on the end of the spritesheet, 0x460 through 0x463. Because tile 393 was the only tile that referenced 0x401 and 0x402, there are no longer any references to those frames in `l1.min`.
> 
> `ReencodeDungeonCels()` was using `frame * 4` to compute the position for each address in the lookup table, but it used `frames.size()` to compute the size of the lookup table. This means that most lookups based on `DPieceMicros` were actually correct, but the address for 0x462 was overwritten by the address of EOF, and the address for 0x463 was overwriting the first four bytes of the rendering data.