### PR TITLE
Fix items.cpp:SortVendor() buffer overflow

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4412,7 +4412,7 @@ void SpawnSmith(int lvl)
 	for (int i = iCnt; i < NumSmithBasicItemsHf; i++)
 		SmithItems[i].clear();
 
-	SortVendor(SmithItems + PinnedItemCount, iCnt);
+	SortVendor(SmithItems + PinnedItemCount, iCnt - PinnedItemCount);
 }
 
 void SpawnPremium(const Player &player)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1907,17 +1907,13 @@ _item_indexes RndSmithItem(const Player &player, int lvl)
 	return RndVendorItem<SmithItemOk, true>(player, 0, lvl);
 }
 
-void SortVendor(Item *itemList)
+void SortVendor(Item *itemList, size_t nmemb)
 {
-	int count = 1;
-	while (!itemList[count].isEmpty())
-		count++;
-
 	auto cmp = [](const Item &a, const Item &b) {
 		return a.IDidx < b.IDidx;
 	};
 
-	std::sort(itemList, itemList + count, cmp);
+	std::sort(itemList, itemList + nmemb, cmp);
 }
 
 bool PremiumItemOk(const Player &player, const ItemData &item)
@@ -4416,7 +4412,7 @@ void SpawnSmith(int lvl)
 	for (int i = iCnt; i < NumSmithBasicItemsHf; i++)
 		SmithItems[i].clear();
 
-	SortVendor(SmithItems + PinnedItemCount);
+	SortVendor(SmithItems + PinnedItemCount, iCnt);
 }
 
 void SpawnPremium(const Player &player)
@@ -4516,7 +4512,7 @@ void SpawnWitch(int lvl)
 		item._iIdentified = true;
 	}
 
-	SortVendor(WitchItems + PinnedItemCount);
+	SortVendor(WitchItems + PinnedItemCount, itemCount - PinnedItemCount);
 }
 
 void SpawnBoy(int lvl)
@@ -4664,7 +4660,7 @@ void SpawnHealer(int lvl)
 		item._iIdentified = true;
 	}
 
-	SortVendor(HealerItems + PinnedItemCount);
+	SortVendor(HealerItems + PinnedItemCount, itemCount - PinnedItemCount);
 }
 
 void MakeGoldStack(Item &goldItem, int value)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1907,13 +1907,13 @@ _item_indexes RndSmithItem(const Player &player, int lvl)
 	return RndVendorItem<SmithItemOk, true>(player, 0, lvl);
 }
 
-void SortVendor(Item *itemList, size_t nmemb)
+void SortVendor(Item *itemList, size_t count)
 {
 	auto cmp = [](const Item &a, const Item &b) {
 		return a.IDidx < b.IDidx;
 	};
 
-	std::sort(itemList, itemList + nmemb, cmp);
+	std::sort(itemList, itemList + count, cmp);
 }
 
 bool PremiumItemOk(const Player &player, const ItemData &item)


### PR DESCRIPTION
Hello,

I have had some very inconsistent crashes on the very recent revisions, and I decided to take some time to debug it. I ran git bisect and it pointed me towards commit f5d430fbf, though given the harmless contents of this commit I really have no idea *why* it exposes this problem. In my mind, this commit should not cause any issues at all.

Regardless, the problem is that if a vendor max rolls their itemCount, SortVendor() will not count the item entries correctly anymore, and thus buffer overflow. This then causes memory corruption and a crash within GetItemAttrs() as it tries to read from an invalid pointer on this line:

```item._itype = baseItemData.itype;```

The issue can be reproduced by assigning `iCnt = maxItems;` within SpawnSmith(). This will always produce a crash, at least on my system. I have attached a crash log to this PR:

[crash.log](https://github.com/user-attachments/files/19402335/crash.log)

This PR fixes the bug by not counting the items within SortVendor(), opting instead to pass the array member count as an argument.