### PR TITLE
Play the sound of the item we're pasting, not what we picked up

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -573,6 +573,10 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 			return;
 	}
 
+	if (&player == MyPlayer) {
+		PlaySFX(ItemInvSnds[ItemCAnimTbl[player.HoldItem._iCurs]]);
+	}
+
 	// Select the parameters that go into
 	// ChangeEquipment and add it to post switch
 	switch (location) {
@@ -601,7 +605,6 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 
 	CalcPlrInv(player, true);
 	if (&player == MyPlayer) {
-		PlaySFX(ItemInvSnds[ItemCAnimTbl[player.HoldItem._iCurs]]);
 		NewCursor(player.HoldItem);
 	}
 }


### PR DESCRIPTION
fixes #7831 

Queuing the sound before performing the paste ensures that the correct sound plays even if swapping with an item already in the inv/body (which would change the held item). This matches vanilla behaviour/stash behaviour