### PR TITLE
Upgrade vcpkg baseline commit

### DIFF
--- a/.github/workflows/Windows_MSVC_x64.yml
+++ b/.github/workflows/Windows_MSVC_x64.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Restore or setup vcpkg
       uses: lukka/run-vcpkg@v11.5
       with:
-        vcpkgGitCommitId: '99c9bc8b94f80cdb5caf9614d9d197d270e0b32e'
+        vcpkgGitCommitId: 'acd5bba5aac8b6573b5f6f463dc0341ac0ee6fa4'
 
     - name: Fetch test data
       run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
 		"bzip2",
 		"lua"
 	],
-	"builtin-baseline": "99c9bc8b94f80cdb5caf9614d9d197d270e0b32e",
+	"builtin-baseline": "acd5bba5aac8b6573b5f6f463dc0341ac0ee6fa4",
 	"features": {
 		"sdl1": {
 			"description": "Use SDL1.2 instead of SDL2",


### PR DESCRIPTION
This upgrades the following MSVC dependencies:

* Google Benchmark to 1.9.2
* SDL2 to 2.32.2
* SDL2-image to 2.8.8