### PR TITLE
Add alternative download for bzip2

### DIFF
--- a/3rdParty/bzip2/CMakeLists.txt
+++ b/3rdParty/bzip2/CMakeLists.txt
@@ -1,9 +1,11 @@
 include(functions/FetchContent_ExcludeFromAll_backport)
 
 include(FetchContent)
+
 FetchContent_Declare_ExcludeFromAll(bzip2
-    URL https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
-    URL_HASH MD5=67e051268d0c475ea773822f7500d0e5
+    GIT_REPOSITORY https://sourceware.org/git/bzip2
+    GIT_REPOSITORY https://gitlab.com/bzip2/bzip2
+    GIT_TAG bzip2-1.0.8
 )
 FetchContent_MakeAvailable_ExcludeFromAll(bzip2)
 


### PR DESCRIPTION
Sourceware URL is too unreliable
This downloads source from a tag in experimental 1.1 bzip2 repo
https://gitlab.com/bzip2/bzip2/-/tags/bzip2-1.0.8
New hash is because new source archive is not identical to one from Sourceware for some reason

Proof this is official repo: https://sourceware.org/bzip2/downloads.html
