### PR TITLE
lighting: fix vision through diagonally adjacent tiles

### DIFF
--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -254,9 +254,6 @@ void DoVision(Point position, uint8_t radius, MapExplorationType doAutomap, bool
 				if (!InDungeonBounds(rayPoint))
 					break;
 
-				bool visible = true;
-
-				//
 				// We've cast an approximated ray on an integer 2D
 				// grid, so we need to check if a ray can pass through
 				// the diagonally adjacent tiles. For example, consider
@@ -283,10 +280,13 @@ void DoVision(Point position, uint8_t radius, MapExplorationType doAutomap, bool
 					Displacement adjacent1 = { -quadrant.deltaX, 0 };
 					Displacement adjacent2 = { 0, -quadrant.deltaY };
 
-					visible = (TileAllowsLight(rayPoint + adjacent1) || TileAllowsLight(rayPoint + adjacent2));
+					bool passesLight = (TileAllowsLight(rayPoint + adjacent1) || TileAllowsLight(rayPoint + adjacent2));
+					if (!passesLight)
+						// Diagonally adjacent tiles do not pass the
+						// light further, we are done with this ray
+						break;
 				}
-				if (visible)
-					DoVisionFlags(rayPoint, doAutomap, visible);
+				DoVisionFlags(rayPoint, doAutomap, visible);
 
 				bool passesLight = TileAllowsLight(rayPoint);
 				if (!passesLight)


### PR DESCRIPTION
This commit fixes a very subtle case where players could see through diagonally adjacent tiles. The bug was introduced in the recent commit: 88d0cb749fdc ("lighting: fix long-standing issue with invisible objects (#7901)").

The following 2D grid illustrates the bug:

```
  . .                                       . .
  . . .                                   . . .
    . . .                               . . .
      . . .                           . . .
        . . .                       . . .
          . . .                   . . .
            . .                   . .
                  # # # # # # #
                # . . . . . . . #
                # . . . . . . . #
                # . . . . . . . #
                # . . . x . . . #
                # . . . . . . . #
                # . . . . . . . #
                # . . . . . . . #
                  # # # # # # #
            . .                   . .
          . . .                   . . .
        . . .                       . . .
      . . .                           . . .
    . . .                               . . .
  . . .                                   . . .
  . .                                       . .
```

Where 'x' represents the player, surrounded by walls with diagonally adjacent corners, and '.' represents visible tiles reached by vision rays cast from the player's position. The figure clearly shows that rays "leak" through corners. To be honest, I do not know if the described room can be generated by the DevilutionX engine, but of course better to be on the safe side and fix the issue. 

The fix is quite simple: stop traversing the ray if "light" can't pass through the adjacent tiles or if the ray hits a tile that doesn't allow "light" to pass through. Previously, the ray continued to be traversed even when the "light" couldn't pass through the adjacent tiles, which is incorrect and leads to the described issue.

Here is the Python script which simulates the bug and the fix:

  https://gist.github.com/rouming/8a24789fd5d18c36c40e2b4925915d16