### PR TITLE
Make breakable objects breakable with missiles.

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -470,7 +470,7 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 	if (IsMissileBlockedByTile({ mx, my })) {
 		Object *object = FindObjectAtPosition({ mx, my });
 		if (object != nullptr && object->IsBreakable()) {
-			BreakObjectMissile(missile.sourcePlayer(), *object);
+			BreakObject(*missile.sourcePlayer(), *object);
 		}
 
 		if (!dontDeleteOnCollision)

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -4674,11 +4674,6 @@ void SyncOpObject(Player &player, int cmd, Object &object)
 	}
 }
 
-void BreakObjectMissile(const Player *player, Object &object)
-{
-	if (object.IsCrux())
-		BreakCrux(object, true);
-}
 void BreakObject(const Player &player, Object &object)
 {
 	if (object.IsBarrel()) {

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -351,7 +351,6 @@ void ObjChangeMapResync(int x1, int y1, int x2, int y2);
 _item_indexes ItemMiscIdIdx(item_misc_id imiscid);
 void OperateObject(Player &player, Object &object);
 void SyncOpObject(Player &player, int cmd, Object &object);
-void BreakObjectMissile(const Player *player, Object &object);
 void BreakObject(const Player &player, Object &object);
 void DeltaSyncOpObject(Object &object);
 void DeltaSyncCloseObj(Object &object);

--- a/assets/txtdata/objects/objdat.tsv
+++ b/assets/txtdata/objects/objdat.tsv
@@ -56,8 +56,8 @@ OBJ_TRAPL	traphole	1	24				MissilesPassThrough,Light	1	0	64
 OBJ_TRAPR	traphole	1	24				MissilesPassThrough,Light	2	0	64	
 OBJ_BOOKSHELF	bcase	0	0				Solid,Light	1	0	96	
 OBJ_WEAPRACK	weapstnd	0	0				Solid,Light	1	0	96	
-OBJ_BARREL	barrel	1	15				Solid,MissilesPassThrough,Light,Breakable	1	9	96	Bottom,Middle
-OBJ_BARRELEX	barrelex	1	15				Solid,MissilesPassThrough,Light,Breakable	1	10	96	Bottom,Middle
+OBJ_BARREL	barrel	1	15				Solid,Light,Breakable	1	9	96	Bottom,Middle
+OBJ_BARRELEX	barrelex	1	15				Solid,Light,Breakable	1	10	96	Bottom,Middle
 OBJ_SHRINEL	lshrineg	0	0		THEME_SHRINE		Light	1	11	128	Bottom,Middle
 OBJ_SHRINER	rshrineg	0	0		THEME_SHRINE		Light	1	11	128	Bottom,Middle
 OBJ_SKELBOOK	book2	0	0		THEME_SKELROOM		Solid,MissilesPassThrough,Light	4	0	96	Bottom,Middle
@@ -98,10 +98,10 @@ OBJ_LAZSTAND	lzstand	0	0			Q_BETRAYER	Solid,Light	1	0	128	Bottom,Middle
 OBJ_SLAINHERO	decap	9	9				Solid,MissilesPassThrough,Light	2	0	96	Bottom
 OBJ_SIGNCHEST	chest3	0	0				Solid,MissilesPassThrough,Light	1	0	96	Bottom
 OBJ_BOOKSHELFR	bcase	0	0				Solid,Light	2	0	96	
-OBJ_POD	l6pod1	17	20				Solid,MissilesPassThrough,Light,Breakable	1	9	96	Bottom,Middle
-OBJ_PODEX	l6pod2	17	20				Solid,MissilesPassThrough,Light,Breakable	1	10	96	Bottom,Middle
-OBJ_URN	urn	21	24				Solid,MissilesPassThrough,Light,Breakable	1	9	96	Bottom,Middle
-OBJ_URNEX	urnexpld	21	24				Solid,MissilesPassThrough,Light,Breakable	1	10	96	Bottom,Middle
+OBJ_POD	l6pod1	17	20				Solid,Light,Breakable	1	9	96	Bottom,Middle
+OBJ_PODEX	l6pod2	17	20				Solid,Light,Breakable	1	10	96	Bottom,Middle
+OBJ_URN	urn	21	24				Solid,Light,Breakable	1	9	96	Bottom,Middle
+OBJ_URNEX	urnexpld	21	24				Solid,Light,Breakable	1	10	96	Bottom,Middle
 OBJ_L5BOOKS	l5books	21	24				Solid,MissilesPassThrough,Light	1	0	96	Bottom,Middle
 OBJ_L5CANDLE	l5light	21	23				Animated,Solid,MissilesPassThrough,Light	2	4	96	
 OBJ_L5LDOOR	l5door	0	0	DTYPE_CRYPT			Light,Trap	1	0	64	Bottom,Middle


### PR DESCRIPTION
Known issue: previously created barrels will remain unbreakable with missiles, since they’re loaded in the level data, with their missable flag already set to true.