### PR TITLE
Handle loaded MPQ files in a map instead of bespoke globals

### DIFF
--- a/Source/DiabloUI/mainmenu.cpp
+++ b/Source/DiabloUI/mainmenu.cpp
@@ -105,7 +105,7 @@ bool UiMainMenuDialog(const char *name, _mainmenu_selections *pdwResult, int att
 		while (MainMenuResult == MAINMENU_NONE) {
 			UiClearScreen();
 			UiPollAndRender();
-			if (SDL_GetTicks() >= dwAttractTicks && (HaveDiabdat() || HaveHellfire())) {
+			if (SDL_GetTicks() >= dwAttractTicks && (HaveIntro() || gbIsHellfire)) {
 				MainMenuResult = MAINMENU_ATTRACT_MODE;
 			}
 		}

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -66,7 +66,7 @@ std::string padEntryTimerText;
 bool IsValidEntry(OptionEntryBase *pOptionEntry)
 {
 	auto flags = pOptionEntry->GetFlags();
-	if (HasAnyOf(flags, OptionEntryFlags::NeedDiabloMpq) && !HaveDiabdat())
+	if (HasAnyOf(flags, OptionEntryFlags::NeedDiabloMpq) && !HaveIntro())
 		return false;
 	if (HasAnyOf(flags, OptionEntryFlags::NeedHellfireMpq) && !HaveHellfire())
 		return false;

--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -380,7 +380,7 @@ void LoadCoreArchives()
 #else // !UNPACKED_MPQS
 #if !defined(__ANDROID__) && !defined(__APPLE__) && !defined(__3DS__) && !defined(__SWITCH__)
 	// Load devilutionx.mpq first to get the font file for error messages
-	LoadMPQ(paths, "devilutionx.mpq", LangMpqPriority);
+	LoadMPQ(paths, "devilutionx.mpq", DevilutionXMpqPriority);
 #endif
 	LoadMPQ(paths, "fonts.mpq", FontMpqPriority); // Extra fonts
 	HasHellfireMpq = FindMPQ(paths, "hellfire.mpq");

--- a/Source/engine/assets.hpp
+++ b/Source/engine/assets.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -284,20 +285,13 @@ extern std::optional<std::string> hellfire_data_path;
 extern std::optional<std::string> font_data_path;
 extern std::optional<std::string> lang_data_path;
 #else
-/** A handle to the spawn.mpq archive. */
-extern DVL_API_FOR_TEST std::optional<MpqArchive> spawn_mpq;
-/** A handle to the diabdat.mpq archive. */
-extern DVL_API_FOR_TEST std::optional<MpqArchive> diabdat_mpq;
-/** A handle to an hellfire.mpq archive. */
-extern std::optional<MpqArchive> hellfire_mpq;
-extern std::optional<MpqArchive> hfmonk_mpq;
-extern std::optional<MpqArchive> hfbard_mpq;
-extern std::optional<MpqArchive> hfbarb_mpq;
-extern std::optional<MpqArchive> hfmusic_mpq;
-extern std::optional<MpqArchive> hfvoice_mpq;
-extern std::optional<MpqArchive> font_mpq;
-extern std::optional<MpqArchive> lang_mpq;
-extern std::optional<MpqArchive> devilutionx_mpq;
+extern DVL_API_FOR_TEST std::map<int, std::unique_ptr<MpqArchive>> MpqArchives;
+extern bool font_mpq;
+extern bool spawn_mpq;
+extern bool diabdat_mpq;
+extern bool hellfire_mpq;
+extern bool hfbard_mpq;
+extern bool hfbarb_mpq;
 #endif
 
 void LoadCoreArchives();
@@ -314,12 +308,12 @@ void LoadGameArchives();
 [[nodiscard]] inline bool HaveBardAssets() { return false; }
 [[nodiscard]] inline bool HaveBarbarianAssets() { return false; }
 #else
-[[nodiscard]] inline bool HaveSpawn() { return spawn_mpq.has_value(); }
-[[nodiscard]] inline bool HaveDiabdat() { return diabdat_mpq.has_value(); }
-[[nodiscard]] inline bool HaveHellfire() { return hellfire_mpq.has_value(); }
-[[nodiscard]] inline bool HaveExtraFonts() { return font_mpq.has_value(); }
-[[nodiscard]] inline bool HaveBardAssets() { return hfbard_mpq.has_value(); }
-[[nodiscard]] inline bool HaveBarbarianAssets() { return hfbarb_mpq.has_value(); }
+[[nodiscard]] inline bool HaveSpawn() { return spawn_mpq; }
+[[nodiscard]] inline bool HaveDiabdat() { return diabdat_mpq; }
+[[nodiscard]] inline bool HaveHellfire() { return hellfire_mpq; }
+[[nodiscard]] inline bool HaveExtraFonts() { return font_mpq; }
+[[nodiscard]] inline bool HaveBardAssets() { return hfbard_mpq; }
+[[nodiscard]] inline bool HaveBarbarianAssets() { return hfbarb_mpq; }
 #endif
 
 } // namespace devilution

--- a/Source/engine/assets.hpp
+++ b/Source/engine/assets.hpp
@@ -287,6 +287,7 @@ extern std::optional<std::string> lang_data_path;
 #else
 extern DVL_API_FOR_TEST std::map<int, std::unique_ptr<MpqArchive>> MpqArchives;
 constexpr int MainMpqPriority = 1000;
+constexpr int DevilutionXMpqPriority = 9000;
 constexpr int LangMpqPriority = 9100;
 constexpr int FontMpqPriority = 9200;
 extern bool HasHellfireMpq;

--- a/Source/engine/assets.hpp
+++ b/Source/engine/assets.hpp
@@ -286,34 +286,33 @@ extern std::optional<std::string> font_data_path;
 extern std::optional<std::string> lang_data_path;
 #else
 extern DVL_API_FOR_TEST std::map<int, std::unique_ptr<MpqArchive>> MpqArchives;
-extern bool font_mpq;
-extern bool spawn_mpq;
-extern bool diabdat_mpq;
-extern bool hellfire_mpq;
-extern bool hfbard_mpq;
-extern bool hfbarb_mpq;
+constexpr int MainMpqPriority = 1000;
+constexpr int LangMpqPriority = 9100;
+constexpr int FontMpqPriority = 9200;
+extern bool HasHellfireMpq;
 #endif
 
 void LoadCoreArchives();
 void LoadLanguageArchive();
 void LoadGameArchives();
+void LoadHellfireArchives();
 
 #ifdef UNPACKED_MPQS
-[[nodiscard]] inline bool HaveSpawn() { return spawn_data_path.has_value(); }
-[[nodiscard]] inline bool HaveDiabdat() { return diabdat_data_path.has_value(); }
+#ifdef BUILD_TESTING
+[[nodiscard]] inline bool HaveMainData() { return diabdat_data_path.has_value() || spawn_data_path.has_value(); }
+#endif
 [[nodiscard]] inline bool HaveHellfire() { return hellfire_data_path.has_value(); }
 [[nodiscard]] inline bool HaveExtraFonts() { return font_data_path.has_value(); }
-
-// Bard and barbarian are not currently supported in unpacked mode.
-[[nodiscard]] inline bool HaveBardAssets() { return false; }
-[[nodiscard]] inline bool HaveBarbarianAssets() { return false; }
 #else
-[[nodiscard]] inline bool HaveSpawn() { return spawn_mpq; }
-[[nodiscard]] inline bool HaveDiabdat() { return diabdat_mpq; }
-[[nodiscard]] inline bool HaveHellfire() { return hellfire_mpq; }
-[[nodiscard]] inline bool HaveExtraFonts() { return font_mpq; }
-[[nodiscard]] inline bool HaveBardAssets() { return hfbard_mpq; }
-[[nodiscard]] inline bool HaveBarbarianAssets() { return hfbarb_mpq; }
+#ifdef BUILD_TESTING
+[[nodiscard]] inline bool HaveMainData() { return MpqArchives.find(MainMpqPriority) != MpqArchives.end(); }
 #endif
+[[nodiscard]] inline bool HaveHellfire() { return HasHellfireMpq; }
+[[nodiscard]] inline bool HaveExtraFonts() { return MpqArchives.find(FontMpqPriority) != MpqArchives.end(); }
+#endif
+[[nodiscard]] inline bool HaveIntro() { return FindAsset("gendata\\diablo1.smk").ok(); }
+[[nodiscard]] inline bool HaveFullMusic() { return FindAsset("music\\dintro.wav").ok() || FindAsset("music\\dintro.mp3").ok(); }
+[[nodiscard]] inline bool HaveBardAssets() { return FindAsset("plrgfx\\bard\\bha\\bhaas.clx").ok(); }
+[[nodiscard]] inline bool HaveBarbarianAssets() { return FindAsset("plrgfx\\barbarian\\cha\\chaas.clx").ok(); }
 
 } // namespace devilution

--- a/Source/engine/sound.cpp
+++ b/Source/engine/sound.cpp
@@ -293,10 +293,10 @@ void music_start(_music_id nTrack)
 	music_stop();
 	if (!gbMusicOn)
 		return;
-	if (HaveSpawn())
-		trackPath = SpawnMusicTracks[nTrack];
-	else
+	if (HaveDiabdat())
 		trackPath = MusicTracks[nTrack];
+	else
+		trackPath = SpawnMusicTracks[nTrack];
 
 #ifdef DISABLE_STREAMING_MUSIC
 	const bool stream = false;

--- a/Source/engine/sound.cpp
+++ b/Source/engine/sound.cpp
@@ -293,7 +293,7 @@ void music_start(_music_id nTrack)
 	music_stop();
 	if (!gbMusicOn)
 		return;
-	if (HaveDiabdat())
+	if (HaveFullMusic())
 		trackPath = MusicTracks[nTrack];
 	else
 		trackPath = SpawnMusicTracks[nTrack];

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -120,12 +120,7 @@ void init_cleanup()
 	spawn_data_path = std::nullopt;
 #else
 	MpqArchives.clear();
-	font_mpq = false;
-	spawn_mpq = false;
-	diabdat_mpq = false;
-	hellfire_mpq = false;
-	hfbard_mpq = false;
-	hfbarb_mpq = false;
+	HasHellfireMpq = false;
 #endif
 
 	NetClose();

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -71,21 +71,13 @@ bool CheckExtraFontsVersion(AssetRef &&ref)
 
 } // namespace
 
