### PR TITLE
Variable Zoom Levels

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -424,7 +424,8 @@ void UiHandleEvents(SDL_Event *event)
 #ifdef USE_SDL1
 		OutputToLogical(&event->motion.x, &event->motion.y);
 #endif
-		MousePosition = { event->motion.x, event->motion.y };
+		MousePositionRaw = { event->motion.x, event->motion.y };
+		MousePositionWorld = ScreenToGame(MousePositionRaw);
 		return;
 	}
 
@@ -435,6 +436,7 @@ void UiHandleEvents(SDL_Event *event)
 			SaveOptions();
 			if (gfnFullscreen != nullptr)
 				gfnFullscreen();
+			UpdateZoomLimits();
 			return;
 		}
 	}
@@ -457,6 +459,7 @@ void UiHandleEvents(SDL_Event *event)
 			// For example, if the previous size was too large for a hardware cursor then it was invisible
 			// but may now become visible.
 			DoReinitializeHardwareCursor();
+			UpdateZoomLimits();
 		} else if (event->window.event == SDL_WINDOWEVENT_FOCUS_LOST && *GetOptions().Gameplay.pauseOnFocusLoss) {
 			music_mute();
 		} else if (event->window.event == SDL_WINDOWEVENT_FOCUS_GAINED && *GetOptions().Gameplay.pauseOnFocusLoss) {
@@ -1134,6 +1137,6 @@ void DrawMouse()
 {
 	if (ControlDevice != ControlTypes::KeyboardAndMouse || IsHardwareCursor() || !ArtCursor)
 		return;
-	RenderClxSprite(Surface(DiabloUiSurface()), (*ArtCursor)[0], MousePosition);
+	RenderClxSprite(Surface(DiabloUiSurface()), (*ArtCursor)[0], MousePositionWorld);
 }
 } // namespace devilution

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1003,7 +1003,7 @@ void CheckMainPanelButton()
 
 		SetPanelObjectPosition(UiPanels::Main, button);
 
-		if (button.contains(MousePosition)) {
+		if (button.contains(MousePositionWorld)) {
 			SetMainPanelButtonDown(i);
 		}
 	}
@@ -1012,7 +1012,7 @@ void CheckMainPanelButton()
 
 	SetPanelObjectPosition(UiPanels::Main, spellSelectButton);
 
