### PR TITLE
Fix Automap movement being hardcoded to right stick on gamepad

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -43,6 +43,7 @@ set(libdevilutionx_SRCS
   controls/devices/joystick.cpp
   controls/devices/kbcontroller.cpp
   controls/game_controls.cpp
+  controls/gamepad_repeater.cpp
   controls/keymapper.cpp
   controls/menu_controls.cpp
   controls/modifier_hints.cpp

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -2,12 +2,14 @@
 
 #include <cstdint>
 
+#include "automap.h"
 #include "controls/control_mode.hpp"
 #include "controls/controller_motion.h"
 #ifndef USE_SDL1
 #include "controls/devices/game_controller.h"
 #endif
 #include "controls/devices/joystick.h"
+#include "controls/gamepad_repeater.h"
 #include "controls/padmapper.hpp"
 #include "controls/plrctrls.h"
 #include "controls/touch/gamepad.h"
@@ -394,6 +396,28 @@ bool HandleControllerButtonEvent(const SDL_Event &event, const ControllerButtonE
 	}
 
 	return false;
+}
+
+static devilution::GamepadComboRepeater Repeater;
+
+void RepeatGamepadAction()
+{
+	using namespace devilution;
+
+	if (!AutomapActive)
+		return;
+
+	auto &pad = GetOptions().Padmapper;
+
+	// Repeat inputs for Automap Directional Padmapped Buttons
+	if (Repeater.ShouldFire(pad.ButtonComboForAction("Automap Move Up")))
+		AutomapUp();
+	if (Repeater.ShouldFire(pad.ButtonComboForAction("Automap Move Down")))
+		AutomapDown();
+	if (Repeater.ShouldFire(pad.ButtonComboForAction("Automap Move Left")))
+		AutomapLeft();
+	if (Repeater.ShouldFire(pad.ButtonComboForAction("Automap Move Right")))
+		AutomapRight();
 }
 
 } // namespace devilution

--- a/Source/controls/game_controls.h
+++ b/Source/controls/game_controls.h
@@ -21,6 +21,10 @@ enum GameActionType : uint8_t {
 	GameActionType_TOGGLE_SPELL_BOOK,
 	GameActionType_TOGGLE_QUEST_LOG,
 	GameActionType_SEND_KEY,
+	GameActionType_AutomapMoveUp,
+	GameActionType_AutomapMoveDown,
+	GameActionType_AutomapMoveLeft,
+	GameActionType_AutomapMoveRight,
 };
 
 struct GameActionSendKey {
@@ -71,5 +75,7 @@ extern bool PadHotspellMenuActive;
 // The event processor may interpret the second event's button as a modifier for the action taken when processing the first event.
 // The code for the modifier will be stored here, and the event processor can check this value when processing the second event to suppress it.
 extern ControllerButton SuppressedButton;
+
+void RepeatGamepadAction();
 
 } // namespace devilution

--- a/Source/controls/gamepad_repeater.cpp
+++ b/Source/controls/gamepad_repeater.cpp
@@ -1,0 +1,33 @@
+#include "gamepad_repeater.h"
+
+#include <SDL.h>
+
+namespace devilution {
+
+GamepadComboRepeater::GamepadComboRepeater(int repeatIntervalMs)
+    : repeatIntervalMs_(repeatIntervalMs)
+{
+}
+
+bool GamepadComboRepeater::ShouldFire(const ControllerButtonCombo &combo)
+{
+	if (combo.button == ControllerButton_NONE)
+		return false;
+
+	if (!IsControllerButtonComboPressed(combo)) {
+		lastTriggerTime_.erase(combo.button); // Reset timer if released
+		return false;
+	}
+
+	Uint32 now = SDL_GetTicks();
+	Uint32 &lastTime = lastTriggerTime_[combo.button];
+
+	if (now - lastTime >= static_cast<Uint32>(repeatIntervalMs_)) {
+		lastTime = now;
+		return true;
+	}
+
+	return false;
+}
+
+} // namespace devilution