-#ifndef UNPACKED_MPQS
-bool IsDevilutionXMpqOutOfDate(MpqArchive &archive)
+bool IsDevilutionXMpqOutOfDate()
 {
-	const char filename[] = "ASSETS_VERSION";
-	const MpqFileHash fileHash = CalculateMpqFileHash(filename);
-	uint32_t fileNumber;
-	if (!archive.GetFileNumber(fileHash, fileNumber))
+	AssetRef ref = FindAsset("ASSETS_VERSION");
+	if (!ref.ok())
 		return true;
-	AssetRef ref;
-	ref.archive = &archive;
-	ref.fileNumber = fileNumber;
-	ref.filename = filename;
 	return CheckDevilutionXMpqVersion(std::move(ref));
 }
-#endif
 
 #ifdef UNPACKED_MPQS
 bool AreExtraFontsOutOfDate(const std::string &path)
@@ -127,17 +119,13 @@ void init_cleanup()
 	diabdat_data_path = std::nullopt;
 	spawn_data_path = std::nullopt;
 #else
-	spawn_mpq = std::nullopt;
-	diabdat_mpq = std::nullopt;
-	hellfire_mpq = std::nullopt;
-	hfmonk_mpq = std::nullopt;
-	hfbard_mpq = std::nullopt;
-	hfbarb_mpq = std::nullopt;
-	hfmusic_mpq = std::nullopt;
-	hfvoice_mpq = std::nullopt;
-	lang_mpq = std::nullopt;
-	font_mpq = std::nullopt;
-	devilutionx_mpq = std::nullopt;
+	MpqArchives.clear();
+	font_mpq = false;
+	spawn_mpq = false;
+	diabdat_mpq = false;
+	hellfire_mpq = false;
+	hfbard_mpq = false;
+	hfbarb_mpq = false;
 #endif
 
 	NetClose();

