### PR TITLE
Add data() method to StaticVector

### DIFF
--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -55,6 +55,9 @@ public:
 	[[nodiscard]] const T &back() const { return (*this)[size_ - 1]; }
 	[[nodiscard]] T &back() { return (*this)[size_ - 1]; }
 
+	[[nodiscard]] const T *data() const { return data_[0].ptr(); }
+	[[nodiscard]] T *data() { return data_[0].ptr(); }
+
 	template <typename... Args>
 	void push_back(Args &&...args) // NOLINT(readability-identifier-naming)
 	{


### PR DESCRIPTION
Hello

This is just a very small PR and shouldn't require much time to review. https://github.com/diasurgical/DevilutionX/pull/7912 is unable to build on PS4 and Xbox due to the following build errors:

```
/home/runner/work/DevilutionX/DevilutionX/Source/stores.cpp:1034:2: error: no matching function for call to 'ScrollVendorStore'
        ScrollVendorStore(HealerItems, static_cast<int>(HealerItems.size()), idx);
        ^~~~~~~~~~~~~~~~~
/home/runner/work/DevilutionX/DevilutionX/Source/stores.cpp:357:6: note: candidate function not viable: no known conversion from 'StaticVector<devilution::Item, NumHealerItemsHf>' to 'std::span<Item>' for 1st argument
void ScrollVendorStore(std::span<Item> itemData, int storeLimit, int idx, int selling = true)
```

This is because these builds use the `data()` and `size()` member functions as part of their constructor for std::span conversions. Adding `data()` to `StaticVector` fixes this problem and they are able to convert to `std::span`. Merging this PR allows usage of `std::span` generics with StaticVector on all platforms.

Regards,
yggdrasill