### PR TITLE
Allow 1.09 Missing Logic in Hellfire

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -206,13 +206,11 @@ void StartRangeAttack(Player &player, Direction d, WorldTileCoord cx, WorldTileC
 	int8_t skippedAnimationFrames = 0;
 	const auto flags = player._pIFlags;
 
-	if (!gbIsHellfire) {
-		if (includesFirstFrame && HasAnyOf(flags, ItemSpecialEffect::QuickAttack | ItemSpecialEffect::FastAttack)) {
-			skippedAnimationFrames += 1;
-		}
-		if (HasAnyOf(flags, ItemSpecialEffect::FastAttack)) {
-			skippedAnimationFrames += 1;
-		}
+	if (includesFirstFrame && HasAnyOf(flags, ItemSpecialEffect::QuickAttack | ItemSpecialEffect::FastAttack)) {
+		skippedAnimationFrames += 1;
+	}
+	if (HasAnyOf(flags, ItemSpecialEffect::FastAttack)) {
+		skippedAnimationFrames += 1;
 	}
 
 	auto animationFlags = AnimationDistributionFlags::ProcessAnimationPending;


### PR DESCRIPTION
Allows for "Readiness and Swiftness" Bows in Hellfire to match their Diablo counterparts without removing the increased arrow velocity introduced in Hellfire.

The reason this logic is missing in Hellfire is because due to programming oversights at the time Hellfire was developed within Diablo 1.04. We've made changes in DevilutionX similar to this type of change already, unifying behavior between Diablo and Hellfire.

# Diablo 1.04 + Hellfire -VS- Diablo 1.09 -VS- DevilutionX

## Mana Shield
**Diablo 1.04:** Formula was backwards, resulting in a loss of efficiency with increased Spell Level
**Hellfire:** Bug wasn't noticed, and remained
**Diablo 1.09:** Bug was sloppily fixed by forcing max damage reduction at any Spell Level
**DevilutionX:** Behavior unified; 1.04 formula was reversed and correct bugfix applied

## Hit Recovery
**Diablo 1.04:** Logic was entirely absent
**Hellfire:** Added frame skipping logic
**Diablo 1.09:** Added frame skipping logic, but differently than Hellfire, creating the "Zen" exploit
**DevilutionX:** Behavior unified and Zen exploit was removed

## Increased Attack Speed
**Diablo 1.04:** Logic was entirely absent
**Hellfire:** Added increased arrow velocity
**Diablo 1.09:** Added the missing logic, matching both the affix description and mirroring the logic from melee IAS (frame skipping)
**DevilutionX:** Left it as-is

As you can see, increased arrow velocity was not intended to remove 1.09 frame skipping logic, because it never existed at the time, a known bug. I don't believe the behavior should be fully unified, because the increased arrow velocity itself is an intended added feature by Sierra. Both the 1.09 logic and Hellfire logic working in tandem doesn't necessarily create a situation where the affix power becomes overpowered. Re-inserting this logic into DevilutionX Hellfire doesn't involve overwriting original Hellfire logic, so it's a safe bet. The 1.09 frame skipping logic missing from Hellfire has overall been a turn-off for Rogue players playing Hellfire, making the Swiftness Bow virtually useless.