--- a/Source/init.h
+++ b/Source/init.h
@@ -32,23 +32,11 @@ inline bool AreExtraFontsOutOfDate()
 #ifdef UNPACKED_MPQS
 	return font_data_path && AreExtraFontsOutOfDate(*font_data_path);
 #else
-	return font_mpq && AreExtraFontsOutOfDate(*font_mpq);
+	return font_mpq && AreExtraFontsOutOfDate(*MpqArchives[9200]);
 #endif
 }
 
-#ifndef UNPACKED_MPQS
-bool IsDevilutionXMpqOutOfDate(MpqArchive &archive);
-#endif
-
-inline bool IsDevilutionXMpqOutOfDate()
-{
-#ifdef UNPACKED_MPQS
-	return false;
-#else
-	return devilutionx_mpq.has_value() && IsDevilutionXMpqOutOfDate(*devilutionx_mpq);
-#endif
-}
-
+bool IsDevilutionXMpqOutOfDate();
 void init_cleanup();
 void init_create_window();
 void MainWndProc(const SDL_Event &event);

--- a/Source/init.h
+++ b/Source/init.h
@@ -32,7 +32,12 @@ inline bool AreExtraFontsOutOfDate()
 #ifdef UNPACKED_MPQS
 	return font_data_path && AreExtraFontsOutOfDate(*font_data_path);
 #else
