### PR TITLE
Fix dropped unique item synchronisation bug

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1873,8 +1873,9 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 	if (ActiveItemCount >= MAXITEMS)
 		return -1;
 
-	Item item;
+	Item item = {};
 
+	item.dwBuff = ibuff;
 	RecreateItem(*MyPlayer, item, idx, icreateinfo, iseed, ivalue, (ibuff & CF_HELLFIRE) != 0);
 	if (id != 0)
 		item._iIdentified = true;
@@ -1886,7 +1887,6 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 		item._iPLToHit = ClampToHit(item, toHit);
 		item._iMaxDam = ClampMaxDam(item, maxDam);
 	}
-	item.dwBuff = ibuff;
 
 	return PlaceItemInWorld(std::move(item), position);
 }


### PR DESCRIPTION
Hello,

This is just a small fix-up of network synchronisation code and a use of an uninitialised variable, which is most likely only noticeable now due to the new unique item generation code introduced in https://github.com/diasurgical/DevilutionX/pull/7060. 

Basically, on the receiving system, dropped items temporarily morph until the save is reloaded. The reason is that RecreateItem() tries to extract uidOffset from item.dwBuff. Since item.dwBuff was never initialised in SyncDropItem() before the call to RecreateItem(), a Xorine's Ring would morph into a Ring of Thunder temporarily on my system.

The fix is simple, and simply moves initialisation of item.dwBuff to before the call. I have attached a character file with Bramble and Xorine's Ring in the inventory for you to test.

Thanks,
Yggdrasill