--- a/Source/controls/gamepad_repeater.h
+++ b/Source/controls/gamepad_repeater.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include "controller.h"
+
+namespace devilution {
+
+class GamepadComboRepeater {
+public:
+	explicit GamepadComboRepeater(int repeatIntervalMs = 10);
+
+	/**
+	 * @brief Checks if the given button combo should fire based on the repeat interval.
+	 * Must be called once per frame.
+	 */
+	bool ShouldFire(const ControllerButtonCombo &combo);
+
+private:
+	std::unordered_map<ControllerButton, Uint32> lastTriggerTime_;
+	int repeatIntervalMs_;
+};
+
+} // namespace devilution

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -1826,14 +1826,15 @@ void HandleRightStickMotion()
 		return;
 	}
 
-	if (AutomapActive) { // move map
-		int dx = 0;
-		int dy = 0;
-		acc.Pool(&dx, &dy, 32);
-		AutomapOffset.deltaX += dy + dx;
-		AutomapOffset.deltaY += dy - dx;
-		return;
-	}
+	// Disabled map movement via right stick to allow mouse control during automap
+	// if (AutomapActive) { // move map
+	// 	int dx = 0;
+	// 	int dy = 0;
+	// 	acc.Pool(&dx, &dy, 32);
+	// 	AutomapOffset.deltaX += dy + dx;
+	// 	AutomapOffset.deltaY += dy - dx;
+	// 	return;
+	// }
 
 	{ // move cursor
 		InvalidateInventorySlot();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -225,6 +225,7 @@ bool ProcessInput()
 		CheckCursMove();
 		plrctrls_after_check_curs_move();
 		RepeatMouseAction();
+		RepeatGamepadAction();
 	}
 
 	return true;
@@ -2228,6 +2229,30 @@ void InitPadmapActions()
 	    N_("Toggles if automap is displayed."),
 	    ControllerButton_BUTTON_LEFTSTICK,
 	    DoAutoMap);
+	options.Padmapper.AddAction(
+		"Automap Move Up",
+		N_("Automap Move Up"),
+		N_("Moves the automap up when active."),
+		ControllerButton_NONE,
+		[] { if (AutomapActive) AutomapUp(); });
+	options.Padmapper.AddAction(
+		"Automap Move Down",
+		N_("Automap Move Down"),
+		N_("Moves the automap down when active."),
+		ControllerButton_NONE,
+		[] { if (AutomapActive) AutomapDown(); });
+	options.Padmapper.AddAction(
+		"Automap Move Left",
+		N_("Automap Move Left"),
+		N_("Moves the automap left when active."),
+		ControllerButton_NONE,
+		[] { if (AutomapActive) AutomapLeft(); });
+	options.Padmapper.AddAction(
+		"Automap Move Right",
+		N_("Automap Move Right"),
+		N_("Moves the automap right when active."),
+		ControllerButton_NONE,
+		[] { if (AutomapActive) AutomapRight(); });
 	options.Padmapper.AddAction(
 	    "MouseUp",
 	    N_("Move mouse up"),


### PR DESCRIPTION
This PR does the following:

- Removes the Automap movement from being hardcoded to the right stick of gamepads.  The issue here is that the only way to target on gamepads is via the mouse emulation tied to the right stick.  With the Automap movement also being hardcoded to right stick, this means that when playing DevilutionX on gamepad, if your automap is open, you cannot target.  You have to close your map in order to successfully target your spells.
- Adds four new padmapping entries for Automap Movement that can be mapped using any valid button/button combo
- Creates a new file called gamepad_repeater which can be used for other padmapping entries, but for now is just being used for the automap scrolling with the padmap buttons.  This allows the user to scroll the automap without having to tap the movement buttons mimicking the functionality of moving the automap with the keyboard arrow keys.