-	return font_mpq && AreExtraFontsOutOfDate(*MpqArchives[9200]);
+	auto it = MpqArchives.find(FontMpqPriority);
+	if (it == MpqArchives.end()) {
+		return false;
+	}
+
+	return AreExtraFontsOutOfDate(*it->second);
 #endif
 }
 

--- a/Source/menu.cpp
+++ b/Source/menu.cpp
@@ -167,7 +167,7 @@ void mainmenu_loop()
 				done = true;
 			break;
 		case MAINMENU_ATTRACT_MODE:
-			if (gbIsSpawn && !HaveDiabdat())
+			if (gbIsSpawn && !HaveIntro())
 				done = false;
 			else if (gbActive)
 				PlayIntro();

--- a/Source/player.h
+++ b/Source/player.h
@@ -189,8 +189,8 @@ constexpr std::array<char, 6> CharChar = {
 	'r', // rogue
 	's', // sorcerer
 	'm', // monk
-	'b',
-	'c',
+	'b', // Bard
+	'c', // Barbarian
 };
 
 /**

--- a/Source/player.h
+++ b/Source/player.h
@@ -189,8 +189,8 @@ constexpr std::array<char, 6> CharChar = {
 	'r', // rogue
 	's', // sorcerer
 	'm', // monk
-	'b', // Bard
-	'c', // Barbarian
+	'b', // bard
+	'c', // barbarian
 };
 
 /**

--- a/test/dun_render_benchmark.cpp
+++ b/test/dun_render_benchmark.cpp
@@ -29,7 +29,7 @@ void InitOnce()
 	[[maybe_unused]] static const bool GlobalInitDone = []() {
 		LoadCoreArchives();
 		LoadGameArchives();
-		if (!HaveSpawn() && !HaveDiabdat()) {
+		if (!HaveMainData()) {
 			LogError("This benchmark needs spawn.mpq or diabdat.mpq");
 			exit(1);
 		}

--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -24,7 +24,7 @@ public:
 
 		// The tests need spawn.mpq or diabdat.mpq
 		// Please provide them so that the tests can run successfully
-		ASSERT_TRUE(HaveSpawn() || HaveDiabdat());
+		ASSERT_TRUE(HaveMainData());
 
 		InitCursor();
 		LoadSpellData();

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -966,7 +966,7 @@ public:
 
 		// The tests need spawn.mpq or diabdat.mpq
 		// Please provide them so that the tests can run successfully
-		ASSERT_TRUE(HaveSpawn() || HaveDiabdat());
+		ASSERT_TRUE(HaveMainData());
 
 		gbIsHellfire = false;
 		InitCursor();

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -186,7 +186,7 @@ TEST(Player, CreatePlayer)
 
 	// The tests need spawn.mpq or diabdat.mpq
 	// Please provide them so that the tests can run successfully
-	ASSERT_TRUE(HaveSpawn() || HaveDiabdat());
+	ASSERT_TRUE(HaveMainData());
 
 	LoadPlayerDataFiles();
 	LoadMonsterData();

--- a/test/timedemo_test.cpp
+++ b/test/timedemo_test.cpp
@@ -42,7 +42,7 @@ void RunTimedemo(std::string timedemoFolderName)
 
 	// The tests need spawn.mpq or diabdat.mpq
 	// Please provide them so that the tests can run successfully
-	ASSERT_TRUE(HaveSpawn() || HaveDiabdat());
+	ASSERT_TRUE(HaveMainData());
 
 	std::string unitTestFolderCompletePath = paths::BasePath() + "test/fixtures/timedemo/" + timedemoFolderName;
 	paths::SetPrefPath(unitTestFolderCompletePath);

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -368,7 +368,7 @@ TEST(Writehero, pfile_write_hero)
 
 	// The tests need spawn.mpq or diabdat.mpq
 	// Please provide them so that the tests can run successfully
-	ASSERT_TRUE(HaveSpawn() || HaveDiabdat());
+	ASSERT_TRUE(HaveMainData());
 
 	const std::string savePath = paths::BasePath() + "multi_0.sv";
 	paths::SetPrefPath(paths::BasePath());


### PR DESCRIPTION
This is done as prep work for being able to load and unload mods that are distributed as MPQ files.

The changes here are done in a way that changes as little as possible about how things works.
- bespoke bools are still used to track what was loaded
- Hellfire is always loaded but it's files are skipped if not active
- priority values match the original Diablo/Hellfire

In a follow up to this PR I would like to:
- mods are automatically loaded in to the 1xxxx range (the specific value will depend on what order they appear in the ini).
- 1xxx and 9xxxx stays loaded but changing the mod will reload the 8xxx and 1xxxx range.
- Hellfire is loaded via a lua function