### PR TITLE
Make RecreateItem() take whole dwBuff flag as argument

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1886,7 +1886,6 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 		item._iPLToHit = ClampToHit(item, toHit);
 		item._iMaxDam = ClampMaxDam(item, maxDam);
 	}
-	item.dwBuff = ibuff;
 
 	return PlaceItemInWorld(std::move(item), position);
 }

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1875,7 +1875,7 @@ int SyncDropItem(Point position, _item_indexes idx, uint16_t icreateinfo, int is
 
 	Item item;
 
-	RecreateItem(*MyPlayer, item, idx, icreateinfo, iseed, ivalue, (ibuff & CF_HELLFIRE) != 0);
+	RecreateItem(*MyPlayer, item, idx, icreateinfo, iseed, ivalue, ibuff);
 	if (id != 0)
 		item._iIdentified = true;
 	item._iMaxDur = mdur;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3512,7 +3512,8 @@ void CreateTypeItem(Point position, bool onlygood, ItemType itemType, int imisc,
 void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t icreateinfo, uint32_t iseed, int ivalue, uint32_t dwBuff)
 {
 	bool tmpIsHellfire = gbIsHellfire;
-	gbIsHellfire = dwBuff & CF_HELLFIRE;
+	item.dwBuff = dwBuff;
+	gbIsHellfire = item.dwBuff & CF_HELLFIRE;
 
 	if (idx == IDI_GOLD) {
 		InitializeItem(item, IDI_GOLD);
@@ -3556,7 +3557,7 @@ void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t 
 	bool onlygood = (icreateinfo & CF_ONLYGOOD) != 0;
 	bool forceNotUnique = (icreateinfo & CF_UNIQUE) == 0;
 	bool pregen = (icreateinfo & CF_PREGEN) != 0;
-	auto uidOffset = static_cast<int>((dwBuff & CF_UIDOFFSET) >> 1);
+	auto uidOffset = static_cast<int>((item.dwBuff & CF_UIDOFFSET) >> 1);
 
 	SetupAllItems(player, item, idx, iseed, level, uper, onlygood, pregen, uidOffset, forceNotUnique);
 	SetupItem(item);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3513,7 +3513,7 @@ void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t 
 {
 	bool tmpIsHellfire = gbIsHellfire;
 	item.dwBuff = dwBuff;
-	gbIsHellfire = item.dwBuff & CF_HELLFIRE;
+	gbIsHellfire = (item.dwBuff & CF_HELLFIRE) != 0;
 
 	if (idx == IDI_GOLD) {
 		InitializeItem(item, IDI_GOLD);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3509,10 +3509,10 @@ void CreateTypeItem(Point position, bool onlygood, ItemType itemType, int imisc,
 	SetupBaseItem(position, idx, onlygood, sendmsg, delta, spawn);
 }
 
-void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t icreateinfo, uint32_t iseed, int ivalue, uint32_t ibuff)
+void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t icreateinfo, uint32_t iseed, int ivalue, uint32_t dwBuff)
 {
 	bool tmpIsHellfire = gbIsHellfire;
-	gbIsHellfire = ibuff & CF_HELLFIRE;
+	gbIsHellfire = dwBuff & CF_HELLFIRE;
 
 	if (idx == IDI_GOLD) {
 		InitializeItem(item, IDI_GOLD);
@@ -3556,7 +3556,7 @@ void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t 
 	bool onlygood = (icreateinfo & CF_ONLYGOOD) != 0;
 	bool forceNotUnique = (icreateinfo & CF_UNIQUE) == 0;
 	bool pregen = (icreateinfo & CF_PREGEN) != 0;
-	auto uidOffset = static_cast<int>((ibuff & CF_UIDOFFSET) >> 1);
+	auto uidOffset = static_cast<int>((dwBuff & CF_UIDOFFSET) >> 1);
 
 	SetupAllItems(player, item, idx, iseed, level, uper, onlygood, pregen, uidOffset, forceNotUnique);
 	SetupItem(item);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3509,10 +3509,10 @@ void CreateTypeItem(Point position, bool onlygood, ItemType itemType, int imisc,
 	SetupBaseItem(position, idx, onlygood, sendmsg, delta, spawn);
 }
 
-void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t icreateinfo, uint32_t iseed, int ivalue, bool isHellfire)
+void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t icreateinfo, uint32_t iseed, int ivalue, uint32_t ibuff)
 {
 	bool tmpIsHellfire = gbIsHellfire;
-	gbIsHellfire = isHellfire;
+	gbIsHellfire = ibuff & CF_HELLFIRE;
 
 	if (idx == IDI_GOLD) {
 		InitializeItem(item, IDI_GOLD);
@@ -3556,7 +3556,7 @@ void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t 
 	bool onlygood = (icreateinfo & CF_ONLYGOOD) != 0;
 	bool forceNotUnique = (icreateinfo & CF_UNIQUE) == 0;
 	bool pregen = (icreateinfo & CF_PREGEN) != 0;
-	auto uidOffset = static_cast<int>((item.dwBuff & CF_UIDOFFSET) >> 1);
+	auto uidOffset = static_cast<int>((ibuff & CF_UIDOFFSET) >> 1);
 
 	SetupAllItems(player, item, idx, iseed, level, uper, onlygood, pregen, uidOffset, forceNotUnique);
 	SetupItem(item);

--- a/Source/items.h
+++ b/Source/items.h
@@ -531,7 +531,7 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg, bool spawn = fals
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta);
 void CreateRndUseful(Point position, bool sendmsg);
 void CreateTypeItem(Point position, bool onlygood, ItemType itemType, int imisc, bool sendmsg, bool delta, bool spawn = false);
-void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t icreateinfo, uint32_t iseed, int ivalue, uint32_t ibuff);
+void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t icreateinfo, uint32_t iseed, int ivalue, uint32_t dwBuff);
 void RecreateEar(Item &item, uint16_t ic, uint32_t iseed, uint8_t bCursval, std::string_view heroName);
 void CornerstoneSave();
 void CornerstoneLoad(Point position);

--- a/Source/items.h
+++ b/Source/items.h
@@ -531,7 +531,7 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg, bool spawn = fals
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta);
 void CreateRndUseful(Point position, bool sendmsg);
 void CreateTypeItem(Point position, bool onlygood, ItemType itemType, int imisc, bool sendmsg, bool delta, bool spawn = false);
-void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t icreateinfo, uint32_t iseed, int ivalue, bool isHellfire);
+void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t icreateinfo, uint32_t iseed, int ivalue, uint32_t ibuff);
 void RecreateEar(Item &item, uint16_t ic, uint32_t iseed, uint8_t bCursval, std::string_view heroName);
 void CornerstoneSave();
 void CornerstoneLoad(Point position);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1009,7 +1009,7 @@ void LoadMatchingItems(LoadHelper &file, const Player &player, const int n, Item
 			// game's item generation logic before attempting to use it for validation
 			if ((heroItem.dwBuff & CF_HELLFIRE) != (unpackedItem.dwBuff & CF_HELLFIRE)) {
 				unpackedItem = {};
-				RecreateItem(player, unpackedItem, heroItem.IDidx, heroItem._iCreateInfo, heroItem._iSeed, heroItem._ivalue, (heroItem.dwBuff & CF_HELLFIRE) != 0);
+				RecreateItem(player, unpackedItem, heroItem.IDidx, heroItem._iCreateInfo, heroItem._iSeed, heroItem._ivalue, heroItem.dwBuff);
 				unpackedItem._iIdentified = heroItem._iIdentified;
 				unpackedItem._iMaxDur = heroItem._iMaxDur;
 				unpackedItem._iDurability = ClampDurability(unpackedItem, heroItem._iDurability);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2429,7 +2429,6 @@ void PrepareEarForNetwork(const Item &item, TEar &ear)
 void RecreateItem(const Player &player, const TItem &messageItem, Item &item)
 {
 	const uint32_t dwBuff = SDL_SwapLE32(messageItem.dwBuff);
-	item.dwBuff = dwBuff;
 	RecreateItem(player, item,
 	    static_cast<_item_indexes>(SDL_SwapLE16(messageItem.wIndx)), SDL_SwapLE16(messageItem.wCI),
 	    SDL_SwapLE32(messageItem.dwSeed), SDL_SwapLE16(messageItem.wValue), dwBuff);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2432,7 +2432,7 @@ void RecreateItem(const Player &player, const TItem &messageItem, Item &item)
 	item.dwBuff = dwBuff;
 	RecreateItem(player, item,
 	    static_cast<_item_indexes>(SDL_SwapLE16(messageItem.wIndx)), SDL_SwapLE16(messageItem.wCI),
-	    SDL_SwapLE32(messageItem.dwSeed), SDL_SwapLE16(messageItem.wValue), (dwBuff & CF_HELLFIRE) != 0);
+	    SDL_SwapLE32(messageItem.dwSeed), SDL_SwapLE16(messageItem.wValue), dwBuff);
 	if (messageItem.bId != 0)
 		item._iIdentified = true;
 	item._iMaxDur = messageItem.bMDur;

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -334,8 +334,8 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 		item = {};
 		// Item generation logic will assign CF_HELLFIRE based on isHellfire
 		// so if we carry it over from packedItem, it may be incorrect
-		item.dwBuff = SDL_SwapLE32(packedItem.dwBuff) & ~CF_HELLFIRE;
-		RecreateItem(player, item, idx, SDL_SwapLE16(packedItem.iCreateInfo), SDL_SwapLE32(packedItem.iSeed), SDL_SwapLE16(packedItem.wValue), isHellfire);
+		item.dwBuff = (SDL_SwapLE32(packedItem.dwBuff) & ~CF_HELLFIRE) | isHellfire;
+		RecreateItem(player, item, idx, SDL_SwapLE16(packedItem.iCreateInfo), SDL_SwapLE32(packedItem.iSeed), SDL_SwapLE16(packedItem.wValue), item.dwBuff);
 		item._iIdentified = (packedItem.bId & 1) != 0;
 		item._iMaxDur = packedItem.bMDur;
 		item._iDurability = ClampDurability(item, packedItem.bDur);

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -334,7 +334,7 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 		item = {};
 		// Item generation logic will assign CF_HELLFIRE based on isHellfire
 		// so if we carry it over from packedItem, it may be incorrect
-		const uint32_t dwBuff = (SDL_SwapLE32(packedItem.dwBuff) & ~CF_HELLFIRE) | (isHellfire ? CF_HELLFIRE : 0);
+		const uint32_t dwBuff = SDL_SwapLE32(packedItem.dwBuff) | (isHellfire ? CF_HELLFIRE : 0);
 		RecreateItem(player, item, idx, SDL_SwapLE16(packedItem.iCreateInfo), SDL_SwapLE32(packedItem.iSeed), SDL_SwapLE16(packedItem.wValue), dwBuff);
 		item._iIdentified = (packedItem.bId & 1) != 0;
 		item._iMaxDur = packedItem.bMDur;

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -334,8 +334,8 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 		item = {};
 		// Item generation logic will assign CF_HELLFIRE based on isHellfire
 		// so if we carry it over from packedItem, it may be incorrect
-		item.dwBuff = (SDL_SwapLE32(packedItem.dwBuff) & ~CF_HELLFIRE) | isHellfire;
-		RecreateItem(player, item, idx, SDL_SwapLE16(packedItem.iCreateInfo), SDL_SwapLE32(packedItem.iSeed), SDL_SwapLE16(packedItem.wValue), item.dwBuff);
+		const uint32_t dwBuff = (SDL_SwapLE32(packedItem.dwBuff) & ~CF_HELLFIRE) | (isHellfire ? CF_HELLFIRE : 0);
+		RecreateItem(player, item, idx, SDL_SwapLE16(packedItem.iCreateInfo), SDL_SwapLE32(packedItem.iSeed), SDL_SwapLE16(packedItem.wValue), dwBuff);
 		item._iIdentified = (packedItem.bId & 1) != 0;
 		item._iMaxDur = packedItem.bMDur;
 		item._iDurability = ClampDurability(item, packedItem.bDur);


### PR DESCRIPTION
Hello,

I discussed making these changes on Discord for a little bit, and I think they make sense. This more comprehensively addresses the bug that was fixed by https://github.com/diasurgical/DevilutionX/pull/7859. The changes are as follows:

- items.cpp:RecreateItem() no longer takes an isHellfire argument, but rather the entire dwBuff flag.
- Simplifies and makes the logic in pack.cpp:UnPackItem() for setting the CF_HELLFIRE flag clearer, at @StephenCWills suggestion.
- Assigns dwBuff flag to item.dwBuff within RecreateItem() to prevent any future cases of uninitialised use when calling.
- Removes obsolete assignments to item.dwBuff.

I would like to make this change for the following reasons:

- Uninitialised uses of the dwBuff flag are now very unlikely in RecreateItem().
- Allows dwBuff to be used for more item creation flags in the future.
- Fixes the aforementioned dropped item synchronisation bug.

Regards,
Yggdrasill