### PR TITLE
FormatInteger (unsigned)

### DIFF
--- a/Source/utils/format_int.cpp
+++ b/Source/utils/format_int.cpp
@@ -44,4 +44,36 @@ std::string FormatInteger(int n)
 	return out;
 }
 
+std::string FormatInteger(uint32_t n)
+{
+	constexpr size_t GroupSize = 3;
+
+	char buf[40];
+	char *begin = buf;
+	const char *end = BufCopy(buf, n);
+	const size_t len = end - begin;
+
+	std::string out;
+	const size_t numLen = len;
+	if (numLen <= GroupSize) {
+		out.append(begin, len);
+		return out;
+	}
+
+	const std::string_view separator = _(/* TRANSLATORS: Thousands separator */ ",");
+	out.reserve(len + separator.size() * (numLen - 1) / GroupSize);
+
+	size_t mlen = numLen % GroupSize;
+	if (mlen == 0)
+		mlen = GroupSize;
+	out.append(begin, mlen);
+	begin += mlen;
+	for (; begin != end; begin += GroupSize) {
+		out.append(separator);
+		out.append(begin, GroupSize);
+	}
+
+	return out;
+}
+
 } // namespace devilution

--- a/Source/utils/format_int.cpp
+++ b/Source/utils/format_int.cpp
@@ -1,5 +1,6 @@
 #include "utils/format_int.hpp"
 
+#include <cstdint>
 #include <string_view>
 
 #include "utils/language.h"

--- a/Source/utils/format_int.hpp
+++ b/Source/utils/format_int.hpp
@@ -8,5 +8,6 @@ namespace devilution {
  * @brief Formats integer with thousands separator.
  */
 std::string FormatInteger(int n);
+std::string FormatInteger(uint32_t n);
 
 } // namespace devilution

--- a/Source/utils/format_int.hpp
+++ b/Source/utils/format_int.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace devilution {


### PR DESCRIPTION
Adds an overload for `FormatInteger()` that uses `uint32_t` function argument to avoid overflow with large numbers.

Fixes: https://github.com/diasurgical/DevilutionX/issues/7909