### PR TITLE
Use existing fn for Spell Book Trans matching Skill

### DIFF
--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -89,7 +89,7 @@ void PrintSBookStr(const Surface &out, Point position, std::string_view text, Ui
 SpellType GetSBookTrans(SpellID ii, bool townok)
 {
 	Player &player = *InspectPlayer;
-	if (ii == GetPlayerStartingLoadoutForClass(InspectPlayer->_pClass).skill)
+	if (ii == GetPlayerStartingLoadoutForClass(player._pClass).skill)
 		return SpellType::Skill;
 	SpellType st = SpellType::Spell;
 	if ((player._pISpells & GetSpellBitmask(ii)) != 0) {

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -89,7 +89,7 @@ void PrintSBookStr(const Surface &out, Point position, std::string_view text, Ui
 SpellType GetSBookTrans(SpellID ii, bool townok)
 {
 	Player &player = *InspectPlayer;
-	if ((player._pClass == HeroClass::Monk) && (ii == SpellID::Search))
+	if (ii == GetPlayerStartingLoadoutForClass(InspectPlayer->_pClass).skill)
 		return SpellType::Skill;
 	SpellType st = SpellType::Spell;
 	if ((player._pISpells & GetSpellBitmask(ii)) != 0) {


### PR DESCRIPTION
Use the Starting Loadout table to color a Spell Book spell as a skill if it matches the player's skill