### PR TITLE
Enable Pepin and Adria to Sell Elixir of Vitality

### DIFF
--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -66,6 +66,7 @@ enum _item_indexes : int16_t { // TODO defines all indexes in AllItemsList
 	IDI_FULLNOTE,
 	IDI_BROWNSUIT,
 	IDI_GREYSUIT,
+	IDI_ELIXVIT = 90,
 	IDI_BOOK1 = 114,
 	IDI_BOOK2,
 	IDI_BOOK3,

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4683,8 +4683,8 @@ void SpawnHealer(int lvl)
 			tempLvl = expandedLvl;
 		}
 
-		GetItemAttrs(item, itemData, lvl);
-		item._iCreateInfo = lvl | CF_HEALER;
+		GetItemAttrs(item, itemData, tempLvl);
+		item._iCreateInfo = tempLvl | CF_HEALER;
 		item._iIdentified = true;
 	}
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4493,22 +4493,36 @@ void SpawnWitch(int lvl)
 			continue;
 		}
 
+		const Player &myPlayer = *MyPlayer;
+		int tempLvl;
+		const int expandedLvl = GetStoreLevel(myPlayer);
+
 		do {
 			item = {};
 			item._iSeed = AdvanceRndSeed();
 			SetRndSeed(item._iSeed);
-			_item_indexes itemData = RndWitchItem(*MyPlayer, lvl);
-			GetItemAttrs(item, itemData, lvl);
+
+			tempLvl = lvl;
+			_item_indexes itemData = RndWitchItem(myPlayer, tempLvl);
+			SetRndSeed(item._iSeed); // We need to restore the RNG state to preserve compatibility since RndWitchItem() burns one seed
+			const _item_indexes expandedItemData = RndWitchItem(myPlayer, expandedLvl);
+
+			if (expandedItemData == IDI_ELIXVIT) {
+				itemData = expandedItemData;
+				tempLvl = expandedLvl;
+			}
+
+			GetItemAttrs(item, itemData, tempLvl);
 			int maxlvl = -1;
 			if (GenerateRnd(100) <= 5)
-				maxlvl = 2 * lvl;
+				maxlvl = 2 * tempLvl;
 			if (maxlvl == -1 && item._iMiscId == IMISC_STAFF)
-				maxlvl = 2 * lvl;
+				maxlvl = 2 * tempLvl;
 			if (maxlvl != -1)
-				GetItemBonus(*MyPlayer, item, maxlvl / 2, maxlvl, true, true);
+				GetItemBonus(myPlayer, item, maxlvl / 2, maxlvl, true, true);
 		} while (item._iIvalue > maxValue);
 
-		item._iCreateInfo = lvl | CF_WITCH;
+		item._iCreateInfo = tempLvl | CF_WITCH;
 		item._iIdentified = true;
 	}
 
@@ -4654,8 +4668,22 @@ void SpawnHealer(int lvl)
 
 		item._iSeed = AdvanceRndSeed();
 		SetRndSeed(item._iSeed);
-		_item_indexes itype = RndHealerItem(*MyPlayer, lvl);
-		GetItemAttrs(item, itype, lvl);
+
+		const Player &myPlayer = *MyPlayer;
+		int tempLvl = lvl;
+		_item_indexes itemData = RndHealerItem(myPlayer, tempLvl);
+
+		SetRndSeed(item._iSeed); // We need to restore the RNG state to preserve compatibility since RndHealerItem() burns one seed
+
+		const int expandedLvl = GetStoreLevel(myPlayer);
+		const _item_indexes expandedItemData = RndHealerItem(myPlayer, expandedLvl);
+
+		if (expandedItemData == IDI_ELIXVIT) {
+			itemData = expandedItemData;
+			tempLvl = expandedLvl;
+		}
+
+		GetItemAttrs(item, itemData, lvl);
 		item._iCreateInfo = lvl | CF_HEALER;
 		item._iIdentified = true;
 	}

