### PR TITLE
Upgrade SDL2 to 2.23.4

### DIFF
--- a/.github/workflows/Windows_MSVC_x64.yml
+++ b/.github/workflows/Windows_MSVC_x64.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Restore or setup vcpkg
       uses: lukka/run-vcpkg@v11.5
       with:
-        vcpkgGitCommitId: 'acd5bba5aac8b6573b5f6f463dc0341ac0ee6fa4'
+        vcpkgGitCommitId: '533a5fda5c0646d1771345fb572e759283444d5f'
 
     - name: Fetch test data
       run: |

--- a/3rdParty/SDL2/CMakeLists.txt
+++ b/3rdParty/SDL2/CMakeLists.txt
@@ -15,7 +15,7 @@ set(SDL_TEST_ENABLED_BY_DEFAULT OFF)
 include(functions/FetchContent_ExcludeFromAll_backport)
 include(FetchContent)
 FetchContent_Declare(SDL2
-    URL https://github.com/libsdl-org/SDL/releases/download/release-2.32.2/SDL2-2.32.2.tar.gz
-    URL_HASH SHA256=c5f30c427fd8107ee4a400c84d4447dd211352512eaf0b6e89cc6a50a2821922
+    URL https://github.com/libsdl-org/SDL/releases/download/release-2.32.4/SDL2-2.32.4.tar.gz
+    URL_HASH SHA256=f15b478253e1ff6dac62257ded225ff4e7d0c5230204ac3450f1144ee806f934
 )
 FetchContent_MakeAvailable_ExcludeFromAll(SDL2)

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -61,7 +61,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     private static final String TAG = "SDL";
     private static final int SDL_MAJOR_VERSION = 2;
     private static final int SDL_MINOR_VERSION = 32;
-    private static final int SDL_MICRO_VERSION = 2;
+    private static final int SDL_MICRO_VERSION = 4;
 /*
     // Display InputType.SOURCE/CLASS of events and devices
     //

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
 		"bzip2",
 		"lua"
 	],
-	"builtin-baseline": "acd5bba5aac8b6573b5f6f463dc0341ac0ee6fa4",
+	"builtin-baseline": "533a5fda5c0646d1771345fb572e759283444d5f",
 	"features": {
 		"sdl1": {
 			"description": "Use SDL1.2 instead of SDL2",


### PR DESCRIPTION
Upgrade includes build-from source, Android and VCPKG

`Fixed controller GUIDs changing randomly on Windows` this fix is important, because it made bindings reset after unplugging and plugging the controller back in: https://github.com/azahar-emu/azahar/issues/391
Don't know if affected us, but good, that it's fixed now!