### PR TITLE
clang-tidy-check: Use a compilation database

### DIFF
--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - master
-    paths: ['**.c', '**.cpp', '**.h', '**.hpp', '**.cxx', '**.hxx', '**.cc', '**.hh', '**CMakeLists.txt', 'meson.build', '**.cmake']
+    paths: ['**.c', '**.cpp', '**.h', '**.hpp', '**.cxx', '**.hxx', '**.cc', '**.hh', '**CMakeLists.txt', 'meson.build', '**.cmake', '.github/workflows/clang-tidy-check.yml']
   pull_request:
     types: [ opened, synchronize ]
-    paths: ['**.c', '**.cpp', '**.h', '**.hpp', '**.cxx', '**.hxx', '**.cc', '**.hh', '**CMakeLists.txt', 'meson.build', '**.cmake']
+    paths: ['**.c', '**.cpp', '**.h', '**.hpp', '**.cxx', '**.hxx', '**.cc', '**.hh', '**CMakeLists.txt', 'meson.build', '**.cmake', '.github/workflows/clang-tidy-check.yml']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,10 +22,19 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y cmake curl g++ git libgtest-dev libgmock-dev libbenchmark-dev libfmt-dev libsdl2-dev libsodium-dev libpng-dev libbz2-dev wget
+
+    - name: CMake Configure
+      run: cmake -S. -Bbuild
+
     - name: clang-tidy Check
       uses: cpp-linter/cpp-linter-action@v2
       id: linter
       with:
+        database: build # directory containing compile_commands.json
         style: '' # using an empty string here disables clang-format checks. We leave the existing clang-format-check workflow to run clang-format instead
         tidy-checks: '' # using an empty string here instructs the action to use only checks from the .clang-tidy file
         ignore-tidy: '3rdParty'


### PR DESCRIPTION
Without this, clang-tidy-check cannot see any dependencies (such as SDL), resulting in spurious warnings.