--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -49,16 +49,10 @@ bool IsTownItemValid(uint16_t iCreateInfo, const Player &player)
 {
 	const uint8_t level = iCreateInfo & CF_LEVEL;
 	const bool isBoyItem = (iCreateInfo & CF_BOY) != 0;
-	const bool isPremiumItem = (iCreateInfo & CF_SMITHPREMIUM) != 0;
-	const bool isHealerItem = (iCreateInfo & CF_HEALER) != 0;
-	const uint8_t maxTownItemLevel = 16;
+	const uint8_t maxTownItemLevel = 30;
 
 	// Wirt items in multiplayer are equal to the level of the player, therefore they cannot exceed the max character level
 	if (isBoyItem && level <= player.getMaxCharacterLevel())
-		return true;
-	if (isPremiumItem && level <= 30)
-		return true;
-	if (isHealerItem && level <= 20)
 		return true;
 
 	return level <= maxTownItemLevel;

--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -49,10 +49,16 @@ bool IsTownItemValid(uint16_t iCreateInfo, const Player &player)
 {
 	const uint8_t level = iCreateInfo & CF_LEVEL;
 	const bool isBoyItem = (iCreateInfo & CF_BOY) != 0;
-	const uint8_t maxTownItemLevel = 30;
+	const bool isPremiumItem = (iCreateInfo & CF_SMITHPREMIUM) != 0;
+	const bool isHealerItem = (iCreateInfo & CF_HEALER) != 0;
+	const uint8_t maxTownItemLevel = 16;
 
 	// Wirt items in multiplayer are equal to the level of the player, therefore they cannot exceed the max character level
 	if (isBoyItem && level <= player.getMaxCharacterLevel())
+		return true;
+	if (isPremiumItem && level <= 30)
+		return true;
+	if (isHealerItem && level <= 20)
 		return true;
 
 	return level <= maxTownItemLevel;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2144,7 +2144,7 @@ void SetupTownStores()
 	l = std::clamp(l + 2, 6, 16);
 	SpawnSmith(l);
 	SpawnWitch(l);
-	SpawnHealer(l);
+	SpawnHealer((l >= 15) ? 20 : l);
 	SpawnBoy(myPlayer.getCharacterLevel());
 	SpawnPremium(myPlayer);
 }

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2128,23 +2128,33 @@ void InitStores()
 	BoyItemLevel = 0;
 }
 
+int GetStoreLevel(const Player &player)
+{
+	int baseLevel;
+
+	if (!gbIsMultiplayer) {
+		baseLevel = 0;
+		for (int i = NUMLEVELS - 1; i > 0; i--) {
+			if (player._pLvlVisited[i]) {
+				baseLevel = i;
+				break;
+			}
+		}
+	} else {
+		baseLevel = player.getCharacterLevel() / 2;
+	}
+
+	return std::clamp(baseLevel + 2, 6, 20);
+}
+
 void SetupTownStores()
 {
 	Player &myPlayer = *MyPlayer;
 
-	int l = myPlayer.getCharacterLevel() / 2;
-	if (!gbIsMultiplayer) {
-		l = 0;
-		for (int i = 0; i < NUMLEVELS; i++) {
-			if (myPlayer._pLvlVisited[i])
-				l = i;
-		}
-	}
-
-	l = std::clamp(l + 2, 6, 16);
+	int l = std::clamp(GetStoreLevel(myPlayer), 6, 16);
 	SpawnSmith(l);
 	SpawnWitch(l);
-	SpawnHealer((l >= 15) ? 20 : l);
+	SpawnHealer(l);
 	SpawnBoy(myPlayer.getCharacterLevel());
 	SpawnPremium(myPlayer);
 }

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -96,6 +96,8 @@ void AddStoreHoldRepair(Item *itm, int8_t i);
 /** Clears premium items sold by Griswold and Wirt. */
 void InitStores();
 
+int GetStoreLevel(const Player &player);
+
 /** Spawns items sold by vendors, including premium items sold by Griswold and Wirt. */
 void SetupTownStores();
 

--- a/assets/txtdata/items/itemdat.tsv
+++ b/assets/txtdata/items/itemdat.tsv
@@ -89,7 +89,7 @@ IDI_GREYSUIT	0	Quest	Unequippable	GREY_SUIT	Misc	NONE	Grey Suit		0	0	0	0	0	0	0	0
 	1	Misc	Unequippable	ELIXIR_OF_STRENGTH	Misc	NONE	Elixir of Strength		15	0	0	0	0	0	0	0	0		ELIXSTR	Null	true	5000
 	1	Misc	Unequippable	ELIXIR_OF_MAGIC	Misc	NONE	Elixir of Magic		15	0	0	0	0	0	0	0	0		ELIXMAG	Null	true	5000
 	1	Misc	Unequippable	ELIXIR_OF_DEXTERITY	Misc	NONE	Elixir of Dexterity		15	0	0	0	0	0	0	0	0		ELIXDEX	Null	true	5000
-	1	Misc	Unequippable	ELIXIR_OF_VITALITY	Misc	NONE	Elixir of Vitality		20	0	0	0	0	0	0	0	0		ELIXVIT	Null	true	5000
+IDI_ELIXVIT	1	Misc	Unequippable	ELIXIR_OF_VITALITY	Misc	NONE	Elixir of Vitality		20	0	0	0	0	0	0	0	0		ELIXVIT	Null	true	5000
 	1	Misc	Unequippable	SCROLL_OF	Misc	NONE	Scroll of Healing		1	0	0	0	0	0	0	0	0		SCROLL	Healing	true	50
 	1	Misc	Unequippable	SCROLL_OF	Misc	NONE	Scroll of Search		1	0	0	0	0	0	0	0	0		SCROLL	Search	true	50
 	1	Misc	Unequippable	SCROLL_OF	Misc	NONE	Scroll of Lightning		4	0	0	0	0	0	0	0	0		SCROLLT	Lightning	true	150


