### PR TITLE
Workaround for deprecation of old CMake versions

### DIFF
--- a/.github/workflows/Windows_MinGW_x64.yml
+++ b/.github/workflows/Windows_MinGW_x64.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}
-      run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DCPACK=ON -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/mingwcc64.toolchain.cmake -DDEVILUTIONX_SYSTEM_BZIP2=OFF -DDEVILUTIONX_STATIC_LIBSODIUM=ON -DDISCORD_INTEGRATION=ON -DSCREEN_READER_INTEGRATION=ON
+      run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DCPACK=ON -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/mingwcc64.toolchain.cmake -DDEVILUTIONX_SYSTEM_BZIP2=OFF -DDEVILUTIONX_STATIC_LIBSODIUM=ON -DDISCORD_INTEGRATION=ON -DSCREEN_READER_INTEGRATION=ON -DMINGW_STDTHREADS_GENERATE_STDHEADERS=ON
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/.github/workflows/Windows_MinGW_x86.yml
+++ b/.github/workflows/Windows_MinGW_x86.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}
-      run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DCPACK=ON -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/mingwcc.toolchain.cmake -DDEVILUTIONX_SYSTEM_BZIP2=OFF -DDEVILUTIONX_STATIC_LIBSODIUM=ON -DDISCORD_INTEGRATION=ON -DSCREEN_READER_INTEGRATION=ON
+      run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF -DCPACK=ON -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/mingwcc.toolchain.cmake -DDEVILUTIONX_SYSTEM_BZIP2=OFF -DDEVILUTIONX_STATIC_LIBSODIUM=ON -DDISCORD_INTEGRATION=ON -DSCREEN_READER_INTEGRATION=ON -DMINGW_STDTHREADS_GENERATE_STDHEADERS=ON
 
     - name: Build
       working-directory: ${{github.workspace}}

--- a/3rdParty/Lua/CMakeLists.txt
+++ b/3rdParty/Lua/CMakeLists.txt
@@ -1,5 +1,8 @@
 include(functions/FetchContent_ExcludeFromAll_backport)
 
+# Workaround for deprecation of older CMake versions
+set(CMAKE_POLICY_VERSION_MINIMUM 3.22)
+
 set(LUA_ENABLE_TESTING OFF)
 set(LUA_BUILD_COMPILER OFF)
 if(DEVILUTIONX_STATIC_LUA)

--- a/3rdParty/libpng/CMakeLists.txt
+++ b/3rdParty/libpng/CMakeLists.txt
@@ -1,5 +1,8 @@
 include(functions/FetchContent_ExcludeFromAll_backport)
 
+# Workaround for deprecation of older CMake versions
+set(CMAKE_POLICY_VERSION_MINIMUM 3.22)
+
 if(NOT DISABLE_LTO)
   # Force CMake to raise an error if INTERPROCEDURAL_OPTIMIZATION
   # is enabled and compiler does not support IPO

--- a/3rdParty/tolk/CMakeLists.txt
+++ b/3rdParty/tolk/CMakeLists.txt
@@ -1,5 +1,8 @@
 include(functions/FetchContent_ExcludeFromAll_backport)
 
+# Workaround for deprecation of older CMake versions
+set(CMAKE_POLICY_VERSION_MINIMUM 3.22)
+
 include(FetchContent)
 FetchContent_Declare_ExcludeFromAll(Tolk
     URL https://github.com/sig-a11y/tolk/archive/89de98779e3b6365dc1688538d5de4ecba3fdbab.tar.gz

--- a/CMake/platforms/mingw/zt_defs.cmake
+++ b/CMake/platforms/mingw/zt_defs.cmake
@@ -1,4 +1,7 @@
-option(MINGW_STDTHREADS_GENERATE_STDHEADERS "" ON)
+option(MINGW_STDTHREADS_GENERATE_STDHEADERS "" OFF)
+
+# Workaround for deprecation of older CMake versions
+set(CMAKE_POLICY_VERSION_MINIMUM 3.22)
 
 FetchContent_Declare_ExcludeFromAll(mingw-std-threads
   GIT_REPOSITORY https://github.com/meganz/mingw-std-threads


### PR DESCRIPTION
See also https://github.com/walterschell/Lua/pull/36

I'm not sure how soon we should expect the maintainer of the Lua repo we're referencing to respond so I'm submitting this to at least get CI working again.