### PR TITLE
Party Information Panel

### DIFF
--- a/Source/control.h
+++ b/Source/control.h
@@ -129,7 +129,7 @@ void DrawFlaskValues(const Surface &out, Point pos, int currValue, int maxValue)
 void UpdateLifeManaPercent();
 
 /**
- * Draws all currently connected players health and mana pools in the middle left of the screen.
+ * Draws all currently connected players health and mana pools in the top left of the screen.
  */
 
 void DrawPartyMemberInfo(const Surface &out);

--- a/Source/control.h
+++ b/Source/control.h
@@ -128,6 +128,12 @@ void DrawFlaskValues(const Surface &out, Point pos, int currValue, int maxValue)
  */
 void UpdateLifeManaPercent();
 
+/**
+ * Draws all currently connected players health and mana pools in the middle left of the screen.
+ */
+
+void DrawPartyMemberInfo(const Surface &out);
+
 tl::expected<void, std::string> InitMainPanel();
 void DrawMainPanel(const Surface &out);
 

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1752,6 +1752,9 @@ void DrawAndBlit()
 
 	DrawFPS(out);
 
+	if (*GetOptions().Gameplay.showMultiplayerPartyInfo)
+		DrawPartyMemberInfo(out);
+
 	LuaEvent("GameDrawComplete");
 
 	DrawMain(hgt, drawInfoBox, drawHealth, drawMana, drawBelt, drawControlButtons);

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -736,6 +736,7 @@ GameplayOptions::GameplayOptions()
     , showItemGraphicsInStores("Show Item Graphics in Stores", OptionEntryFlags::None, N_("Show Item Graphics in Stores"), N_("Show item graphics to the left of item descriptions in store menus."), false)
     , showHealthValues("Show health values", OptionEntryFlags::None, N_("Show health values"), N_("Displays current / max health value on health globe."), false)
     , showManaValues("Show mana values", OptionEntryFlags::None, N_("Show mana values"), N_("Displays current / max mana value on mana globe."), false)
+    , showMultiplayerPartyInfo("Show Multiplayer Party Information", OptionEntryFlags::CantChangeInMultiPlayer, N_("Show Party Information"), N_("Displays the health and mana of all connected multiplayer party members."), false)
     , enemyHealthBar("Enemy Health Bar", OptionEntryFlags::None, N_("Enemy Health Bar"), N_("Enemy Health Bar is displayed at the top of the screen."), false)
     , autoGoldPickup("Auto Gold Pickup", OptionEntryFlags::None, N_("Auto Gold Pickup"), N_("Gold is automatically collected when in close proximity to the player."), false)
     , autoElixirPickup("Auto Elixir Pickup", OptionEntryFlags::None, N_("Auto Elixir Pickup"), N_("Elixirs are automatically collected when in close proximity to the player."), false)
@@ -786,6 +787,7 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&showItemGraphicsInStores,
 		&showHealthValues,
 		&showManaValues,
+		&showMultiplayerPartyInfo,
 		&enemyHealthBar,
 		&showMonsterType,
 		&showItemLabels,

--- a/Source/options.h
+++ b/Source/options.h
@@ -580,6 +580,8 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryBoolean showHealthValues;
 	/** @brief Display current/max mana values on mana globe. */
 	OptionEntryBoolean showManaValues;
+	/** @brief Enable the multiplayer party information display */
+	OptionEntryBoolean showMultiplayerPartyInfo;
 	/** @brief Show enemy health at the top of the screen. */
 	OptionEntryBoolean enemyHealthBar;
 	/** @brief Automatically pick up gold when walking over it. */


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e9ed986f-f267-4eda-b181-cf14d9d0e347)

Allows the player to toggle on/off a simple party info display on the top left hand side of the game screen. This display will show all connected players current health and mana. The option to toggle it on/off is found in the Gameplay settings underneath Show Mana Values