### PR DESCRIPTION
### Fix: Enable Pepin and Adria to Sell Elixir of Vitality

This PR resolves a long-standing oversight in *Diablo* and *Hellfire* where vendors are unable to sell the **Elixir of Vitality**, despite the game logic explicitly allowing it.

---

### Background

The function `HealerItemOk()` includes the following line:
https://github.com/diasurgical/devilution/blob/14a96209215607b1a2dfb7637921c02c925d2da2/Source/items.cpp#L5552-L5553

```cpp
if (AllItemsList[i].iMiscId == IMISC_ELIXVIT)
    result = TRUE;
```

This clearly indicates that the **Elixir of Vitality** (`IMISC_ELIXVIT`) is intended to be part of Pepin's potential item pool. However, due to how item generation logic is constrained by a clamped level range, it is never actually selected.

In *single player*, the store level is calculated as:

```text
level = highest dungeon level explored + 2 (clamped to 6–16)
```

In *multiplayer*, it is:

```text
level = character level / 2 + 2 (also clamped to 6–16)
```

Meanwhile, the qlvls of elixirs are:
- Strength, Magic, Dexterity: **15**
- **Vitality: 20**

Because of the upper clamp at 16, the Elixir of Vitality (qlvl 20) is unreachable during item selection, even though it is explicitly allowed for sale by Pepin.

This issue also extends to Adria. While the Elixir of Vitality is not explicitly permitted in her `WitchItemOk()` function, she can sell elixirs in general, and there's no reason to assume this one was meant to be excluded. This makes the behavior inconsistent and likely unintended.

---

### Solution

This PR modifies the logic inside the vendor item spawning functions (`SpawnHealer` and `SpawnWitch`) to allow for a special-case fallback when the Elixir of Vitality is eligible.

Here’s how it works:

1. For each item spawn, the vendor performs two rolls using the same seed:
   - One roll using the *clamped level* (up to 16)
   - One roll using the *true store level* (up to 20)

2. If the second roll (with the unclamped level) produces *Elixir of Vitality*, that result is selected instead.

3. The item is then spawned using the correct affix level (clamped or unclamped), and all other logic remains untouched.

4. The seed is preserved before and after each roll to avoid item morphing, ensuring full compatibility with existing saves and deterministic RNG behavior.

This method preserves the affix tier behavior and ensures that only the Elixir of Vitality can appear beyond the previous level cap — no other high-qlvl items are introduced into the vendor pool.

---

### Additional Context

Some have speculated that Pepin's inability to sell Elixir of Vitality may have been intentional, suggesting the inclusion of the check in `HealerItemOk()` was an oversight. However, investigation into the **pre-release demo decompilation** of *Diablo*—the earliest leaked version—suggests otherwise:

- In this pre-release version ([stores.cpp](https://gitlab.com/moralbacteria/diablo-prdemo-decomp/-/blob/main/src/stores.cpp), [items.cpp](https://gitlab.com/moralbacteria/diablo-prdemo-decomp/-/blob/main/src/items.cpp)), **Pepin the Healer does not yet exist**.
- However, in [itemdat.cpp](https://gitlab.com/moralbacteria/diablo-prdemo-decomp/-/blob/main/src/itemdat.cpp), **all four elixirs already exist**, and their **qlvl** values match the final release—**Elixir of Vitality is already qlvl 20**.

This means the lines to explicitly allow Elixir of Vitality in `HealerItemOk()` were added **after** its qlvl of 20 was already established. Therefore, its exclusion from the shop inventory was almost certainly the result of a **qlvl clamping oversight**, not a deliberate design choice.

To further confirm this, the **pre-release executable** was examined directly. Disassembly of `SetupTownStores()` shows the same logic as the retail version:
- It calculates `l` based on the highest visited dungeon level (or player level in multiplayer), then adds 2.
- It clamps `l` to a **minimum of 6** and a **maximum of 16**.

This proves that the clamping behavior was already present in early builds, and the Elixir of Vitality's **qlvl** of 20 would have **always** been out of reach without an adjustment—making this PR a correction of a long-standing, overlooked edge case.

Since Elixir of Vitality is qlvl 20, this means it remains unobtainable from vendors in Diablo Single Player, but is available in Hellfire Single player, since the player needs to have been to dlvl 18 or higher. In Multiplayer, the player needs to be at least clvl 36 and purchasing from Adria (the changes in this PR continue to respect that Pepin does not sell Elixirs in Multiplayer).

---
