### PR TITLE
Do not deactivate dlvl 15 pentagram

### DIFF
--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -1195,7 +1195,7 @@ void GenerateLevel(lvl_entry entry)
 	DRLG_CheckQuests(SetPieceRoom.position);
 
 	if (currlevel == 15) {
-		bool isGateOpen = UseMultiplayerQuests() || Quests[Q_DIABLO]._qactive == QUEST_ACTIVE;
+		bool isGateOpen = UseMultiplayerQuests() || IsAnyOf(Quests[Q_DIABLO]._qactive, QUEST_ACTIVE, QUEST_DONE);
 		if (!isGateOpen)
 			L4PENTA.place(Quests[Q_DIABLO].position);
 


### PR DESCRIPTION
In Multiplayer with full quests on, if someone sticks around in-game after Diablo is defeated, the pentagram leading from dlvl 15 to 16 is deactivated. This prevents players from reaching dlvl 16 if there was not already a Town Portal present on the dungeon level.