### PR TITLE
Left shift in StaticVector::erase(), add tests

### DIFF
--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -71,17 +71,15 @@ public:
 	const T &operator[](std::size_t pos) const { return *data_[pos].ptr(); }
 	T &operator[](std::size_t pos) { return *data_[pos].ptr(); }
 
-	void erase(const T *begin, const T *end)
+	void erase(const T *first, const T *last)
 	{
-		size_t count = end - begin;
-		if (empty() || begin < this->begin() || begin >= end || (size() - count) > size()) {
-			return;
-		}
+		assert(first >= begin() && last <= end() && first <= last);
+		size_t count = last - first;
 
-		T *beginPtr = data_[begin - this->begin()].ptr();
-		T *endPtr = data_[end - this->begin()].ptr();
+		T *firstPtr = data_[first - this->begin()].ptr();
+		T *lastPtr = data_[last - this->begin()].ptr();
 
-		std::move(endPtr, this->end(), beginPtr);
+		std::move(lastPtr, this->end(), firstPtr);
 		for (const T *it = this->end() - count; it < this->end(); ++it) {
 			std::destroy_at(it);
 		}
@@ -89,9 +87,10 @@ public:
 		size_ -= count;
 	}
 
-	void erase(const T *begin)
+	void erase(const T *element)
 	{
-		erase(begin, begin + 1);
+		assert(element >= begin() && (element + 1) <= end());
+		erase(element, element + 1);
 	}
 
 	void pop_back() // NOLINT(readability-identifier-naming)

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -71,12 +71,14 @@ public:
 	const T &operator[](std::size_t pos) const { return *data_[pos].ptr(); }
 	T &operator[](std::size_t pos) { return *data_[pos].ptr(); }
 
