### PR TITLE
Fix Rage

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2512,7 +2512,7 @@ void AddRage(Missile &missile, AddMissileParameter &parameter)
 	missile.var2 = (6 << 6) * player.getCharacterLevel(); // 6 points of damage per clvl
 
 	// Recalculate stats to get updated max Life
-	CalcPlrItemVals(player, true);
+	CalcPlrItemVals(player, false);
 
 	// Adjust current Life proportionally to match new max Life after recalculation
 	player._pHitPoints = std::max(1, (player._pMaxHP * player._pHPPer) / 80);
@@ -3873,7 +3873,7 @@ void ProcessRage(Missile &missile)
 	}
 
 	// Recalculate stats to get updated max Life
-	CalcPlrItemVals(player, true);
+	CalcPlrItemVals(player, false);
 
 	// Adjust current Life proportionally to match new max Life after recalculation
 	player._pHitPoints = std::max(1, (player._pMaxHP * player._pHPPer) / 80);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2510,7 +2510,16 @@ void AddRage(Missile &missile, AddMissileParameter &parameter)
 	missile.duration = (player.getCharacterLevel() * 2) + (10 * missile._mispllvl) + 245;
 	missile.var1 = missile.duration;                      // Store the original duration to be used for RageCooldown
 	missile.var2 = (6 << 6) * player.getCharacterLevel(); // 6 points of damage per clvl
+
+	// Recalculate stats to get updated max Life
 	CalcPlrItemVals(player, true);
+
+	// Adjust current Life proportionally to match new max Life after recalculation
+	player._pHitPoints = std::max(1, (player._pMaxHP * player._pHPPer) / 80);
+
+	// Immediately finalize Life
+	CalcPlrItemVals(player, true);
+
 	RedrawEverything();
 	player.Say(HeroSpeech::Aaaaargh);
 }
@@ -3863,14 +3872,18 @@ void ProcessRage(Missile &missile)
 		missile._miDelFlag = true;
 	}
 
+	// Recalculate stats to get updated max Life
 	CalcPlrItemVals(player, true);
 
-	// Adjust current Life proportionally to match new max HP after recalculation
+	// Adjust current Life proportionally to match new max Life after recalculation
 	player._pHitPoints = std::max(1, (player._pMaxHP * player._pHPPer) / 80);
 
 	// Apply Life penalty to the player when RageCooldown finishes
 	if (missile._miDelFlag)
 		ApplyPlrDamage(DamageType::Physical, player, 0, 1, missile.var2);
+
+	// Immediately finalize Life
+	CalcPlrItemVals(player, true);
 
 	RedrawEverything();
 	player.Say(HeroSpeech::HeavyBreathing);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3865,7 +3865,7 @@ void ProcessRage(Missile &missile)
 
 	// Prevent the player from dying as a result of recalculating their current life
 	if ((player._pHitPoints >> 6) <= 0)
