### PR TITLE
Draw Hotkeys on Belt

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1296,7 +1296,7 @@ void DrawInvBelt(const Surface &out)
 
 		if (myPlayer.SpdList[i].isUsable()
 		    && myPlayer.SpdList[i]._itype != ItemType::Gold) {
-			DrawString(out, ControlMode == ControlTypes::Gamepad ? GetOptions().Padmapper.InputNameForAction(beltKey, useShortName) : GetOptions().Keymapper.KeyNameForAction(beltKey), { position - Displacement { 0, 12 }, InventorySlotSizeInPixels },
+			DrawString(out, ControlMode == ControlTypes::Gamepad ? GetOptions().Padmapper.InputNameForAction(beltKey, true) : GetOptions().Keymapper.KeyNameForAction(beltKey), { position - Displacement { 0, 12 }, InventorySlotSizeInPixels },
 			    { .flags = UiFlags::ColorWhite | UiFlags::AlignRight });
 		}
 	}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1296,7 +1296,14 @@ void DrawInvBelt(const Surface &out)
 
 		if (myPlayer.SpdList[i].isUsable()
 		    && myPlayer.SpdList[i]._itype != ItemType::Gold) {
-			DrawString(out, ControlMode == ControlTypes::Gamepad ? GetOptions().Padmapper.InputNameForAction(beltKey, true) : GetOptions().Keymapper.KeyNameForAction(beltKey), { position - Displacement { 0, 12 }, InventorySlotSizeInPixels },
+			std::string_view keyName = ControlMode == ControlTypes::Gamepad
+			    ? GetOptions().Padmapper.InputNameForAction(beltKey, true)
+			    : GetOptions().Keymapper.KeyNameForAction(beltKey);
+
+			if (keyName.length() > 2)
+				keyName = {};
+
+			DrawString(out, keyName, { position - Displacement { 0, 12 }, InventorySlotSizeInPixels },
 			    { .flags = UiFlags::ColorWhite | UiFlags::AlignRight });
 		}
 	}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1292,10 +1292,9 @@ void DrawInvBelt(const Surface &out)
 
 		DrawItem(myPlayer.SpdList[i], out, position, sprite);
 
-		auto beltKey = StrCat("BeltItem", i + 1);
-
 		if (myPlayer.SpdList[i].isUsable()
 		    && myPlayer.SpdList[i]._itype != ItemType::Gold) {
+			auto beltKey = StrCat("BeltItem", i + 1);
 			std::string_view keyName = ControlMode == ControlTypes::Gamepad
 			    ? GetOptions().Padmapper.InputNameForAction(beltKey, true)
 			    : GetOptions().Keymapper.KeyNameForAction(beltKey);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1292,9 +1292,11 @@ void DrawInvBelt(const Surface &out)
 
 		DrawItem(myPlayer.SpdList[i], out, position, sprite);
 
+		auto beltKey = StrCat("BeltItem", i + 1);
+
 		if (myPlayer.SpdList[i].isUsable()
 		    && myPlayer.SpdList[i]._itype != ItemType::Gold) {
-			DrawString(out, StrCat(i + 1), { position - Displacement { 0, 12 }, InventorySlotSizeInPixels },
+			DrawString(out, ControlMode == ControlTypes::Gamepad ? GetOptions().Padmapper.InputNameForAction(beltKey, useShortName) : GetOptions().Keymapper.KeyNameForAction(beltKey), { position - Displacement { 0, 12 }, InventorySlotSizeInPixels },
 			    { .flags = UiFlags::ColorWhite | UiFlags::AlignRight });
 		}
 	}


### PR DESCRIPTION
Displays the hotkey for each belt slot on the belt, rather than displaying 1-8 (Since 1-8 is no longer hardcoded as the hotkeys for the belt).

 
Fixes: https://github.com/diasurgical/DevilutionX/issues/7908