-	if (!SpellSelectFlag && spellSelectButton.contains(MousePosition)) {
+	if (!SpellSelectFlag && spellSelectButton.contains(MousePositionWorld)) {
 		if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
 			Player &myPlayer = *MyPlayer;
 			myPlayer._pRSpell = SpellID::Invalid;
@@ -1031,7 +1031,7 @@ void CheckMainPanelButtonDead()
 
 	SetPanelObjectPosition(UiPanels::Main, menuButton);
 
-	if (menuButton.contains(MousePosition)) {
+	if (menuButton.contains(MousePositionWorld)) {
 		SetMainPanelButtonDown(PanelButtonMainmenu);
 		return;
 	}
@@ -1040,7 +1040,7 @@ void CheckMainPanelButtonDead()
 
 	SetPanelObjectPosition(UiPanels::Main, chatButton);
 
-	if (chatButton.contains(MousePosition)) {
+	if (chatButton.contains(MousePositionWorld)) {
 		SetMainPanelButtonDown(PanelButtonSendmsg);
 	}
 }
@@ -1079,7 +1079,7 @@ void CheckPanelInfo()
 
 		SetPanelObjectPosition(UiPanels::Main, button);
 
-		if (button.contains(MousePosition)) {
+		if (button.contains(MousePositionWorld)) {
 			if (i != 7) {
 				InfoString = _(PanBtnStr[i]);
 			} else {
@@ -1100,7 +1100,7 @@ void CheckPanelInfo()
 
 	SetPanelObjectPosition(UiPanels::Main, spellSelectButton);
 
-	if (!SpellSelectFlag && spellSelectButton.contains(MousePosition)) {
+	if (!SpellSelectFlag && spellSelectButton.contains(MousePositionWorld)) {
 		InfoString = _("Select current spell button");
 		InfoColor = UiFlags::ColorWhite;
 		MainPanelFlag = true;
@@ -1138,7 +1138,7 @@ void CheckPanelInfo()
 
 	SetPanelObjectPosition(UiPanels::Main, belt);
 
-	if (belt.contains(MousePosition))
+	if (belt.contains(MousePositionWorld))
 		pcursinvitem = CheckInvHLight();
 
 	if (CheckXPBarInfo())
@@ -1161,7 +1161,7 @@ void CheckMainPanelButtonUp()
 
 		SetPanelObjectPosition(UiPanels::Main, button);
 
-		if (!button.contains(MousePosition))
+		if (!button.contains(MousePositionWorld))
 			continue;
 
 		switch (i) {
@@ -1308,7 +1308,7 @@ void CheckLevelButton()
 
 	SetPanelObjectPosition(UiPanels::Main, button);
 
-	if (!LevelButtonDown && button.contains(MousePosition))
+	if (!LevelButtonDown && button.contains(MousePositionWorld))
 		LevelButtonDown = true;
 }
 
@@ -1318,7 +1318,7 @@ void CheckLevelButtonUp()
 
 	SetPanelObjectPosition(UiPanels::Main, button);
 
-	if (button.contains(MousePosition)) {
+	if (button.contains(MousePositionWorld)) {
 		OpenCharPanel();
 	}
 	LevelButtonDown = false;
@@ -1347,7 +1347,7 @@ void CheckChrBtns()
 		auto buttonId = static_cast<size_t>(attribute);
 		Rectangle button = CharPanelButtonRect[buttonId];
 		SetPanelObjectPosition(UiPanels::Character, button);
-		if (button.contains(MousePosition)) {
+		if (button.contains(MousePositionWorld)) {
 			CharPanelButton[buttonId] = true;
 			CharPanelButtonActive = true;
 		}
@@ -1365,7 +1365,7 @@ void ReleaseChrBtns(bool addAllStatPoints)
 		CharPanelButton[buttonId] = false;
 		Rectangle button = CharPanelButtonRect[buttonId];
 		SetPanelObjectPosition(UiPanels::Character, button);
-		if (button.contains(MousePosition)) {
+		if (button.contains(MousePositionWorld)) {
 			Player &myPlayer = *MyPlayer;
 			int statPointsToAdd = 1;
 			if (addAllStatPoints)
@@ -1615,7 +1615,7 @@ bool CheckMuteButton()
 
 	buttons.size.height = (MuteButtons * buttons.size.height) + ((MuteButtons - 1) * MuteButtonPadding);
 
-	if (!buttons.contains(MousePosition))
+	if (!buttons.contains(MousePositionWorld))
 		return false;
 
 	for (bool &talkButtonDown : TalkButtonsDown) {
@@ -1624,7 +1624,7 @@ bool CheckMuteButton()
 
 	const Point mainPanelPosition = GetMainPanel().position;
 
-	TalkButtonsDown[(MousePosition.y - (69 + mainPanelPosition.y)) / 18] = true;
+	TalkButtonsDown[(MousePositionWorld.y - (69 + mainPanelPosition.y)) / 18] = true;
 
 	return true;
 }
@@ -1643,10 +1643,10 @@ void CheckMuteButtonUp()
 
 	buttons.size.height = (MuteButtons * buttons.size.height) + ((MuteButtons - 1) * MuteButtonPadding);
 
-	if (!buttons.contains(MousePosition))
+	if (!buttons.contains(MousePositionWorld))
 		return;
 
-	int off = (MousePosition.y - buttons.position.y) / (MuteButtonRect.size.height + MuteButtonPadding);
+	int off = (MousePositionWorld.y - buttons.position.y) / (MuteButtonRect.size.height + MuteButtonPadding);
 
 	size_t playerId = 0;
 	for (; playerId < Players.size() && off != -1; ++playerId) {

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -558,7 +558,7 @@ void AttrIncBtnSnap(AxisDirection dir)
 	for (int i = 0; i < 4; i++) {
 		button = CharPanelButtonRect[i];
 		button.position = GetPanelPosition(UiPanels::Character, button.position);
-		if (button.contains(MousePosition)) {
+		if (button.contains(MousePositionWorld)) {
 			slot = i;
 			break;
 		}
@@ -824,7 +824,7 @@ Point FindClosestStashSlot(Point mousePos)
 
 void LiftInventoryItem()
 {
-	int inventorySlot = (Slot >= 0) ? Slot : FindClosestInventorySlot(MousePosition, MyPlayer->HoldItem);
+	int inventorySlot = (Slot >= 0) ? Slot : FindClosestInventorySlot(MousePositionWorld, MyPlayer->HoldItem);
 
 	int jumpSlot = inventorySlot; // If the cursor is over an inventory slot we may need to adjust it due to pasting items of different sizes over each other
 	if (inventorySlot >= SLOTXY_INV_FIRST && inventorySlot <= SLOTXY_INV_LAST) {
@@ -865,7 +865,7 @@ void LiftInventoryItem()
 
 void LiftStashItem()
 {
-	Point stashSlot = (ActiveStashSlot != InvalidStashPoint) ? ActiveStashSlot : FindClosestStashSlot(MousePosition);
+	Point stashSlot = (ActiveStashSlot != InvalidStashPoint) ? ActiveStashSlot : FindClosestStashSlot(MousePositionWorld);
 
 	Size cursorSizeInCells = MyPlayer->HoldItem.isEmpty() ? Size { 1, 1 } : GetInventorySize(MyPlayer->HoldItem);
 
@@ -884,7 +884,7 @@ void LiftStashItem()
 	}(stashSlot, cursorSizeInCells);
 
 	Point jumpSlot = itemUnderCursor == StashStruct::EmptyCell ? stashSlot : FindFirstStashSlotOnItem(itemUnderCursor);
-	CheckStashItem(MousePosition);
+	CheckStashItem(MousePositionWorld);
 
 	Point mousePos = GetStashSlotCoord(jumpSlot);
 	ActiveStashSlot = jumpSlot;
@@ -914,7 +914,7 @@ inv_xy_slot InventoryMoveToBody(int slot)
 
 void InventoryMove(AxisDirection dir)
 {
-	Point mousePos = MousePosition;
+	Point mousePos = MousePositionWorld;
 
 	const Item &heldItem = MyPlayer->HoldItem;
 	// normalize slots
@@ -1136,7 +1136,7 @@ void InventoryMove(AxisDirection dir)
 		mousePos.y += ((itemSize.height - 1) * InventorySlotSizeInPixels.height) / 2;
 	}
 
-	if (mousePos == MousePosition) {
+	if (mousePos == MousePositionWorld) {
 		return; // Avoid wobbling when scaled
 	}
 
@@ -1189,13 +1189,13 @@ void StashMove(AxisDirection dir)
 
 	Item &holdItem = MyPlayer->HoldItem;
 	if (Slot < 0 && ActiveStashSlot == InvalidStashPoint) {
-		int invSlot = FindClosestInventorySlot(MousePosition, holdItem);
+		int invSlot = FindClosestInventorySlot(MousePositionWorld, holdItem);
 		Point invSlotCoord = GetSlotCoord(invSlot);
-		int invDistance = MousePosition.ManhattanDistance(invSlotCoord);
+		int invDistance = MousePositionWorld.ManhattanDistance(invSlotCoord);
 
-		Point stashSlot = FindClosestStashSlot(MousePosition);
+		Point stashSlot = FindClosestStashSlot(MousePositionWorld);
 		Point stashSlotCoord = GetStashSlotCoord(stashSlot);
-		int stashDistance = MousePosition.ManhattanDistance(stashSlotCoord);
+		int stashDistance = MousePositionWorld.ManhattanDistance(stashSlotCoord);
 
 		if (invDistance < stashDistance) {
 			BeltReturnsToStash = false;
@@ -1348,11 +1348,11 @@ void HotSpellMove(AxisDirection dir)
 
 	auto spellListItems = GetSpellListItems();
 
-	Point position = MousePosition;
+	Point position = MousePositionWorld;
 	int shortestDistance = std::numeric_limits<int>::max();
 	for (auto &spellListItem : spellListItems) {
 		Point center = spellListItem.location + Displacement { SPLICONLENGTH / 2, -SPLICONLENGTH / 2 };
-		int distance = MousePosition.ManhattanDistance(center);
+		int distance = MousePositionWorld.ManhattanDistance(center);
 		if (distance < shortestDistance) {
 			position = center;
 			shortestDistance = distance;
@@ -1371,15 +1371,15 @@ void HotSpellMove(AxisDirection dir)
 				continue;
 
 			Point center = spellListItem.location + Displacement { SPLICONLENGTH / 2, -SPLICONLENGTH / 2 };
-			if (dir.x == AxisDirectionX_LEFT && center.x >= MousePosition.x)
+			if (dir.x == AxisDirectionX_LEFT && center.x >= MousePositionWorld.x)
 				continue;
-			if (dir.x == AxisDirectionX_RIGHT && center.x <= MousePosition.x)
+			if (dir.x == AxisDirectionX_RIGHT && center.x <= MousePositionWorld.x)
 				continue;
 			if (dir.x == AxisDirectionX_NONE && center.x != position.x)
 				continue;
-			if (dir.y == AxisDirectionY_UP && center.y >= MousePosition.y)
+			if (dir.y == AxisDirectionY_UP && center.y >= MousePositionWorld.y)
 				continue;
-			if (dir.y == AxisDirectionY_DOWN && center.y <= MousePosition.y)
+			if (dir.y == AxisDirectionY_DOWN && center.y <= MousePositionWorld.y)
 				continue;
 			if (dir.y == AxisDirectionY_NONE && center.y != position.y)
 				continue;
@@ -1391,7 +1391,7 @@ void HotSpellMove(AxisDirection dir)
 	search({ AxisDirectionX_NONE, dir.y }, dir.y == AxisDirectionY_DOWN);
 	search({ dir.x, AxisDirectionY_NONE }, dir.x == AxisDirectionX_RIGHT);
 
-	if (position != MousePosition) {
+	if (position != MousePositionWorld) {
 		SetCursorPos(position);
 	}
 }
@@ -1837,8 +1837,8 @@ void HandleRightStickMotion()
 
 	{ // move cursor
 		InvalidateInventorySlot();
-		int x = MousePosition.x;
-		int y = MousePosition.y;
+		int x = MousePositionWorld.x;
+		int y = MousePositionWorld.y;
 		acc.Pool(&x, &y, 2);
 		x = std::min(std::max(x, 0), gnScreenWidth - 1);
 		y = std::min(std::max(y, 0), gnScreenHeight - 1);
@@ -1975,9 +1975,9 @@ void PerformPrimaryAction()
 				return;
 			TryIconCurs();
 			NewCursor(CURSOR_HAND);
-		} else if (GetRightPanel().contains(MousePosition) || GetMainPanel().contains(MousePosition)) {
+		} else if (GetRightPanel().contains(MousePositionWorld) || GetMainPanel().contains(MousePositionWorld)) {
 			LiftInventoryItem();
-		} else if (IsStashOpen && GetLeftPanel().contains(MousePosition)) {
+		} else if (IsStashOpen && GetLeftPanel().contains(MousePositionWorld)) {
 			LiftStashItem();
 		}
 		return;
@@ -2079,7 +2079,7 @@ void PerformSpellAction()
 			if (itemId != GetItemIdOnSlot(Slot))
 				ResetInvCursorPosition();
 		} else if (pcursstashitem != StashStruct::EmptyCell) {
-			CheckStashItem(MousePosition, true, false);
+			CheckStashItem(MousePositionWorld, true, false);
 		}
 		return;
 	}
@@ -2152,7 +2152,7 @@ void CtrlUseStashItem()
 	}
 
 	if (item.isEquipment()) {
-		CheckStashItem(MousePosition, true, false); // Auto-equip if it's equipment
+		CheckStashItem(MousePositionWorld, true, false); // Auto-equip if it's equipment
 	} else {
 		UseStashItem(pcursstashitem);
 	}

--- a/Source/controls/touch/event_handlers.cpp
+++ b/Source/controls/touch/event_handlers.cpp
@@ -50,7 +50,8 @@ void SimulateMouseMovement(const SDL_Event &event)
 			return;
 	}
 
-	MousePosition = position;
+	MousePositionRaw = position;
+	MousePositionWorld = ScreenToGame(MousePositionRaw);
 
 	SetPointAndClick(true);
 
@@ -130,9 +131,9 @@ void HandleStashPanelInteraction(const SDL_Event &event)
 		return;
 
 	if (event.type != SDL_FINGERUP) {
-		CheckStashButtonPress(MousePosition);
+		CheckStashButtonPress(MousePositionWorld);
 	} else {
-		CheckStashButtonRelease(MousePosition);
+		CheckStashButtonRelease(MousePositionWorld);
 	}
 }
 

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -394,7 +394,7 @@ VirtualGamepadButtonType PrimaryActionButtonRenderer::GetButtonType()
 	// NEED: Confirm surface
 	if (qtextflag)
 		return GetTalkButtonType(virtualPadButton->isHeld);
-	if (CharFlag && InteractsWithCharButton(MousePosition))
+	if (CharFlag && InteractsWithCharButton(MousePositionWorld))
 		return GetApplyButtonType(virtualPadButton->isHeld);
 	if (invflag)
 		return GetInventoryButtonType();

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -20,6 +20,7 @@
 #include "doom.h"
 #include "engine/backbuffer_state.hpp"
 #include "engine/demomode.h"
+#include "engine/dx.h"
 #include "engine/point.hpp"
 #include "engine/points_in_rectangle_range.hpp"
 #include "engine/render/clx_render.hpp"
@@ -262,9 +263,9 @@ bool TrySelectPixelBased(Point tile)
 			spriteTopLeft *= 2;
 		}
 		const Rectangle spriteCoords = Rectangle(spriteTopLeft, spriteSize);
-		if (!spriteCoords.contains(MousePosition))
+		if (!spriteCoords.contains(MousePositionWorld))
 			return false;
-		Point pointInSprite = Point { 0, 0 } + (MousePosition - spriteCoords.position);
+		Point pointInSprite = Point { 0, 0 } + (MousePositionWorld - spriteCoords.position);
 		if (*GetOptions().Graphics.zoom)
 			pointInSprite /= 2;
 		return IsPointWithinClx(pointInSprite, sprite);
@@ -581,6 +582,7 @@ void NewCursor(int cursId)
 void DrawSoftwareCursor(const Surface &out, Point position, int cursId)
 {
 	const ClxSprite sprite = GetInvItemSprite(cursId);
+
 	if (cursId >= CURSOR_FIRSTITEM && !MyPlayer->HoldItem.isEmpty()) {
 		const auto &heldItem = MyPlayer->HoldItem;
 		ClxDrawOutline(out, GetOutlineColor(heldItem, true), position, sprite);
@@ -657,7 +659,7 @@ void AlterMousePositionViaPanels(Point &screenPosition)
  */
 void AlterMousePositionViaScrolling(Point &screenPosition, Rectangle mainPanel)
 {
-	if (mainPanel.contains(MousePosition) && track_isscrolling()) {
+	if (mainPanel.contains(MousePositionWorld) && track_isscrolling()) {
 		screenPosition.y = mainPanel.position.y - 1;
 	}
 }
@@ -805,24 +807,24 @@ bool CheckPlayerState(const Point currentTile, const Player &myPlayer)
 
 bool CheckPanelsAndFlags(Rectangle mainPanel)
 {
-	if (mainPanel.contains(MousePosition)) {
+	if (mainPanel.contains(MousePositionWorld)) {
 		CheckPanelInfo();
 		return true;
 	}
 	if (DoomFlag) {
 		return true;
 	}
-	if (invflag && GetRightPanel().contains(MousePosition)) {
+	if (invflag && GetRightPanel().contains(MousePositionWorld)) {
 		pcursinvitem = CheckInvHLight();
 		return true;
 	}
-	if (IsStashOpen && GetLeftPanel().contains(MousePosition)) {
-		pcursstashitem = CheckStashHLight(MousePosition);
+	if (IsStashOpen && GetLeftPanel().contains(MousePositionWorld)) {
+		pcursstashitem = CheckStashHLight(MousePositionWorld);
 	}
-	if (SpellbookFlag && GetRightPanel().contains(MousePosition)) {
+	if (SpellbookFlag && GetRightPanel().contains(MousePositionWorld)) {
 		return true;
 	}
-	if (IsLeftPanelOpen() && GetLeftPanel().contains(MousePosition)) {
+	if (IsLeftPanelOpen() && GetLeftPanel().contains(MousePositionWorld)) {
 		return true;
 	}
 	return false;
@@ -879,7 +881,7 @@ void CheckCursMove()
 	if (IsItemLabelHighlighted())
 		return;
 
-	Point screenPosition = MousePosition;
+	Point screenPosition = MousePositionWorld;
 	const Rectangle &mainPanel = GetMainPanel();
 
 	AlterMousePositionViaPanels(screenPosition);

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -65,7 +65,8 @@ enum class MouseActionType : uint8_t {
 
 extern uint32_t DungeonSeeds[NUMLEVELS];
 extern DVL_API_FOR_TEST std::optional<uint32_t> LevelSeeds[NUMLEVELS];
-extern Point MousePosition;
+extern Point MousePositionRaw;
+extern Point MousePositionWorld;
 extern DVL_API_FOR_TEST bool gbRunGame;
 extern bool gbRunGameResult;
 extern bool ReturnToMainMenu;
@@ -118,5 +119,8 @@ extern GameLogicStep gGameLogicStep;
 #ifdef __UWP__
 void setOnInitialized(void (*)());
 #endif
+
+Point ScreenToGame(Point screenPos);
+Point GetMousePosGameSpace();
 
 } // namespace devilution

--- a/Source/engine/dx.cpp
+++ b/Source/engine/dx.cpp
@@ -304,7 +304,7 @@ void UpdateZoomLimits()
 	SDL_GetRendererOutputSize(renderer, &screenWidth, &screenHeight);
 
 	const float internalHeight = static_cast<float>(screenHeight); // Game renders at full screen resolution
-	constexpr float minVisibleHeight = 360.0f;                     // max zoom-in (tight view)
+	constexpr float minVisibleHeight = 240.0f;                     // max zoom-in (tight view)
 	constexpr float maxVisibleHeight = 720.0f;                     // max zoom-out (full screen)
 
 	MinZoom = minVisibleHeight / internalHeight;

--- a/Source/engine/dx.h
+++ b/Source/engine/dx.h
@@ -16,6 +16,10 @@ extern bool RenderDirectlyToOutputSurface;
 
 extern SDL_Surface *PalSurface;
 
+extern float CurrentZoomLevel;
+extern float MinZoom;
+extern float MaxZoom;
+
 Surface GlobalBackBuffer();
 
 void dx_init();
@@ -26,5 +30,6 @@ void BltFast(SDL_Rect *srcRect, SDL_Rect *dstRect);
 void Blit(SDL_Surface *src, SDL_Rect *srcRect, SDL_Rect *dstRect);
 void RenderPresent();
 void PaletteGetEntries(int dwNumEntries, SDL_Color *lpEntries);
+void UpdateZoomLimits();
 
 } // namespace devilution

--- a/Source/engine/events.cpp
+++ b/Source/engine/events.cpp
@@ -54,7 +54,7 @@ bool FetchMessage_Real(SDL_Event *event, uint16_t *modState)
 	*modState = SDL_GetModState();
 
 #ifdef __vita__
-	HandleTouchEvent(&e, MousePosition);
+	HandleTouchEvent(&e, MousePositionWorld);
 #elif !defined(USE_SDL1)
 	HandleTouchEvent(e);
 #endif

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -257,7 +257,7 @@ void DrawCursor(const Surface &out)
 	// Copy the buffer before the item cursor and its 1px outline are drawn to a temporary buffer.
 	const int outlineWidth = !MyPlayer->HoldItem.isEmpty() ? 1 : 0;
 	Displacement offset = !MyPlayer->HoldItem.isEmpty() ? Displacement { cursSize / 2 } : Displacement { 0 };
-	Point cursPosition = MousePosition - offset;
+	Point cursPosition = MousePositionWorld - offset;
 
 	Rectangle &rect = cursor.rect;
 	rect.position.x = cursPosition.x - outlineWidth;
@@ -1602,7 +1602,7 @@ void ScrollView()
 	if (!MyPlayer->HoldItem.isEmpty())
 		return;
 
-	if (MousePosition.x < 20) {
+	if (MousePositionWorld.x < 20) {
 		if (dmaxPosition.y - 1 <= ViewPosition.y || dminPosition.x >= ViewPosition.x) {
 			if (dmaxPosition.y - 1 > ViewPosition.y) {
 				ViewPosition.y++;
@@ -1615,7 +1615,7 @@ void ScrollView()
 			ViewPosition.x--;
 		}
 	}
-	if (MousePosition.x > gnScreenWidth - 20) {
+	if (MousePositionWorld.x > gnScreenWidth - 20) {
 		if (dmaxPosition.x - 1 <= ViewPosition.x || dminPosition.y >= ViewPosition.y) {
 			if (dmaxPosition.x - 1 > ViewPosition.x) {
 				ViewPosition.x++;
@@ -1628,7 +1628,7 @@ void ScrollView()
 			ViewPosition.x++;
 		}
 	}
-	if (MousePosition.y < 20) {
+	if (MousePositionWorld.y < 20) {
 		if (dminPosition.y >= ViewPosition.y || dminPosition.x >= ViewPosition.x) {
 			if (dminPosition.y < ViewPosition.y) {
 				ViewPosition.y--;
@@ -1641,7 +1641,7 @@ void ScrollView()
 			ViewPosition.y--;
 		}
 	}
-	if (MousePosition.y > gnScreenHeight - 20) {
+	if (MousePositionWorld.y > gnScreenHeight - 20) {
 		if (dmaxPosition.y - 1 <= ViewPosition.y || dmaxPosition.x - 1 <= ViewPosition.x) {
 			if (dmaxPosition.y - 1 > ViewPosition.y) {
 				ViewPosition.y++;

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -153,10 +153,10 @@ void GameMenuMove()
 bool GmenuMouseIsOverSlider()
 {
 	int uiPositionX = GetUIRectangle().position.x;
-	if (MousePosition.x < SliderValueLeft + uiPositionX) {
+	if (MousePositionWorld.x < SliderValueLeft + uiPositionX) {
 		return false;
 	}
-	if (MousePosition.x >= SliderValueLeft + SliderValueWidth + uiPositionX) {
+	if (MousePositionWorld.x >= SliderValueLeft + SliderValueWidth + uiPositionX) {
 		return false;
 	}
 	return true;
@@ -164,7 +164,7 @@ bool GmenuMouseIsOverSlider()
 
 int GmenuGetSliderFill()
 {
-	return std::clamp(MousePosition.x - SliderValueLeft - GetUIRectangle().position.x, SliderFillMin, SliderFillMax);
+	return std::clamp(MousePositionWorld.x - SliderValueLeft - GetUIRectangle().position.x, SliderFillMin, SliderFillMax);
 }
 
 } // namespace
@@ -330,13 +330,13 @@ bool gmenu_left_mouse(bool isDown)
 		return false;
 	}
 	const Point uiPosition = GetUIRectangle().position;
-	if (MousePosition.y >= GetMainPanel().position.y) {
+	if (MousePositionWorld.y >= GetMainPanel().position.y) {
 		return false;
 	}
-	if (MousePosition.y - (GMenuTop + uiPosition.y) < 0) {
+	if (MousePositionWorld.y - (GMenuTop + uiPosition.y) < 0) {
 		return true;
 	}
-	int i = (MousePosition.y - (GMenuTop + uiPosition.y)) / GMenuItemHeight;
+	int i = (MousePositionWorld.y - (GMenuTop + uiPosition.y)) / GMenuItemHeight;
 	if (i >= sgCurrentMenuIdx) {
 		return true;
 	}
@@ -346,10 +346,10 @@ bool gmenu_left_mouse(bool isDown)
 	}
 	int w = GmenuGetLineWidth(pItem);
 	uint16_t screenWidth = GetScreenWidth();
-	if (MousePosition.x < screenWidth / 2 - w / 2) {
+	if (MousePositionWorld.x < screenWidth / 2 - w / 2) {
 		return true;
 	}
-	if (MousePosition.x > screenWidth / 2 + w / 2) {
+	if (MousePositionWorld.x > screenWidth / 2 + w / 2) {
 		return true;
 	}
 	sgpCurrItem = pItem;

--- a/Source/hwcursor.hpp
+++ b/Source/hwcursor.hpp
@@ -173,4 +173,6 @@ inline void ReinitializeHardwareCursor()
 	}
 }
 
+void RefreshCurrentHardwareCursor();
+
 } // namespace devilution

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1633,19 +1633,19 @@ void CheckInvItem(bool isShiftHeld, bool isCtrlHeld)
 	if (IsInspectingPlayer())
 		return;
 	if (!MyPlayer->HoldItem.isEmpty()) {
-		CheckInvPaste(*MyPlayer, MousePosition);
+		CheckInvPaste(*MyPlayer, MousePositionWorld);
 	} else if (IsStashOpen && isCtrlHeld) {
 		TransferItemToStash(*MyPlayer, pcursinvitem);
 	} else {
-		CheckInvCut(*MyPlayer, MousePosition, isShiftHeld, isCtrlHeld);
+		CheckInvCut(*MyPlayer, MousePositionWorld, isShiftHeld, isCtrlHeld);
 	}
 }
 
 void CheckInvScrn(bool isShiftHeld, bool isCtrlHeld)
 {
 	const Point mainPanelPosition = GetMainPanel().position;
-	if (MousePosition.x > 190 + mainPanelPosition.x && MousePosition.x < 437 + mainPanelPosition.x
-	    && MousePosition.y > mainPanelPosition.y && MousePosition.y < 33 + mainPanelPosition.y) {
+	if (MousePositionWorld.x > 190 + mainPanelPosition.x && MousePositionWorld.x < 437 + mainPanelPosition.x
+	    && MousePositionWorld.y > mainPanelPosition.y && MousePositionWorld.y < 33 + mainPanelPosition.y) {
 		CheckInvItem(isShiftHeld, isCtrlHeld);
 	}
 }
@@ -1912,7 +1912,7 @@ int8_t CheckInvHLight()
 			yo = GetMainPanel().position.y;
 		}
 
-		if (InvRect[r].contains(MousePosition - Displacement(xo, yo))) {
+		if (InvRect[r].contains(MousePositionWorld - Displacement(xo, yo))) {
 			break;
 		}
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1741,7 +1741,7 @@ void PrintItemOil(char iDidx)
 
 Point DrawUniqueInfoWindow(const Surface &out)
 {
-	const bool isInStash = IsStashOpen && GetLeftPanel().contains(MousePosition);
+	const bool isInStash = IsStashOpen && GetLeftPanel().contains(MousePositionWorld);
 	int panelX, panelY;
 	if (isInStash) {
 		ClxDraw(out, GetPanelPosition(UiPanels::Stash, { 24 + SidePanelSize.width, 327 }), (*pSTextBoxCels)[0]);

--- a/Source/levels/trigs.cpp
+++ b/Source/levels/trigs.cpp
@@ -810,7 +810,7 @@ void CheckTrigForce()
 {
 	trigflag = false;
 
-	if (ControlMode == ControlTypes::KeyboardAndMouse && GetMainPanel().contains(MousePosition)) {
+	if (ControlMode == ControlTypes::KeyboardAndMouse && GetMainPanel().contains(MousePositionWorld)) {
 		return;
 	}
 

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -92,8 +92,8 @@ void play_movie(const char *pszMovie, bool userCanClose)
 
 	movie_playing = false;
 
-	SDL_GetMouseState(&MousePosition.x, &MousePosition.y);
-	OutputToLogical(&MousePosition.x, &MousePosition.y);
+	SDL_GetMouseState(&MousePositionWorld.x, &MousePositionWorld.y);
+	OutputToLogical(&MousePositionWorld.x, &MousePositionWorld.y);
 	InitBackbufferState();
 }
 

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -211,8 +211,8 @@ void CheckSBook()
 	// enough to the height of the space given to spell descriptions that we can reuse that value and subtract the
 	// padding from the end of the area.
 	Rectangle iconArea = { GetPanelPosition(UiPanels::Spell, { 11, 18 }), Size { 37, SpellBookDescription.height * 7 - 5 } };
-	if (iconArea.contains(MousePosition) && !IsInspectingPlayer()) {
-		SpellID sn = GetSpellFromSpellPage(SpellbookTab, (MousePosition.y - iconArea.position.y) / SpellBookDescription.height);
+	if (iconArea.contains(MousePositionWorld) && !IsInspectingPlayer()) {
+		SpellID sn = GetSpellFromSpellPage(SpellbookTab, (MousePositionWorld.y - iconArea.position.y) / SpellBookDescription.height);
 		Player &player = *InspectPlayer;
 		uint64_t spl = player._pMemSpells | player._pISpells | player._pAblSpells;
 		if (IsValidSpell(sn) && (spl & GetSpellBitmask(sn)) != 0) {
@@ -236,8 +236,8 @@ void CheckSBook()
 	const int buttonWidth = SpellBookButtonWidth();
 	// Tabs are drawn in a row near the bottom of the panel
 	Rectangle tabArea = { GetPanelPosition(UiPanels::Spell, { 7, 320 }), Size { 305, 29 } };
-	if (tabArea.contains(MousePosition)) {
-		int hitColumn = MousePosition.x - tabArea.position.x;
+	if (tabArea.contains(MousePositionWorld)) {
+		int hitColumn = MousePositionWorld.x - tabArea.position.x;
 		// Clicking on the gutter currently activates tab 3. Could make it do nothing by checking for == here and return early.
 		if (!gbIsHellfire && hitColumn > buttonWidth * 2) {
 			// Subtract 1 pixel to account for the gutter between buttons 2/3

--- a/Source/panels/spell_list.cpp
+++ b/Source/panels/spell_list.cpp
@@ -230,7 +230,7 @@ std::vector<SpellListItem> GetSpellListItems()
 				continue;
 			int lx = x;
 			int ly = y - SPLICONLENGTH;
-			bool isSelected = (MousePosition.x >= lx && MousePosition.x < lx + SPLICONLENGTH && MousePosition.y >= ly && MousePosition.y < ly + SPLICONLENGTH);
+			bool isSelected = (MousePositionWorld.x >= lx && MousePositionWorld.x < lx + SPLICONLENGTH && MousePositionWorld.y >= ly && MousePositionWorld.y < ly + SPLICONLENGTH);
 			spellListItems.emplace_back(SpellListItem { { x, y }, static_cast<SpellType>(i), static_cast<SpellID>(j), isSelected });
 			x -= SPLICONLENGTH;
 			if (x == mainPanelPosition.x + 12 - SPLICONLENGTH) {

--- a/Source/platform/switch/docking.cpp
+++ b/Source/platform/switch/docking.cpp
@@ -5,6 +5,7 @@
 #include <SDL.h>
 #include <switch.h>
 
+#include "engine/dx.h"
 #include "utils/display.h"
 
 namespace devilution {

--- a/Source/platform/switch/docking.cpp
+++ b/Source/platform/switch/docking.cpp
@@ -54,6 +54,7 @@ void HandleDocking()
 			SDL_RenderPresent(renderer);
 		}
 		SDL_SetWindowSize(ghMainWnd, display_width, display_height);
+		UpdateZoomLimits();
 	}
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3083,12 +3083,12 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 		if (pcurs != CURSOR_HAND)
 			return;
 
-		if (GetMainPanel().contains(MousePosition)) // inside main panel
+		if (GetMainPanel().contains(MousePositionWorld)) // inside main panel
 			return;
 
 		if (
-		    (IsLeftPanelOpen() && GetLeftPanel().contains(MousePosition))      // inside left panel
-		    || (IsRightPanelOpen() && GetRightPanel().contains(MousePosition)) // inside right panel
+		    (IsLeftPanelOpen() && GetLeftPanel().contains(MousePositionWorld))      // inside left panel
+		    || (IsRightPanelOpen() && GetRightPanel().contains(MousePositionWorld)) // inside right panel
 		) {
 			if (spellID != SpellID::Healing
 			    && spellID != SpellID::Identify

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -135,11 +135,11 @@ void AddItemToLabelQueue(int id, Point position)
 
 bool IsMouseOverGameArea()
 {
-	if ((IsRightPanelOpen()) && GetRightPanel().contains(MousePosition))
+	if ((IsRightPanelOpen()) && GetRightPanel().contains(MousePositionWorld))
 		return false;
-	if ((IsLeftPanelOpen()) && GetLeftPanel().contains(MousePosition))
+	if ((IsLeftPanelOpen()) && GetLeftPanel().contains(MousePositionWorld))
 		return false;
-	if (GetMainPanel().contains(MousePosition))
+	if (GetMainPanel().contains(MousePositionWorld))
 		return false;
 
 	return true;
@@ -189,8 +189,8 @@ void DrawItemNameLabels(const Surface &out)
 	for (const ItemLabel &label : labelQueue) {
 		Item &item = Items[label.id];
 
-		if (MousePosition.x >= label.pos.x && MousePosition.x < label.pos.x + label.width
-		    && MousePosition.y >= label.pos.y && MousePosition.y < label.pos.y + labelHeight) {
+		if (MousePositionWorld.x >= label.pos.x && MousePositionWorld.x < label.pos.x + label.width
+		    && MousePositionWorld.y >= label.pos.y && MousePositionWorld.y < label.pos.y + labelHeight) {
 			if (!gmenu_is_active()
 			    && PauseMode == 0
 			    && !MyPlayerIsDead

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -128,7 +128,7 @@ bool CheckXPBarInfo()
 	const int backX = mainPanel.position.x + mainPanel.size.width / 2 - 155;
 	const int backY = mainPanel.position.y + mainPanel.size.height - 11;
 
-	if (MousePosition.x < backX || MousePosition.x >= backX + BackWidth || MousePosition.y < backY || MousePosition.y >= backY + BackHeight)
+	if (MousePositionWorld.x < backX || MousePositionWorld.x >= backX + BackWidth || MousePositionWorld.y < backY || MousePositionWorld.y >= backY + BackHeight)
 		return false;
 
 	const Player &player = *MyPlayer;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -182,9 +182,9 @@ int QuestLogMouseToEntry()
 {
 	Rectangle innerArea = InnerPanel;
 	innerArea.position += Displacement(GetLeftPanel().position.x, GetLeftPanel().position.y);
-	if (!innerArea.contains(MousePosition) || (EncounteredQuestCount == 0))
+	if (!innerArea.contains(MousePositionWorld) || (EncounteredQuestCount == 0))
 		return -1;
-	int y = MousePosition.y - innerArea.position.y;
+	int y = MousePositionWorld.y - innerArea.position.y;
 	for (int i = 0; i < FirstFinishedQuest; i++) {
 		if ((y >= ListYOffset + i * LineSpacing)
 		    && (y < ListYOffset + i * LineSpacing + LineHeight)) {

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2702,12 +2702,12 @@ void CheckStoreBtn()
 	const Rectangle windowRectFull { { uiPosition.x + 24, uiPosition.y + PaddingTop - 7 }, { 591, 303 } };
 
 	if (!IsTextFullSize) {
-		if (!windowRect.contains(MousePosition)) {
+		if (!windowRect.contains(MousePositionWorld)) {
 			while (IsPlayerInStore())
 				StoreESC();
 		}
 	} else {
-		if (!windowRectFull.contains(MousePosition)) {
+		if (!windowRectFull.contains(MousePositionWorld)) {
 			while (IsPlayerInStore())
 				StoreESC();
 		}
@@ -2718,9 +2718,9 @@ void CheckStoreBtn()
 		if (leveltype == DTYPE_TOWN)
 			stream_stop();
 	} else if (CurrentTextLine != -1) {
-		const int relativeY = MousePosition.y - (uiPosition.y + PaddingTop);
+		const int relativeY = MousePositionWorld.y - (uiPosition.y + PaddingTop);
 
-		if (HasScrollbar && MousePosition.x > 600 + uiPosition.x) {
+		if (HasScrollbar && MousePositionWorld.x > 600 + uiPosition.x) {
 			// Scroll bar is always measured in terms of the small line height.
 			int y = relativeY / SmallLineHeight;
 			if (y == 4) {

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -593,6 +593,7 @@ void ReinitializeRenderer()
 		SDL_GetWindowSize(ghMainWnd, &windowSize.width, &windowSize.height);
 		AdjustToScreenGeometry(windowSize);
 	}
+	UpdateZoomLimits();
 #endif
 }
 


### PR DESCRIPTION
Adds variable zooming between 240p FOV and 720p FOV. The zoom out cap is a direct inverse of the vanilla zoom in function (480 - 240 = 240, 480 + 240 = 720). This range is to allow the same level of zoom in as vanilla, and an established level of zoom out for fair play. 

### Plans
All set resolutions 720p+ will render an internal resolution of 720p, as it will be impossible to tell the difference between 720p and any set resolution higher than that.

Upscaling will be permanently removed as it will no longer be necessary.

Fit to Screen will be permanently enabled, however the toggle will be repurposed to force the Surface to render at a 4:3 ratio.

I plan on adding an option to render the internal game resolution at 720p for systems using a native screen resolution lower than 720p to zoom out to achieve 720p FOV. It won't be rendering at 720p by default as it may massively impact performance of low end systems.