### PR TITLE
Update IsShopPriceValid()

### DIFF
--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -60,9 +60,10 @@ bool IsTownItemValid(uint16_t iCreateInfo, const Player &player)
 
 bool IsShopPriceValid(const Item &item)
 {
-	const int maxBoyValue = gbIsHellfire ? MaxBoyValueHf : MaxBoyValue;
-	if ((item._iCreateInfo & CF_BOY) != 0 && item._iIvalue > maxBoyValue)
-		return false;
+	if ((item._iCreateInfo & CF_BOY) != 0) {
+		const int maxBoyValue = gbIsHellfire ? MaxBoyValueHf : MaxBoyValue;
+		return item._iIvalue <= maxBoyValue;
+	}
 
 	const int maxVendorValue = gbIsHellfire ? MaxVendorValueHf : MaxVendorValue;
 	return item._iIvalue <= maxVendorValue;

--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -60,20 +60,12 @@ bool IsTownItemValid(uint16_t iCreateInfo, const Player &player)
 
 bool IsShopPriceValid(const Item &item)
 {
-	const int boyPriceLimit = MaxBoyValue;
-	if (!gbIsHellfire && (item._iCreateInfo & CF_BOY) != 0 && item._iIvalue > boyPriceLimit)
+	const int maxBoyValue = gbIsHellfire ? MaxBoyValueHf : MaxBoyValue;
+	if ((item._iCreateInfo & CF_BOY) != 0 && item._iIvalue > maxBoyValue)
 		return false;
 
-	const int premiumPriceLimit = MaxVendorValue;
-	if (!gbIsHellfire && (item._iCreateInfo & CF_SMITHPREMIUM) != 0 && item._iIvalue > premiumPriceLimit)
-		return false;
-
-	const uint16_t smithOrWitch = CF_SMITH | CF_WITCH;
-	const int smithAndWitchPriceLimit = gbIsHellfire ? MaxVendorValueHf : MaxVendorValue;
-	if ((item._iCreateInfo & smithOrWitch) != 0 && item._iIvalue > smithAndWitchPriceLimit)
-		return false;
-
-	return true;
+	const int maxVendorValue = gbIsHellfire ? MaxVendorValueHf : MaxVendorValue;
+	return item._iIvalue <= maxVendorValue;
 }
 
 bool IsUniqueMonsterItemValid(uint16_t iCreateInfo, uint32_t dwBuff)

--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -60,13 +60,9 @@ bool IsTownItemValid(uint16_t iCreateInfo, const Player &player)
 
 bool IsShopPriceValid(const Item &item)
 {
-	if ((item._iCreateInfo & CF_BOY) != 0) {
-		const int maxBoyValue = gbIsHellfire ? MaxBoyValueHf : MaxBoyValue;
-		return item._iIvalue <= maxBoyValue;
-	}
-
-	const int maxVendorValue = gbIsHellfire ? MaxVendorValueHf : MaxVendorValue;
-	return item._iIvalue <= maxVendorValue;
+	if ((item._iCreateInfo & CF_BOY) != 0)
+		return item._iIvalue <= (gbIsHellfire ? MaxBoyValueHf : MaxBoyValue);
+	return item._iIvalue <= (gbIsHellfire ? MaxVendorValueHf : MaxVendorValue);
 }
 
 bool IsUniqueMonsterItemValid(uint16_t iCreateInfo, uint32_t dwBuff)


### PR DESCRIPTION
Used with: https://github.com/diasurgical/DevilutionX/pull/7924

Since the linked PR ensures that items exceeding the maximum vendor value cannot be sold the player, when previously it was technically possible in Hellfire, we can validate more item values that are sourced from Town.