-	void erase(const T *begin, const T *end)
+	void erase(T *begin, T *end)
 	{
-		for (const T *it = begin; it < end; ++it) {
+		size_t count = end - begin;
+		std::move(end, this->end(), begin);
+		for (const T *it = this->end() - count; it < this->end(); ++it) {
 			std::destroy_at(it);
 		}
-		size_ -= end - begin;
+		size_ -= count;
 	}
 
 	void pop_back() // NOLINT(readability-identifier-naming)

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -71,14 +71,17 @@ public:
 	const T &operator[](std::size_t pos) const { return *data_[pos].ptr(); }
 	T &operator[](std::size_t pos) { return *data_[pos].ptr(); }
 
-	void erase(T *begin, T *end)
+	void erase(const T *begin, const T *end)
 	{
 		size_t count = end - begin;
 		if (empty() || begin < this->begin() || begin >= end || (size() - count) > size()) {
 			return;
 		}
 
-		std::move(end, this->end(), begin);
+		T *beginPtr = data_[begin - this->begin()].ptr();
+		T *endPtr = data_[end - this->begin()].ptr();
+
+		std::move(endPtr, this->end(), beginPtr);
 		for (const T *it = this->end() - count; it < this->end(); ++it) {
 			std::destroy_at(it);
 		}

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -74,7 +74,7 @@ public:
 	void erase(T *begin, T *end)
 	{
 		size_t count = end - begin;
-		if (empty() || begin >= end || (size() - count) > size()) {
+		if (empty() || begin < this->begin() || begin >= end || (size() - count) > size()) {
 			return;
 		}
 

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -74,10 +74,15 @@ public:
 	void erase(T *begin, T *end)
 	{
 		size_t count = end - begin;
+		if (empty() || begin >= end || (size() - count) > size()) {
+			return;
+		}
+
 		std::move(end, this->end(), begin);
 		for (const T *it = this->end() - count; it < this->end(); ++it) {
 			std::destroy_at(it);
 		}
+
 		size_ -= count;
 	}
 

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -89,7 +89,7 @@ public:
 
 	void erase(const T *element)
 	{
-		assert(element >= begin() && (element + 1) <= end());
+		assert(element >= begin() && element < end());
 		erase(element, element + 1);
 	}
 

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -95,9 +95,6 @@ public:
 
 	void clear()
 	{
-		if (empty()) {
-			return;
-		}
 		erase(begin(), end());
 	}
 

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -89,6 +89,9 @@ public:
 
 	void clear()
 	{
+		if (empty()) {
+			return;
+		}
 		erase(begin(), end());
 	}
 

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -89,6 +89,11 @@ public:
 		size_ -= count;
 	}
 
+	void erase(const T *begin)
+	{
+		erase(begin, begin + 1);
+	}
+
 	void pop_back() // NOLINT(readability-identifier-naming)
 	{
 		std::destroy_at(&back());

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -79,10 +79,10 @@ public:
 		T *firstPtr = data_[first - this->begin()].ptr();
 		T *lastPtr = data_[last - this->begin()].ptr();
 
-		std::move(lastPtr, this->end(), firstPtr);
-		for (const T *it = this->end() - count; it < this->end(); ++it) {
+		for (const T *it = firstPtr; it < lastPtr; ++it) {
 			std::destroy_at(it);
 		}
+		std::move(lastPtr, this->end(), firstPtr);
 
 		size_ -= count;
 	}

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -73,17 +73,11 @@ public:
 
 	void erase(const T *first, const T *last)
 	{
+		if (last == first) return;
 		assert(first >= begin() && last <= end() && first <= last);
-		size_t count = last - first;
-
-		T *firstPtr = data_[first - this->begin()].ptr();
-		T *lastPtr = data_[last - this->begin()].ptr();
-
-		for (const T *it = firstPtr; it < lastPtr; ++it) {
-			std::destroy_at(it);
-		}
-		std::move(lastPtr, this->end(), firstPtr);
-
+		const auto count = last - first;
+		auto tail = std::move(const_cast<T *>(last), end(), const_cast<T *>(first));
+		std::destroy(tail, end());
 		size_ -= count;
 	}
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(tests
   tile_properties_test
   timedemo_test
   writehero_test
+  staticvector_test
 )
 set(standalone_tests
   codec_test

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -41,7 +41,6 @@ TEST(StaticVector, StaticVector_push_back_full)
 		EXPECT_EQ(container[i], i);
 	}
 
-
 #ifdef _DEBUG
 	ASSERT_DEATH(container.push_back(size + 1), "");
 #endif

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -44,7 +44,10 @@ TEST(StaticVector, StaticVector_erase)
 	}
 
 	for (int idx : erase_idx) {
-		if (container.size() == 0 || expected.size() == 0) {
+		/* This is actually to guard against gcc's vector implementation causing
+		 * crashes, rather than StaticVector
+		 */
+		if (expected.size() == 0) {
 			break;
 		}
 		container.erase(container.begin() + idx, container.begin() + idx + 1);

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -27,6 +27,51 @@ TEST(StaticVector, StaticVector_push_back)
 	}
 }
 
+TEST(StaticVector, StaticVector_push_back_full)
+{
+	StaticVector<int, MAX_SIZE> container;
+
+	size_t size = MAX_SIZE;
+	for (size_t i = 0; i < size; i++) {
+		container.push_back(i);
+	}
+
+	EXPECT_EQ(container.size(), MAX_SIZE);
+	for (size_t i = 0; i < size; i++) {
+		EXPECT_EQ(container[i], i);
+	}
+}
+
+TEST(StaticVector, StaticVector_erase)
+{
+	StaticVector<int, MAX_SIZE> container;
+	std::vector<int> expected;
+
+	container.erase(container.begin(), container.begin() + 1);
+	EXPECT_EQ(container.size(), 0);
+
+	container = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+	expected = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+	container.erase(container.begin(), container.begin() + 1);
+	EXPECT_EQ(container.size(), expected.size());
+	for (size_t i = 0; i < container.size(); i++) {
+		EXPECT_EQ(container[i], expected[i]);
+	}
+
+	expected = { 1, 2, 3, 4, 5, 6, 7, 8 };
+	container.erase(container.end() - 1, container.end());
+	EXPECT_EQ(container.size(), expected.size());
+	for (size_t i = 0; i < container.size(); i++) {
+		EXPECT_EQ(container[i], expected[i]);
+	}
+
+	container.erase(container.begin(), container.end() + 1);
+	EXPECT_EQ(container.size(), expected.size());
+
+	container.erase(container.begin() - 1, container.end());
+	EXPECT_EQ(container.size(), expected.size());
+}
+
 TEST(StaticVector, StaticVector_erase_random)
 {
 	StaticVector<int, MAX_SIZE> container;
@@ -41,7 +86,6 @@ TEST(StaticVector, StaticVector_erase_random)
 	}
 
 	int erasures = RandomIntBetween(1, size, true);
-
 
 	for (int i = 0; i < erasures; i++) {
 		erase_idx.push_back(RandomIntBetween(0, size, true));
@@ -62,6 +106,43 @@ TEST(StaticVector, StaticVector_erase_random)
 
 	EXPECT_EQ(container.size(), expected.size());
 	for (size_t i = 0; i < expected.size(); i++) {
+		EXPECT_EQ(container[i], expected[i]);
+	}
+}
+
+TEST(StaticVector, StaticVector_erase_range)
+{
+	StaticVector<int, MAX_SIZE> container;
+	std::vector<int> erase_idx;
+	std::vector<int> expected;
+
+	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
+
+	container = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+	expected = { 3, 4, 5, 6, 7, 8, 9 };
+	container.erase(container.begin(), container.begin() + 3);
+
+	EXPECT_EQ(container.size(), expected.size());
+	for (size_t i = 0; i < container.size(); i++) {
+		EXPECT_EQ(container[i], expected[i]);
+	}
+
+	container.erase(container.begin() + 1, container.begin() + 1);
+	EXPECT_EQ(container.size(), expected.size());
+	for (size_t i = 0; i < container.size(); i++) {
+		EXPECT_EQ(container[i], expected[i]);
+	}
+
+	int from = RandomIntBetween(0, container.size() - 1, true);
+	int to = RandomIntBetween(from, container.size() - 1, true);
+
+	container.erase(container.begin() + from, container.begin() + to);
+	for (int i = to - from; i > 0; i--) {
+		expected.erase(expected.begin() + from);
+	}
+
+	EXPECT_EQ(container.size(), expected.size());
+	for (size_t i = 0; i < container.size(); i++) {
 		EXPECT_EQ(container[i], expected[i]);
 	}
 }

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -4,7 +4,7 @@
 
 #include "utils/static_vector.hpp"
 
-#define MAX_SIZE 256
+#define MAX_SIZE 32
 
 using namespace devilution;
 
@@ -46,6 +46,20 @@ TEST(StaticVector, StaticVector_erase)
 	}
 
 	for (size_t i = 0; i < expected.size(); i++) {
+		EXPECT_EQ(container[i], expected[i]);
+	}
+}
+
+TEST(StaticVector, StaticVector_clear)
+{
+	std::vector<int> expected;
+
+	container.clear();
+	expected.clear();
+
+	EXPECT_EQ(container.size(), expected.size());
+
+	for(size_t i = 0; i < container.size(); i++) {
 		EXPECT_EQ(container[i], expected[i]);
 	}
 }

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -47,12 +47,12 @@ TEST(StaticVector, StaticVector_erase)
 	StaticVector<int, MAX_SIZE> container;
 	std::vector<int> expected;
 
-	container.erase(container.begin(), container.begin() + 1);
+	container.erase(container.begin());
 	EXPECT_EQ(container.size(), 0);
 
 	container = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 	expected = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-	container.erase(container.begin(), container.begin() + 1);
+	container.erase(container.begin());
 	EXPECT_EQ(container.size(), expected.size());
 	for (size_t i = 0; i < container.size(); i++) {
 		EXPECT_EQ(container[i], expected[i]);

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -72,8 +72,7 @@ TEST(StaticVector, StaticVector_erase)
 		EXPECT_EQ(container[i], expected[i]);
 	}
 
-	size_t erasures = container.size();
-	for (size_t i = 0; i < erasures && container.size() > 0; i++) {
+	while (!container.empty()) {
 		size_t idx = RandomIntLessThan(static_cast<int32_t>(container.size()));
 		container.erase(container.begin() + idx);
 		expected.erase(expected.begin() + idx);
@@ -85,7 +84,6 @@ TEST(StaticVector, StaticVector_erase)
 			EXPECT_EQ(container[idx], expected[idx]);
 		}
 	}
-
 	EXPECT_EQ(container.size(), 0);
 
 #ifdef _DEBUG
@@ -97,34 +95,21 @@ TEST(StaticVector, StaticVector_erase)
 TEST(StaticVector, StaticVector_erase_random)
 {
 	StaticVector<size_t, MAX_SIZE> container;
-	std::vector<size_t> erase_idx;
 	std::vector<size_t> expected;
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
 	size_t size = RandomIntBetween(10, MAX_SIZE, true);
+	size_t erasures = RandomIntBetween(1, static_cast<int32_t>(size) - 1, true);
 
 	for (size_t i = 0; i < size; i++) {
 		container.push_back(i);
-	}
-
-	size_t erasures = RandomIntBetween(1, static_cast<int32_t>(size) - 1, true);
-
-	for (size_t i = 0; i < erasures; i++) {
-		erase_idx.push_back(RandomIntLessThan(static_cast<int32_t>(size)));
-	}
-
-	for (int i = 0; expected.size() < container.size(); i++) {
 		expected.push_back(i);
 	}
 
-	while (erase_idx.size() > 0) {
-		size_t idx = erase_idx.front();
+	while (erasures-- > 0) {
+		size_t idx = RandomIntLessThan(static_cast<int32_t>(container.size()));
 		container.erase(container.begin() + idx);
 		expected.erase(expected.begin() + idx);
-		erase_idx.erase(erase_idx.begin());
-		for (size_t i = 0; i < erase_idx.size(); i++) {
-			erase_idx[i] -= erase_idx[i] != 0 ? 1 : 0;
-		}
 	}
 
 	EXPECT_EQ(container.size(), expected.size());
@@ -144,7 +129,6 @@ TEST(StaticVector, StaticVector_erase_range)
 	container = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 	expected = { 3, 4, 5, 6, 7, 8, 9 };
 	container.erase(container.begin(), container.begin() + 3);
-
 	EXPECT_EQ(container.size(), expected.size());
 	for (size_t i = 0; i < container.size(); i++) {
 		EXPECT_EQ(container[i], expected[i]);
@@ -158,7 +142,6 @@ TEST(StaticVector, StaticVector_erase_range)
 
 	int32_t from = RandomIntLessThan(static_cast<int32_t>(container.size()));
 	int32_t to = RandomIntBetween(from, static_cast<int32_t>(container.size() - 1), true);
-
 	container.erase(container.begin() + from, container.begin() + to);
 	for (int32_t i = to - from; i > 0; i--) {
 		expected.erase(expected.begin() + from);

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -14,7 +14,7 @@ StaticVector<int, MAX_SIZE> container;
 TEST(StaticVector, StaticVector_push_back)
 {
 	std::srand(clock());
-	size_t size = 1 + std::rand() % (MAX_SIZE - 1);
+	size_t size = 10 + (std::rand() % (MAX_SIZE - 10) );
 	for (size_t i = 0; i < size; i++) {
 		container.push_back(i);
 	}
@@ -27,6 +27,11 @@ TEST(StaticVector, StaticVector_push_back)
 TEST(StaticVector, StaticVector_erase)
 {
 	std::srand(clock());
+
+	if(container.size() == 0) {
+		return;
+	}
+
 	int erasures = std::rand() % container.size();
 
 	std::vector<int> erase_idx;

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -1,0 +1,53 @@
+#include <cstdlib>
+#include <ctime>
+#include <gtest/gtest.h>
+
+#include "utils/static_vector.hpp"
+
+#define MAX_SIZE 256
+
+using namespace devilution;
+
+namespace {
+StaticVector<int, MAX_SIZE> container;
+
+TEST(StaticVector, StaticVector_push_back)
+{
+	std::srand(clock());
+	size_t size = std::rand() % MAX_SIZE;
+	for (size_t i = 0; i < size; i++) {
+		container.push_back(i);
+	}
+
+	for (size_t i = 0; i < container.size(); i++) {
+		EXPECT_EQ(container[i], i);
+	}
+}
+
+TEST(StaticVector, StaticVector_erase)
+{
+	std::srand(clock());
+	int erasures = std::rand() % container.size();
+
+	std::vector<int> erase_idx;
+	std::vector<int> expected;
+
+	for (int i = 0; i < erasures; i++) {
+		erase_idx.push_back(std::rand() % container.size());
+	}
+
+	for (int i = 0; expected.size() < container.size(); i++) {
+		expected.push_back(i);
+	}
+
+	for (int idx : erase_idx) {
+		container.erase(container.begin() + idx, container.begin() + idx + 1);
+		expected.erase(expected.begin() + idx);
+	}
+
+	for (size_t i = 0; i < expected.size(); i++) {
+		EXPECT_EQ(container[i], expected[i]);
+	}
+}
+
+} // namespace

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -41,7 +41,10 @@ TEST(StaticVector, StaticVector_push_back_full)
 		EXPECT_EQ(container[i], i);
 	}
 
+
+#ifdef _DEBUG
 	ASSERT_DEATH(container.push_back(size + 1), "");
+#endif
 }
 
 TEST(StaticVector, StaticVector_erase)
@@ -51,7 +54,9 @@ TEST(StaticVector, StaticVector_erase)
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
 
+#ifdef _DEBUG
 	ASSERT_DEATH(container.erase(container.begin()), "");
+#endif
 
 	container = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 	expected = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -84,8 +89,10 @@ TEST(StaticVector, StaticVector_erase)
 
 	EXPECT_EQ(container.size(), 0);
 
+#ifdef _DEBUG
 	ASSERT_DEATH(container.erase(container.begin(), container.end() + 1), "");
 	ASSERT_DEATH(container.erase(container.begin() - 1, container.end()), "");
+#endif
 }
 
 TEST(StaticVector, StaticVector_erase_random)

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -107,10 +107,10 @@ TEST(StaticVector, StaticVector_erase_random)
 		container.push_back(i);
 	}
 
-	size_t erasures = RandomIntBetween(1, static_cast<int32_t>(size), true);
+	size_t erasures = RandomIntBetween(1, static_cast<int32_t>(size) - 1, true);
 
 	for (size_t i = 0; i < erasures; i++) {
-		erase_idx.push_back(RandomIntBetween(0, static_cast<int32_t>(size), true));
+		erase_idx.push_back(RandomIntLessThan(static_cast<int32_t>(size)));
 	}
 
 	for (int i = 0; expected.size() < container.size(); i++) {
@@ -156,7 +156,7 @@ TEST(StaticVector, StaticVector_erase_range)
 		EXPECT_EQ(container[i], expected[i]);
 	}
 
-	int32_t from = RandomIntBetween(0, static_cast<int32_t>(container.size() - 1), true);
+	int32_t from = RandomIntLessThan(static_cast<int32_t>(container.size()));
 	int32_t to = RandomIntBetween(from, static_cast<int32_t>(container.size() - 1), true);
 
 	container.erase(container.begin() + from, container.begin() + to);

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -14,7 +14,7 @@ StaticVector<int, MAX_SIZE> container;
 TEST(StaticVector, StaticVector_push_back)
 {
 	std::srand(clock());
-	size_t size = 10 + (std::rand() % (MAX_SIZE - 10) );
+	size_t size = 10 + (std::rand() % (MAX_SIZE - 10));
 	for (size_t i = 0; i < size; i++) {
 		container.push_back(i);
 	}
@@ -28,7 +28,7 @@ TEST(StaticVector, StaticVector_erase)
 {
 	std::srand(clock());
 
-	if(container.size() == 0) {
+	if (container.size() == 0) {
 		return;
 	}
 

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -14,7 +14,7 @@ StaticVector<int, MAX_SIZE> container;
 TEST(StaticVector, StaticVector_push_back)
 {
 	std::srand(clock());
-	size_t size = std::rand() % MAX_SIZE;
+	size_t size = 1 + std::rand() % (MAX_SIZE - 1);
 	for (size_t i = 0; i < size; i++) {
 		container.push_back(i);
 	}
@@ -32,6 +32,9 @@ TEST(StaticVector, StaticVector_erase)
 	std::vector<int> erase_idx;
 	std::vector<int> expected;
 
+	erase_idx.push_back(0);
+	erase_idx.push_back(container.size() - 1);
+
 	for (int i = 0; i < erasures; i++) {
 		erase_idx.push_back(std::rand() % container.size());
 	}
@@ -41,10 +44,14 @@ TEST(StaticVector, StaticVector_erase)
 	}
 
 	for (int idx : erase_idx) {
+		if (container.size() == 0 || expected.size() == 0) {
+			break;
+		}
 		container.erase(container.begin() + idx, container.begin() + idx + 1);
 		expected.erase(expected.begin() + idx);
 	}
 
+	EXPECT_EQ(container.size(), expected.size() );
 	for (size_t i = 0; i < expected.size(); i++) {
 		EXPECT_EQ(container[i], expected[i]);
 	}

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -80,10 +80,10 @@ TEST(StaticVector, StaticVector_erase)
 		expected.erase(expected.begin() + idx);
 		if (container.size() > 0) {
 			EXPECT_EQ(container.size(), expected.size());
-			idx = idx == 0 ? 1 : idx;
-			EXPECT_EQ(container[idx - 1], expected[idx - 1]);
-			idx = (idx + 1) >= container.size() ? container.size() - 1 : idx;
-			EXPECT_EQ(container[idx + 1], expected[idx + 1]);
+			idx = idx <= 1 ? 0 : idx - 1;
+			EXPECT_EQ(container[idx], expected[idx]);
+			idx = (idx + 1) >= container.size() ? container.size() - 1 : idx + 1;
+			EXPECT_EQ(container[idx], expected[idx]);
 		}
 	}
 

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -75,14 +75,16 @@ TEST(StaticVector, StaticVector_erase)
 
 	int erasures = container.size();
 	for (int i = 0; i < erasures && container.size() > 0; i++) {
-		size_t idx = RandomIntBetween(0, container.size(), true);
+		size_t idx = RandomIntLessThan(container.size());
 		container.erase(container.begin() + idx);
 		expected.erase(expected.begin() + idx);
-		EXPECT_EQ(container.size(), expected.size());
-		idx = idx == 0 ? 1 : idx;
-		EXPECT_EQ(container[idx - 1], expected[idx - 1]);
-		idx = (idx + 1) >= container.size() ? container.size() - 1 : idx;
-		EXPECT_EQ(container[idx + 1], expected[idx + 1]);
+		if(container.size() > 0) {
+			EXPECT_EQ(container.size(), expected.size());
+			idx = idx == 0 ? 1 : idx;
+			EXPECT_EQ(container[idx - 1], expected[idx - 1]);
+			idx = (idx + 1) >= container.size() ? container.size() - 1 : idx;
+			EXPECT_EQ(container[idx + 1], expected[idx + 1]);
+		}
 	}
 
 	EXPECT_EQ(container.size(), 0);
@@ -111,7 +113,8 @@ TEST(StaticVector, StaticVector_erase_random)
 		expected.push_back(i);
 	}
 
-	for (int idx : erase_idx) {
+	while (erase_idx.size() > 0) {
+		int idx = erase_idx.front();
 		container.erase(container.begin() + idx, container.begin() + idx + 1);
 		expected.erase(expected.begin() + idx);
 		erase_idx.erase(erase_idx.begin());

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -78,7 +78,7 @@ TEST(StaticVector, StaticVector_erase)
 		size_t idx = RandomIntLessThan(container.size());
 		container.erase(container.begin() + idx);
 		expected.erase(expected.begin() + idx);
-		if(container.size() > 0) {
+		if (container.size() > 0) {
 			EXPECT_EQ(container.size(), expected.size());
 			idx = idx == 0 ? 1 : idx;
 			EXPECT_EQ(container[idx - 1], expected[idx - 1]);

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -8,11 +8,11 @@ using namespace devilution;
 
 namespace {
 
-constexpr size_t MAX_SIZE = 32;
+constexpr int MAX_SIZE = 32;
 
 TEST(StaticVector, StaticVector_push_back)
 {
-	StaticVector<int, MAX_SIZE> container;
+	StaticVector<size_t, MAX_SIZE> container;
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
 	size_t size = RandomIntBetween(10, MAX_SIZE, true);
@@ -29,7 +29,7 @@ TEST(StaticVector, StaticVector_push_back)
 
 TEST(StaticVector, StaticVector_push_back_full)
 {
-	StaticVector<int, MAX_SIZE> container;
+	StaticVector<size_t, MAX_SIZE> container;
 
 	size_t size = MAX_SIZE;
 	for (size_t i = 0; i < size; i++) {
@@ -40,17 +40,18 @@ TEST(StaticVector, StaticVector_push_back_full)
 	for (size_t i = 0; i < size; i++) {
 		EXPECT_EQ(container[i], i);
 	}
+
+	ASSERT_DEATH(container.push_back(size + 1), "");
 }
 
 TEST(StaticVector, StaticVector_erase)
 {
-	StaticVector<int, MAX_SIZE> container;
-	std::vector<int> expected;
+	StaticVector<size_t, MAX_SIZE> container;
+	std::vector<size_t> expected;
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
 
-	container.erase(container.begin());
-	EXPECT_EQ(container.size(), 0);
+	ASSERT_DEATH(container.erase(container.begin()), "");
 
 	container = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 	expected = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -67,15 +68,9 @@ TEST(StaticVector, StaticVector_erase)
 		EXPECT_EQ(container[i], expected[i]);
 	}
 
-	container.erase(container.begin(), container.end() + 1);
-	EXPECT_EQ(container.size(), expected.size());
-
-	container.erase(container.begin() - 1, container.end());
-	EXPECT_EQ(container.size(), expected.size());
-
-	int erasures = container.size();
-	for (int i = 0; i < erasures && container.size() > 0; i++) {
-		size_t idx = RandomIntLessThan(container.size());
+	size_t erasures = container.size();
+	for (size_t i = 0; i < erasures && container.size() > 0; i++) {
+		size_t idx = RandomIntLessThan(static_cast<int32_t>(container.size()));
 		container.erase(container.begin() + idx);
 		expected.erase(expected.begin() + idx);
 		if (container.size() > 0) {
@@ -88,13 +83,17 @@ TEST(StaticVector, StaticVector_erase)
 	}
 
 	EXPECT_EQ(container.size(), 0);
+
+	ASSERT_DEATH(container.erase(container.begin(), container.end() + 1), "");
+	ASSERT_DEATH(container.erase(container.begin() - 1, container.end()), "");
+
 }
 
 TEST(StaticVector, StaticVector_erase_random)
 {
-	StaticVector<int, MAX_SIZE> container;
-	std::vector<int> erase_idx;
-	std::vector<int> expected;
+	StaticVector<size_t, MAX_SIZE> container;
+	std::vector<size_t> erase_idx;
+	std::vector<size_t> expected;
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
 	size_t size = RandomIntBetween(10, MAX_SIZE, true);
@@ -103,10 +102,10 @@ TEST(StaticVector, StaticVector_erase_random)
 		container.push_back(i);
 	}
 
-	int erasures = RandomIntBetween(1, size, true);
+	size_t erasures = RandomIntBetween(1, static_cast<int32_t>(size), true);
 
-	for (int i = 0; i < erasures; i++) {
-		erase_idx.push_back(RandomIntBetween(0, size, true));
+	for (size_t i = 0; i < erasures; i++) {
+		erase_idx.push_back(RandomIntBetween(0, static_cast<int32_t>(size), true));
 	}
 
 	for (int i = 0; expected.size() < container.size(); i++) {
@@ -114,11 +113,11 @@ TEST(StaticVector, StaticVector_erase_random)
 	}
 
 	while (erase_idx.size() > 0) {
-		int idx = erase_idx.front();
-		container.erase(container.begin() + idx, container.begin() + idx + 1);
+		size_t idx = erase_idx.front();
+		container.erase(container.begin() + idx);
 		expected.erase(expected.begin() + idx);
 		erase_idx.erase(erase_idx.begin());
-		for (int i = erase_idx.size() - 1; i >= 0; i--) {
+		for (size_t i = 0; i < erase_idx.size(); i++) {
 			erase_idx[i] -= erase_idx[i] != 0 ? 1 : 0;
 		}
 	}
@@ -131,9 +130,9 @@ TEST(StaticVector, StaticVector_erase_random)
 
 TEST(StaticVector, StaticVector_erase_range)
 {
-	StaticVector<int, MAX_SIZE> container;
-	std::vector<int> erase_idx;
-	std::vector<int> expected;
+	StaticVector<size_t, MAX_SIZE> container;
+	std::vector<size_t> erase_idx;
+	std::vector<size_t> expected;
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
 
@@ -152,11 +151,11 @@ TEST(StaticVector, StaticVector_erase_range)
 		EXPECT_EQ(container[i], expected[i]);
 	}
 
-	int from = RandomIntBetween(0, container.size() - 1, true);
-	int to = RandomIntBetween(from, container.size() - 1, true);
+	int32_t from = RandomIntBetween(0, static_cast<int32_t>(container.size() - 1), true);
+	int32_t to = RandomIntBetween(from, static_cast<int32_t>(container.size() - 1), true);
 
 	container.erase(container.begin() + from, container.begin() + to);
-	for (int i = to - from; i > 0; i--) {
+	for (int32_t i = to - from; i > 0; i--) {
 		expected.erase(expected.begin() + from);
 	}
 
@@ -168,7 +167,7 @@ TEST(StaticVector, StaticVector_erase_range)
 
 TEST(StaticVector, StaticVector_clear)
 {
-	StaticVector<int, MAX_SIZE> container;
+	StaticVector<size_t, MAX_SIZE> container;
 
 	container.clear();
 	EXPECT_EQ(container.size(), 0);

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -15,7 +15,7 @@ TEST(StaticVector, StaticVector_push_back)
 	StaticVector<size_t, MAX_SIZE> container;
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
-	size_t size = RandomIntBetween(10, MAX_SIZE, true);
+	size_t size = RandomIntBetween(10, MAX_SIZE);
 
 	for (size_t i = 0; i < size; i++) {
 		container.push_back(i);
@@ -98,7 +98,7 @@ TEST(StaticVector, StaticVector_erase_random)
 	std::vector<size_t> expected;
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
-	size_t size = RandomIntBetween(10, MAX_SIZE, true);
+	size_t size = RandomIntBetween(10, MAX_SIZE);
 	size_t erasures = RandomIntBetween(1, static_cast<int32_t>(size) - 1, true);
 
 	for (size_t i = 0; i < size; i++) {
@@ -140,8 +140,8 @@ TEST(StaticVector, StaticVector_erase_range)
 		EXPECT_EQ(container[i], expected[i]);
 	}
 
-	int32_t from = RandomIntLessThan(static_cast<int32_t>(container.size()));
-	int32_t to = RandomIntBetween(from, static_cast<int32_t>(container.size() - 1), true);
+	int32_t from = RandomIntBetween(0, static_cast<int32_t>(container.size()) - 1);
+	int32_t to = RandomIntBetween(from + 1, static_cast<int32_t>(container.size()));
 	container.erase(container.begin() + from, container.begin() + to);
 	for (int32_t i = to - from; i > 0; i--) {
 		expected.erase(expected.begin() + from);

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -54,7 +54,7 @@ TEST(StaticVector, StaticVector_erase)
 		expected.erase(expected.begin() + idx);
 	}
 
-	EXPECT_EQ(container.size(), expected.size() );
+	EXPECT_EQ(container.size(), expected.size());
 	for (size_t i = 0; i < expected.size(); i++) {
 		EXPECT_EQ(container[i], expected[i]);
 	}
@@ -69,7 +69,7 @@ TEST(StaticVector, StaticVector_clear)
 
 	EXPECT_EQ(container.size(), expected.size());
 
-	for(size_t i = 0; i < container.size(); i++) {
+	for (size_t i = 0; i < container.size(); i++) {
 		EXPECT_EQ(container[i], expected[i]);
 	}
 }

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -86,7 +86,6 @@ TEST(StaticVector, StaticVector_erase)
 
 	ASSERT_DEATH(container.erase(container.begin(), container.end() + 1), "");
 	ASSERT_DEATH(container.erase(container.begin() - 1, container.end()), "");
-
 }
 
 TEST(StaticVector, StaticVector_erase_random)

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -52,14 +52,12 @@ TEST(StaticVector, StaticVector_erase_random)
 	}
 
 	for (int idx : erase_idx) {
-		/* This is actually to guard against gcc's vector implementation causing
-		 * crashes, rather than StaticVector
-		 */
-		if (expected.size() == 0) {
-			break;
-		}
 		container.erase(container.begin() + idx, container.begin() + idx + 1);
 		expected.erase(expected.begin() + idx);
+		erase_idx.erase(erase_idx.begin());
+		for (int i = erase_idx.size() - 1; i >= 0; i--) {
+			erase_idx[i] -= erase_idx[i] != 0 ? 1 : 0;
+		}
 	}
 
 	EXPECT_EQ(container.size(), expected.size());
@@ -70,16 +68,14 @@ TEST(StaticVector, StaticVector_erase_random)
 
 TEST(StaticVector, StaticVector_clear)
 {
-	std::vector<int> expected;
+	StaticVector<int, MAX_SIZE> container;
 
 	container.clear();
-	expected.clear();
+	EXPECT_EQ(container.size(), 0);
 
-	EXPECT_EQ(container.size(), expected.size());
-
-	for (size_t i = 0; i < container.size(); i++) {
-		EXPECT_EQ(container[i], expected[i]);
-	}
+	container = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+	container.clear();
+	EXPECT_EQ(container.size(), 0);
 }
 
 } // namespace

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -1,47 +1,50 @@
 #include <cstdlib>
-#include <ctime>
 #include <gtest/gtest.h>
 
+#include "engine/random.hpp"
 #include "utils/static_vector.hpp"
-
-#define MAX_SIZE 32
 
 using namespace devilution;
 
 namespace {
-StaticVector<int, MAX_SIZE> container;
+
+constexpr size_t MAX_SIZE = 32;
 
 TEST(StaticVector, StaticVector_push_back)
 {
-	std::srand(clock());
-	size_t size = 10 + (std::rand() % (MAX_SIZE - 10));
+	StaticVector<int, MAX_SIZE> container;
+
+	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
+	size_t size = RandomIntBetween(10, MAX_SIZE, true);
+
 	for (size_t i = 0; i < size; i++) {
 		container.push_back(i);
 	}
 
-	for (size_t i = 0; i < container.size(); i++) {
+	EXPECT_EQ(container.size(), size);
+	for (size_t i = 0; i < size; i++) {
 		EXPECT_EQ(container[i], i);
 	}
 }
 
-TEST(StaticVector, StaticVector_erase)
+TEST(StaticVector, StaticVector_erase_random)
 {
-	std::srand(clock());
-
-	if (container.size() == 0) {
-		return;
-	}
-
-	int erasures = std::rand() % container.size();
-
+	StaticVector<int, MAX_SIZE> container;
 	std::vector<int> erase_idx;
 	std::vector<int> expected;
 
-	erase_idx.push_back(0);
-	erase_idx.push_back(container.size() - 1);
+	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
+	size_t size = RandomIntBetween(10, MAX_SIZE, true);
+
+	for (size_t i = 0; i < size; i++) {
+		container.push_back(i);
+	}
+
+	int erasures = RandomIntBetween(1, size, true);
+
 
 	for (int i = 0; i < erasures; i++) {
-		erase_idx.push_back(std::rand() % container.size());
+		erase_idx.push_back(RandomIntBetween(0, size, true));
 	}
 
 	for (int i = 0; expected.size() < container.size(); i++) {

--- a/test/staticvector_test.cpp
+++ b/test/staticvector_test.cpp
@@ -47,6 +47,8 @@ TEST(StaticVector, StaticVector_erase)
 	StaticVector<int, MAX_SIZE> container;
 	std::vector<int> expected;
 
+	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
+
 	container.erase(container.begin());
 	EXPECT_EQ(container.size(), 0);
 
@@ -70,6 +72,20 @@ TEST(StaticVector, StaticVector_erase)
 
 	container.erase(container.begin() - 1, container.end());
 	EXPECT_EQ(container.size(), expected.size());
+
+	int erasures = container.size();
+	for (int i = 0; i < erasures && container.size() > 0; i++) {
+		size_t idx = RandomIntBetween(0, container.size(), true);
+		container.erase(container.begin() + idx);
+		expected.erase(expected.begin() + idx);
+		EXPECT_EQ(container.size(), expected.size());
+		idx = idx == 0 ? 1 : idx;
+		EXPECT_EQ(container[idx - 1], expected[idx - 1]);
+		idx = (idx + 1) >= container.size() ? container.size() - 1 : idx;
+		EXPECT_EQ(container[idx + 1], expected[idx + 1]);
+	}
+
+	EXPECT_EQ(container.size(), 0);
 }
 
 TEST(StaticVector, StaticVector_erase_random)


### PR DESCRIPTION
Hello,

While I was working on using `StaticVector` for vendor item arrays, I noticed that `StaticVector::erase()` doesn't seem to behave as expected. I asked about this on Discord and @glebm concluded it is a bug, and says that it is intended to work exactly like `std::vector`'s erase. 

The following changes have been made to `static_vector.hpp`:

- `std::move` is called before `std::destroy_at`, shifting items left.
- `std::destroy_at()` now destroys the entries at the back of the array after the move.
- `StaticVector::clear()` returns early if there are no member items.

I am not an expert in C++ and am not 100% confident in this PR or the changes made, so feedback is greatly appreciated. 

Regards,
Yggdrasill