-		SetPlayerHitPoints(player, 1);
+		SetPlayerHitPoints(player, 64);
 
 	RedrawEverything();
 	player.Say(HeroSpeech::HeavyBreathing);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1144,8 +1144,8 @@ void InitMissiles()
 	}
 
 	if (HasAnyOf(myPlayer._pSpellFlags, SpellFlag::RageActive | SpellFlag::RageCooldown)) {
-		myPlayer._pSpellFlags &= ~SpellFlag::RageActive;
-		myPlayer._pSpellFlags &= ~SpellFlag::RageCooldown;
+		ClearFlags(myPlayer._pSpellFlags, SpellFlag::RageActive);
+		ClearFlags(myPlayer._pSpellFlags, SpellFlag::RageCooldown);
 		for (auto &missile : Missiles) {
 			if (missile._mitype == MissileID::Rage) {
 				if (missile.sourcePlayer() == MyPlayer) {

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3859,7 +3859,7 @@ void ProcessRage(Missile &missile)
 	if (HasAnyOf(player._pSpellFlags, SpellFlag::RageActive)) {
 		player._pSpellFlags &= ~SpellFlag::RageActive;
 		player._pSpellFlags |= SpellFlag::RageCooldown;
-		missile.duration = (player.getCharacterLevel() * 2) + 10 * missile._mispllvl + 245;
+		missile.duration = (player.getCharacterLevel() * 2) + (10 * missile._mispllvl) + 245;
 	} else {
 		player._pSpellFlags &= ~SpellFlag::RageCooldown;
 		missile._miDelFlag = true;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1149,9 +1149,8 @@ void InitMissiles()
 		for (auto &missile : Missiles) {
 			if (missile._mitype == MissileID::Rage) {
 				if (missile.sourcePlayer() == MyPlayer) {
-					int missingHP = myPlayer._pMaxHP - myPlayer._pHitPoints;
 					CalcPlrItemVals(myPlayer, true);
-					ApplyPlrDamage(DamageType::Physical, myPlayer, 0, 1, missingHP + missile.var2);
+					ApplyPlrDamage(DamageType::Physical, myPlayer, missile._midam, 1);
 				}
 			}
 		}
@@ -2506,21 +2505,12 @@ void AddRage(Missile &missile, AddMissileParameter &parameter)
 		return;
 	}
 
-	player._pSpellFlags |= SpellFlag::RageActive;
-	missile.duration = (player.getCharacterLevel() * 2) + (10 * missile._mispllvl) + 245;
-	missile.var1 = missile.duration;                      // Store the original duration to be used for RageCooldown
-	missile.var2 = (6 << 6) * player.getCharacterLevel(); // 6 points of damage per clvl
+	missile._midam = player.getCharacterLevel() * 6;
+	missile.duration = 245 + (player.getCharacterLevel() * 2);
+	missile.var1 = missile.duration;
 
-	// Recalculate stats to get updated max Life
-	CalcPlrItemVals(player, false);
-
-	// Adjust current Life proportionally to match new max Life after recalculation
-	player._pHitPoints = std::max(1, (player._pMaxHP * player._pHPPer) / 80);
-
-	// Immediately finalize Life
+	SetFlags(player._pSpellFlags, SpellFlag::RageActive);
 	CalcPlrItemVals(player, true);
-
-	RedrawEverything();
 	player.Say(HeroSpeech::Aaaaargh);
 }
 
@@ -3855,38 +3845,27 @@ void ProcessFlameWaveControl(Missile &missile)
 
 void ProcessRage(Missile &missile)
 {
-	missile.duration--;
+	if (--missile.duration == 0) {
+		Player &player = Players[missile._misource];
 
-	if (missile.duration != 0) {
-		return;
+		if (HasAnyOf(player._pSpellFlags, SpellFlag::RageActive)) {
+			ClearFlags(player._pSpellFlags, SpellFlag::RageActive);
+			SetFlags(player._pSpellFlags, SpellFlag::RageCooldown);
+			missile.duration = missile.var1; // Start timer over
+		} else if (HasAnyOf(player._pSpellFlags, SpellFlag::RageCooldown)) {
+			ClearFlags(player._pSpellFlags, SpellFlag::RageCooldown);
+			missile._miDelFlag = true;
+		}
+
+		CalcPlrItemVals(player, true);
+		if ((player._pHitPoints >> 6) <= 0)
+			SetPlayerHitPoints(player, 1);
+		RedrawEverything();
+		player.Say(HeroSpeech::HeavyBreathing);
+
+		if (missile._miDelFlag)
+			ApplyPlrDamage(DamageType::Physical, player, missile._midam, 1);
 	}
-
-	Player &player = Players[missile._misource];
-
-	if (HasAnyOf(player._pSpellFlags, SpellFlag::RageActive)) {
-		player._pSpellFlags &= ~SpellFlag::RageActive;
-		player._pSpellFlags |= SpellFlag::RageCooldown;
-		missile.duration = missile.var1; // Use the same duration for RageCooldown as was used for RageActive
-	} else {
-		player._pSpellFlags &= ~SpellFlag::RageCooldown;
-		missile._miDelFlag = true;
-	}
-
-	// Recalculate stats to get updated max Life
-	CalcPlrItemVals(player, false);
-
-	// Adjust current Life proportionally to match new max Life after recalculation
-	player._pHitPoints = std::max(1, (player._pMaxHP * player._pHPPer) / 80);
-
-	// Apply Life penalty to the player when RageCooldown finishes
-	if (missile._miDelFlag)
-		ApplyPlrDamage(DamageType::Physical, player, 0, 1, missile.var2);
-
-	// Immediately finalize Life
-	CalcPlrItemVals(player, true);
-
-	RedrawEverything();
-	player.Say(HeroSpeech::HeavyBreathing);
 }
 
 void ProcessInferno(Missile &missile)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3862,13 +3862,16 @@ void ProcessRage(Missile &missile)
 	}
 
 	CalcPlrItemVals(player, true);
+
+	// Prevent the player from dying as a result of recalculating their current life
 	if ((player._pHitPoints >> 6) <= 0)
 		SetPlayerHitPoints(player, 1);
+
 	RedrawEverything();
 	player.Say(HeroSpeech::HeavyBreathing);
 
 	if (missile._miDelFlag)
-		ApplyPlrDamage(DamageType::Physical, player, missile._midam, 1);
+		ApplyPlrDamage(DamageType::Physical, player, missile._midam, 1); // Prevent penalty from killing the player
 }
 
 void ProcessInferno(Missile &missile)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1144,7 +1144,8 @@ void InitMissiles()
 	}
 
 	if (HasAnyOf(myPlayer._pSpellFlags, SpellFlag::RageActive | SpellFlag::RageCooldown)) {
-		ClearFlags(myPlayer._pSpellFlags, SpellFlag::RageActive, SpellFlag::RageCooldown);
+		myPlayer._pSpellFlags &= ~SpellFlag::RageActive;
+		myPlayer._pSpellFlags &= ~SpellFlag::RageCooldown;
 		for (auto &missile : Missiles) {
 			if (missile._mitype == MissileID::Rage) {
 				if (missile.sourcePlayer() == MyPlayer) {
@@ -2508,7 +2509,7 @@ void AddRage(Missile &missile, AddMissileParameter &parameter)
 	missile.duration = 245 + (player.getCharacterLevel() * 2);
 	missile.var1 = missile.duration;
 
-	SetFlags(player._pSpellFlags, SpellFlag::RageActive);
+	player._pSpellFlags |= SpellFlag::RageActive;
 	CalcPlrItemVals(player, true);
 	player.Say(HeroSpeech::Aaaaargh);
 }
@@ -3852,11 +3853,11 @@ void ProcessRage(Missile &missile)
 	Player &player = Players[missile._misource];
 
 	if (HasAnyOf(player._pSpellFlags, SpellFlag::RageActive)) {
-		ClearFlags(player._pSpellFlags, SpellFlag::RageActive);
-		SetFlags(player._pSpellFlags, SpellFlag::RageCooldown);
+		player._pSpellFlags &= ~SpellFlag::RageActive;
+		player._pSpellFlags |= SpellFlag::RageCooldown;
 		missile.duration = missile.var1; // Start timer over
 	} else if (HasAnyOf(player._pSpellFlags, SpellFlag::RageCooldown)) {
-		ClearFlags(player._pSpellFlags, SpellFlag::RageCooldown);
+		player._pSpellFlags &= ~SpellFlag::RageCooldown;
 		missile._miDelFlag = true;
 	}
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3844,27 +3844,30 @@ void ProcessFlameWaveControl(Missile &missile)
 
 void ProcessRage(Missile &missile)
 {
-	if (--missile.duration == 0) {
-		Player &player = Players[missile._misource];
+	missile.duration--;
 
-		if (HasAnyOf(player._pSpellFlags, SpellFlag::RageActive)) {
-			ClearFlags(player._pSpellFlags, SpellFlag::RageActive);
-			SetFlags(player._pSpellFlags, SpellFlag::RageCooldown);
-			missile.duration = missile.var1; // Start timer over
-		} else if (HasAnyOf(player._pSpellFlags, SpellFlag::RageCooldown)) {
-			ClearFlags(player._pSpellFlags, SpellFlag::RageCooldown);
-			missile._miDelFlag = true;
-		}
+	if (missile.duration != 0)
+		return;
 
-		CalcPlrItemVals(player, true);
-		if ((player._pHitPoints >> 6) <= 0)
-			SetPlayerHitPoints(player, 1);
-		RedrawEverything();
-		player.Say(HeroSpeech::HeavyBreathing);
+	Player &player = Players[missile._misource];
 
-		if (missile._miDelFlag)
-			ApplyPlrDamage(DamageType::Physical, player, missile._midam, 1);
+	if (HasAnyOf(player._pSpellFlags, SpellFlag::RageActive)) {
+		ClearFlags(player._pSpellFlags, SpellFlag::RageActive);
+		SetFlags(player._pSpellFlags, SpellFlag::RageCooldown);
+		missile.duration = missile.var1; // Start timer over
+	} else if (HasAnyOf(player._pSpellFlags, SpellFlag::RageCooldown)) {
+		ClearFlags(player._pSpellFlags, SpellFlag::RageCooldown);
+		missile._miDelFlag = true;
 	}
+
+	CalcPlrItemVals(player, true);
+	if ((player._pHitPoints >> 6) <= 0)
+		SetPlayerHitPoints(player, 1);
+	RedrawEverything();
+	player.Say(HeroSpeech::HeavyBreathing);
+
+	if (missile._miDelFlag)
+		ApplyPlrDamage(DamageType::Physical, player, missile._midam, 1);
 }
 
 void ProcessInferno(Missile &missile)

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3856,21 +3856,22 @@ void ProcessRage(Missile &missile)
 
 	Player &player = Players[missile._misource];
 
-	int hpdif = player._pMaxHP - player._pHitPoints;
-
 	if (HasAnyOf(player._pSpellFlags, SpellFlag::RageActive)) {
 		player._pSpellFlags &= ~SpellFlag::RageActive;
 		player._pSpellFlags |= SpellFlag::RageCooldown;
-		int lvl = player.getCharacterLevel() * 2;
-		missile.duration = lvl + 10 * missile._mispllvl + 245;
+		missile.duration = (player.getCharacterLevel() * 2) + 10 * missile._mispllvl + 245;
 	} else {
 		player._pSpellFlags &= ~SpellFlag::RageCooldown;
 		missile._miDelFlag = true;
-		hpdif += missile.var2;
 	}
 
 	CalcPlrItemVals(player, true);
-	ApplyPlrDamage(DamageType::Physical, player, 0, 1, hpdif);
+
+	player._pHitPoints = std::max(1, (player._pMaxHP * player._pHPPer) / 80);
+
+	if (missile._miDelFlag)
+		ApplyPlrDamage(DamageType::Physical, player, 0, 1, missile.var2);
+
 	RedrawEverything();
 	player.Say(HeroSpeech::HeavyBreathing);
 }

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3865,8 +3865,10 @@ void ProcessRage(Missile &missile)
 
 	CalcPlrItemVals(player, true);
 
+	// Adjust current Life proportionally to match new max HP after recalculation
 	player._pHitPoints = std::max(1, (player._pMaxHP * player._pHPPer) / 80);
 
+	// Apply Life penalty to the player when RageCooldown finishes
 	if (missile._miDelFlag)
 		ApplyPlrDamage(DamageType::Physical, player, 0, 1, missile.var2);
 

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2506,12 +2506,10 @@ void AddRage(Missile &missile, AddMissileParameter &parameter)
 		return;
 	}
 
-	int tmp = 3 * player.getCharacterLevel();
-	tmp <<= 7;
 	player._pSpellFlags |= SpellFlag::RageActive;
-	missile.var2 = tmp;
-	int lvl = player.getCharacterLevel() * 2;
-	missile.duration = lvl + 10 * missile._mispllvl + 245;
+	missile.duration = (player.getCharacterLevel() * 2) + (10 * missile._mispllvl) + 245;
+	missile.var1 = missile.duration;                      // Store the original duration to be used for RageCooldown
+	missile.var2 = (6 << 6) * player.getCharacterLevel(); // 6 points of damage per clvl
 	CalcPlrItemVals(player, true);
 	RedrawEverything();
 	player.Say(HeroSpeech::Aaaaargh);
@@ -3859,7 +3857,7 @@ void ProcessRage(Missile &missile)
 	if (HasAnyOf(player._pSpellFlags, SpellFlag::RageActive)) {
 		player._pSpellFlags &= ~SpellFlag::RageActive;
 		player._pSpellFlags |= SpellFlag::RageCooldown;
-		missile.duration = (player.getCharacterLevel() * 2) + (10 * missile._mispllvl) + 245;
+		missile.duration = missile.var1; // Use the same duration for RageCooldown as was used for RageActive
 	} else {
 		player._pSpellFlags &= ~SpellFlag::RageCooldown;
 		missile._miDelFlag = true;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1144,8 +1144,7 @@ void InitMissiles()
 	}
 
 	if (HasAnyOf(myPlayer._pSpellFlags, SpellFlag::RageActive | SpellFlag::RageCooldown)) {
-		ClearFlags(myPlayer._pSpellFlags, SpellFlag::RageActive);
-		ClearFlags(myPlayer._pSpellFlags, SpellFlag::RageCooldown);
+		ClearFlags(myPlayer._pSpellFlags, SpellFlag::RageActive, SpellFlag::RageCooldown);
 		for (auto &missile : Missiles) {
 			if (missile._mitype == MissileID::Rage) {
 				if (missile.sourcePlayer() == MyPlayer) {

--- a/Source/utils/enum_traits.h
+++ b/Source/utils/enum_traits.h
@@ -120,16 +120,22 @@ template <typename EnumType, std::enable_if_t<std::is_enum<EnumType>::value && i
 	return !HasAnyOf(lhs, test);
 }
 
-template <typename EnumType, std::enable_if_t<std::is_enum_v<EnumType> && is_flags_enum<EnumType>::value, bool> = true>
-DVL_ALWAYS_INLINE constexpr void SetFlags(EnumType &lhs, EnumType flagsToSet)
+template <
+    typename EnumType,
+    typename... Flags,
+    std::enable_if_t<std::is_enum_v<EnumType> && is_flags_enum<EnumType>::value && (std::is_same_v<EnumType, Flags> && ...), bool> = true>
+DVL_ALWAYS_INLINE constexpr void SetFlags(EnumType &lhs, Flags... flagsToSet)
 {
-	lhs |= flagsToSet;
+	((lhs |= flagsToSet), ...);
 }
 
-template <typename EnumType, std::enable_if_t<std::is_enum_v<EnumType> && is_flags_enum<EnumType>::value, bool> = true>
-DVL_ALWAYS_INLINE constexpr void ClearFlags(EnumType &lhs, EnumType flagsToClear)
+template <
+    typename EnumType,
+    typename... Flags,
+    std::enable_if_t<std::is_enum_v<EnumType> && is_flags_enum<EnumType>::value && (std::is_same_v<EnumType, Flags> && ...), bool> = true>
+DVL_ALWAYS_INLINE constexpr void ClearFlags(EnumType &lhs, Flags... flagsToClear)
 {
-	lhs &= ~flagsToClear;
+	((lhs &= ~flagsToClear), ...);
 }
 
 } // namespace devilution

--- a/Source/utils/enum_traits.h
+++ b/Source/utils/enum_traits.h
@@ -120,4 +120,16 @@ template <typename EnumType, std::enable_if_t<std::is_enum<EnumType>::value && i
 	return !HasAnyOf(lhs, test);
 }
 
+template <typename EnumType, std::enable_if_t<std::is_enum_v<EnumType> && is_flags_enum<EnumType>::value, bool> = true>
+DVL_ALWAYS_INLINE constexpr void SetFlags(EnumType &lhs, EnumType flagsToSet)
+{
+	lhs |= flagsToSet;
+}
+
+template <typename EnumType, std::enable_if_t<std::is_enum_v<EnumType> && is_flags_enum<EnumType>::value, bool> = true>
+DVL_ALWAYS_INLINE constexpr void ClearFlags(EnumType &lhs, EnumType flagsToClear)
+{
+	lhs &= ~flagsToClear;
+}
+
 } // namespace devilution

--- a/Source/utils/enum_traits.h
+++ b/Source/utils/enum_traits.h
@@ -120,22 +120,4 @@ template <typename EnumType, std::enable_if_t<std::is_enum<EnumType>::value && i
 	return !HasAnyOf(lhs, test);
 }
 
-template <
-    typename EnumType,
-    typename... Flags,
-    std::enable_if_t<std::is_enum_v<EnumType> && is_flags_enum<EnumType>::value && (std::is_same_v<EnumType, Flags> && ...), bool> = true>
-DVL_ALWAYS_INLINE constexpr void SetFlags(EnumType &lhs, Flags... flagsToSet)
-{
-	((lhs |= flagsToSet), ...);
-}
-
-template <
-    typename EnumType,
-    typename... Flags,
-    std::enable_if_t<std::is_enum_v<EnumType> && is_flags_enum<EnumType>::value && (std::is_same_v<EnumType, Flags> && ...), bool> = true>
-DVL_ALWAYS_INLINE constexpr void ClearFlags(EnumType &lhs, Flags... flagsToClear)
-{
-	((lhs &= ~flagsToClear), ...);
-}
-
 } // namespace devilution


### PR DESCRIPTION
## Bug Description

In vanilla Hellfire, the Rage spell applies temporary stat boosts (increasing Strength, Dexterity, and Vitality) and subsequently a cooldown phase (Lethargy), which reduces the player's stats temporarily. However, the original implementation mistakenly tried to manually manage the player's life adjustments during these state transitions, resulting in unintended health penalties due to how the internal game function (`CalcPlrItemVals`) recalculates player life.

Specifically, the original Rage logic attempted to manually preserve the player's missing life and explicitly prevent death upon transitioning between Rage and Lethargy, not realizing that `CalcPlrItemVals` would immediately perform life adjustments. This caused inconsistent, confusing, and potentially fatal behavior.

## How This PR Fixes the Bug

This PR clarifies and simplifies the Rage spell implementation to properly handle the life adjustments:

- Removes the unnecessary manual HP adjustments.
- Uses the game's existing `CalcPlrItemVals` function to handle life recalculations consistently.
- Explicitly ensures the player never drops below 1 HP upon recalculation, preventing unintended deaths.

## Implementation Details

- Adds explicit checks after calling `CalcPlrItemVals` to ensure the player's HP does not fall below 1, guaranteeing survival through stat transitions.
- Clearly separates the application of the final Rage damage penalty at the end of cooldown.
- Adjusts the Rage damage penalty calculation to a straightforward `player.getCharacterLevel() * 6` rather than using bitshifts (`tmp <<= 7`).
- Modifies `ApplyPlrDamage` calls to directly use non-bitshifted life/damage values, simplifying code readability and preventing confusion regarding bitshift multipliers.

## Resulting Behavior

With this fix, players using the Rage spell will experience:

- Temporary stat boosts correctly applied.
- Predictable life recalculations when entering and exiting cooldown.
- Guaranteed survival when transitioning phases, as originally intended by the developers.
- Consistent and clear Rage damage penalty behavior.