### PR TITLE
Reindex all level cel blocks

### DIFF
--- a/Source/levels/reencode_dun_cels.hpp
+++ b/Source/levels/reencode_dun_cels.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <span>
 #include <utility>
+#include <vector>
 
 #include "levels/dun_tile.hpp"
 
@@ -16,8 +17,6 @@ struct DunFrameInfo {
 
 	TileType type;
 	TileProperties properties;
-
-	uint16_t *celBlockData;
 
 	[[nodiscard]] bool isFloor() const
 	{
@@ -39,11 +38,11 @@ struct DunFrameInfo {
 void ReencodeDungeonCels(std::unique_ptr<std::byte[]> &dungeonCels, std::span<std::pair<uint16_t, DunFrameInfo>> frames);
 
 /**
- * @brief Adjusts frame indexes in cel block data.
+ * @brief Computes adjustments to apply to frame indexes in cel block data.
  *
  * Re-encoding the dungeon cels removes frames that are not referenced.
  * Indexes must also be adjusted to avoid errors when doing lookups.
  */
-void ReindexCelBlocks(std::span<std::pair<uint16_t, DunFrameInfo>> frames);
+std::vector<std::pair<uint16_t, uint16_t>> ComputeCelBlockAdjustments(std::span<std::pair<uint16_t, DunFrameInfo>> frames);
 
 } // namespace devilution


### PR DESCRIPTION
Follow-up to fix an issue with #7852

It occurred to me that frames may be referenced by multiple tiles, and therefore one pointer per frame is not going to be enough to reindex all the references to that frame in `DPieceMicros`. If the unreferenced frames precede a frame that is referenced more than once in the min file, there will still be at least one reference in `DPieceMicros` that wasn't properly reindexed.

I removed the pointer from `DunFrameInfo`. We can still compute the adjustment values based on the sorted vector of frames, but we need to scan all the active blocks in `DPieceMicros` to find the ones that need to be reindexed. To make it work, I generate a sparse vector of "frame index gaps" that can be used to find the adjustment value for a given frame index using a binary search. This also enables us to detect when there are no gaps at all, skipping the reindexing step in the most common case where every frame is used by at least one tile.