### PR TITLE
Update portuguese translation

### DIFF
--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2023-07-05 03:51+0200\n"
-"PO-Revision-Date: 2023-07-09 20:20-0700\n"
+"POT-Creation-Date: 2025-04-18 23:03+0200\n"
+"PO-Revision-Date: 2025-04-18 23:03+0200\n"
 "Last-Translator: Altieres Lima da Silva <altieres.lima@gmail.com>\n"
 "Language-Team: \n"
 "Language: pt_BR\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-KeywordsList: _;N_;P_:1c,2\n"
 "X-Poedit-Basepath: ..\n"
@@ -102,7 +102,7 @@ msgstr "Produtor Associado"
 msgid "Diablo Strike Team"
 msgstr "Equipe Strike Team Diablo"
 
-#: Source/DiabloUI/credits_lines.cpp:77 Source/gamemenu.cpp:71
+#: Source/DiabloUI/credits_lines.cpp:77 Source/gamemenu.cpp:78
 msgid "Music"
 msgstr "Música"
 
@@ -317,78 +317,79 @@ msgstr "O Anel dos Mil"
 msgid "\tNo souls were sold in the making of this game."
 msgstr "\tNenhuma alma foi vendida na criação deste jogo."
 
-#: Source/DiabloUI/dialogs.cpp:84 Source/DiabloUI/dialogs.cpp:96
-#: Source/DiabloUI/hero/selhero.cpp:177 Source/DiabloUI/hero/selhero.cpp:203
-#: Source/DiabloUI/hero/selhero.cpp:288 Source/DiabloUI/hero/selhero.cpp:528
-#: Source/DiabloUI/multi/selconn.cpp:82 Source/DiabloUI/multi/selgame.cpp:171
-#: Source/DiabloUI/multi/selgame.cpp:335 Source/DiabloUI/multi/selgame.cpp:361
-#: Source/DiabloUI/multi/selgame.cpp:503 Source/DiabloUI/multi/selgame.cpp:580
-#: Source/DiabloUI/selok.cpp:71
+#: Source/DiabloUI/dialogs.cpp:90 Source/DiabloUI/dialogs.cpp:102
+#: Source/DiabloUI/hero/selhero.cpp:179 Source/DiabloUI/hero/selhero.cpp:205
+#: Source/DiabloUI/hero/selhero.cpp:290 Source/DiabloUI/hero/selhero.cpp:530
+#: Source/DiabloUI/multi/selconn.cpp:84 Source/DiabloUI/multi/selgame.cpp:173
+#: Source/DiabloUI/multi/selgame.cpp:336 Source/DiabloUI/multi/selgame.cpp:362
+#: Source/DiabloUI/multi/selgame.cpp:504 Source/DiabloUI/multi/selgame.cpp:581
+#: Source/DiabloUI/selok.cpp:72
 msgid "OK"
 msgstr "OK"
 
-#: Source/DiabloUI/hero/selhero.cpp:155
+#: Source/DiabloUI/hero/selhero.cpp:157
 msgid "Choose Class"
 msgstr "Escolha uma Classe"
 
 #. TRANSLATORS: Player Block start
 #. HeroClass::Warrior
-#: Source/DiabloUI/hero/selhero.cpp:159 Source/playerdat.cpp:89
+#: Source/DiabloUI/hero/selhero.cpp:161 Source/playerdat.cpp:254
 msgid "Warrior"
 msgstr "Guerreiro"
 
-#: Source/DiabloUI/hero/selhero.cpp:160 Source/playerdat.cpp:90
+#: Source/DiabloUI/hero/selhero.cpp:162 Source/playerdat.cpp:255
 msgid "Rogue"
 msgstr "Ladina"
 
-#: Source/DiabloUI/hero/selhero.cpp:161 Source/playerdat.cpp:91
+#: Source/DiabloUI/hero/selhero.cpp:163 Source/playerdat.cpp:256
 msgid "Sorcerer"
 msgstr "Feiticeiro"
 
-#: Source/DiabloUI/hero/selhero.cpp:163 Source/playerdat.cpp:92
+#: Source/DiabloUI/hero/selhero.cpp:165 Source/playerdat.cpp:257
 msgid "Monk"
 msgstr "Monge"
 
-#: Source/DiabloUI/hero/selhero.cpp:166 Source/playerdat.cpp:93
+#: Source/DiabloUI/hero/selhero.cpp:167 Source/playerdat.cpp:258
 msgid "Bard"
 msgstr "Bardo"
 
-#: Source/DiabloUI/hero/selhero.cpp:169 Source/playerdat.cpp:94
+#. TRANSLATORS: Player Block end
+#. HeroClass::Barbarian
+#: Source/DiabloUI/hero/selhero.cpp:170 Source/playerdat.cpp:260
 msgid "Barbarian"
 msgstr "Bárbaro"
 
-#: Source/DiabloUI/hero/selhero.cpp:180 Source/DiabloUI/hero/selhero.cpp:206
-#: Source/DiabloUI/hero/selhero.cpp:291 Source/DiabloUI/hero/selhero.cpp:536
-#: Source/DiabloUI/multi/selconn.cpp:85 Source/DiabloUI/progress.cpp:44
+#: Source/DiabloUI/hero/selhero.cpp:182 Source/DiabloUI/hero/selhero.cpp:208
+#: Source/DiabloUI/hero/selhero.cpp:293 Source/DiabloUI/hero/selhero.cpp:538
+#: Source/DiabloUI/multi/selconn.cpp:87 Source/DiabloUI/progress.cpp:45
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: Source/DiabloUI/hero/selhero.cpp:186 Source/DiabloUI/hero/selhero.cpp:276
+#: Source/DiabloUI/hero/selhero.cpp:188 Source/DiabloUI/hero/selhero.cpp:278
 msgid "New Multi Player Hero"
 msgstr "Novo Herói Multijogador"
 
-#: Source/DiabloUI/hero/selhero.cpp:186 Source/DiabloUI/hero/selhero.cpp:276
+#: Source/DiabloUI/hero/selhero.cpp:188 Source/DiabloUI/hero/selhero.cpp:278
 msgid "New Single Player Hero"
 msgstr "Novo Herói"
 
-#: Source/DiabloUI/hero/selhero.cpp:195
+#: Source/DiabloUI/hero/selhero.cpp:197
 msgid "Save File Exists"
 msgstr "Jogo Salvo Existente"
 
-#: Source/DiabloUI/hero/selhero.cpp:198 Source/gamemenu.cpp:42
+#: Source/DiabloUI/hero/selhero.cpp:200 Source/gamemenu.cpp:49
 msgid "Load Game"
 msgstr "Carregar Jogo"
 
-#: Source/DiabloUI/hero/selhero.cpp:199 Source/gamemenu.cpp:41
-#: Source/gamemenu.cpp:52 Source/multi.cpp:796
+#: Source/DiabloUI/hero/selhero.cpp:201 Source/multi.cpp:829
 msgid "New Game"
 msgstr "Novo Jogo"
 
-#: Source/DiabloUI/hero/selhero.cpp:209 Source/DiabloUI/hero/selhero.cpp:542
+#: Source/DiabloUI/hero/selhero.cpp:211 Source/DiabloUI/hero/selhero.cpp:544
 msgid "Single Player Characters"
 msgstr "Personagens"
 
-#: Source/DiabloUI/hero/selhero.cpp:268
+#: Source/DiabloUI/hero/selhero.cpp:270
 msgid ""
 "The Rogue and Sorcerer are only available in the full retail version of "
 "Diablo. Visit https://www.gog.com/game/diablo to purchase."
@@ -396,11 +397,11 @@ msgstr ""
 "A Ladina e o Feiticeiro estão disponíveis apenas na versão comercial "
 "completa do Diablo. Visite https://www.gog.com/game/diablo para comprar."
 
-#: Source/DiabloUI/hero/selhero.cpp:282 Source/DiabloUI/hero/selhero.cpp:285
+#: Source/DiabloUI/hero/selhero.cpp:284 Source/DiabloUI/hero/selhero.cpp:287
 msgid "Enter Name"
 msgstr "Inserir nome"
 
-#: Source/DiabloUI/hero/selhero.cpp:314
+#: Source/DiabloUI/hero/selhero.cpp:316
 msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
@@ -409,143 +410,143 @@ msgstr ""
 "palavras.\n"
 
 #. TRANSLATORS: Error Message
-#: Source/DiabloUI/hero/selhero.cpp:321
+#: Source/DiabloUI/hero/selhero.cpp:323
 msgid "Unable to create character."
 msgstr "Não foi possível criar o personagem."
 
-#: Source/DiabloUI/hero/selhero.cpp:487
+#: Source/DiabloUI/hero/selhero.cpp:489
 msgid "Level:"
 msgstr "Nível:"
 
-#: Source/DiabloUI/hero/selhero.cpp:491
+#: Source/DiabloUI/hero/selhero.cpp:493
 msgid "Strength:"
 msgstr "Força:"
 
-#: Source/DiabloUI/hero/selhero.cpp:491
+#: Source/DiabloUI/hero/selhero.cpp:493
 msgid "Magic:"
 msgstr "Magia:"
 
-#: Source/DiabloUI/hero/selhero.cpp:491
+#: Source/DiabloUI/hero/selhero.cpp:493
 msgid "Dexterity:"
 msgstr "Destreza:"
 
-#: Source/DiabloUI/hero/selhero.cpp:491
+#: Source/DiabloUI/hero/selhero.cpp:493
 msgid "Vitality:"
 msgstr "Vitalidade:"
 
-#: Source/DiabloUI/hero/selhero.cpp:493
+#: Source/DiabloUI/hero/selhero.cpp:495
 msgid "Savegame:"
 msgstr "Jogo Salvo:"
 
-#: Source/DiabloUI/hero/selhero.cpp:512
+#: Source/DiabloUI/hero/selhero.cpp:514
 msgid "Select Hero"
 msgstr "Selecione um Herói"
 
-#: Source/DiabloUI/hero/selhero.cpp:520
+#: Source/DiabloUI/hero/selhero.cpp:522
 msgid "New Hero"
 msgstr "Novo herói"
 
-#: Source/DiabloUI/hero/selhero.cpp:531
+#: Source/DiabloUI/hero/selhero.cpp:533
 msgid "Delete"
 msgstr "Apagar"
 
-#: Source/DiabloUI/hero/selhero.cpp:540
+#: Source/DiabloUI/hero/selhero.cpp:542
 msgid "Multi Player Characters"
 msgstr "Personagens Multijogador"
 
-#: Source/DiabloUI/hero/selhero.cpp:591
+#: Source/DiabloUI/hero/selhero.cpp:593
 msgid "Delete Multi Player Hero"
 msgstr "Apagar Herói Multijogador"
 
-#: Source/DiabloUI/hero/selhero.cpp:593
+#: Source/DiabloUI/hero/selhero.cpp:595
 msgid "Delete Single Player Hero"
 msgstr "Apagar Herói"
 
-#: Source/DiabloUI/hero/selhero.cpp:595
+#: Source/DiabloUI/hero/selhero.cpp:597
 msgid "Are you sure you want to delete the character \"{:s}\"?"
 msgstr "Tem certeza de que deseja apagar o personagem \"{:s}\"?"
 
-#: Source/DiabloUI/mainmenu.cpp:38
+#: Source/DiabloUI/mainmenu.cpp:40
 msgid "Single Player"
 msgstr "Um Jogador"
 
-#: Source/DiabloUI/mainmenu.cpp:39
+#: Source/DiabloUI/mainmenu.cpp:41
 msgid "Multi Player"
 msgstr "Multijogador"
 
-#: Source/DiabloUI/mainmenu.cpp:40 Source/DiabloUI/settingsmenu.cpp:366
+#: Source/DiabloUI/mainmenu.cpp:42 Source/DiabloUI/settingsmenu.cpp:372
 msgid "Settings"
 msgstr "Configurações"
 
-#: Source/DiabloUI/mainmenu.cpp:41
+#: Source/DiabloUI/mainmenu.cpp:43
 msgid "Support"
 msgstr "Suporte"
 
-#: Source/DiabloUI/mainmenu.cpp:42
+#: Source/DiabloUI/mainmenu.cpp:44
 msgid "Show Credits"
 msgstr "Exibir Créditos"
 
-#: Source/DiabloUI/mainmenu.cpp:44
+#: Source/DiabloUI/mainmenu.cpp:46
 msgid "Exit Hellfire"
 msgstr "Sair do Hellfire"
 
-#: Source/DiabloUI/mainmenu.cpp:44
+#: Source/DiabloUI/mainmenu.cpp:46
 msgid "Exit Diablo"
 msgstr "Sair do Diablo"
 
-#: Source/DiabloUI/mainmenu.cpp:62
+#: Source/DiabloUI/mainmenu.cpp:64
 msgid "Shareware"
 msgstr "Shareware"
 
-#: Source/DiabloUI/multi/selconn.cpp:14
+#: Source/DiabloUI/multi/selconn.cpp:16
 msgid "Client-Server (TCP)"
 msgstr "Cliente-Servidor (TCP)"
 
-#: Source/DiabloUI/multi/selconn.cpp:15
+#: Source/DiabloUI/multi/selconn.cpp:17
 #, fuzzy
 msgid "Offline"
 msgstr "Loopback"
 
-#: Source/DiabloUI/multi/selconn.cpp:56 Source/DiabloUI/multi/selgame.cpp:647
-#: Source/DiabloUI/multi/selgame.cpp:671
+#: Source/DiabloUI/multi/selconn.cpp:58 Source/DiabloUI/multi/selgame.cpp:648
+#: Source/DiabloUI/multi/selgame.cpp:674
 msgid "Multi Player Game"
 msgstr "Jogo Multijogador"
 
-#: Source/DiabloUI/multi/selconn.cpp:62
+#: Source/DiabloUI/multi/selconn.cpp:64
 msgid "Requirements:"
 msgstr "Requisitos:"
 
-#: Source/DiabloUI/multi/selconn.cpp:68
+#: Source/DiabloUI/multi/selconn.cpp:70
 msgid "no gateway needed"
 msgstr "sem gateway"
 
-#: Source/DiabloUI/multi/selconn.cpp:74
+#: Source/DiabloUI/multi/selconn.cpp:76
 msgid "Select Connection"
 msgstr "Selecione uma conexão"
 
-#: Source/DiabloUI/multi/selconn.cpp:77
+#: Source/DiabloUI/multi/selconn.cpp:79
 msgid "Change Gateway"
 msgstr "Mudar Gateway"
 
-#: Source/DiabloUI/multi/selconn.cpp:110
+#: Source/DiabloUI/multi/selconn.cpp:112
 msgid "All computers must be connected to a TCP-compatible network."
 msgstr ""
 "Todos os computadores devem estar conectados a uma rede compatível com TCP."
 
-#: Source/DiabloUI/multi/selconn.cpp:114
+#: Source/DiabloUI/multi/selconn.cpp:116
 msgid "All computers must be connected to the internet."
 msgstr "Todos os computadores devem estar conectados à internet."
 
-#: Source/DiabloUI/multi/selconn.cpp:118
+#: Source/DiabloUI/multi/selconn.cpp:120
 msgid "Play by yourself with no network exposure."
 msgstr "Jogue sozinho sem exposição na rede."
 
-#: Source/DiabloUI/multi/selconn.cpp:123
+#: Source/DiabloUI/multi/selconn.cpp:125
 msgid "Players Supported: {:d}"
 msgstr "Jogadores Suport.: {:d}"
 
-#: Source/DiabloUI/multi/selgame.cpp:86 Source/options.cpp:571
-#: Source/options.cpp:610 Source/quests.cpp:53
+#: Source/DiabloUI/multi/selgame.cpp:86 Source/options.cpp:419
+#: Source/options.cpp:467 Source/quests.cpp:58
 msgid "Diablo"
 msgstr "Diablo"
 
@@ -553,8 +554,8 @@ msgstr "Diablo"
 msgid "Diablo Shareware"
 msgstr "Diablo Shareware"
 
-#: Source/DiabloUI/multi/selgame.cpp:92 Source/options.cpp:573
-#: Source/options.cpp:624
+#: Source/DiabloUI/multi/selgame.cpp:92 Source/options.cpp:421
+#: Source/options.cpp:481
 msgid "Hellfire"
 msgstr "Hellfire"
 
@@ -575,52 +576,53 @@ msgstr "O anfitrião está executando o modo de jogo ({:s}) diferente de você."
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
 msgstr "Sua versão {:s} não corresponde com a do anfitrião {:d}.{:d}.{:d}."
 
-#: Source/DiabloUI/multi/selgame.cpp:137 Source/DiabloUI/multi/selgame.cpp:566
+#: Source/DiabloUI/multi/selgame.cpp:139 Source/DiabloUI/multi/selgame.cpp:567
 msgid "Description:"
 msgstr "Descrição:"
 
-#: Source/DiabloUI/multi/selgame.cpp:143
+#: Source/DiabloUI/multi/selgame.cpp:145
 msgid "Select Action"
 msgstr "Selecionar Ação"
 
-#: Source/DiabloUI/multi/selgame.cpp:146 Source/DiabloUI/multi/selgame.cpp:323
-#: Source/DiabloUI/multi/selgame.cpp:484
+#: Source/DiabloUI/multi/selgame.cpp:148 Source/DiabloUI/multi/selgame.cpp:324
+#: Source/DiabloUI/multi/selgame.cpp:485
 msgid "Create Game"
 msgstr "Criar jogo"
 
-#: Source/DiabloUI/multi/selgame.cpp:148
+#: Source/DiabloUI/multi/selgame.cpp:150
 msgid "Create Public Game"
 msgstr "Criar Jogo Público"
 
-#: Source/DiabloUI/multi/selgame.cpp:149
+#: Source/DiabloUI/multi/selgame.cpp:151
 msgid "Join Game"
 msgstr "Entrar no jogo"
 
-#: Source/DiabloUI/multi/selgame.cpp:153
+#: Source/DiabloUI/multi/selgame.cpp:155
 msgid "Public Games"
 msgstr "Jogos Públicos"
 
-#: Source/DiabloUI/multi/selgame.cpp:158 Source/error.cpp:63
+#: Source/DiabloUI/multi/selgame.cpp:160 Source/diablo_msg.cpp:72
 msgid "Loading..."
 msgstr "Carregando..."
 
 #. TRANSLATORS: type of dungeon (i.e. Cathedral, Caves)
-#: Source/DiabloUI/multi/selgame.cpp:160 Source/discord/discord.cpp:73
-#: Source/options.cpp:592 Source/panels/charpanel.cpp:135
+#: Source/DiabloUI/multi/selgame.cpp:162 Source/discord/discord.cpp:86
+#: Source/options.cpp:453 Source/options.cpp:718
+#: Source/panels/charpanel.cpp:142
 msgid "None"
 msgstr "Nenhum"
 
-#: Source/DiabloUI/multi/selgame.cpp:174 Source/DiabloUI/multi/selgame.cpp:338
-#: Source/DiabloUI/multi/selgame.cpp:364 Source/DiabloUI/multi/selgame.cpp:506
-#: Source/DiabloUI/multi/selgame.cpp:583
+#: Source/DiabloUI/multi/selgame.cpp:176 Source/DiabloUI/multi/selgame.cpp:339
+#: Source/DiabloUI/multi/selgame.cpp:365 Source/DiabloUI/multi/selgame.cpp:507
+#: Source/DiabloUI/multi/selgame.cpp:584
 msgid "CANCEL"
 msgstr "CANCELAR"
 
-#: Source/DiabloUI/multi/selgame.cpp:214
+#: Source/DiabloUI/multi/selgame.cpp:215
 msgid "Create a new game with a difficulty setting of your choice."
 msgstr "Crie um novo jogo com uma dificuldade de sua escolha."
 
-#: Source/DiabloUI/multi/selgame.cpp:217
+#: Source/DiabloUI/multi/selgame.cpp:218
 msgid ""
 "Create a new public game that anyone can join with a difficulty setting of "
 "your choice."
@@ -628,79 +630,79 @@ msgstr ""
 "Crie um novo jogo público aberto a qualquer pessoa com uma dificuldade de "
 "sua escolha."
 
-#: Source/DiabloUI/multi/selgame.cpp:221
+#: Source/DiabloUI/multi/selgame.cpp:222
 msgid "Enter Game ID to join a game already in progress."
 msgstr "Insira o ID do Jogo para entrar em um jogo já em andamento."
 
-#: Source/DiabloUI/multi/selgame.cpp:223
+#: Source/DiabloUI/multi/selgame.cpp:224
 msgid "Enter an IP or a hostname to join a game already in progress."
 msgstr "Insira um IP ou nome do servidor e entre em um jogo já em andamento."
 
-#: Source/DiabloUI/multi/selgame.cpp:228
+#: Source/DiabloUI/multi/selgame.cpp:229
 msgid "Join the public game already in progress."
 msgstr "Entrar em um jogo público já em andamento."
 
-#: Source/DiabloUI/multi/selgame.cpp:234 Source/DiabloUI/multi/selgame.cpp:328
-#: Source/DiabloUI/multi/selgame.cpp:389 Source/DiabloUI/multi/selgame.cpp:495
-#: Source/DiabloUI/multi/selgame.cpp:515 Source/automap.cpp:768
-#: Source/discord/discord.cpp:102
+#: Source/DiabloUI/multi/selgame.cpp:235 Source/DiabloUI/multi/selgame.cpp:329
+#: Source/DiabloUI/multi/selgame.cpp:390 Source/DiabloUI/multi/selgame.cpp:496
+#: Source/DiabloUI/multi/selgame.cpp:516 Source/automap.cpp:1461
+#: Source/discord/discord.cpp:114
 msgid "Normal"
 msgstr "Normal"
 
-#: Source/DiabloUI/multi/selgame.cpp:237 Source/DiabloUI/multi/selgame.cpp:329
-#: Source/DiabloUI/multi/selgame.cpp:393 Source/automap.cpp:771
-#: Source/discord/discord.cpp:102
+#: Source/DiabloUI/multi/selgame.cpp:238 Source/DiabloUI/multi/selgame.cpp:330
+#: Source/DiabloUI/multi/selgame.cpp:394 Source/automap.cpp:1464
+#: Source/discord/discord.cpp:114
 msgid "Nightmare"
 msgstr "Pesadelo"
 
-#: Source/DiabloUI/multi/selgame.cpp:240 Source/DiabloUI/multi/selgame.cpp:330
-#: Source/DiabloUI/multi/selgame.cpp:397 Source/automap.cpp:774
-#: Source/discord/discord.cpp:68 Source/discord/discord.cpp:102
+#: Source/DiabloUI/multi/selgame.cpp:241 Source/DiabloUI/multi/selgame.cpp:331
+#: Source/DiabloUI/multi/selgame.cpp:398 Source/automap.cpp:1467
+#: Source/discord/discord.cpp:81 Source/discord/discord.cpp:114
 msgid "Hell"
 msgstr "Inferno"
 
 #. TRANSLATORS: {:s} means: Game Difficulty.
-#: Source/DiabloUI/multi/selgame.cpp:243 Source/automap.cpp:778
+#: Source/DiabloUI/multi/selgame.cpp:244 Source/automap.cpp:1471
 msgid "Difficulty: {:s}"
 msgstr "Dificuldade: {:s}"
 
-#: Source/DiabloUI/multi/selgame.cpp:247 Source/gamemenu.cpp:167
+#: Source/DiabloUI/multi/selgame.cpp:248 Source/gamemenu.cpp:164
 msgid "Speed: Normal"
 msgstr "Velocidade: Normal"
 
-#: Source/DiabloUI/multi/selgame.cpp:250 Source/gamemenu.cpp:165
+#: Source/DiabloUI/multi/selgame.cpp:251 Source/gamemenu.cpp:162
 msgid "Speed: Fast"
 msgstr "Velocidade: Rápido"
 
-#: Source/DiabloUI/multi/selgame.cpp:253 Source/gamemenu.cpp:163
+#: Source/DiabloUI/multi/selgame.cpp:254 Source/gamemenu.cpp:160
 msgid "Speed: Faster"
 msgstr "Velocidade: Muito rápido"
 
-#: Source/DiabloUI/multi/selgame.cpp:256 Source/gamemenu.cpp:161
+#: Source/DiabloUI/multi/selgame.cpp:257 Source/gamemenu.cpp:158
 msgid "Speed: Fastest"
 msgstr "Velocidade: Super rápido"
 
-#: Source/DiabloUI/multi/selgame.cpp:264
+#: Source/DiabloUI/multi/selgame.cpp:265
 msgid "Players: "
 msgstr "Jogadores: "
 
-#: Source/DiabloUI/multi/selgame.cpp:326
+#: Source/DiabloUI/multi/selgame.cpp:327
 msgid "Select Difficulty"
 msgstr "Dificuldade"
 
-#: Source/DiabloUI/multi/selgame.cpp:344
+#: Source/DiabloUI/multi/selgame.cpp:345
 msgid "Join {:s} Games"
 msgstr "Entrar em jogos {:s}"
 
-#: Source/DiabloUI/multi/selgame.cpp:349
+#: Source/DiabloUI/multi/selgame.cpp:350
 msgid "Enter Game ID"
 msgstr "Insira ID do Jogo"
 
-#: Source/DiabloUI/multi/selgame.cpp:351
+#: Source/DiabloUI/multi/selgame.cpp:352
 msgid "Enter address"
 msgstr "Inserir endereço"
 
-#: Source/DiabloUI/multi/selgame.cpp:390
+#: Source/DiabloUI/multi/selgame.cpp:391
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -708,7 +710,7 @@ msgstr ""
 "Dificuldade Normal\n"
 "É aqui que um personagem inicial deve começar a jornada para derrotar Diablo."
 
-#: Source/DiabloUI/multi/selgame.cpp:394
+#: Source/DiabloUI/multi/selgame.cpp:395
 msgid ""
 "Nightmare Difficulty\n"
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
@@ -718,7 +720,7 @@ msgstr ""
 "Os habitantes do Labirinto foram reforçados e provarão ser um grande "
 "desafio. Recomendado apenas para personagens experientes."
 
-#: Source/DiabloUI/multi/selgame.cpp:398
+#: Source/DiabloUI/multi/selgame.cpp:399
 msgid ""
 "Hell Difficulty\n"
 "The most powerful of the underworld's creatures lurk at the gateway into "
@@ -729,7 +731,7 @@ msgstr ""
 "Inferno. Somente os personagens mais experientes devem se aventurar nesse "
 "reino."
 
-#: Source/DiabloUI/multi/selgame.cpp:413
+#: Source/DiabloUI/multi/selgame.cpp:414
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
@@ -737,7 +739,7 @@ msgstr ""
 "Seu personagem deve atingir o nível 20 antes de poder entrar em um jogo "
 "multijogador na dificuldade Pesadelo."
 
-#: Source/DiabloUI/multi/selgame.cpp:415
+#: Source/DiabloUI/multi/selgame.cpp:416
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
@@ -745,23 +747,23 @@ msgstr ""
 "Seu personagem deve atingir o nível 30 antes de poder entrar em um jogo "
 "multijogador na dificuldade Inferno."
 
-#: Source/DiabloUI/multi/selgame.cpp:493
+#: Source/DiabloUI/multi/selgame.cpp:494
 msgid "Select Game Speed"
 msgstr "Velocidade do jogo"
 
-#: Source/DiabloUI/multi/selgame.cpp:496 Source/DiabloUI/multi/selgame.cpp:519
+#: Source/DiabloUI/multi/selgame.cpp:497 Source/DiabloUI/multi/selgame.cpp:520
 msgid "Fast"
 msgstr "Rápido"
 
-#: Source/DiabloUI/multi/selgame.cpp:497 Source/DiabloUI/multi/selgame.cpp:523
+#: Source/DiabloUI/multi/selgame.cpp:498 Source/DiabloUI/multi/selgame.cpp:524
 msgid "Faster"
 msgstr "Muito Rápido"
 
-#: Source/DiabloUI/multi/selgame.cpp:498 Source/DiabloUI/multi/selgame.cpp:527
+#: Source/DiabloUI/multi/selgame.cpp:499 Source/DiabloUI/multi/selgame.cpp:528
 msgid "Fastest"
 msgstr "Super Rápido"
 
-#: Source/DiabloUI/multi/selgame.cpp:516
+#: Source/DiabloUI/multi/selgame.cpp:517
 msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
@@ -770,7 +772,7 @@ msgstr ""
 "É aqui que um personagem iniciante deve começar a jornada para derrotar "
 "Diablo."
 
-#: Source/DiabloUI/multi/selgame.cpp:520
+#: Source/DiabloUI/multi/selgame.cpp:521
 msgid ""
 "Fast Speed\n"
 "The denizens of the Labyrinth have been hastened and will prove to be a "
@@ -780,7 +782,7 @@ msgstr ""
 "Os habitantes do Labirinto foram acelerados e provarão ser um desafio maior. "
 "Isso é recomendado apenas para personagens experientes."
 
-#: Source/DiabloUI/multi/selgame.cpp:524
+#: Source/DiabloUI/multi/selgame.cpp:525
 msgid ""
 "Faster Speed\n"
 "Most monsters of the dungeon will seek you out quicker than ever before. "
@@ -790,7 +792,7 @@ msgstr ""
 "A maioria dos monstros da masmorra irão procurá-lo mais rápido do que nunca. "
 "Apenas um campeão experiente deve tentar a sorte nesta velocidade."
 
-#: Source/DiabloUI/multi/selgame.cpp:528
+#: Source/DiabloUI/multi/selgame.cpp:529
 msgid ""
 "Fastest Speed\n"
 "The minions of the underworld will rush to attack without hesitation. Only a "
@@ -800,7 +802,7 @@ msgstr ""
 "Os asseclas do submundo correrão para atacar sem hesitação. Apenas um "
 "verdadeiro demônio da velocidade deve entrar neste ritmo."
 
-#: Source/DiabloUI/multi/selgame.cpp:572 Source/DiabloUI/multi/selgame.cpp:577
+#: Source/DiabloUI/multi/selgame.cpp:573 Source/DiabloUI/multi/selgame.cpp:578
 msgid "Enter Password"
 msgstr "Inserir senha"
 
@@ -812,51 +814,51 @@ msgstr "Entrar no Hellfire"
 msgid "Switch to Diablo"
 msgstr "Mudar para Diablo"
 
-#: Source/DiabloUI/selyesno.cpp:57 Source/stores.cpp:1001
+#: Source/DiabloUI/selyesno.cpp:57 Source/stores.cpp:967
 msgid "Yes"
 msgstr "Sim"
 
-#: Source/DiabloUI/selyesno.cpp:58 Source/stores.cpp:1002
+#: Source/DiabloUI/selyesno.cpp:58 Source/stores.cpp:968
 msgid "No"
 msgstr "Não"
 
-#: Source/DiabloUI/settingsmenu.cpp:146
+#: Source/DiabloUI/settingsmenu.cpp:150
 msgid "Press gamepad buttons to change."
 msgstr "Pressione qualquer botão do controle para alterar."
 
-#: Source/DiabloUI/settingsmenu.cpp:424
+#: Source/DiabloUI/settingsmenu.cpp:427
 msgid "Bound key:"
 msgstr "Tecla Associada:"
 
-#: Source/DiabloUI/settingsmenu.cpp:460
+#: Source/DiabloUI/settingsmenu.cpp:476
 msgid "Press any key to change."
 msgstr "Pressione qualquer tecla para mudar."
 
-#: Source/DiabloUI/settingsmenu.cpp:462
+#: Source/DiabloUI/settingsmenu.cpp:478
 msgid "Unbind key"
 msgstr "Desassociar tecla"
 
-#: Source/DiabloUI/settingsmenu.cpp:466
+#: Source/DiabloUI/settingsmenu.cpp:482
 msgid "Bound button combo:"
 msgstr "Combinação de botões associada:"
 
-#: Source/DiabloUI/settingsmenu.cpp:475
+#: Source/DiabloUI/settingsmenu.cpp:491
 msgid "Unbind button combo"
 msgstr "Remover combo de botões"
 
-#: Source/DiabloUI/settingsmenu.cpp:519 Source/gamemenu.cpp:65
+#: Source/DiabloUI/settingsmenu.cpp:535 Source/gamemenu.cpp:72
 msgid "Previous Menu"
 msgstr "Menu anterior"
 
 #: Source/DiabloUI/support_lines.cpp:8
 msgid ""
-"We maintain a chat server at Discord.gg/devilutionx Follow the links to join our "
-"community where we talk about things related to Diablo, and the Hellfire "
+"We maintain a chat server at Discord.gg/devilutionx Follow the links to join "
+"our community where we talk about things related to Diablo, and the Hellfire "
 "expansion."
 msgstr ""
-"Nós mantemos um servidor de chat em Discord.gg/devilutionx Clique nos links para "
-"se juntar a comunidade onde nós conversamos sobre assuntos relacionados ao "
-"Diablo, e a expansão Hellfire."
+"Nós mantemos um servidor de chat em Discord.gg/devilutionx Clique nos links "
+"para se juntar a comunidade onde nós conversamos sobre assuntos relacionados "
+"ao Diablo, e a expansão Hellfire."
 
 #: Source/DiabloUI/support_lines.cpp:10
 msgid ""
@@ -900,16 +902,16 @@ msgstr ""
 "Twitmoji que é licenciada sob CC-BY 4.0. O port também faz uso da SDL, a "
 "qual é licenciada sob a zlib-license. Leia o ReadMe para mais detalhes."
 
-#: Source/DiabloUI/title.cpp:57
+#: Source/DiabloUI/title.cpp:59
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:52
+#: Source/appfat.cpp:63
 msgid "Error"
 msgstr "Erro"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:67
+#: Source/appfat.cpp:77
 msgid ""
 "{:s}\n"
 "\n"
@@ -919,7 +921,11 @@ msgstr ""
 "\n"
 "O erro ocorreu em: {:s} linha {:d}"
 
-#: Source/appfat.cpp:76
+#: Source/appfat.cpp:83
+msgid "Data File Error"
+msgstr "Erro de arquivo de dados"
+
+#: Source/appfat.cpp:84
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
@@ -929,12 +935,12 @@ msgstr ""
 "\n"
 "Certifique-se de que ele esteja na pasta do jogo."
 
-#: Source/appfat.cpp:81
-msgid "Data File Error"
-msgstr "Erro de arquivo de dados"
+#: Source/appfat.cpp:93
+msgid "Read-Only Directory Error"
+msgstr "Erro de diretório, somente leitura"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:87
+#: Source/appfat.cpp:94
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
@@ -942,100 +948,96 @@ msgstr ""
 "Não foi possível gravar no local:\n"
 "{:s}"
 
-#: Source/appfat.cpp:89
-msgid "Read-Only Directory Error"
-msgstr "Erro de diretório, somente leitura"
-
-#: Source/automap.cpp:723
+#: Source/automap.cpp:1416
 msgid "Game: "
 msgstr "Jogo: "
 
-#: Source/automap.cpp:731
+#: Source/automap.cpp:1424
 #, fuzzy
 msgid "Offline Game"
 msgstr "Loopback"
 
-#: Source/automap.cpp:733
+#: Source/automap.cpp:1426
 msgid "Password: "
 msgstr "Senha: "
 
-#: Source/automap.cpp:736
+#: Source/automap.cpp:1429
 msgid "Public Game"
 msgstr "Jogo Público"
 
-#: Source/automap.cpp:750
+#: Source/automap.cpp:1443
 msgid "Level: Nest {:d}"
 msgstr "Nível: Enxame {:d}"
 
-#: Source/automap.cpp:753
+#: Source/automap.cpp:1446
 msgid "Level: Crypt {:d}"
 msgstr "Nível: Cripta {:d}"
 
-#: Source/automap.cpp:756 Source/discord/discord.cpp:68 Source/objects.cpp:150
+#: Source/automap.cpp:1449 Source/discord/discord.cpp:81 Source/objects.cpp:157
 msgid "Town"
 msgstr "Cidade"
 
-#: Source/automap.cpp:759
+#: Source/automap.cpp:1452
 msgid "Level: {:d}"
 msgstr "Nível: {:d}"
 
-#: Source/control.cpp:160
+#: Source/control.cpp:199
 msgid "Tab"
 msgstr "Tab"
 
-#: Source/control.cpp:160
+#: Source/control.cpp:199
 msgid "Esc"
 msgstr "Esc"
 
-#: Source/control.cpp:160
+#: Source/control.cpp:199
 msgid "Enter"
 msgstr "Enter"
 
-#: Source/control.cpp:163
+#: Source/control.cpp:202
 msgid "Character Information"
 msgstr "Informações do personagem"
 
-#: Source/control.cpp:164
+#: Source/control.cpp:203
 msgid "Quests log"
 msgstr "Registro de missões"
 
-#: Source/control.cpp:165
+#: Source/control.cpp:204
 msgid "Automap"
 msgstr "Automapa"
 
-#: Source/control.cpp:166
+#: Source/control.cpp:205
 msgid "Main Menu"
 msgstr "Menu Principal"
 
-#: Source/control.cpp:167 Source/diablo.cpp:1701 Source/diablo.cpp:2019
+#: Source/control.cpp:206 Source/diablo.cpp:1843 Source/diablo.cpp:2187
 msgid "Inventory"
 msgstr "Inventário"
 
-#: Source/control.cpp:168
+#: Source/control.cpp:207
 msgid "Spell book"
 msgstr "Livro de feitiços"
 
-#: Source/control.cpp:169
+#: Source/control.cpp:208
 msgid "Send Message"
 msgstr "Enviar Mensagem"
 
-#: Source/control.cpp:348
+#: Source/control.cpp:403
 msgid "Available Commands:"
 msgstr "Comandos Disponíveis:"
 
-#: Source/control.cpp:356
+#: Source/control.cpp:411 Source/control.cpp:601
 msgid "Command "
 msgstr "Comando "
 
-#: Source/control.cpp:356
+#: Source/control.cpp:411 Source/control.cpp:601
 msgid " is unknown."
 msgstr " é desconhecido."
 
-#: Source/control.cpp:359 Source/control.cpp:360
+#: Source/control.cpp:414 Source/control.cpp:415
 msgid "Description: "
 msgstr "Descrição: "
 
-#: Source/control.cpp:359
+#: Source/control.cpp:414
 msgid ""
 "\n"
 "Parameters: No additional parameter needed."
@@ -1043,7 +1045,7 @@ msgstr ""
 "\n"
 "Parâmetros: Nenhum parâmetro adicional é necessário."
 
-#: Source/control.cpp:360
+#: Source/control.cpp:415
 msgid ""
 "\n"
 "Parameters: "
@@ -1051,315 +1053,333 @@ msgstr ""
 "\n"
 "Parâmetros: "
 
-#: Source/control.cpp:380 Source/control.cpp:412
+#: Source/control.cpp:435 Source/control.cpp:467
 msgid "Arenas are only supported in multiplayer."
 msgstr "Arenas só estão disponíveis no modo multijogador."
 
-#: Source/control.cpp:385
+#: Source/control.cpp:440
 msgid "What arena do you want to visit?"
 msgstr "Qual arena você quer visitar?"
 
-#: Source/control.cpp:393
+#: Source/control.cpp:448
 msgid "Invalid arena-number. Valid numbers are:"
 msgstr "Número de arena inválido. Os números válidos são:"
 
-#: Source/control.cpp:399
+#: Source/control.cpp:454
 msgid "To enter a arena, you need to be in town or another arena."
 msgstr ""
 "Para entrar em uma arena, você precisa estar na cidade ou em outra arena."
 
-#: Source/control.cpp:436
+#: Source/control.cpp:492
 msgid "Inspecting only supported in multiplayer."
 msgstr "Inspeção só está disponível no modo multijogador."
 
-#: Source/control.cpp:441 Source/control.cpp:730
+#: Source/control.cpp:497 Source/control.cpp:784
 msgid "Stopped inspecting players."
 msgstr "Parar de inspecionar os jogadores."
 
-#: Source/control.cpp:451
-msgid "Inspecting player: "
-msgstr "Inspecionar jogador: "
-
-#: Source/control.cpp:460
+#: Source/control.cpp:512
 msgid "No players found with such a name"
 msgstr "Nenhum jogador encontrado com este nome"
 
-#: Source/control.cpp:524
-msgid "/help"
-msgstr "/help"
+#: Source/control.cpp:518
+msgid "Inspecting player: "
+msgstr "Inspecionar jogador: "
 
-#: Source/control.cpp:524
+#: Source/control.cpp:587
 msgid "Prints help overview or help for a specific command."
 msgstr "Exibe a visão geral da ajuda ou ajuda para um comando específico."
 
-#: Source/control.cpp:524
+#: Source/control.cpp:587
 msgid "[command]"
 msgstr "[comando]"
 
-#: Source/control.cpp:525
-msgid "/arena"
-msgstr "/arena"
-
-#: Source/control.cpp:525
+#: Source/control.cpp:588
 msgid "Enter a PvP Arena."
 msgstr "Entrar em uma Arena PvP."
 
-#: Source/control.cpp:525
+#: Source/control.cpp:588
 msgid "<arena-number>"
 msgstr "<número-da-arena>"
 
-#: Source/control.cpp:526
-msgid "/arenapot"
-msgstr "/arenapot"
-
-#: Source/control.cpp:526
+#: Source/control.cpp:589
 msgid "Gives Arena Potions."
 msgstr "Dá Poções de Arena."
 
-#: Source/control.cpp:526
+#: Source/control.cpp:589
 msgid "<number>"
 msgstr "<number>"
 
-#: Source/control.cpp:527
-msgid "/inspect"
-msgstr "/inspect"
-
-#: Source/control.cpp:527
+#: Source/control.cpp:590
 msgid "Inspects stats and equipment of another player."
 msgstr "Inspeciona atributos e equipamentos de outro jogador."
 
-#: Source/control.cpp:527
+#: Source/control.cpp:590
 msgid "<player name>"
 msgstr "<nome do jogador>"
 
-#: Source/control.cpp:528
-msgid "/seedinfo"
-msgstr "/seedinfo"
-
-#: Source/control.cpp:528
+#: Source/control.cpp:591
 msgid "Show seed infos for current level."
 msgstr "Mostrar informações de seed do nível atual."
 
-#: Source/control.cpp:538
-msgid "Command \""
-msgstr "Comando \""
-
-#: Source/control.cpp:1012
+#: Source/control.cpp:1087
 msgid "Player friendly"
 msgstr "Amigável a jogadores"
 
-#: Source/control.cpp:1014
+#: Source/control.cpp:1089
 msgid "Player attack"
 msgstr "Hostil a jogadores"
 
-#: Source/control.cpp:1017
+#: Source/control.cpp:1092
 msgid "Hotkey: {:s}"
 msgstr "Tecla de atalho: {:s}"
 
-#: Source/control.cpp:1024
+#: Source/control.cpp:1104
 msgid "Select current spell button"
 msgstr "Selecionar feitiço atual"
 
-#: Source/control.cpp:1027
+#: Source/control.cpp:1107
 msgid "Hotkey: 's'"
 msgstr "Tecla de atalho: 's'"
 
-#: Source/control.cpp:1033 Source/panels/spell_list.cpp:151
+#: Source/control.cpp:1113 Source/panels/spell_list.cpp:153
 msgid "{:s} Skill"
 msgstr "Habilidade de {:s}"
 
-#: Source/control.cpp:1036 Source/panels/spell_list.cpp:158
+#: Source/control.cpp:1116 Source/panels/spell_list.cpp:160
 msgid "{:s} Spell"
 msgstr "Feitiço de {:s}"
 
-#: Source/control.cpp:1038 Source/panels/spell_list.cpp:163
+#: Source/control.cpp:1118 Source/panels/spell_list.cpp:165
 msgid "Spell Level 0 - Unusable"
 msgstr "Nível do feitiço 0 - Inutilizável"
 
-#: Source/control.cpp:1038 Source/panels/spell_list.cpp:165
+#: Source/control.cpp:1118 Source/panels/spell_list.cpp:167
 msgid "Spell Level {:d}"
 msgstr "Nível do feitiço {:d}"
 
-#: Source/control.cpp:1041 Source/panels/spell_list.cpp:172
+#: Source/control.cpp:1121 Source/panels/spell_list.cpp:174
 msgid "Scroll of {:s}"
 msgstr "Pergaminho de {:s}"
 
-#: Source/control.cpp:1046 Source/panels/spell_list.cpp:177
+#: Source/control.cpp:1125 Source/panels/spell_list.cpp:178
 msgid "{:d} Scroll"
 msgid_plural "{:d} Scrolls"
 msgstr[0] "{:d} pergaminho"
 msgstr[1] "{:d} pergaminhos"
 
-#: Source/control.cpp:1049 Source/panels/spell_list.cpp:184
+#: Source/control.cpp:1128 Source/panels/spell_list.cpp:185
 msgid "Staff of {:s}"
 msgstr "Cajado de {:s}"
 
-#: Source/control.cpp:1050 Source/panels/spell_list.cpp:186
+#: Source/control.cpp:1129 Source/panels/spell_list.cpp:187
 msgid "{:d} Charge"
 msgid_plural "{:d} Charges"
 msgstr[0] "{:d} carga"
 msgstr[1] "{:d} cargas"
 
-#: Source/control.cpp:1175 Source/inv.cpp:1878 Source/items.cpp:3638
+#: Source/control.cpp:1262 Source/inv.cpp:1986 Source/items.cpp:3819
 msgid "{:s} gold piece"
 msgid_plural "{:s} gold pieces"
 msgstr[0] "{:s} peça de ouro"
 msgstr[1] "{:s} peças de ouro"
 
-#: Source/control.cpp:1177
+#: Source/control.cpp:1264
 msgid "Requirements not met"
 msgstr "Pré-requisitos não atendidos"
 
-#: Source/control.cpp:1206
+#: Source/control.cpp:1293
 msgid "{:s}, Level: {:d}"
 msgstr "{:s}, Nível: {:d}"
 
-#: Source/control.cpp:1207
+#: Source/control.cpp:1294
 msgid "Hit Points {:d} of {:d}"
 msgstr "Pontos de vida {:d} de {:d}"
 
-#: Source/control.cpp:1238
+#: Source/control.cpp:1331
 msgid "Level Up"
 msgstr "Subiu de Nível"
 
+#: Source/control.cpp:1445
+msgid "You have died"
+msgstr ""
+
+#: Source/control.cpp:1453
+msgid "ESC"
+msgstr ""
+
+#: Source/control.cpp:1459
+msgid "Menu Button"
+msgstr ""
+
+#: Source/control.cpp:1467
+msgid "Press {} to load last save."
+msgstr ""
+
+#: Source/control.cpp:1469
+msgid "Press {} to return to Main Menu."
+msgstr ""
+
+#: Source/control.cpp:1472
+msgid "Press {} to restart in town."
+msgstr ""
+
 #. TRANSLATORS: {:s} is a number with separators. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1346
+#: Source/control.cpp:1490
 msgid "You have {:s} gold piece. How many do you want to remove?"
 msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
 msgstr[0] "Você tem {:s} peça de ouro. Quanto quer remover?"
 msgstr[1] "Você tem {:s} peças de ouro. Quanto quer remover?"
 
-#: Source/cursor.cpp:326
+#: Source/cursor.cpp:612
 msgid "Town Portal"
 msgstr "Portal da cidade"
 
-#: Source/cursor.cpp:327
+#: Source/cursor.cpp:613
 msgid "from {:s}"
 msgstr "de {:s}"
 
-#: Source/cursor.cpp:340
+#: Source/cursor.cpp:626
 msgid "Portal to"
 msgstr "Portal para"
 
-#: Source/cursor.cpp:341
+#: Source/cursor.cpp:627
 msgid "The Unholy Altar"
 msgstr "O Altar Profano"
 
-#: Source/cursor.cpp:341
+#: Source/cursor.cpp:627
 msgid "level 15"
 msgstr "o nível 15"
 
-#: Source/diablo.cpp:125
-msgid "I need help! Come Here!"
-msgstr "Preciso de ajuda! Venha aqui!"
+#. TRANSLATORS: Error message when a data file is missing or corrupt. Arguments are {file name}
+#: Source/data/file.cpp:52
+#, fuzzy
+#| msgid "Unable to load character"
+msgid "Unable to load data from file {0}"
+msgstr "Não é possível carregar o personagem"
 
-#: Source/diablo.cpp:126
-msgid "Follow me."
-msgstr "Siga-me."
+#. TRANSLATORS: Error message when a data file is empty or only contains the header row. Arguments are {file name}
+#: Source/data/file.cpp:57
+msgid "{0} is incomplete, please check the file contents."
+msgstr ""
 
-#: Source/diablo.cpp:127
-msgid "Here's something for you."
-msgstr "Tenho algo pra você."
+#. TRANSLATORS: Error message when a data file doesn't contain the expected columns. Arguments are {file name}
+#: Source/data/file.cpp:62
+msgid ""
+"Your {0} file doesn't have the expected columns, please make sure it matches "
+"the documented format."
+msgstr ""
 
-#: Source/diablo.cpp:128
-msgid "Now you DIE!"
-msgstr "Agora você MORRE!"
+#. TRANSLATORS: Error message when parsing a data file and a text value is encountered when a number is expected. Arguments are {found value}, {column heading}, {file name}, {row/record number}, {column/field number}
+#: Source/data/file.cpp:77
+msgid "Non-numeric value {0} for {1} in {2} at row {3} and column {4}"
+msgstr ""
+
+#. TRANSLATORS: Error message when parsing a data file and we find a number larger than expected. Arguments are {found value}, {column heading}, {file name}, {row/record number}, {column/field number}
+#: Source/data/file.cpp:83
+msgid "Out of range value {0} for {1} in {2} at row {3} and column {4}"
+msgstr ""
+
+#. TRANSLATORS: Error message when we find an unrecognised value in a key column. Arguments are {found value}, {column heading}, {file name}, {row/record number}, {column/field number}
+#: Source/data/file.cpp:89
+msgid "Invalid value {0} for {1} in {2} at row {3} and column {4}"
+msgstr ""
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:916
+#: Source/diablo.cpp:968
 msgid "Print this message and exit"
 msgstr "Imprime esta mensagem e sai"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:917
+#: Source/diablo.cpp:969
 msgid "Print the version and exit"
 msgstr "Imprime a versão e sai"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:918
+#: Source/diablo.cpp:970
 msgid "Specify the folder of diabdat.mpq"
 msgstr "Especifique a pasta de diabdat.mpq"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:919
+#: Source/diablo.cpp:971
 msgid "Specify the folder of save files"
 msgstr "Especifique a pasta dos arquivos salvos"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:920
+#: Source/diablo.cpp:972
 msgid "Specify the location of diablo.ini"
 msgstr "Especifique o local do diablo.ini"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:921
+#: Source/diablo.cpp:973
 msgid "Specify the language code (e.g. en or pt_BR)"
 msgstr "Especifique o código do idioma (por exemplo, en ou pt_BR)"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:922
+#: Source/diablo.cpp:974
 msgid "Skip startup videos"
 msgstr "Pular vídeos de abertura"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:923
+#: Source/diablo.cpp:975
 msgid "Display frames per second"
 msgstr "Exibir quadros por segundo"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:924
+#: Source/diablo.cpp:976
 msgid "Enable verbose logging"
 msgstr "Habilitar relatório detalhado"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:926
+#: Source/diablo.cpp:978
 msgid "Record a demo file"
 msgstr "Grava um arquivo de demonstração"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:927
+#: Source/diablo.cpp:979
 msgid "Play a demo file"
 msgstr "Toca um arquivo de demonstração"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:928
+#: Source/diablo.cpp:980
 msgid "Disable all frame limiting during demo playback"
 msgstr "Desabilita todos os limites de frame durante a demonstração"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:931
+#: Source/diablo.cpp:983
 msgid "Game selection:"
 msgstr "Seleção do jogo:"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:933
+#: Source/diablo.cpp:985
 msgid "Force Shareware mode"
 msgstr "Forçar modo Shareware"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:934
+#: Source/diablo.cpp:986
 msgid "Force Diablo mode"
 msgstr "Forçar modo Diablo"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:935
+#: Source/diablo.cpp:987
 msgid "Force Hellfire mode"
 msgstr "Forçar modo Hellfire"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:936
+#: Source/diablo.cpp:988
 msgid "Hellfire options:"
 msgstr "Opções do Hellfire:"
 
-#: Source/diablo.cpp:946
+#: Source/diablo.cpp:998
 msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
 msgstr "Reportar erros em https://github.com/diasurgical/devilutionX/"
 
-#: Source/diablo.cpp:1103
+#: Source/diablo.cpp:1165
 msgid "Please update devilutionx.mpq and fonts.mpq to the latest version"
 msgstr ""
 "Por favor, atualize devilutionx.mpq e fonts.mpq para a versão mais recente"
 
-#: Source/diablo.cpp:1105
+#: Source/diablo.cpp:1167
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
@@ -1370,730 +1390,913 @@ msgstr ""
 "Certifique-se de que o arquivo devilutionx.mpq esteja na pasta do jogo e de "
 "que esteja atualizado."
 
-#: Source/diablo.cpp:1109
+#: Source/diablo.cpp:1171
 msgid "Please update fonts.mpq to the latest version"
 msgstr "Por favor, atualize o fonts.mpq para a versão mais recente"
 
-#: Source/diablo.cpp:1423
+#: Source/diablo.cpp:1501
 msgid "-- Network timeout --"
 msgstr "-- Tempo limite da rede excedido --"
 
-#: Source/diablo.cpp:1424
+#: Source/diablo.cpp:1502
 msgid "-- Waiting for players --"
 msgstr "-- Aguardando jogadores --"
 
-#: Source/diablo.cpp:1447
+#: Source/diablo.cpp:1525
 msgid "No help available"
 msgstr "Nenhuma ajuda disponível"
 
-#: Source/diablo.cpp:1448
+#: Source/diablo.cpp:1526
 msgid "while in stores"
 msgstr "enquanto estiver em lojas"
 
-#: Source/diablo.cpp:1587 Source/diablo.cpp:1851
+#: Source/diablo.cpp:1705 Source/diablo.cpp:2017
 msgid "Belt item {}"
 msgstr "Item do Cinto {}"
 
-#: Source/diablo.cpp:1588 Source/diablo.cpp:1852
+#: Source/diablo.cpp:1706 Source/diablo.cpp:2018
 msgid "Use Belt item."
 msgstr "Usar item do Cinto."
 
-#: Source/diablo.cpp:1603 Source/diablo.cpp:1867
+#: Source/diablo.cpp:1721 Source/diablo.cpp:2033
 msgid "Quick spell {}"
 msgstr "Feitiço rápido {}"
 
-#: Source/diablo.cpp:1604 Source/diablo.cpp:1868
+#: Source/diablo.cpp:1722 Source/diablo.cpp:2034
 msgid "Hotkey for skill or spell."
 msgstr "Tecla de atalho para habilidade ou feitiço."
 
-#: Source/diablo.cpp:1622 Source/diablo.cpp:1995
+#: Source/diablo.cpp:1740
+#, fuzzy
+#| msgid "Previous Menu"
+msgid "Previous quick spell"
+msgstr "Menu anterior"
+
+#: Source/diablo.cpp:1741
+msgid "Selects the previous quick spell (cycles)."
+msgstr ""
+
+#: Source/diablo.cpp:1748
+#, fuzzy
+#| msgid "Quick spell {}"
+msgid "Next quick spell"
+msgstr "Feitiço rápido {}"
+
+#: Source/diablo.cpp:1749
+msgid "Selects the next quick spell (cycles)."
+msgstr ""
+
+#: Source/diablo.cpp:1756 Source/diablo.cpp:2161
 msgid "Use health potion"
 msgstr "Usar poção de vida"
 
-#: Source/diablo.cpp:1623 Source/diablo.cpp:1996
+#: Source/diablo.cpp:1757 Source/diablo.cpp:2162
 msgid "Use health potions from belt."
 msgstr "Usar poção de vida do cinto."
 
-#: Source/diablo.cpp:1630 Source/diablo.cpp:2003
+#: Source/diablo.cpp:1764 Source/diablo.cpp:2169
 msgid "Use mana potion"
 msgstr "Usar poção de mana"
 
-#: Source/diablo.cpp:1631 Source/diablo.cpp:2004
+#: Source/diablo.cpp:1765 Source/diablo.cpp:2170
 msgid "Use mana potions from belt."
 msgstr "Usar poção de mana do cinto."
 
-#: Source/diablo.cpp:1638 Source/diablo.cpp:2049
+#: Source/diablo.cpp:1772 Source/diablo.cpp:2217
 msgid "Speedbook"
 msgstr "Livro de Acesso Rápido"
 
-#: Source/diablo.cpp:1639 Source/diablo.cpp:2050
+#: Source/diablo.cpp:1773 Source/diablo.cpp:2218
 msgid "Open Speedbook."
 msgstr "Abrir livro de Acesso Rápido."
 
-#: Source/diablo.cpp:1646 Source/diablo.cpp:2182
+#: Source/diablo.cpp:1780 Source/diablo.cpp:2350
 msgid "Quick save"
 msgstr "Salvamento rápido"
 
-#: Source/diablo.cpp:1647 Source/diablo.cpp:2183
+#: Source/diablo.cpp:1781 Source/diablo.cpp:2351
 msgid "Saves the game."
 msgstr "Salvar o jogo."
 
-#: Source/diablo.cpp:1654 Source/diablo.cpp:2190
+#: Source/diablo.cpp:1788 Source/diablo.cpp:2358
 msgid "Quick load"
 msgstr "Carregamento rápido"
 
-#: Source/diablo.cpp:1655 Source/diablo.cpp:2191
+#: Source/diablo.cpp:1789 Source/diablo.cpp:2359
 msgid "Loads the game."
 msgstr "Carregar Jogo."
 
-#: Source/diablo.cpp:1663
+#: Source/diablo.cpp:1797
 msgid "Quit game"
 msgstr "Sair do jogo"
 
-#: Source/diablo.cpp:1664
+#: Source/diablo.cpp:1798
 msgid "Closes the game."
 msgstr "Fechar o jogo."
 
-#: Source/diablo.cpp:1670
+#: Source/diablo.cpp:1804
 msgid "Stop hero"
 msgstr "Parar herói"
 
-#: Source/diablo.cpp:1671
+#: Source/diablo.cpp:1805
 msgid "Stops walking and cancel pending actions."
 msgstr "Para de andar e cancela ações pendentes."
 
-#: Source/diablo.cpp:1678 Source/diablo.cpp:2198
+#: Source/diablo.cpp:1812 Source/diablo.cpp:2366
 msgid "Item highlighting"
 msgstr "Destacar Items"
 
-#: Source/diablo.cpp:1679 Source/diablo.cpp:2199
+#: Source/diablo.cpp:1813 Source/diablo.cpp:2367
 msgid "Show/hide items on ground."
 msgstr "Exibir/esconder items no chão."
 
-#: Source/diablo.cpp:1685 Source/diablo.cpp:2205
+#: Source/diablo.cpp:1819 Source/diablo.cpp:2373
 msgid "Toggle item highlighting"
 msgstr "Habilitar/desabilitar destaque de Items"
 
-#: Source/diablo.cpp:1686 Source/diablo.cpp:2206
+#: Source/diablo.cpp:1820 Source/diablo.cpp:2374
 msgid "Permanent show/hide items on ground."
 msgstr "Exibir/esconder items no chão permanetemente."
 
-#: Source/diablo.cpp:1692 Source/diablo.cpp:2059
+#: Source/diablo.cpp:1826 Source/diablo.cpp:2227
 msgid "Toggle automap"
 msgstr "Habilitar/desabilitar mapa"
 
-#: Source/diablo.cpp:1693 Source/diablo.cpp:2060
+#: Source/diablo.cpp:1827 Source/diablo.cpp:2228
 msgid "Toggles if automap is displayed."
 msgstr "Habilitar/desabilitar se mapa está visível."
 
-#: Source/diablo.cpp:1702 Source/diablo.cpp:2020
+#: Source/diablo.cpp:1834
+msgid "Cycle map type"
+msgstr ""
+
+#: Source/diablo.cpp:1835
+msgid "Opaque -> Transparent -> Minimap -> None"
+msgstr ""
+
+#: Source/diablo.cpp:1844 Source/diablo.cpp:2188
 msgid "Open Inventory screen."
 msgstr "Abrir tela de inventário."
 
-#: Source/diablo.cpp:1709 Source/diablo.cpp:2011
+#: Source/diablo.cpp:1851 Source/diablo.cpp:2177
 msgid "Character"
 msgstr "Person."
 
-#: Source/diablo.cpp:1710 Source/diablo.cpp:2012
+#: Source/diablo.cpp:1852 Source/diablo.cpp:2178
 msgid "Open Character screen."
 msgstr "Abrir tela de Personagem."
 
-#: Source/diablo.cpp:1717 Source/diablo.cpp:2029
+#: Source/diablo.cpp:1859 Source/diablo.cpp:2197
 msgid "Quest log"
 msgstr "Registro de Missões"
 
-#: Source/diablo.cpp:1718 Source/diablo.cpp:2030
+#: Source/diablo.cpp:1860 Source/diablo.cpp:2198
 msgid "Open Quest log."
 msgstr "Abrir registro de missões."
 
-#: Source/diablo.cpp:1725 Source/diablo.cpp:2039
+#: Source/diablo.cpp:1867 Source/diablo.cpp:2207
 msgid "Spellbook"
 msgstr "Livro de Feitiços"
 
-#: Source/diablo.cpp:1726 Source/diablo.cpp:2040
+#: Source/diablo.cpp:1868 Source/diablo.cpp:2208
 msgid "Open Spellbook."
 msgstr "Abrir Livro de Feitiços."
 
-#: Source/diablo.cpp:1734
+#: Source/diablo.cpp:1876
 msgid "Quick Message {}"
 msgstr "Mensagem Rápida {}"
 
-#: Source/diablo.cpp:1735
+#: Source/diablo.cpp:1877
 msgid "Use Quick Message in chat."
 msgstr "Usar Mensagem Rápida no chat."
 
-#: Source/diablo.cpp:1744 Source/diablo.cpp:2212
+#: Source/diablo.cpp:1886 Source/diablo.cpp:2380
 msgid "Hide Info Screens"
 msgstr "Esconder Telas de Informação"
 
-#: Source/diablo.cpp:1745 Source/diablo.cpp:2213
+#: Source/diablo.cpp:1887 Source/diablo.cpp:2381
 msgid "Hide all info screens."
 msgstr "Esconder todas as telas de informação."
 
-#: Source/diablo.cpp:1765 Source/diablo.cpp:2233 Source/options.cpp:986
+#: Source/diablo.cpp:1910 Source/diablo.cpp:2404 Source/options.cpp:725
 msgid "Zoom"
 msgstr "Zoom"
 
-#: Source/diablo.cpp:1766 Source/diablo.cpp:2234
+#: Source/diablo.cpp:1911 Source/diablo.cpp:2405
 msgid "Zoom Game Screen."
 msgstr "Zoom da Tela do Jogo."
 
-#: Source/diablo.cpp:1776 Source/diablo.cpp:2244
+#: Source/diablo.cpp:1921 Source/diablo.cpp:2415
 msgid "Pause Game"
 msgstr "Pausar Jogo"
 
-#: Source/diablo.cpp:1777 Source/diablo.cpp:2245
+#: Source/diablo.cpp:1922 Source/diablo.cpp:1928 Source/diablo.cpp:2416
 msgid "Pauses the game."
 msgstr "Pausa o jogo."
 
-#: Source/diablo.cpp:1782 Source/diablo.cpp:2250
-msgid "Decrease Gamma"
-msgstr "Diminuir Gama"
+#: Source/diablo.cpp:1927
+#, fuzzy
+#| msgid "Pause Game"
+msgid "Pause Game (Alternate)"
+msgstr "Pausar Jogo"
 
-#: Source/diablo.cpp:1783 Source/diablo.cpp:2251
+#: Source/diablo.cpp:1933 Source/diablo.cpp:2421
+#, fuzzy
+#| msgid "Increase screen brightness."
+msgid "Decrease Brightness"
+msgstr "Aumentar o brilho da tela."
+
+#: Source/diablo.cpp:1934 Source/diablo.cpp:2422
 msgid "Reduce screen brightness."
 msgstr "Reduzir o brilho da tela."
 
-#: Source/diablo.cpp:1790 Source/diablo.cpp:2258
-msgid "Increase Gamma"
-msgstr "Aumentar Gama"
+#: Source/diablo.cpp:1941 Source/diablo.cpp:2429
+#, fuzzy
+#| msgid "Increase screen brightness."
+msgid "Increase Brightness"
+msgstr "Aumentar o brilho da tela."
 
-#: Source/diablo.cpp:1791 Source/diablo.cpp:2259
+#: Source/diablo.cpp:1942 Source/diablo.cpp:2430
 msgid "Increase screen brightness."
 msgstr "Aumentar o brilho da tela."
 
-#: Source/diablo.cpp:1798 Source/diablo.cpp:2266
+#: Source/diablo.cpp:1949 Source/diablo.cpp:2437
 msgid "Help"
 msgstr "Ajuda"
 
-#: Source/diablo.cpp:1799 Source/diablo.cpp:2267
+#: Source/diablo.cpp:1950 Source/diablo.cpp:2438
 msgid "Open Help Screen."
 msgstr "Abrir Tela de Ajuda."
 
-#: Source/diablo.cpp:1806 Source/diablo.cpp:2274
+#: Source/diablo.cpp:1957 Source/diablo.cpp:2445
 msgid "Screenshot"
 msgstr "Captura de tela"
 
-#: Source/diablo.cpp:1807 Source/diablo.cpp:2275
+#: Source/diablo.cpp:1958 Source/diablo.cpp:2446
 msgid "Takes a screenshot."
 msgstr "Captura a tela."
 
-#: Source/diablo.cpp:1813 Source/diablo.cpp:2281
+#: Source/diablo.cpp:1964 Source/diablo.cpp:2452
 msgid "Game info"
 msgstr "Informações do jogo"
 
-#: Source/diablo.cpp:1814 Source/diablo.cpp:2282
+#: Source/diablo.cpp:1965 Source/diablo.cpp:2453
 msgid "Displays game infos."
 msgstr "Exibir informações do jogo."
 
 #. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
-#: Source/diablo.cpp:1818 Source/diablo.cpp:2286
+#: Source/diablo.cpp:1969 Source/diablo.cpp:2457
 msgid "{:s} {:s}"
 msgstr "{:s} {:s}"
 
-#: Source/diablo.cpp:1827 Source/diablo.cpp:2295
+#: Source/diablo.cpp:1978 Source/diablo.cpp:2474
 msgid "Chat Log"
 msgstr "Chat"
 
-#: Source/diablo.cpp:1828 Source/diablo.cpp:2296
+#: Source/diablo.cpp:1979 Source/diablo.cpp:2475
 msgid "Displays chat log."
 msgstr "Exibe chat."
 
-#: Source/diablo.cpp:1886
+#: Source/diablo.cpp:1986 Source/diablo.cpp:2466
+#, fuzzy
+#| msgid "Inventory"
+msgid "Sort Inventory"
+msgstr "Inventário"
+
+#: Source/diablo.cpp:1987 Source/diablo.cpp:2467
+msgid "Sorts the inventory."
+msgstr ""
+
+#: Source/diablo.cpp:1995
+msgid "Console"
+msgstr ""
+
+#: Source/diablo.cpp:1996
+msgid "Opens Lua console."
+msgstr ""
+
+#: Source/diablo.cpp:2052
 msgid "Primary action"
 msgstr "Ação primária"
 
-#: Source/diablo.cpp:1887
+#: Source/diablo.cpp:2053
 msgid "Attack monsters, talk to towners, lift and place inventory items."
 msgstr ""
 "Atacar monstros, conversar com os habitantes da cidade, tirar e colocar "
 "itens de inventário."
 
-#: Source/diablo.cpp:1901
+#: Source/diablo.cpp:2067
 msgid "Secondary action"
 msgstr "Ação secundária"
 
-#: Source/diablo.cpp:1902
+#: Source/diablo.cpp:2068
 msgid "Open chests, interact with doors, pick up items."
 msgstr "Abrir baús, interagir com portas, pegar itens."
 
-#: Source/diablo.cpp:1916
+#: Source/diablo.cpp:2082
 msgid "Spell action"
 msgstr "Ação de feitiço"
 
-#: Source/diablo.cpp:1917
+#: Source/diablo.cpp:2083
 msgid "Cast the active spell."
 msgstr "Lança o feitiço ativo."
 
-#: Source/diablo.cpp:1931
+#: Source/diablo.cpp:2097
 msgid "Cancel action"
 msgstr "Cancelar ação"
 
-#: Source/diablo.cpp:1932
+#: Source/diablo.cpp:2098
 msgid "Close menus."
 msgstr "Fechar os menus."
 
-#: Source/diablo.cpp:1957
+#: Source/diablo.cpp:2123
 msgid "Move up"
 msgstr "Mover pra cima"
 
-#: Source/diablo.cpp:1958
+#: Source/diablo.cpp:2124
 msgid "Moves the player character up."
 msgstr "Move personagem para cima."
 
-#: Source/diablo.cpp:1963
+#: Source/diablo.cpp:2129
 msgid "Move down"
 msgstr "Mover pra baixo"
 
-#: Source/diablo.cpp:1964
+#: Source/diablo.cpp:2130
 msgid "Moves the player character down."
 msgstr "Move personagem para baixo."
 
-#: Source/diablo.cpp:1969
+#: Source/diablo.cpp:2135
 msgid "Move left"
 msgstr "Mover pra esquerda"
 
-#: Source/diablo.cpp:1970
+#: Source/diablo.cpp:2136
 msgid "Moves the player character left."
 msgstr "Move personagem para esquerda."
 
-#: Source/diablo.cpp:1975
+#: Source/diablo.cpp:2141
 msgid "Move right"
 msgstr "Mover pra direita"
 
-#: Source/diablo.cpp:1976
+#: Source/diablo.cpp:2142
 msgid "Moves the player character right."
 msgstr "Move personagem para direita."
 
-#: Source/diablo.cpp:1981
+#: Source/diablo.cpp:2147
 msgid "Stand ground"
 msgstr "Ficar parado"
 
-#: Source/diablo.cpp:1982
+#: Source/diablo.cpp:2148
 msgid "Hold to prevent the player from moving."
 msgstr "Segure para evitar que o personagem se mova."
 
-#: Source/diablo.cpp:1987
+#: Source/diablo.cpp:2153
 msgid "Toggle stand ground"
 msgstr "Habilita/Desabilita ficar parado"
 
-#: Source/diablo.cpp:1988
+#: Source/diablo.cpp:2154
 msgid "Toggle whether the player moves."
 msgstr "Habilita/Desabilita movimento do personagem."
 
-#: Source/diablo.cpp:2065
+#: Source/diablo.cpp:2233
 msgid "Move mouse up"
 msgstr "Mover mouse pra cima"
 
-#: Source/diablo.cpp:2066
+#: Source/diablo.cpp:2234
 msgid "Simulates upward mouse movement."
 msgstr "Simula movimento do mouse para cima."
 
-#: Source/diablo.cpp:2071
+#: Source/diablo.cpp:2239
 msgid "Move mouse down"
 msgstr "Mover mouse pra baixo"
 
-#: Source/diablo.cpp:2072
+#: Source/diablo.cpp:2240
 msgid "Simulates downward mouse movement."
 msgstr "Simula movimento do mouse para baixo."
 
-#: Source/diablo.cpp:2077
+#: Source/diablo.cpp:2245
 msgid "Move mouse left"
 msgstr "Mover mouse pra esquerda"
 
-#: Source/diablo.cpp:2078
+#: Source/diablo.cpp:2246
 msgid "Simulates leftward mouse movement."
 msgstr "Simula movimento do mouse para esquerda."
 
-#: Source/diablo.cpp:2083
+#: Source/diablo.cpp:2251
 msgid "Move mouse right"
 msgstr "Mover mouse pra direita"
 
-#: Source/diablo.cpp:2084
+#: Source/diablo.cpp:2252
 msgid "Simulates rightward mouse movement."
 msgstr "Simula movimento do mouse para direita."
 
-#: Source/diablo.cpp:2102 Source/diablo.cpp:2109
+#: Source/diablo.cpp:2270 Source/diablo.cpp:2277
 msgid "Left mouse click"
 msgstr "Clique com botão esquerdo do mouse"
 
-#: Source/diablo.cpp:2103 Source/diablo.cpp:2110
+#: Source/diablo.cpp:2271 Source/diablo.cpp:2278
 msgid "Simulates the left mouse button."
 msgstr "Simula clique com botão esquerdo do mouse."
 
-#: Source/diablo.cpp:2127 Source/diablo.cpp:2134
+#: Source/diablo.cpp:2295 Source/diablo.cpp:2302
 msgid "Right mouse click"
 msgstr "Clique com botão direito do mouse"
 
-#: Source/diablo.cpp:2128 Source/diablo.cpp:2135
+#: Source/diablo.cpp:2296 Source/diablo.cpp:2303
 msgid "Simulates the right mouse button."
 msgstr "Simula clique com botão direito do mouse."
 
-#: Source/diablo.cpp:2141
+#: Source/diablo.cpp:2309
 msgid "Gamepad hotspell menu"
 msgstr "Menu de feitiços do controle"
 
-#: Source/diablo.cpp:2142
+#: Source/diablo.cpp:2310
 msgid "Hold to set or use spell hotkeys."
 msgstr "Segure para definir ou usar hotkeys de feitiços."
 
-#: Source/diablo.cpp:2148
+#: Source/diablo.cpp:2316
 msgid "Gamepad menu navigator"
 msgstr "Navegação de menu do controle"
 
-#: Source/diablo.cpp:2149
+#: Source/diablo.cpp:2317
 msgid "Hold to access gamepad menu navigation."
 msgstr "Segure para acessar o menu de navegação do controle."
 
-#: Source/diablo.cpp:2164 Source/diablo.cpp:2173
+#: Source/diablo.cpp:2332 Source/diablo.cpp:2341
 msgid "Toggle game menu"
 msgstr "Abrir/Fechar menu do jogo"
 
-#: Source/diablo.cpp:2165 Source/diablo.cpp:2174
+#: Source/diablo.cpp:2333 Source/diablo.cpp:2342
 msgid "Opens the game menu."
 msgstr "Abre o menu do jogo."
 
-#: Source/discord/discord.cpp:68
-msgid "Cathedral"
-msgstr "Catedral"
+#: Source/diablo_msg.cpp:63
+#, fuzzy
+#| msgctxt "spell"
+#| msgid "Flame Wave"
+msgid "Game saved"
+msgstr "Onda de Chamas"
 
-#: Source/discord/discord.cpp:68
-msgid "Catacombs"
-msgstr "Catacumbas"
-
-#: Source/discord/discord.cpp:68
-msgid "Caves"
-msgstr "Cavernas"
-
-#: Source/discord/discord.cpp:68
-msgid "Nest"
-msgstr "Enxame"
-
-#: Source/discord/discord.cpp:68
-msgid "Crypt"
-msgstr "Cripta"
-
-#. TRANSLATORS: dungeon type and floor number i.e. "Cathedral 3"
-#: Source/discord/discord.cpp:84
-msgid "{} {}"
-msgstr "{} {}"
-
-#. TRANSLATORS: Discord character, i.e. "Lv 6 Warrior"
-#: Source/discord/discord.cpp:92
-msgid "Lv {} {}"
-msgstr "Nvl {} {}"
-
-#. TRANSLATORS: Discord state i.e. "Nightmare difficulty"
-#: Source/discord/discord.cpp:104
-msgid "{} difficulty"
-msgstr "Dificuldade {}"
-
-#. TRANSLATORS: Discord activity, not in game
-#: Source/discord/discord.cpp:185
-msgid "In Menu"
-msgstr "No Menu"
-
-#: Source/dvlnet/loopback.cpp:118
-msgid "loopback"
-msgstr "loopback"
-
-#: Source/dvlnet/tcp_client.cpp:67
-msgid "Unable to connect"
-msgstr "Não foi possível se conectar"
-
-#: Source/dvlnet/tcp_client.cpp:93
-msgid "error: read 0 bytes from server"
-msgstr "erro: 0 bytes lidos do servidor"
-
-#: Source/error.cpp:54
-msgid "No automap available in town"
-msgstr "Automapa indisponível na cidade"
-
-#: Source/error.cpp:55
+#: Source/diablo_msg.cpp:64
 msgid "No multiplayer functions in demo"
 msgstr "Sem funções multijogador na demonstração"
 
-#: Source/error.cpp:56
+#: Source/diablo_msg.cpp:65
 msgid "Direct Sound Creation Failed"
 msgstr "Falha na criação de Direct Sound"
 
-#: Source/error.cpp:57
+#: Source/diablo_msg.cpp:66
 msgid "Not available in shareware version"
 msgstr "Indisponível na versão shareware"
 
-#: Source/error.cpp:58
+#: Source/diablo_msg.cpp:67
 msgid "Not enough space to save"
 msgstr "Espaço insuficiente para salvar"
 
-#: Source/error.cpp:59
+#: Source/diablo_msg.cpp:68
 msgid "No Pause in town"
 msgstr "Pausa não permitida na cidade"
 
-#: Source/error.cpp:60
+#: Source/diablo_msg.cpp:69
 msgid "Copying to a hard disk is recommended"
 msgstr "É recomendado copiar para um disco rígido"
 
-#: Source/error.cpp:61
+#: Source/diablo_msg.cpp:70
 msgid "Multiplayer sync problem"
 msgstr "Problema de sincronia do modo multijogador"
 
-#: Source/error.cpp:62
+#: Source/diablo_msg.cpp:71
 msgid "No pause in multiplayer"
 msgstr "Não é permitido pausar no modo multijogador"
 
-#: Source/error.cpp:64
+#: Source/diablo_msg.cpp:73
 msgid "Saving..."
 msgstr "Salvando..."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:65
+#: Source/diablo_msg.cpp:74
 msgid "Some are weakened as one grows strong"
 msgstr "Uns são enfraquecidos enquanto um se torna mais forte"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:66
+#: Source/diablo_msg.cpp:75
 msgid "New strength is forged through destruction"
 msgstr "Nova força é forjada pela destruição"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:67
+#: Source/diablo_msg.cpp:76
 msgid "Those who defend seldom attack"
 msgstr "Aqueles que defendem raramente atacam"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:68
+#: Source/diablo_msg.cpp:77
 msgid "The sword of justice is swift and sharp"
 msgstr "A espada da justiça é veloz e afiada"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:69
+#: Source/diablo_msg.cpp:78
 msgid "While the spirit is vigilant the body thrives"
 msgstr "Enquanto o espírito é vigilante, o corpo prospera"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:70
+#: Source/diablo_msg.cpp:79
 msgid "The powers of mana refocused renews"
 msgstr "Os poderes da mana reorientados se renovam"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:71
+#: Source/diablo_msg.cpp:80
 msgid "Time cannot diminish the power of steel"
 msgstr "O tempo não pode diminuir o poder do aço"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:72
+#: Source/diablo_msg.cpp:81
 msgid "Magic is not always what it seems to be"
 msgstr "A mágica nem sempre é o que parece ser"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:73
+#: Source/diablo_msg.cpp:82
 msgid "What once was opened now is closed"
 msgstr "O que antes estava aberto, agora está fechado"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:74
+#: Source/diablo_msg.cpp:83
 msgid "Intensity comes at the cost of wisdom"
 msgstr "A intensidade vem à custa de sabedoria"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:75
+#: Source/diablo_msg.cpp:84
 msgid "Arcane power brings destruction"
 msgstr "O poder arcano traz destruição"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:76
+#: Source/diablo_msg.cpp:85
 msgid "That which cannot be held cannot be harmed"
 msgstr "Aquilo que não pode ser agarrado não pode ser ferido"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:77
+#: Source/diablo_msg.cpp:86
 msgid "Crimson and Azure become as the sun"
 msgstr "O Rubro e Anil se tornam como o sol"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:78
+#: Source/diablo_msg.cpp:87
 msgid "Knowledge and wisdom at the cost of self"
 msgstr "Conhecimento e sabedoria à custa de seu próprio eu"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:79
+#: Source/diablo_msg.cpp:88
 msgid "Drink and be refreshed"
 msgstr "Beba e refresque-se"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:80
+#: Source/diablo_msg.cpp:89
 msgid "Wherever you go, there you are"
 msgstr "Aonde quer que você vá, lá está você"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:81
+#: Source/diablo_msg.cpp:90
 msgid "Energy comes at the cost of wisdom"
 msgstr "A energia vem à custa de sabedoria"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:82
+#: Source/diablo_msg.cpp:91
 msgid "Riches abound when least expected"
 msgstr "Riquezas abundam quando menos se espera"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:83
+#: Source/diablo_msg.cpp:92
 msgid "Where avarice fails, patience gains reward"
 msgstr "Onde falha a avareza, a paciência é recompensada"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:84
+#: Source/diablo_msg.cpp:93
 msgid "Blessed by a benevolent companion!"
 msgstr "Abençoado por uma companhia benevolente!"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:85
+#: Source/diablo_msg.cpp:94
 msgid "The hands of men may be guided by fate"
 msgstr "As mãos dos homens podem ser guiadas pelo destino"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:86
+#: Source/diablo_msg.cpp:95
 msgid "Strength is bolstered by heavenly faith"
 msgstr "A força é intensificada pela fé celestial"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:87
+#: Source/diablo_msg.cpp:96
 msgid "The essence of life flows from within"
 msgstr "A essência da vida flui de dentro"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:88
+#: Source/diablo_msg.cpp:97
 msgid "The way is made clear when viewed from above"
 msgstr "O caminho se faz claro quando visto de cima"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:89
+#: Source/diablo_msg.cpp:98
 msgid "Salvation comes at the cost of wisdom"
 msgstr "A salvação vem à custa de sabedoria"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:90
+#: Source/diablo_msg.cpp:99
 msgid "Mysteries are revealed in the light of reason"
 msgstr "Mistérios são revelados à luz da razão"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:91
+#: Source/diablo_msg.cpp:100
 msgid "Those who are last may yet be first"
 msgstr "Aqueles que são últimos ainda poderão ser primeiros"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:92
+#: Source/diablo_msg.cpp:101
 msgid "Generosity brings its own rewards"
 msgstr "A generosidade traz suas próprias recompensas"
 
-#: Source/error.cpp:93
+#: Source/diablo_msg.cpp:102
 msgid "You must be at least level 8 to use this."
 msgstr "Você deve estar ao menos no nível 8 para usar isto."
 
-#: Source/error.cpp:94
+#: Source/diablo_msg.cpp:103
 msgid "You must be at least level 13 to use this."
 msgstr "Você deve estar ao menos no nível 13 para usar isto."
 
-#: Source/error.cpp:95
+#: Source/diablo_msg.cpp:104
 msgid "You must be at least level 17 to use this."
 msgstr "Você deve estar ao menos no nível 17 para usar isto."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:96
+#: Source/diablo_msg.cpp:105
 msgid "Arcane knowledge gained!"
 msgstr "Conhecimento arcano obtido!"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:97
+#: Source/diablo_msg.cpp:106
 msgid "That which does not kill you..."
 msgstr "Aquilo que não o mata..."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:98
+#: Source/diablo_msg.cpp:107
 msgid "Knowledge is power."
 msgstr "Conhecimento é poder."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:99
+#: Source/diablo_msg.cpp:108
 msgid "Give and you shall receive."
 msgstr "Doe e você receberá."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:100
+#: Source/diablo_msg.cpp:109
 msgid "Some experience is gained by touch."
 msgstr "Um pouco de experiência é obtida através do toque."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:101
+#: Source/diablo_msg.cpp:110
 msgid "There's no place like home."
 msgstr "Não há lugar como a nossa casa."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:102
+#: Source/diablo_msg.cpp:111
 msgid "Spiritual energy is restored."
 msgstr "A energia espiritual é restaurada."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:103
+#: Source/diablo_msg.cpp:112
 msgid "You feel more agile."
 msgstr "Você se sente mais ágil."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:104
+#: Source/diablo_msg.cpp:113
 msgid "You feel stronger."
 msgstr "Você se sente mais forte."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:105
+#: Source/diablo_msg.cpp:114
 msgid "You feel wiser."
 msgstr "Você se sente mais sábio."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:106
+#: Source/diablo_msg.cpp:115
 msgid "You feel refreshed."
 msgstr "Você se sente revigorado."
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/error.cpp:107
+#: Source/diablo_msg.cpp:116
 msgid "That which can break will."
 msgstr "Aquilo que puder ser quebrado, assim o será."
 
-#: Source/gamemenu.cpp:39
-msgid "Save Game"
-msgstr "Salvar jogo"
+#: Source/discord/discord.cpp:81
+msgid "Cathedral"
+msgstr "Catedral"
 
-#: Source/gamemenu.cpp:40 Source/gamemenu.cpp:51
+#: Source/discord/discord.cpp:81
+msgid "Catacombs"
+msgstr "Catacumbas"
+
+#: Source/discord/discord.cpp:81
+msgid "Caves"
+msgstr "Cavernas"
+
+#: Source/discord/discord.cpp:81
+msgid "Nest"
+msgstr "Enxame"
+
+#: Source/discord/discord.cpp:81
+msgid "Crypt"
+msgstr "Cripta"
+
+#. TRANSLATORS: dungeon type and floor number i.e. "Cathedral 3"
+#: Source/discord/discord.cpp:97
+msgid "{} {}"
+msgstr "{} {}"
+
+#. TRANSLATORS: Discord character, i.e. "Lv 6 Warrior"
+#: Source/discord/discord.cpp:104
+msgid "Lv {} {}"
+msgstr "Nvl {} {}"
+
+#. TRANSLATORS: Discord state i.e. "Nightmare difficulty"
+#: Source/discord/discord.cpp:116
+msgid "{} difficulty"
+msgstr "Dificuldade {}"
+
+#. TRANSLATORS: Discord activity, not in game
+#: Source/discord/discord.cpp:197
+msgid "In Menu"
+msgstr "No Menu"
+
+#: Source/dvlnet/loopback.cpp:117
+msgid "loopback"
+msgstr "loopback"
+
+#: Source/dvlnet/tcp_client.cpp:112
+msgid "Unable to connect"
+msgstr "Não foi possível se conectar"
+
+#: Source/dvlnet/tcp_client.cpp:150
+msgid "error: read 0 bytes from server"
+msgstr "erro: 0 bytes lidos do servidor"
+
+#: Source/engine/assets.cpp:259
+msgid ""
+"Failed to open file:\n"
+"{:s}\n"
+"\n"
+"{:s}\n"
+"\n"
+"The MPQ file(s) might be damaged. Please check the file integrity."
+msgstr ""
+
+#: Source/engine/assets.cpp:422 Source/engine/assets.cpp:441
+msgid "diabdat.mpq or spawn.mpq"
+msgstr "diabdat.mpq ou spawn.mpq"
+
+#: Source/engine/assets.cpp:473
+msgid "Some Hellfire MPQs are missing"
+msgstr "Alguns arquivos MPQs do Hellfire estão faltando"
+
+#: Source/engine/assets.cpp:473
+msgid ""
+"Not all Hellfire MPQs were found.\n"
+"Please copy all the hf*.mpq files."
+msgstr ""
+"Nem todos os arquivos MPQs do Hellfire foram encontrados.\n"
+"Por favor, copie todos os arquivos hf*.mpq."
+
+#: Source/engine/demomode.cpp:182 Source/options.cpp:529
+msgid "Resolution"
+msgstr "Resolução"
+
+#: Source/engine/demomode.cpp:184 Source/options.cpp:772
+msgid "Run in Town"
+msgstr "Correr na Cidade"
+
+#: Source/engine/demomode.cpp:185 Source/options.cpp:775
+msgid "Theo Quest"
+msgstr "Missão do Theo"
+
+#: Source/engine/demomode.cpp:186 Source/options.cpp:776
+msgid "Cow Quest"
+msgstr "Missão da Vaca"
+
+#: Source/engine/demomode.cpp:187 Source/options.cpp:786
+msgid "Auto Gold Pickup"
+msgstr "Pegar Ouro Automaticamente"
+
+#: Source/engine/demomode.cpp:188 Source/options.cpp:787
+msgid "Auto Elixir Pickup"
+msgstr "Pegar Elixir Automaticamente"
+
+#: Source/engine/demomode.cpp:189 Source/options.cpp:788
+msgid "Auto Oil Pickup"
+msgstr "Pegar Óleo Automaticamente"
+
+#: Source/engine/demomode.cpp:190 Source/options.cpp:789
+msgid "Auto Pickup in Town"
+msgstr "Pegar itens na Cidade automaticamente"
+
+#: Source/engine/demomode.cpp:191 Source/options.cpp:790
+msgid "Adria Refills Mana"
+msgstr "Adria Recupera Mana"
+
+#: Source/engine/demomode.cpp:192 Source/options.cpp:791
+msgid "Auto Equip Weapons"
+msgstr "Auto Equipar Armas"
+
+#: Source/engine/demomode.cpp:193 Source/options.cpp:792
+msgid "Auto Equip Armor"
+msgstr "Auto Equipar Armadura"
+
+#: Source/engine/demomode.cpp:194 Source/options.cpp:793
+msgid "Auto Equip Helms"
+msgstr "Auto Equipar Elmos"
+
+#: Source/engine/demomode.cpp:195 Source/options.cpp:794
+msgid "Auto Equip Shields"
+msgstr "Auto Equipar Escudos"
+
+#: Source/engine/demomode.cpp:196 Source/options.cpp:795
+msgid "Auto Equip Jewelry"
+msgstr "Auto Equipar Jóias"
+
+#: Source/engine/demomode.cpp:197 Source/options.cpp:796
+msgid "Randomize Quests"
+msgstr "Randomizar Missões"
+
+#: Source/engine/demomode.cpp:198 Source/options.cpp:798
+msgid "Show Item Labels"
+msgstr "Exibir nome dos items"
+
+#: Source/engine/demomode.cpp:199 Source/options.cpp:799
+msgid "Auto Refill Belt"
+msgstr "Auto Abastecer Cinto"
+
+#: Source/engine/demomode.cpp:200 Source/options.cpp:800
+msgid "Disable Crippling Shrines"
+msgstr "Desabilitar Altares Destrutivos"
+
+#: Source/engine/demomode.cpp:204 Source/options.cpp:802
+msgid "Heal Potion Pickup"
+msgstr "Pegar Poção de Cura"
+
+#: Source/engine/demomode.cpp:205 Source/options.cpp:803
+msgid "Full Heal Potion Pickup"
+msgstr "Pegar Poção de Cura Completa"
+
+#: Source/engine/demomode.cpp:206 Source/options.cpp:804
+msgid "Mana Potion Pickup"
+msgstr "Pegar Poção de Mana"
+
+#: Source/engine/demomode.cpp:207 Source/options.cpp:805
+msgid "Full Mana Potion Pickup"
+msgstr "Pegar Poção de Mana Completa"
+
+#: Source/engine/demomode.cpp:208 Source/options.cpp:806
+msgid "Rejuvenation Potion Pickup"
+msgstr "Pegar Poção de Rejuvenescimento"
+
+#: Source/engine/demomode.cpp:209 Source/options.cpp:807
+msgid "Full Rejuvenation Potion Pickup"
+msgstr "Pegar Poção de Rejuvenecimento Completo"
+
+#: Source/gamemenu.cpp:47 Source/gamemenu.cpp:59
 msgid "Options"
 msgstr "Opções"
 
-#: Source/gamemenu.cpp:43 Source/gamemenu.cpp:54
+#: Source/gamemenu.cpp:48
+msgid "Save Game"
+msgstr "Salvar jogo"
+
+#: Source/gamemenu.cpp:50 Source/gamemenu.cpp:60
+#, fuzzy
+#| msgid "Main Menu"
+msgid "Exit to Main Menu"
+msgstr "Menu Principal"
+
+#: Source/gamemenu.cpp:51 Source/gamemenu.cpp:61
 msgid "Quit Game"
 msgstr "Sair do jogo"
 
-#: Source/gamemenu.cpp:53
-msgid "Restart In Town"
-msgstr "Reiniciar na cidade"
-
-#: Source/gamemenu.cpp:63
+#: Source/gamemenu.cpp:70
 msgid "Gamma"
 msgstr "Gama"
 
-#: Source/gamemenu.cpp:64 Source/gamemenu.cpp:173
+#: Source/gamemenu.cpp:71 Source/gamemenu.cpp:170
 msgid "Speed"
 msgstr "Veloc."
 
-#: Source/gamemenu.cpp:72
+#: Source/gamemenu.cpp:79
 msgid "Music Disabled"
 msgstr "Desativar música"
 
-#: Source/gamemenu.cpp:76
+#: Source/gamemenu.cpp:83
 msgid "Sound"
 msgstr "Som"
 
-#: Source/gamemenu.cpp:77
+#: Source/gamemenu.cpp:84
 msgid "Sound Disabled"
 msgstr "Desativar som"
 
-#: Source/gmenu.cpp:177
+#: Source/gmenu.cpp:179
 msgid "Pause"
 msgstr "Pausa"
 
@@ -2336,1991 +2539,224 @@ msgstr "Ajuda do Diablo Shareware"
 msgid "Diablo Help"
 msgstr "Ajuda do Diablo"
 
-#: Source/help.cpp:233 Source/qol/chatlog.cpp:189
+#: Source/help.cpp:234 Source/qol/chatlog.cpp:199
 msgid "Press ESC to end or the arrow keys to scroll."
 msgstr "Pressione ESC para encerrar ou setas direcionais para rolar."
 
-#: Source/init.cpp:253 Source/init.cpp:293
-msgid "diabdat.mpq or spawn.mpq"
-msgstr "diabdat.mpq ou spawn.mpq"
-
-#: Source/init.cpp:274 Source/init.cpp:314
-msgid "Some Hellfire MPQs are missing"
-msgstr "Alguns arquivos MPQs do Hellfire estão faltando"
-
-#: Source/init.cpp:274 Source/init.cpp:314
-msgid ""
-"Not all Hellfire MPQs were found.\n"
-"Please copy all the hf*.mpq files."
-msgstr ""
-"Nem todos os arquivos MPQs do Hellfire foram encontrados.\n"
-"Por favor, copie todos os arquivos hf*.mpq."
-
-#: Source/init.cpp:323
+#: Source/init.cpp:132
 msgid "Unable to create main window"
 msgstr "Não foi possível criar a janela principal"
 
-#: Source/inv.cpp:2126
+#: Source/inv.cpp:2233
 msgid "No room for item"
 msgstr "Não há espaço para o item"
 
-#: Source/itemdat.cpp:53 Source/itemdat.cpp:236 Source/panels/charpanel.cpp:163
-msgid "Gold"
-msgstr "Ouro"
-
-#: Source/itemdat.cpp:54 Source/itemdat.cpp:172
-msgid "Short Sword"
-msgstr "Espada Curta"
-
-#: Source/itemdat.cpp:55 Source/itemdat.cpp:124
-msgid "Buckler"
-msgstr "Broquel"
-
-#: Source/itemdat.cpp:56 Source/itemdat.cpp:192 Source/itemdat.cpp:193
-msgid "Club"
-msgstr "Clava"
-
-#: Source/itemdat.cpp:57 Source/itemdat.cpp:196
-msgid "Short Bow"
-msgstr "Arco curto"
-
-#: Source/itemdat.cpp:58
-msgid "Short Staff of Mana"
-msgstr "Cajado curto de mana"
-
-#: Source/itemdat.cpp:59
-msgid "Cleaver"
-msgstr "Cutelo"
-
-#: Source/itemdat.cpp:60 Source/itemdat.cpp:435
-msgid "The Undead Crown"
-msgstr "Coroa dos mortos-vivos"
-
-#: Source/itemdat.cpp:61 Source/itemdat.cpp:436
-msgid "Empyrean Band"
-msgstr "Anel empíreo"
-
-#: Source/itemdat.cpp:62
-msgid "Magic Rock"
-msgstr "Rocha mágica"
-
-#: Source/itemdat.cpp:63 Source/itemdat.cpp:437
-msgid "Optic Amulet"
-msgstr "Amuleto óptico"
-
-#: Source/itemdat.cpp:64 Source/itemdat.cpp:438
-msgid "Ring of Truth"
-msgstr "Anel da verdade"
-
-#: Source/itemdat.cpp:65
-msgid "Tavern Sign"
-msgstr "Placa da taverna"
-
-#: Source/itemdat.cpp:66 Source/itemdat.cpp:439
-msgid "Harlequin Crest"
-msgstr "Brasão do arlequim"
-
-#: Source/itemdat.cpp:67 Source/itemdat.cpp:440
-msgid "Veil of Steel"
-msgstr "Véu de aço"
-
-#: Source/itemdat.cpp:68
-msgid "Golden Elixir"
-msgstr "Elixir dourado"
-
-#: Source/itemdat.cpp:69 Source/quests.cpp:58
-msgid "Anvil of Fury"
-msgstr "Bigorna da fúria"
-
-#: Source/itemdat.cpp:70 Source/quests.cpp:49
-msgid "Black Mushroom"
-msgstr "Cogumelo negro"
-
-#: Source/itemdat.cpp:71
-msgid "Brain"
-msgstr "Cérebro"
-
-#: Source/itemdat.cpp:72
-msgid "Fungal Tome"
-msgstr "Tomo fungoso"
-
-#: Source/itemdat.cpp:73
-msgid "Spectral Elixir"
-msgstr "Elixir espectral"
-
-#: Source/itemdat.cpp:74
-msgid "Blood Stone"
-msgstr "Pedra sanguínea"
-
-#: Source/itemdat.cpp:75
-msgid "Cathedral Map"
-msgstr "Mapa da catedral"
-
-#: Source/itemdat.cpp:76
-msgid "Heart"
-msgstr "Coração"
-
-#: Source/itemdat.cpp:77 Source/itemdat.cpp:130
-msgid "Potion of Healing"
-msgstr "Poção de cura"
-
-#: Source/itemdat.cpp:78 Source/itemdat.cpp:132
-msgid "Potion of Mana"
-msgstr "Poção de mana"
-
-#: Source/itemdat.cpp:79 Source/itemdat.cpp:147
-msgid "Scroll of Identify"
-msgstr "Pergaminho de identificar"
-
-#: Source/itemdat.cpp:80 Source/itemdat.cpp:151
-msgid "Scroll of Town Portal"
-msgstr "Pergaminho de portal da cidade"
-
-#: Source/itemdat.cpp:81 Source/itemdat.cpp:441
-msgid "Arkaine's Valor"
-msgstr "Bravura de Arkaine"
-
-#: Source/itemdat.cpp:82 Source/itemdat.cpp:131
-msgid "Potion of Full Healing"
-msgstr "Poção de cura completa"
-
-#: Source/itemdat.cpp:83 Source/itemdat.cpp:133
-msgid "Potion of Full Mana"
-msgstr "Poção de mana completa"
-
-#: Source/itemdat.cpp:84 Source/itemdat.cpp:442
-msgid "Griswold's Edge"
-msgstr "Gume de Griswold"
-
-#: Source/itemdat.cpp:85 Source/itemdat.cpp:443
-msgid "Bovine Plate"
-msgstr "Placa bovina"
-
-#: Source/itemdat.cpp:86
-msgid "Staff of Lazarus"
-msgstr "Cajado de Lázarus"
-
-#: Source/itemdat.cpp:87 Source/itemdat.cpp:148
-msgid "Scroll of Resurrect"
-msgstr "Pergaminho de ressuscitar"
-
-#: Source/itemdat.cpp:88 Source/itemdat.cpp:136 Source/items.cpp:180
-msgid "Blacksmith Oil"
-msgstr "Óleo do ferreiro"
-
-#: Source/itemdat.cpp:89 Source/itemdat.cpp:204
-msgid "Short Staff"
-msgstr "Cajado curto"
-
-#: Source/itemdat.cpp:90 Source/itemdat.cpp:172 Source/itemdat.cpp:173
-#: Source/itemdat.cpp:174 Source/itemdat.cpp:175 Source/itemdat.cpp:178
-#: Source/itemdat.cpp:179 Source/itemdat.cpp:180 Source/itemdat.cpp:181
-#: Source/itemdat.cpp:182
-msgid "Sword"
-msgstr "Espada"
-
-#: Source/itemdat.cpp:91 Source/itemdat.cpp:171
-msgid "Dagger"
-msgstr "Adaga"
-
-#: Source/itemdat.cpp:92
-msgid "Rune Bomb"
-msgstr "Runa explosiva"
-
-#: Source/itemdat.cpp:93
-msgid "Theodore"
-msgstr "Theodore"
-
-#: Source/itemdat.cpp:94
-msgid "Auric Amulet"
-msgstr "Amuleto áurico"
-
-#: Source/itemdat.cpp:95
-msgid "Torn Note 1"
-msgstr "Nota rasgada 1"
-
-#: Source/itemdat.cpp:96
-msgid "Torn Note 2"
-msgstr "Nota rasgada 2"
-
-#: Source/itemdat.cpp:97
-msgid "Torn Note 3"
-msgstr "Nota rasgada 3"
-
-#: Source/itemdat.cpp:98
-msgid "Reconstructed Note"
-msgstr "Nota reconstruída"
-
-#: Source/itemdat.cpp:99
-msgid "Brown Suit"
-msgstr "Traje marrom"
-
-#: Source/itemdat.cpp:100
-msgid "Grey Suit"
-msgstr "Traje cinza"
-
-#: Source/itemdat.cpp:101 Source/itemdat.cpp:102
-msgid "Cap"
-msgstr "Quepe"
-
-#: Source/itemdat.cpp:102
-msgid "Skull Cap"
-msgstr "Cervelliere"
-
-#: Source/itemdat.cpp:103 Source/itemdat.cpp:104 Source/itemdat.cpp:106
-msgid "Helm"
-msgstr "Elmo"
-
-#: Source/itemdat.cpp:104
-msgid "Full Helm"
-msgstr "Elmo Completo"
-
-#: Source/itemdat.cpp:105
-msgid "Crown"
-msgstr "Coroa"
-
-#: Source/itemdat.cpp:106
-msgid "Great Helm"
-msgstr "Grande Elmo"
-
-#: Source/itemdat.cpp:107
-msgid "Cape"
-msgstr "Capa"
-
-#: Source/itemdat.cpp:108
-msgid "Rags"
-msgstr "Trapo"
-
-#: Source/itemdat.cpp:109
-msgid "Cloak"
-msgstr "Manto"
-
-#: Source/itemdat.cpp:110
-msgid "Robe"
-msgstr "Túnica"
-
-#: Source/itemdat.cpp:111
-msgid "Quilted Armor"
-msgstr "Armadura Acolchoada"
-
-#: Source/itemdat.cpp:111 Source/itemdat.cpp:112 Source/itemdat.cpp:113
-#: Source/itemdat.cpp:114 Source/objects.cpp:4928
-msgid "Armor"
-msgstr "Armadura"
-
-#: Source/itemdat.cpp:112
-msgid "Leather Armor"
-msgstr "Armadura de Couro"
-
-#: Source/itemdat.cpp:113
-msgid "Hard Leather Armor"
-msgstr "Armadura de Couro Duro"
-
-#: Source/itemdat.cpp:114
-msgid "Studded Leather Armor"
-msgstr "Armad. de Couro Cravejado"
-
-#: Source/itemdat.cpp:115
-msgid "Ring Mail"
-msgstr "Malha de Anéis"
-
-#: Source/itemdat.cpp:115 Source/itemdat.cpp:116 Source/itemdat.cpp:117
-#: Source/itemdat.cpp:119
-msgid "Mail"
-msgstr "Malha"
-
-#: Source/itemdat.cpp:116
-msgid "Chain Mail"
-msgstr "Cota de Malha"
-
-#: Source/itemdat.cpp:117
-msgid "Scale Mail"
-msgstr "Malha em Escamas"
-
-#: Source/itemdat.cpp:118
-msgid "Breast Plate"
-msgstr "Armadura Peitoral"
-
-#: Source/itemdat.cpp:118 Source/itemdat.cpp:120 Source/itemdat.cpp:121
-#: Source/itemdat.cpp:122 Source/itemdat.cpp:123
-msgid "Plate"
-msgstr "Armadura de Placas"
-
-#: Source/itemdat.cpp:119
-msgid "Splint Mail"
-msgstr "Cota de Talas"
-
-#: Source/itemdat.cpp:120
-msgid "Plate Mail"
-msgstr "Malha de Placas"
-
-#: Source/itemdat.cpp:121
-msgid "Field Plate"
-msgstr "Placa de Campo"
-
-#: Source/itemdat.cpp:122
-msgid "Gothic Plate"
-msgstr "Placa Gótica"
-
-#: Source/itemdat.cpp:123
-msgid "Full Plate Mail"
-msgstr "Malha de Placas Completa"
-
-#: Source/itemdat.cpp:124 Source/itemdat.cpp:125 Source/itemdat.cpp:126
-#: Source/itemdat.cpp:127 Source/itemdat.cpp:128 Source/itemdat.cpp:129
-msgid "Shield"
-msgstr "Escudo"
-
-#: Source/itemdat.cpp:125
-msgid "Small Shield"
-msgstr "Escudo Pequeno"
-
-#: Source/itemdat.cpp:126
-msgid "Large Shield"
-msgstr "Escudo Grande"
-
-#: Source/itemdat.cpp:127
-msgid "Kite Shield"
-msgstr "Escudo Gota"
-
-#: Source/itemdat.cpp:128
-msgid "Tower Shield"
-msgstr "Escudo Torre"
-
-#: Source/itemdat.cpp:129
-msgid "Gothic Shield"
-msgstr "Escudo Gótico"
-
-#: Source/itemdat.cpp:134
-msgid "Potion of Rejuvenation"
-msgstr "Poção de Rejuvenescimento"
-
-#: Source/itemdat.cpp:135
-msgid "Potion of Full Rejuvenation"
-msgstr "Poção de Rejuvenescimento Completo"
-
-#: Source/itemdat.cpp:137 Source/items.cpp:175
+#: Source/items.cpp:180 Source/translation_dummy.cpp:360
 msgid "Oil of Accuracy"
 msgstr "Óleo da Precisão"
 
-#: Source/itemdat.cpp:138 Source/items.cpp:177
-msgid "Oil of Sharpness"
-msgstr "Óleo da Nitidez"
-
-#: Source/itemdat.cpp:139
-msgid "Oil"
-msgstr "Óleo"
-
-#: Source/itemdat.cpp:140
-msgid "Elixir of Strength"
-msgstr "Elixir da Força"
-
-#: Source/itemdat.cpp:141
-msgid "Elixir of Magic"
-msgstr "Elixir da Magia"
-
-#: Source/itemdat.cpp:142
-msgid "Elixir of Dexterity"
-msgstr "Elixir da Destreza"
-
-#: Source/itemdat.cpp:143
-msgid "Elixir of Vitality"
-msgstr "Elixir da Vitalidade"
-
-#: Source/itemdat.cpp:144
-msgid "Scroll of Healing"
-msgstr "Pergaminho de Cura"
-
-#: Source/itemdat.cpp:145
-msgid "Scroll of Search"
-msgstr "Pergaminho de Busca"
-
-#: Source/itemdat.cpp:146
-msgid "Scroll of Lightning"
-msgstr "Pergaminho de Raio"
-
-#: Source/itemdat.cpp:149
-msgid "Scroll of Fire Wall"
-msgstr "Pergaminho de Parede de Fogo"
-
-#: Source/itemdat.cpp:150
-msgid "Scroll of Inferno"
-msgstr "Pergaminho de Inferno"
-
-#: Source/itemdat.cpp:152
-msgid "Scroll of Flash"
-msgstr "Pergaminho de Lampejo"
-
-#: Source/itemdat.cpp:153
-msgid "Scroll of Infravision"
-msgstr "Pergaminho de Infravisão"
-
-#: Source/itemdat.cpp:154
-msgid "Scroll of Phasing"
-msgstr "Pergaminho de Fasear"
-
-#: Source/itemdat.cpp:155
-msgid "Scroll of Mana Shield"
-msgstr "Pergaminho de Escudo de Mana"
-
-#: Source/itemdat.cpp:156
-msgid "Scroll of Flame Wave"
-msgstr "Pergaminho de Onda de Chamas"
-
-#: Source/itemdat.cpp:157
-msgid "Scroll of Fireball"
-msgstr "Pergaminho de Bola de Fogo"
-
-#: Source/itemdat.cpp:158
-msgid "Scroll of Stone Curse"
-msgstr "Pergaminho de Maldição de Pedra"
-
-#: Source/itemdat.cpp:159
-msgid "Scroll of Chain Lightning"
-msgstr "Pergaminho de Relâmp. Encadeado"
-
-#: Source/itemdat.cpp:160
-msgid "Scroll of Guardian"
-msgstr "Pergaminho de Guardião"
-
-#: Source/itemdat.cpp:162
-msgid "Scroll of Nova"
-msgstr "Pergaminho de Nova"
-
-#: Source/itemdat.cpp:163
-msgid "Scroll of Golem"
-msgstr "Pergaminho de Golem"
-
-#: Source/itemdat.cpp:165
-msgid "Scroll of Teleport"
-msgstr "Pergaminho de Teletransporte"
-
-#: Source/itemdat.cpp:166
-msgid "Scroll of Apocalypse"
-msgstr "Pergaminho de Apocalipse"
-
-#: Source/itemdat.cpp:167 Source/itemdat.cpp:168 Source/itemdat.cpp:169
-#: Source/itemdat.cpp:170
-msgid "Book of {:s}"
-msgstr "Livro de {:s}"
-
-#: Source/itemdat.cpp:173
-msgid "Falchion"
-msgstr "Alfanje"
-
-#: Source/itemdat.cpp:174
-msgid "Scimitar"
-msgstr "Cimitarra"
-
-#: Source/itemdat.cpp:175
-msgid "Claymore"
-msgstr "Espada Escocesa"
-
-#: Source/itemdat.cpp:176
-msgid "Blade"
-msgstr "Lâmina"
-
-#: Source/itemdat.cpp:177
-msgid "Sabre"
-msgstr "Sabre"
-
-#: Source/itemdat.cpp:178
-msgid "Long Sword"
-msgstr "Espada Longa"
-
-#: Source/itemdat.cpp:179
-msgid "Broad Sword"
-msgstr "Espada Larga"
-
-#: Source/itemdat.cpp:180
-msgid "Bastard Sword"
-msgstr "Espada Bastarda"
-
-#: Source/itemdat.cpp:181
-msgid "Two-Handed Sword"
-msgstr "Espada de Duas Mãos"
-
-#: Source/itemdat.cpp:182
-msgid "Great Sword"
-msgstr "Espada Montante"
-
-#: Source/itemdat.cpp:183
-msgid "Small Axe"
-msgstr "Machado Pequeno"
-
-#: Source/itemdat.cpp:183 Source/itemdat.cpp:184 Source/itemdat.cpp:185
-#: Source/itemdat.cpp:186 Source/itemdat.cpp:187 Source/itemdat.cpp:188
-msgid "Axe"
-msgstr "Machado"
-
-#: Source/itemdat.cpp:185
-msgid "Large Axe"
-msgstr "Machado Grande"
-
-#: Source/itemdat.cpp:186
-msgid "Broad Axe"
-msgstr "Machado Largo"
-
-#: Source/itemdat.cpp:187
-msgid "Battle Axe"
-msgstr "Machado de Batalha"
-
-#: Source/itemdat.cpp:188
-msgid "Great Axe"
-msgstr "Grão-machado"
-
-#: Source/itemdat.cpp:189 Source/itemdat.cpp:190
-msgid "Mace"
-msgstr "Maça"
-
-#: Source/itemdat.cpp:190
-msgid "Morning Star"
-msgstr "Chicote de Roldão"
-
-#: Source/itemdat.cpp:191
-msgid "War Hammer"
-msgstr "Martelo de Guerra"
-
-#: Source/itemdat.cpp:191
-msgid "Hammer"
-msgstr "Martelo"
-
-#: Source/itemdat.cpp:192
-msgid "Spiked Club"
-msgstr "Clava Cravada"
-
-#: Source/itemdat.cpp:194
-msgid "Flail"
-msgstr "Mangual"
-
-#: Source/itemdat.cpp:195
-msgid "Maul"
-msgstr "Malho"
-
-#: Source/itemdat.cpp:196 Source/itemdat.cpp:197 Source/itemdat.cpp:198
-#: Source/itemdat.cpp:199 Source/itemdat.cpp:200 Source/itemdat.cpp:201
-#: Source/itemdat.cpp:202 Source/itemdat.cpp:203
-msgid "Bow"
-msgstr "Arco"
-
-#: Source/itemdat.cpp:197
-msgid "Hunter's Bow"
-msgstr "Arco de Caçador"
-
-#: Source/itemdat.cpp:198
-msgid "Long Bow"
-msgstr "Arco Longo"
-
-#: Source/itemdat.cpp:199
-msgid "Composite Bow"
-msgstr "Arco Composto"
-
-#: Source/itemdat.cpp:200
-msgid "Short Battle Bow"
-msgstr "Arco de Batalha Curto"
-
-#: Source/itemdat.cpp:201
-msgid "Long Battle Bow"
-msgstr "Arco de Batalha Longo"
-
-#: Source/itemdat.cpp:202
-msgid "Short War Bow"
-msgstr "Arco de Guerra Curto"
-
-#: Source/itemdat.cpp:203
-msgid "Long War Bow"
-msgstr "Arco de Guerra Longo"
-
-#: Source/itemdat.cpp:204 Source/itemdat.cpp:205 Source/itemdat.cpp:206
-#: Source/itemdat.cpp:207 Source/itemdat.cpp:208
-#: Source/panels/spell_list.cpp:183
-msgid "Staff"
-msgstr "Cajado"
-
-#: Source/itemdat.cpp:205
-msgid "Long Staff"
-msgstr "Cajado longo"
-
-#: Source/itemdat.cpp:206
-msgid "Composite Staff"
-msgstr "Cajado composto"
-
-#: Source/itemdat.cpp:207
-msgid "Quarter Staff"
-msgstr "Cajado de combate"
-
-#: Source/itemdat.cpp:208
-msgid "War Staff"
-msgstr "Cajado de guerra"
-
-#: Source/itemdat.cpp:209 Source/itemdat.cpp:210 Source/itemdat.cpp:211
-msgid "Ring"
-msgstr "Anel"
-
-#: Source/itemdat.cpp:212 Source/itemdat.cpp:213
-msgid "Amulet"
-msgstr "Amuleto"
-
-#: Source/itemdat.cpp:214
-msgid "Rune of Fire"
-msgstr "Runa de Fogo"
-
-#: Source/itemdat.cpp:214 Source/itemdat.cpp:215 Source/itemdat.cpp:216
-#: Source/itemdat.cpp:217 Source/itemdat.cpp:218
-msgid "Rune"
-msgstr "Runa"
-
-#: Source/itemdat.cpp:215
-msgid "Rune of Lightning"
-msgstr "Runa de Relâmpago"
-
-#: Source/itemdat.cpp:216
-msgid "Greater Rune of Fire"
-msgstr "Grande Runa de Fogo"
-
-#: Source/itemdat.cpp:217
-msgid "Greater Rune of Lightning"
-msgstr "Grande Runa de Relâmpago"
-
-#: Source/itemdat.cpp:218
-msgid "Rune of Stone"
-msgstr "Runa de Pedra"
-
-#: Source/itemdat.cpp:219
-msgid "Short Staff of Charged Bolt"
-msgstr "Cajado Curto de Raio Carregado"
-
-#: Source/itemdat.cpp:220
-msgid "Arena Potion"
-msgstr "Poção de Arena"
-
-#. TRANSLATORS: Item prefix section.
-#: Source/itemdat.cpp:230
-msgid "Tin"
-msgstr "de lata"
-
-#: Source/itemdat.cpp:231
-msgid "Brass"
-msgstr "de latão"
-
-#: Source/itemdat.cpp:232
-msgid "Bronze"
-msgstr "de bronze"
-
-#: Source/itemdat.cpp:233
-msgid "Iron"
-msgstr "de ferro"
-
-#: Source/itemdat.cpp:234
-msgid "Steel"
-msgstr "de aço"
-
-#: Source/itemdat.cpp:235
-msgid "Silver"
-msgstr "de prata"
-
-#: Source/itemdat.cpp:237
-msgid "Platinum"
-msgstr "de platina"
-
-#: Source/itemdat.cpp:238
-msgid "Mithril"
-msgstr "de mithril"
-
-#: Source/itemdat.cpp:239
-msgid "Meteoric"
-msgstr "meteórico(a)"
-
-#: Source/itemdat.cpp:240 Source/objects.cpp:123
-msgid "Weird"
-msgstr "esquisito(a)"
-
-#: Source/itemdat.cpp:241
-msgid "Strange"
-msgstr "estranho(a)"
-
-#: Source/itemdat.cpp:242
-msgid "Useless"
-msgstr "inútil"
-
-#: Source/itemdat.cpp:243
-msgid "Bent"
-msgstr "envergado(a)"
-
-#: Source/itemdat.cpp:244
-msgid "Weak"
-msgstr "fraco(a)"
-
-#: Source/itemdat.cpp:245
-msgid "Jagged"
-msgstr "serrilhado(a)"
-
-#: Source/itemdat.cpp:246
-msgid "Deadly"
-msgstr "mortal"
-
-#: Source/itemdat.cpp:247
-msgid "Heavy"
-msgstr "pesado(a)"
-
-#: Source/itemdat.cpp:248
-msgid "Vicious"
-msgstr "vicioso(a)"
-
-#: Source/itemdat.cpp:249
-msgid "Brutal"
-msgstr "brutal"
-
-#: Source/itemdat.cpp:250
-msgid "Massive"
-msgstr "imenso(a)"
-
-#: Source/itemdat.cpp:251
-msgid "Savage"
-msgstr "selvagem"
-
-#: Source/itemdat.cpp:252
-msgid "Ruthless"
-msgstr "implacável"
-
-#: Source/itemdat.cpp:253
-msgid "Merciless"
-msgstr "impiedoso(a)"
-
-#: Source/itemdat.cpp:254
-msgid "Clumsy"
-msgstr "desajeitado(a)"
-
-#: Source/itemdat.cpp:255
-msgid "Dull"
-msgstr "enfadonho(a)"
-
-#: Source/itemdat.cpp:256
-msgid "Sharp"
-msgstr "afiado(a)"
-
-#: Source/itemdat.cpp:257 Source/itemdat.cpp:267
-msgid "Fine"
-msgstr "fino(a)"
-
-#: Source/itemdat.cpp:258
-msgid "Warrior's"
-msgstr "de guerreiro"
-
-#: Source/itemdat.cpp:259
-msgid "Soldier's"
-msgstr "de soldado"
-
-#: Source/itemdat.cpp:260
-msgid "Lord's"
-msgstr "do senhor"
-
-#: Source/itemdat.cpp:261
-msgid "Knight's"
-msgstr "de cavaleiro"
-
-#: Source/itemdat.cpp:262
-msgid "Master's"
-msgstr "de mestre"
-
-#: Source/itemdat.cpp:263
-msgid "Champion's"
-msgstr "de campeão"
-
-#: Source/itemdat.cpp:264
-msgid "King's"
-msgstr "de rei"
-
-#: Source/itemdat.cpp:265
-msgid "Vulnerable"
-msgstr "vulnerável"
-
-#: Source/itemdat.cpp:266
-msgid "Rusted"
-msgstr "enferrujado(a)"
-
-#: Source/itemdat.cpp:268
-msgid "Strong"
-msgstr "forte"
-
-#: Source/itemdat.cpp:269
-msgid "Grand"
-msgstr "grandioso(a)"
-
-#: Source/itemdat.cpp:270
-msgid "Valiant"
-msgstr "valente"
-
-#: Source/itemdat.cpp:271
-msgid "Glorious"
-msgstr "glorioso(a)"
-
-#: Source/itemdat.cpp:272
-msgid "Blessed"
-msgstr "abençoado(a)"
-
-#: Source/itemdat.cpp:273
-msgid "Saintly"
-msgstr "santo(a)"
-
-#: Source/itemdat.cpp:274
-msgid "Awesome"
-msgstr "impressionante"
-
-#: Source/itemdat.cpp:275 Source/objects.cpp:135
-msgid "Holy"
-msgstr "sagrado(a)"
-
-#: Source/itemdat.cpp:276
-msgid "Godly"
-msgstr "divino(a)"
-
-#: Source/itemdat.cpp:277
-msgid "Red"
-msgstr "vermelho(a)"
-
-#: Source/itemdat.cpp:278 Source/itemdat.cpp:279
-msgid "Crimson"
-msgstr "carmesim"
-
-#: Source/itemdat.cpp:280
-msgid "Garnet"
-msgstr "granada"
-
-#: Source/itemdat.cpp:281
-msgid "Ruby"
-msgstr "rubi"
-
-#: Source/itemdat.cpp:282
-msgid "Blue"
-msgstr "azul"
-
-#: Source/itemdat.cpp:283
-msgid "Azure"
-msgstr "lazúli"
-
-#: Source/itemdat.cpp:284
-msgid "Lapis"
-msgstr "lápis-lazúli"
-
-#: Source/itemdat.cpp:285
-msgid "Cobalt"
-msgstr "cobalto"
-
-#: Source/itemdat.cpp:286
-msgid "Sapphire"
-msgstr "safira"
-
-#: Source/itemdat.cpp:287
-msgid "White"
-msgstr "branco(a)"
-
-#: Source/itemdat.cpp:288
-msgid "Pearl"
-msgstr "de pérola"
-
-#: Source/itemdat.cpp:289
-msgid "Ivory"
-msgstr "de marfim"
-
-#: Source/itemdat.cpp:290
-msgid "Crystal"
-msgstr "de cristal"
-
-#: Source/itemdat.cpp:291
-msgid "Diamond"
-msgstr "de diamante"
-
-#: Source/itemdat.cpp:292
-msgid "Topaz"
-msgstr "de topázio"
-
-#: Source/itemdat.cpp:293
-msgid "Amber"
-msgstr "de âmbar"
-
-#: Source/itemdat.cpp:294
-msgid "Jade"
-msgstr "de jade"
-
-#: Source/itemdat.cpp:295
-msgid "Obsidian"
-msgstr "de obsidiana"
-
-#: Source/itemdat.cpp:296
-msgid "Emerald"
-msgstr "de esmeralda"
-
-#: Source/itemdat.cpp:297
-msgid "Hyena's"
-msgstr "de hienas"
-
-#: Source/itemdat.cpp:298
-msgid "Frog's"
-msgstr "de sapos"
-
-#: Source/itemdat.cpp:299
-msgid "Spider's"
-msgstr "de aranhas"
-
-#: Source/itemdat.cpp:300
-msgid "Raven's"
-msgstr "de corvos"
-
-#: Source/itemdat.cpp:301
-msgid "Snake's"
-msgstr "de cobras"
-
-#: Source/itemdat.cpp:302
-msgid "Serpent's"
-msgstr "de serpentes"
-
-#: Source/itemdat.cpp:303
-msgid "Drake's"
-msgstr "de draco"
-
-#: Source/itemdat.cpp:304
-msgid "Dragon's"
-msgstr "de dragão"
-
-#: Source/itemdat.cpp:305
-msgid "Wyrm's"
-msgstr "de serpe"
-
-#: Source/itemdat.cpp:306
-msgid "Hydra's"
-msgstr "de hidra"
-
-#: Source/itemdat.cpp:307
-msgid "Angel's"
-msgstr "de anjo"
-
-#: Source/itemdat.cpp:308
-msgid "Arch-Angel's"
-msgstr "de arcanjo"
-
-#: Source/itemdat.cpp:309
-msgid "Plentiful"
-msgstr "farto(a)"
-
-#: Source/itemdat.cpp:310
-msgid "Bountiful"
-msgstr "abundante"
-
-#: Source/itemdat.cpp:311
-msgid "Flaming"
-msgstr "flamejante"
-
-#: Source/itemdat.cpp:312
-msgid "Lightning"
-msgstr "relampejante"
-
-#: Source/itemdat.cpp:313
-msgid "Jester's"
-msgstr "do Bobo"
-
-#: Source/itemdat.cpp:314
-msgid "Crystalline"
-msgstr "Cristalino"
-
-#. TRANSLATORS: Item prefix section end.
-#: Source/itemdat.cpp:316
-msgid "Doppelganger's"
-msgstr "do Impostor"
-
-#. TRANSLATORS: Item suffix section. All items will have a word binding word. (Format: {:s} of {:s} - e.g. Rags of Valor)
-#: Source/itemdat.cpp:326
-msgid "quality"
-msgstr "de qualidade"
-
-#: Source/itemdat.cpp:327
-msgid "maiming"
-msgstr "do aleijamento"
-
-#: Source/itemdat.cpp:328
-msgid "slaying"
-msgstr "do homicídio"
-
-#: Source/itemdat.cpp:329
-msgid "gore"
-msgstr "da ultra-violência"
-
-#: Source/itemdat.cpp:330
-msgid "carnage"
-msgstr "da carnificina"
-
-#: Source/itemdat.cpp:331
-msgid "slaughter"
-msgstr "do massacre"
-
-#: Source/itemdat.cpp:332
-msgid "pain"
-msgstr "da dor"
-
-#: Source/itemdat.cpp:333
-msgid "tears"
-msgstr "das lágrimas"
-
-#: Source/itemdat.cpp:334
-msgid "health"
-msgstr "da saúde"
-
-#: Source/itemdat.cpp:335
-msgid "protection"
-msgstr "da proteção"
-
-#: Source/itemdat.cpp:336
-msgid "absorption"
-msgstr "da absorção"
-
-#: Source/itemdat.cpp:337
-msgid "deflection"
-msgstr "da deflexão"
-
-#: Source/itemdat.cpp:338
-msgid "osmosis"
-msgstr "da osmose"
-
-#: Source/itemdat.cpp:339
-msgid "frailty"
-msgstr "da fragilidade"
-
-#: Source/itemdat.cpp:340
-msgid "weakness"
-msgstr "da fraqueza"
-
-#: Source/itemdat.cpp:341
-msgid "strength"
-msgstr "da força"
-
-#: Source/itemdat.cpp:342
-msgid "might"
-msgstr "do poder"
-
-#: Source/itemdat.cpp:343
-msgid "power"
-msgstr "da potência"
-
-#: Source/itemdat.cpp:344
-msgid "giants"
-msgstr "dos gigantes"
-
-#: Source/itemdat.cpp:345
-msgid "titans"
-msgstr "dos titãs"
-
-#: Source/itemdat.cpp:346
-msgid "paralysis"
-msgstr "da paralisia"
-
-#: Source/itemdat.cpp:347
-msgid "atrophy"
-msgstr "da atrofia"
-
-#: Source/itemdat.cpp:348
-msgid "dexterity"
-msgstr "da destreza"
-
-#: Source/itemdat.cpp:349
-msgid "skill"
-msgstr "da habilidade"
-
-#: Source/itemdat.cpp:350
-msgid "accuracy"
-msgstr "da acurácia"
-
-#: Source/itemdat.cpp:351
-msgid "precision"
-msgstr "da precisão"
-
-#: Source/itemdat.cpp:352
-msgid "perfection"
-msgstr "da perfeição"
-
-#: Source/itemdat.cpp:353
-msgid "the fool"
-msgstr "do tolo"
-
-#: Source/itemdat.cpp:354
-msgid "dyslexia"
-msgstr "da dislexia"
-
-#: Source/itemdat.cpp:355
-msgid "magic"
-msgstr "da magia"
-
-#: Source/itemdat.cpp:356
-msgid "the mind"
-msgstr "da mente"
-
-#: Source/itemdat.cpp:357
-msgid "brilliance"
-msgstr "do brilhantismo"
-
-#: Source/itemdat.cpp:358
-msgid "sorcery"
-msgstr "da feitiçaria"
-
-#: Source/itemdat.cpp:359
-msgid "wizardry"
-msgstr "da bruxaria"
-
-#: Source/itemdat.cpp:360
-msgid "illness"
-msgstr "da enfermidade"
-
-#: Source/itemdat.cpp:361
-msgid "disease"
-msgstr "da doença"
-
-#: Source/itemdat.cpp:362
-msgid "vitality"
-msgstr "da vitalidade"
-
-#: Source/itemdat.cpp:363
-msgid "zest"
-msgstr "do ânimo"
-
-#: Source/itemdat.cpp:364
-msgid "vim"
-msgstr "do afinco"
-
-#: Source/itemdat.cpp:365
-msgid "vigor"
-msgstr "do vigor"
-
-#: Source/itemdat.cpp:366
-msgid "life"
-msgstr "da vida"
-
-#: Source/itemdat.cpp:367
-msgid "trouble"
-msgstr "da encrenca"
-
-#: Source/itemdat.cpp:368
-msgid "the pit"
-msgstr "do poço"
-
-#: Source/itemdat.cpp:369
-msgid "the sky"
-msgstr "do céu"
-
-#: Source/itemdat.cpp:370
-msgid "the moon"
-msgstr "da lua"
-
-#: Source/itemdat.cpp:371
-msgid "the stars"
-msgstr "das estrelas"
-
-#: Source/itemdat.cpp:372
-msgid "the heavens"
-msgstr "do paraíso"
-
-#: Source/itemdat.cpp:373
-msgid "the zodiac"
-msgstr "do zodíaco"
-
-#: Source/itemdat.cpp:374
-msgid "the vulture"
-msgstr "do abutre"
-
-#: Source/itemdat.cpp:375
-msgid "the jackal"
-msgstr "do chacal"
-
-#: Source/itemdat.cpp:376
-msgid "the fox"
-msgstr "da raposa"
-
-#: Source/itemdat.cpp:377
-msgid "the jaguar"
-msgstr "do jaguar"
-
-#: Source/itemdat.cpp:378
-msgid "the eagle"
-msgstr "da águia"
-
-#: Source/itemdat.cpp:379
-msgid "the wolf"
-msgstr "do lobo"
-
-#: Source/itemdat.cpp:380
-msgid "the tiger"
-msgstr "do tigre"
-
-#: Source/itemdat.cpp:381
-msgid "the lion"
-msgstr "do leão"
-
-#: Source/itemdat.cpp:382
-msgid "the mammoth"
-msgstr "do mamute"
-
-#: Source/itemdat.cpp:383
-msgid "the whale"
-msgstr "da baleia"
-
-#: Source/itemdat.cpp:384
-msgid "fragility"
-msgstr "da debilidade"
-
-#: Source/itemdat.cpp:385
-msgid "brittleness"
-msgstr "da ruptilidade"
-
-#: Source/itemdat.cpp:386
-msgid "sturdiness"
-msgstr "da firmeza"
-
-#: Source/itemdat.cpp:387
-msgid "craftsmanship"
-msgstr "da competência"
-
-#: Source/itemdat.cpp:388
-msgid "structure"
-msgstr "da estrutura"
-
-#: Source/itemdat.cpp:389
-msgid "the ages"
-msgstr "das eras"
-
-#: Source/itemdat.cpp:390
-msgid "the dark"
-msgstr "do escuro"
-
-#: Source/itemdat.cpp:391
-msgid "the night"
-msgstr "da noite"
-
-#: Source/itemdat.cpp:392
-msgid "light"
-msgstr "da luz"
-
-#: Source/itemdat.cpp:393
-msgid "radiance"
-msgstr "da radiância"
-
-#: Source/itemdat.cpp:394
-msgid "flame"
-msgstr "da chama"
-
-#: Source/itemdat.cpp:395
-msgid "fire"
-msgstr "do fogo"
-
-#: Source/itemdat.cpp:396
-msgid "burning"
-msgstr "calcinante"
-
-#: Source/itemdat.cpp:397
-msgid "shock"
-msgstr "do choque"
-
-#: Source/itemdat.cpp:398
-msgid "lightning"
-msgstr "do relâmpago"
-
-#: Source/itemdat.cpp:399
-msgid "thunder"
-msgstr "do trovão"
-
-#: Source/itemdat.cpp:400
-msgid "many"
-msgstr "dos muitos"
-
-#: Source/itemdat.cpp:401
-msgid "plenty"
-msgstr "da abundância"
-
-#: Source/itemdat.cpp:402
-msgid "thorns"
-msgstr "dos espinhos"
-
-#: Source/itemdat.cpp:403
-msgid "corruption"
-msgstr "da corrupção"
-
-#: Source/itemdat.cpp:404
-msgid "thieves"
-msgstr "dos ladrões"
-
-#: Source/itemdat.cpp:405
-msgid "the bear"
-msgstr "do urso"
-
-#: Source/itemdat.cpp:406
-msgid "the bat"
-msgstr "do morcego"
-
-#: Source/itemdat.cpp:407
-msgid "vampires"
-msgstr "dos vampiros"
-
-#: Source/itemdat.cpp:408
-msgid "the leech"
-msgstr "do sanguessuga"
-
-#: Source/itemdat.cpp:409
-msgid "blood"
-msgstr "do sangue"
-
-#: Source/itemdat.cpp:410
-msgid "piercing"
-msgstr "da perfuração"
-
-#: Source/itemdat.cpp:411
-msgid "puncturing"
-msgstr "da punção"
-
-#: Source/itemdat.cpp:412
-msgid "bashing"
-msgstr "do esmagamento"
-
-#: Source/itemdat.cpp:413
-msgid "readiness"
-msgstr "da prontidão"
-
-#: Source/itemdat.cpp:414
-msgid "swiftness"
-msgstr "da presteza"
-
-#: Source/itemdat.cpp:415
-msgid "speed"
-msgstr "da velocidade"
-
-#: Source/itemdat.cpp:416
-msgid "haste"
-msgstr "da pressa"
-
-#: Source/itemdat.cpp:417
-msgid "balance"
-msgstr "do equilíbrio"
-
-#: Source/itemdat.cpp:418
-msgid "stability"
-msgstr "da estabilidade"
-
-#: Source/itemdat.cpp:419
-msgid "harmony"
-msgstr "da harmonia"
-
-#: Source/itemdat.cpp:420
-msgid "blocking"
-msgstr "do bloqueio"
-
-#: Source/itemdat.cpp:421
-msgid "devastation"
-msgstr "da devastação"
-
-#: Source/itemdat.cpp:422
-msgid "decay"
-msgstr "declínio"
-
-#. TRANSLATORS: Item suffix section end.
-#: Source/itemdat.cpp:424
-msgid "peril"
-msgstr "perigo"
-
-#. TRANSLATORS: Unique Item section
-#: Source/itemdat.cpp:434
-msgid "The Butcher's Cleaver"
-msgstr "Cutelo do Açougueiro"
-
-#: Source/itemdat.cpp:444
-msgid "The Rift Bow"
-msgstr "Arco da ruptura"
-
-#: Source/itemdat.cpp:445
-msgid "The Needler"
-msgstr "O agulheiro"
-
-#: Source/itemdat.cpp:446
-msgid "The Celestial Bow"
-msgstr "O arco celestial"
-
-#: Source/itemdat.cpp:447
-msgid "Deadly Hunter"
-msgstr "Caçador mortal"
-
-#: Source/itemdat.cpp:448
-msgid "Bow of the Dead"
-msgstr "Arco dos mortos"
-
-#: Source/itemdat.cpp:449
-msgid "The Blackoak Bow"
-msgstr "Arco do carvalho negro"
-
-#: Source/itemdat.cpp:450
-msgid "Flamedart"
-msgstr "Dardo das chamas"
-
-#: Source/itemdat.cpp:451
-msgid "Fleshstinger"
-msgstr "Ferroa-carne"
-
-#: Source/itemdat.cpp:452
-msgid "Windforce"
-msgstr "Força do vento"
-
-#: Source/itemdat.cpp:453
-msgid "Eaglehorn"
-msgstr "Chifre de águia"
-
-#: Source/itemdat.cpp:454
-msgid "Gonnagal's Dirk"
-msgstr "Punhal de Gonnagal"
-
-#: Source/itemdat.cpp:455
-msgid "The Defender"
-msgstr "O defensor"
-
-#: Source/itemdat.cpp:456
-msgid "Gryphon's Claw"
-msgstr "Garra do Grifo"
-
-#: Source/itemdat.cpp:457
-msgid "Black Razor"
-msgstr "Navalha negra"
-
-#: Source/itemdat.cpp:458
-msgid "Gibbous Moon"
-msgstr "Lua crescente"
-
-#: Source/itemdat.cpp:459
-msgid "Ice Shank"
-msgstr "Haste de gelo"
-
-#: Source/itemdat.cpp:460
-msgid "The Executioner's Blade"
-msgstr "Lâmina do carrasco"
-
-#: Source/itemdat.cpp:461
-msgid "The Bonesaw"
-msgstr "A serra de osso"
-
-#: Source/itemdat.cpp:462
-msgid "Shadowhawk"
-msgstr "Gavião das sombras"
-
-#: Source/itemdat.cpp:463
-msgid "Wizardspike"
-msgstr "Espinho arcano"
-
-#: Source/itemdat.cpp:464
-msgid "Lightsabre"
-msgstr "Sabre de luz"
-
-#: Source/itemdat.cpp:465
-msgid "The Falcon's Talon"
-msgstr "Garra do falcão"
-
-#: Source/itemdat.cpp:466
-msgid "Inferno"
-msgstr "Inferno"
-
-#: Source/itemdat.cpp:467
-msgid "Doombringer"
-msgstr "Ruinosa"
-
-#: Source/itemdat.cpp:468
-msgid "The Grizzly"
-msgstr "O Urso Pardo"
-
-#: Source/itemdat.cpp:469
-msgid "The Grandfather"
-msgstr "O Avô"
-
-#: Source/itemdat.cpp:470
-msgid "The Mangler"
-msgstr "O Estraçalhador"
-
-#: Source/itemdat.cpp:471
-msgid "Sharp Beak"
-msgstr "Bico afiado"
-
-#: Source/itemdat.cpp:472
-msgid "BloodSlayer"
-msgstr "Assassino sangrento"
-
-#: Source/itemdat.cpp:473
-msgid "The Celestial Axe"
-msgstr "O machado celestial"
-
-#: Source/itemdat.cpp:474
-msgid "Wicked Axe"
-msgstr "Machado maligno"
-
-#: Source/itemdat.cpp:475
-msgid "Stonecleaver"
-msgstr "Cutelo de pedra"
-
-#: Source/itemdat.cpp:476
-msgid "Aguinara's Hatchet"
-msgstr "Machadinha de Aguinara"
-
-#: Source/itemdat.cpp:477
-msgid "Hellslayer"
-msgstr "Assassino infernal"
-
-#: Source/itemdat.cpp:478
-msgid "Messerschmidt's Reaver"
-msgstr "Ceifador de Messerschmidt"
-
-#: Source/itemdat.cpp:479
-msgid "Crackrust"
-msgstr "Racharrugem"
-
-#: Source/itemdat.cpp:480
-msgid "Hammer of Jholm"
-msgstr "Martelo de Jholm"
-
-#: Source/itemdat.cpp:481
-msgid "Civerb's Cudgel"
-msgstr "Tacape de Civerb"
-
-#: Source/itemdat.cpp:482
-msgid "The Celestial Star"
-msgstr "A estrela celestial"
-
-#: Source/itemdat.cpp:483
-msgid "Baranar's Star"
-msgstr "Estrela de Baranar"
-
-#: Source/itemdat.cpp:484
-msgid "Gnarled Root"
-msgstr "Raiz nodosa"
-
-#: Source/itemdat.cpp:485
-msgid "The Cranium Basher"
-msgstr "O amassador de crânios"
-
-#: Source/itemdat.cpp:486
-msgid "Schaefer's Hammer"
-msgstr "Martelo de Schaefer"
-
-#: Source/itemdat.cpp:487
-msgid "Dreamflange"
-msgstr "Flange onírico"
-
-#: Source/itemdat.cpp:488
-msgid "Staff of Shadows"
-msgstr "Cajado das sombras"
-
-#: Source/itemdat.cpp:489
-msgid "Immolator"
-msgstr "Imolador"
-
-#: Source/itemdat.cpp:490
-msgid "Storm Spire"
-msgstr "Ápice da tempestade"
-
-#: Source/itemdat.cpp:491
-msgid "Gleamsong"
-msgstr "Canção do vislumbre"
-
-#: Source/itemdat.cpp:492
-msgid "Thundercall"
-msgstr "Chamado do trovão"
-
-#: Source/itemdat.cpp:493
-msgid "The Protector"
-msgstr "O protetor"
-
-#: Source/itemdat.cpp:494
-msgid "Naj's Puzzler"
-msgstr "Enigma de Naj"
-
-#: Source/itemdat.cpp:495
-msgid "Mindcry"
-msgstr "Grito da mente"
-
-#: Source/itemdat.cpp:496
-msgid "Rod of Onan"
-msgstr "Vara de Onan"
-
-#: Source/itemdat.cpp:497
-msgid "Helm of Spirits"
-msgstr "Elmo dos Espíritos"
-
-#: Source/itemdat.cpp:498
-msgid "Thinking Cap"
-msgstr "Quepe de reflexão"
-
-#: Source/itemdat.cpp:499
-msgid "OverLord's Helm"
-msgstr "Elmo do Suserano"
-
-#: Source/itemdat.cpp:500
-msgid "Fool's Crest"
-msgstr "Brasão do bobo"
-
-#: Source/itemdat.cpp:501
-msgid "Gotterdamerung"
-msgstr "Götterdämerung"
-
-#: Source/itemdat.cpp:502
-msgid "Royal Circlet"
-msgstr "Diadema real"
-
-#: Source/itemdat.cpp:503
-msgid "Torn Flesh of Souls"
-msgstr "Carne rasgada de almas"
-
-#: Source/itemdat.cpp:504
-msgid "The Gladiator's Bane"
-msgstr "Flagelo do gladiador"
-
-#: Source/itemdat.cpp:505
-msgid "The Rainbow Cloak"
-msgstr "O manto arco-íris"
-
-#: Source/itemdat.cpp:506
-msgid "Leather of Aut"
-msgstr "Couro de Aut"
-
-#: Source/itemdat.cpp:507
-msgid "Wisdom's Wrap"
-msgstr "Xale da sabedoria"
-
-#: Source/itemdat.cpp:508
-msgid "Sparking Mail"
-msgstr "Malha faiscante"
-
-#: Source/itemdat.cpp:509
-msgid "Scavenger Carapace"
-msgstr "Carapaça do Vorazgo"
-
-#: Source/itemdat.cpp:510
-msgid "Nightscape"
-msgstr "Paisagem da noite"
-
-#: Source/itemdat.cpp:511
-msgid "Naj's Light Plate"
-msgstr "Placa leve de Naj"
-
-#: Source/itemdat.cpp:512
-msgid "Demonspike Coat"
-msgstr "Casaco de demonispeto"
-
-#: Source/itemdat.cpp:513
-msgid "The Deflector"
-msgstr "O defletor"
-
-#: Source/itemdat.cpp:514
-msgid "Split Skull Shield"
-msgstr "Escudo de crânio partido"
-
-#: Source/itemdat.cpp:515
-msgid "Dragon's Breach"
-msgstr "Fenda do dragão"
-
-#: Source/itemdat.cpp:516
-msgid "Blackoak Shield"
-msgstr "Escudo do carvalho negro"
-
-#: Source/itemdat.cpp:517
-msgid "Holy Defender"
-msgstr "Defensor santo"
-
-#: Source/itemdat.cpp:518
-msgid "Stormshield"
-msgstr "Escudo da tempestade"
-
-#: Source/itemdat.cpp:519
-msgid "Bramble"
-msgstr "Silveira"
-
-#: Source/itemdat.cpp:520
-msgid "Ring of Regha"
-msgstr "Anel de Regha"
-
-#: Source/itemdat.cpp:521
-msgid "The Bleeder"
-msgstr "O sangrador"
-
-#: Source/itemdat.cpp:522
-msgid "Constricting Ring"
-msgstr "Anel constringente"
-
-#: Source/itemdat.cpp:523
-msgid "Ring of Engagement"
-msgstr "Anel de noivado"
-
-#: Source/itemdat.cpp:524
-msgid "Giant's Knuckle"
-msgstr "Junta do gigante"
-
-#: Source/itemdat.cpp:525
-msgid "Mercurial Ring"
-msgstr "Anel mercurial"
-
-#: Source/itemdat.cpp:526
-msgid "Xorine's Ring"
-msgstr "Anel de Xorine"
-
-#: Source/itemdat.cpp:527
-msgid "Karik's Ring"
-msgstr "Anel de Karik"
-
-#: Source/itemdat.cpp:528
-msgid "Ring of Magma"
-msgstr "Anel de magma"
-
-#: Source/itemdat.cpp:529
-msgid "Ring of the Mystics"
-msgstr "Anel dos místicos"
-
-#: Source/itemdat.cpp:530
-msgid "Ring of Thunder"
-msgstr "Anel do trovão"
-
-#: Source/itemdat.cpp:531
-msgid "Amulet of Warding"
-msgstr "Amuleto de proteção"
-
-#: Source/itemdat.cpp:532
-msgid "Gnat Sting"
-msgstr "Picada de mosquito"
-
-#: Source/itemdat.cpp:533
-msgid "Flambeau"
-msgstr "Tocha"
-
-#: Source/itemdat.cpp:534
-msgid "Armor of Gloom"
-msgstr "Armadura da penumbra"
-
-#: Source/itemdat.cpp:535
-msgid "Blitzen"
-msgstr "Blitzen"
-
-#: Source/itemdat.cpp:536
-msgid "Thunderclap"
-msgstr "Trovoada"
-
-#: Source/itemdat.cpp:537
-msgid "Shirotachi"
-msgstr "Shirotachi"
-
-#: Source/itemdat.cpp:538
-msgid "Eater of Souls"
-msgstr "Devorador de almas"
-
-#: Source/itemdat.cpp:539
-msgid "Diamondedge"
-msgstr "Diamondedge"
-
-#: Source/itemdat.cpp:540
-msgid "Bone Chain Armor"
-msgstr "Armadura de cadeias de ossos"
-
-#: Source/itemdat.cpp:541
-msgid "Demon Plate Armor"
-msgstr "Armadura de placas de demônio"
-
-#: Source/itemdat.cpp:542
-msgid "Acolyte's Amulet"
-msgstr "Amuleto de acólito"
-
-#. TRANSLATORS: Unique Item section end.
-#: Source/itemdat.cpp:544
-msgid "Gladiator's Ring"
-msgstr "Anel do gladiador"
-
-#: Source/items.cpp:176
+#: Source/items.cpp:181
 msgid "Oil of Mastery"
 msgstr "Óleo da maestria"
 
-#: Source/items.cpp:178
+#: Source/items.cpp:182 Source/translation_dummy.cpp:361
+msgid "Oil of Sharpness"
+msgstr "Óleo da Nitidez"
+
+#: Source/items.cpp:183
 msgid "Oil of Death"
 msgstr "Óleo da morte"
 
-#: Source/items.cpp:179
+#: Source/items.cpp:184
 msgid "Oil of Skill"
 msgstr "Óleo de habilidade"
 
-#: Source/items.cpp:181
+#: Source/items.cpp:185 Source/translation_dummy.cpp:282
+#: Source/translation_dummy.cpp:359
+msgid "Blacksmith Oil"
+msgstr "Óleo do ferreiro"
+
+#: Source/items.cpp:186
 msgid "Oil of Fortitude"
 msgstr "Óleo de fortitude"
 
-#: Source/items.cpp:182
+#: Source/items.cpp:187
 msgid "Oil of Permanence"
 msgstr "Óleo de permanência"
 
-#: Source/items.cpp:183
+#: Source/items.cpp:188
 msgid "Oil of Hardening"
 msgstr "Óleo de endurecimento"
 
-#: Source/items.cpp:184
+#: Source/items.cpp:189
 msgid "Oil of Imperviousness"
 msgstr "Óleo de impermeabilidade"
 
 #. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
-#: Source/items.cpp:1113
+#: Source/items.cpp:1101
 msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{0} {1}"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1125
+#: Source/items.cpp:1113
 msgctxt "spell"
 msgid "{0} {1} of {2}"
 msgstr "{0} {1} {2}"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
-#: Source/items.cpp:1163
+#: Source/items.cpp:1151
 msgid "{0} {1} of {2}"
 msgstr "{0} {1} {2}"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#: Source/items.cpp:1166
+#: Source/items.cpp:1154
 msgid "{0} {1}"
 msgstr "{0} {1}"
 
 #. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
-#: Source/items.cpp:1169
+#: Source/items.cpp:1157
 msgid "{0} of {1}"
 msgstr "{0} {1}"
 
-#: Source/items.cpp:1695 Source/items.cpp:1703
+#: Source/items.cpp:1654 Source/items.cpp:1662
 msgid "increases a weapon's"
 msgstr "aumenta"
 
-#: Source/items.cpp:1696
+#: Source/items.cpp:1655
 msgid "chance to hit"
 msgstr "chance de acerto"
 
-#: Source/items.cpp:1699
+#: Source/items.cpp:1658
 msgid "greatly increases a"
 msgstr "aumenta enormemente um"
 
-#: Source/items.cpp:1700
+#: Source/items.cpp:1659
 msgid "weapon's chance to hit"
 msgstr "chance de acerto da arma"
 
-#: Source/items.cpp:1704
+#: Source/items.cpp:1663
 msgid "damage potential"
 msgstr "potencial de dano"
 
-#: Source/items.cpp:1707
+#: Source/items.cpp:1666
 msgid "greatly increases a weapon's"
 msgstr "aumenta enormemente"
 
-#: Source/items.cpp:1708
+#: Source/items.cpp:1667
 msgid "damage potential - not bows"
 msgstr "potencial de dano - não arcos"
 
-#: Source/items.cpp:1711
+#: Source/items.cpp:1670
 msgid "reduces attributes needed"
 msgstr "reduz atributo requerido"
 
-#: Source/items.cpp:1712
+#: Source/items.cpp:1671
 msgid "to use armor or weapons"
 msgstr "para usar armaduras ou armas"
 
-#: Source/items.cpp:1715
+#: Source/items.cpp:1674
 #, no-c-format
 msgid "restores 20% of an"
 msgstr "restaura 20% de um"
 
-#: Source/items.cpp:1716
+#: Source/items.cpp:1675
 msgid "item's durability"
 msgstr "durabilidade do item"
 
-#: Source/items.cpp:1719
+#: Source/items.cpp:1678
 msgid "increases an item's"
 msgstr "aumenta"
 
-#: Source/items.cpp:1720
+#: Source/items.cpp:1679
 msgid "current and max durability"
 msgstr "durabilidade atual e máxima"
 
-#: Source/items.cpp:1723
+#: Source/items.cpp:1682
 msgid "makes an item indestructible"
 msgstr "faz com que um item seja indestrutível"
 
-#: Source/items.cpp:1726
+#: Source/items.cpp:1685
 msgid "increases the armor class"
 msgstr "aumenta a classe de armadura"
 
-#: Source/items.cpp:1727
+#: Source/items.cpp:1686
 msgid "of armor and shields"
 msgstr "de armaduras e escudos"
 
-#: Source/items.cpp:1730
+#: Source/items.cpp:1689
 msgid "greatly increases the armor"
 msgstr "aumenta enormemente a armadura"
 
-#: Source/items.cpp:1731
+#: Source/items.cpp:1690
 msgid "class of armor and shields"
 msgstr "classe de armaduras e escudos"
 
-#: Source/items.cpp:1734 Source/items.cpp:1741
+#: Source/items.cpp:1693 Source/items.cpp:1700
 msgid "sets fire trap"
 msgstr "coloca armadilha de fogo"
 
-#: Source/items.cpp:1738
+#: Source/items.cpp:1697
 msgid "sets lightning trap"
 msgstr "coloca armadilha de relâmpagos"
 
-#: Source/items.cpp:1744
+#: Source/items.cpp:1703
 msgid "sets petrification trap"
 msgstr "coloca armadilha de petrificação"
 
-#: Source/items.cpp:1747
+#: Source/items.cpp:1706
 msgid "restore all life"
 msgstr "restaura toda a vida"
 
-#: Source/items.cpp:1750
+#: Source/items.cpp:1709
 msgid "restore some life"
 msgstr "restaura alguma vida"
 
-#: Source/items.cpp:1753
+#: Source/items.cpp:1712
 msgid "restore some mana"
 msgstr "restaura um pouco de mana"
 
-#: Source/items.cpp:1756
+#: Source/items.cpp:1715
 msgid "restore all mana"
 msgstr "restaura toda a mana"
 
-#: Source/items.cpp:1759
+#: Source/items.cpp:1718
 msgid "increase strength"
 msgstr "aumenta força"
 
-#: Source/items.cpp:1762
+#: Source/items.cpp:1721
 msgid "increase magic"
 msgstr "aumenta magia"
 
-#: Source/items.cpp:1765
+#: Source/items.cpp:1724
 msgid "increase dexterity"
 msgstr "aumenta destreza"
 
-#: Source/items.cpp:1768
+#: Source/items.cpp:1727
 msgid "increase vitality"
 msgstr "aumenta vitalidade"
 
-#: Source/items.cpp:1771
+#: Source/items.cpp:1730
 msgid "restore some life and mana"
 msgstr "restaura um pouco de vida e mana"
 
-#: Source/items.cpp:1774 Source/items.cpp:1777
+#: Source/items.cpp:1733 Source/items.cpp:1736
 msgid "restore all life and mana"
 msgstr "restaura toda a vida e mana"
 
-#: Source/items.cpp:1778
+#: Source/items.cpp:1737
 msgid "(works only in arenas)"
 msgstr "(funciona apenas em arenas)"
 
-#: Source/items.cpp:1792
+#: Source/items.cpp:1772
 msgid "Right-click to view"
 msgstr "Clique direito para visualizar"
 
-#: Source/items.cpp:1795
+#: Source/items.cpp:1775
 msgid "Right-click to use"
 msgstr "Clique direito para usar"
 
-#: Source/items.cpp:1797
+#: Source/items.cpp:1777
 msgid ""
 "Right-click to read, then\n"
 "left-click to target"
@@ -4328,23 +2764,23 @@ msgstr ""
 "Clique direito para ler e então\n"
 "clique esquerdo para golpear"
 
-#: Source/items.cpp:1799
+#: Source/items.cpp:1779
 msgid "Right-click to read"
 msgstr "Clique direito para ler"
 
-#: Source/items.cpp:1806
+#: Source/items.cpp:1786
 msgid "Activate to view"
 msgstr "Ative para visualizar"
 
-#: Source/items.cpp:1810 Source/items.cpp:1848
+#: Source/items.cpp:1790 Source/items.cpp:1815
 msgid "Open inventory to use"
 msgstr "Abrir tela de inventário"
 
-#: Source/items.cpp:1812
+#: Source/items.cpp:1792
 msgid "Activate to use"
 msgstr "Ative para usar"
 
-#: Source/items.cpp:1815
+#: Source/items.cpp:1795
 msgid ""
 "Select from spell book, then\n"
 "cast spell to read"
@@ -4352,19 +2788,19 @@ msgstr ""
 "Selecione do livro de feitiços, então\n"
 "lance o feitiço para ler"
 
-#: Source/items.cpp:1817
+#: Source/items.cpp:1797
 msgid "Activate to read"
 msgstr "Ative para ler"
 
-#: Source/items.cpp:1844
+#: Source/items.cpp:1811
 msgid "{} to view"
 msgstr "{} para visualizar"
 
-#: Source/items.cpp:1850
+#: Source/items.cpp:1817
 msgid "{} to use"
 msgstr "{} para usar"
 
-#: Source/items.cpp:1853
+#: Source/items.cpp:1820
 msgid ""
 "Select from spell book,\n"
 "then {} to read"
@@ -4372,425 +2808,430 @@ msgstr ""
 "Selecionar feitiço atual, \n"
 "então {} para ler"
 
-#: Source/items.cpp:1855
+#: Source/items.cpp:1822
 msgid "{} to read"
 msgstr "{} para ler"
 
-#: Source/items.cpp:1862
+#: Source/items.cpp:1829
 msgctxt "player"
 msgid "Level: {:d}"
 msgstr "Nível: {:d}"
 
-#: Source/items.cpp:1866
+#: Source/items.cpp:1833
 msgid "Doubles gold capacity"
 msgstr "Duplica a capacidade de ouro"
 
-#: Source/items.cpp:1898 Source/stores.cpp:325
+#: Source/items.cpp:1866 Source/stores.cpp:327
 msgid "Required:"
 msgstr "Requerido:"
 
-#: Source/items.cpp:1900 Source/stores.cpp:327
+#: Source/items.cpp:1868 Source/stores.cpp:329
 msgid " {:d} Str"
 msgstr " {:d} For"
 
-#: Source/items.cpp:1902 Source/stores.cpp:329
+#: Source/items.cpp:1870 Source/stores.cpp:331
 msgid " {:d} Mag"
 msgstr " {:d} Mag"
 
-#: Source/items.cpp:1904 Source/stores.cpp:331
+#: Source/items.cpp:1872 Source/stores.cpp:333
 msgid " {:d} Dex"
 msgstr " {:d} Des"
 
+#. TRANSLATORS: {:s} will be a spell name
+#: Source/items.cpp:2227
+msgid "Book of {:s}"
+msgstr "Livro de {:s}"
+
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:2279
+#: Source/items.cpp:2229
 msgid "Ear of {:s}"
 msgstr "Orelha de {:s}"
 
-#: Source/items.cpp:3704
+#: Source/items.cpp:3885
 msgid "chance to hit: {:+d}%"
 msgstr "chance de acerto: {:+d}%"
 
-#: Source/items.cpp:3707
+#: Source/items.cpp:3888
 #, no-c-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% de dano"
 
-#: Source/items.cpp:3710 Source/items.cpp:3894
+#: Source/items.cpp:3891 Source/items.cpp:4073
 msgid "to hit: {:+d}%, {:+d}% damage"
 msgstr "acerto: {:+d}%, {:+d}% de dano"
 
-#: Source/items.cpp:3713
+#: Source/items.cpp:3894
 #, no-c-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% de armadura"
 
-#: Source/items.cpp:3716
+#: Source/items.cpp:3897
 msgid "armor class: {:d}"
 msgstr "classe de armadura: {:d}"
 
-#: Source/items.cpp:3720
+#: Source/items.cpp:3901
 msgid "Resist Fire: {:+d}%"
 msgstr "Resistência a fogo: {:+d}%"
 
-#: Source/items.cpp:3722
+#: Source/items.cpp:3903
 msgid "Resist Fire: {:+d}% MAX"
 msgstr "Resistência a fogo: {:+d}% MÁX"
 
-#: Source/items.cpp:3726
+#: Source/items.cpp:3907
 msgid "Resist Lightning: {:+d}%"
 msgstr "Resistência a raios: {:+d}%"
 
-#: Source/items.cpp:3728
+#: Source/items.cpp:3909
 msgid "Resist Lightning: {:+d}% MAX"
 msgstr "Resistência a raios: {:+d}% MÁX"
 
-#: Source/items.cpp:3732
+#: Source/items.cpp:3913
 msgid "Resist Magic: {:+d}%"
 msgstr "Resistência à magia: {:+d}%"
 
-#: Source/items.cpp:3734
+#: Source/items.cpp:3915
 msgid "Resist Magic: {:+d}% MAX"
 msgstr "Resistência à magia: {:+d}% MÁX"
 
-#: Source/items.cpp:3737
+#: Source/items.cpp:3918
 msgid "Resist All: {:+d}%"
 msgstr "Resistência a tudo: {:+d}%"
 
-#: Source/items.cpp:3739
+#: Source/items.cpp:3920
 msgid "Resist All: {:+d}% MAX"
 msgstr "Resistência a tudo: {:+d}% MÁX"
 
-#: Source/items.cpp:3742
+#: Source/items.cpp:3923
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "feitiços aumentam {:d} nível"
 msgstr[1] "feitiços aumentam {:d} níveis"
 
-#: Source/items.cpp:3744
+#: Source/items.cpp:3925
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "feitiços diminuem {:d} nível"
 msgstr[1] "feitiços diminuem {:d} níveis"
 
-#: Source/items.cpp:3746
+#: Source/items.cpp:3927
 msgid "spell levels unchanged (?)"
 msgstr "níveis de feitiço inalterados (?)"
 
-#: Source/items.cpp:3748
+#: Source/items.cpp:3929
 msgid "Extra charges"
 msgstr "Cargas extra"
 
-#: Source/items.cpp:3750
+#: Source/items.cpp:3931
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} carga"
 msgstr[1] "{:d} {:s} cargas"
 
-#: Source/items.cpp:3753
+#: Source/items.cpp:3934
 msgid "Fire hit damage: {:d}"
 msgstr "Dano do acerto de fogo: {:d}"
 
-#: Source/items.cpp:3755
+#: Source/items.cpp:3936
 msgid "Fire hit damage: {:d}-{:d}"
 msgstr "Dano do acerto de fogo: {:d}-{:d}"
 
-#: Source/items.cpp:3758
+#: Source/items.cpp:3939
 msgid "Lightning hit damage: {:d}"
 msgstr "Dano do acerto de raios: {:d}"
 
-#: Source/items.cpp:3760
+#: Source/items.cpp:3941
 msgid "Lightning hit damage: {:d}-{:d}"
 msgstr "Dano do acerto de raios: {:d}-{:d}"
 
-#: Source/items.cpp:3763
+#: Source/items.cpp:3944
 msgid "{:+d} to strength"
 msgstr "{:+d} para força"
 
-#: Source/items.cpp:3766
+#: Source/items.cpp:3947
 msgid "{:+d} to magic"
 msgstr "{:+d} para magia"
 
-#: Source/items.cpp:3769
+#: Source/items.cpp:3950
 msgid "{:+d} to dexterity"
 msgstr "{:+d} para destreza"
 
-#: Source/items.cpp:3772
+#: Source/items.cpp:3953
 msgid "{:+d} to vitality"
 msgstr "{:+d} para vitalidade"
 
-#: Source/items.cpp:3775
+#: Source/items.cpp:3956
 msgid "{:+d} to all attributes"
 msgstr "{:+d} a todos os atributos"
 
-#: Source/items.cpp:3778
+#: Source/items.cpp:3959
 msgid "{:+d} damage from enemies"
 msgstr "{:+d} de dano a inimigos"
 
-#: Source/items.cpp:3781
+#: Source/items.cpp:3962
 msgid "Hit Points: {:+d}"
 msgstr "Pontos de vida: {:+d}"
 
-#: Source/items.cpp:3784
+#: Source/items.cpp:3965
 msgid "Mana: {:+d}"
 msgstr "Mana: {:+d}"
 
-#: Source/items.cpp:3786
+#: Source/items.cpp:3967
 msgid "high durability"
 msgstr "alta durabilidade"
 
-#: Source/items.cpp:3788
+#: Source/items.cpp:3969
 msgid "decreased durability"
 msgstr "durabilidade diminuída"
 
-#: Source/items.cpp:3790
+#: Source/items.cpp:3971
 msgid "indestructible"
 msgstr "indestrutível"
 
-#: Source/items.cpp:3792
+#: Source/items.cpp:3973
 #, no-c-format
 msgid "+{:d}% light radius"
 msgstr "+{:d}% de alcance de visão"
 
-#: Source/items.cpp:3794
+#: Source/items.cpp:3975
 #, no-c-format
 msgid "-{:d}% light radius"
 msgstr "-{:d}% de alcance de visão"
 
-#: Source/items.cpp:3796
+#: Source/items.cpp:3977
 msgid "multiple arrows per shot"
 msgstr "várias flechas por disparo"
 
-#: Source/items.cpp:3799
+#: Source/items.cpp:3980
 msgid "fire arrows damage: {:d}"
 msgstr "dano das flechas de fogo: {:d}"
 
-#: Source/items.cpp:3801
+#: Source/items.cpp:3982
 msgid "fire arrows damage: {:d}-{:d}"
 msgstr "dano das flechas de fogo: {:d}-{:d}"
 
-#: Source/items.cpp:3804
+#: Source/items.cpp:3985
 msgid "lightning arrows damage {:d}"
 msgstr "dano das flechas de raios {:d}"
 
-#: Source/items.cpp:3806
+#: Source/items.cpp:3987
 msgid "lightning arrows damage {:d}-{:d}"
 msgstr "dano das flechas de raios {:d}-{:d}"
 
-#: Source/items.cpp:3809
+#: Source/items.cpp:3990
 msgid "fireball damage: {:d}"
 msgstr "dano das bolas de fogo: {:d}"
 
-#: Source/items.cpp:3811
+#: Source/items.cpp:3992
 msgid "fireball damage: {:d}-{:d}"
 msgstr "dano das bolas de fogo: {:d}-{:d}"
 
-#: Source/items.cpp:3813
+#: Source/items.cpp:3994
 msgid "attacker takes 1-3 damage"
 msgstr "atacante leva 1-3 de dano"
 
-#: Source/items.cpp:3815
+#: Source/items.cpp:3996
 msgid "user loses all mana"
 msgstr "usuário perde toda a mana"
 
-#: Source/items.cpp:3817
+#: Source/items.cpp:3998
 msgid "absorbs half of trap damage"
 msgstr "enfraquece armadilhas 50%"
 
-#: Source/items.cpp:3819
+#: Source/items.cpp:4000
 msgid "knocks target back"
 msgstr "empurra alvo para trás"
 
-#: Source/items.cpp:3821
+#: Source/items.cpp:4002
 #, no-c-format
 msgid "+200% damage vs. demons"
 msgstr "+200% de dano vs. demônios"
 
-#: Source/items.cpp:3823
+#: Source/items.cpp:4004
 msgid "All Resistance equals 0"
 msgstr "Todas Resistências viram 0"
 
-#: Source/items.cpp:3826
+#: Source/items.cpp:4007
 #, no-c-format
 msgid "hit steals 3% mana"
 msgstr "acerto rouba 3% de mana"
 
-#: Source/items.cpp:3828
+#: Source/items.cpp:4009
 #, no-c-format
 msgid "hit steals 5% mana"
 msgstr "acerto rouba 5% de mana"
 
-#: Source/items.cpp:3832
+#: Source/items.cpp:4013
 #, no-c-format
 msgid "hit steals 3% life"
 msgstr "acerto rouba 3% de vida"
 
-#: Source/items.cpp:3834
+#: Source/items.cpp:4015
 #, no-c-format
 msgid "hit steals 5% life"
 msgstr "acerto rouba 5% de vida"
 
-#: Source/items.cpp:3837
+#: Source/items.cpp:4018
 msgid "penetrates target's armor"
 msgstr "danifica armadura do alvo"
 
-#: Source/items.cpp:3840
+#: Source/items.cpp:4021
 msgid "quick attack"
 msgstr "ataque breve"
 
-#: Source/items.cpp:3842
+#: Source/items.cpp:4023
 msgid "fast attack"
 msgstr "ataque rápido"
 
-#: Source/items.cpp:3844
+#: Source/items.cpp:4025
 msgid "faster attack"
 msgstr "ataque mais rápido"
 
-#: Source/items.cpp:3846
+#: Source/items.cpp:4027
 msgid "fastest attack"
 msgstr "ataque muito rápido"
 
-#: Source/items.cpp:3847 Source/items.cpp:3855 Source/items.cpp:3904
+#: Source/items.cpp:4028 Source/items.cpp:4036 Source/items.cpp:4083
 msgid "Another ability (NW)"
 msgstr "Outra habilidade (NW)"
 
-#: Source/items.cpp:3850
+#: Source/items.cpp:4031
 msgid "fast hit recovery"
 msgstr "recupera rápido de ataque"
 
-#: Source/items.cpp:3852
+#: Source/items.cpp:4033
 msgid "faster hit recovery"
 msgstr "rec. mais rápido de ataque"
 
-#: Source/items.cpp:3854
+#: Source/items.cpp:4035
 msgid "fastest hit recovery"
 msgstr "rec. muito rápida de atq."
 
-#: Source/items.cpp:3857
+#: Source/items.cpp:4038
 msgid "fast block"
 msgstr "bloqueio rápido"
 
-#: Source/items.cpp:3859
+#: Source/items.cpp:4040
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "adiciona {:d} ponto de dano"
 msgstr[1] "adiciona {:d} pontos de dano"
 
-#: Source/items.cpp:3861
+#: Source/items.cpp:4042
 msgid "fires random speed arrows"
 msgstr "dá flechas de vel. variada"
 
-#: Source/items.cpp:3863
+#: Source/items.cpp:4044
 msgid "unusual item damage"
 msgstr "dano de item incomum"
 
-#: Source/items.cpp:3865
+#: Source/items.cpp:4046
 msgid "altered durability"
 msgstr "durabilidade alterada"
 
-#: Source/items.cpp:3867
+#: Source/items.cpp:4048
 msgid "one handed sword"
 msgstr "espada de uma mão"
 
-#: Source/items.cpp:3869
+#: Source/items.cpp:4050
 msgid "constantly lose hit points"
 msgstr "constantemente perde PV"
 
-#: Source/items.cpp:3871
+#: Source/items.cpp:4052
 msgid "life stealing"
 msgstr "rouba vida"
 
-#: Source/items.cpp:3873
+#: Source/items.cpp:4054
 msgid "no strength requirement"
 msgstr "força não requerida"
 
-#: Source/items.cpp:3878
+#: Source/items.cpp:4057
 msgid "lightning damage: {:d}"
 msgstr "dano de raio: {:d}"
 
-#: Source/items.cpp:3880
+#: Source/items.cpp:4059
 msgid "lightning damage: {:d}-{:d}"
 msgstr "dano de raio: {:d}-{:d}"
 
-#: Source/items.cpp:3882
+#: Source/items.cpp:4061
 msgid "charged bolts on hits"
 msgstr "raios carregados nos golpes"
 
-#: Source/items.cpp:3884
+#: Source/items.cpp:4063
 msgid "occasional triple damage"
 msgstr "triplo dano ocasional"
 
-#: Source/items.cpp:3886
+#: Source/items.cpp:4065
 #, no-c-format
 msgid "decaying {:+d}% damage"
 msgstr "declínio de {:+d}% de dano"
 
-#: Source/items.cpp:3888
+#: Source/items.cpp:4067
 msgid "2x dmg to monst, 1x to you"
 msgstr "2x dano para monst, 1x a você"
 
-#: Source/items.cpp:3890
+#: Source/items.cpp:4069
 #, no-c-format
 msgid "Random 0 - 600% damage"
 msgstr "Dano aleatório 0 - 600%"
 
-#: Source/items.cpp:3892
+#: Source/items.cpp:4071
 #, no-c-format
 msgid "low dur, {:+d}% damage"
 msgstr "baixa dur, {:+d}% de dano"
 
-#: Source/items.cpp:3896
+#: Source/items.cpp:4075
 msgid "extra AC vs demons"
 msgstr "AC extra vs demônios"
 
-#: Source/items.cpp:3898
+#: Source/items.cpp:4077
 msgid "extra AC vs undead"
 msgstr "AC extra vs mortos vivos"
 
-#: Source/items.cpp:3900
+#: Source/items.cpp:4079
 msgid "50% Mana moved to Health"
 msgstr "50% de Mana foi para a Vida"
 
-#: Source/items.cpp:3902
+#: Source/items.cpp:4081
 msgid "40% Health moved to Mana"
 msgstr "40% de Mana foi para a Vida"
 
-#: Source/items.cpp:3942 Source/items.cpp:3983
+#: Source/items.cpp:4124 Source/items.cpp:4165
 msgid "damage: {:d}  Indestructible"
 msgstr "dano: {:d}  Indestrutível"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:3944 Source/items.cpp:3985
+#: Source/items.cpp:4126 Source/items.cpp:4167
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "dano: {:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:3947 Source/items.cpp:3988
+#: Source/items.cpp:4129 Source/items.cpp:4170
 msgid "damage: {:d}-{:d}  Indestructible"
 msgstr "dano: {:d}-{:d}  Indestrutível"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:3949 Source/items.cpp:3990
+#: Source/items.cpp:4131 Source/items.cpp:4172
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "dano: {:d}-{:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:3954 Source/items.cpp:4000
+#: Source/items.cpp:4136 Source/items.cpp:4182
 msgid "armor: {:d}  Indestructible"
 msgstr "armadura: {:d}  Indestrutível"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:3956 Source/items.cpp:4002
+#: Source/items.cpp:4138 Source/items.cpp:4184
 msgid "armor: {:d}  Dur: {:d}/{:d}"
 msgstr "armadura: {:d}  Dur: {:d}/{:d}"
 
-#: Source/items.cpp:3959 Source/items.cpp:3993 Source/items.cpp:4006
-#: Source/stores.cpp:299
+#: Source/items.cpp:4141 Source/items.cpp:4175 Source/items.cpp:4188
+#: Source/stores.cpp:301
 msgid "Charges: {:d}/{:d}"
 msgstr "Cargas: {:d}/{:d}"
 
-#: Source/items.cpp:3968
+#: Source/items.cpp:4150
 msgid "unique item"
 msgstr "item único"
 
-#: Source/items.cpp:3996 Source/items.cpp:4004 Source/items.cpp:4010
+#: Source/items.cpp:4178 Source/items.cpp:4186 Source/items.cpp:4192
 msgid "Not Identified"
 msgstr "Não identificado"
 
@@ -4803,11 +3244,11 @@ msgid "Chamber of Bone"
 msgstr "Câmara de Ossos"
 
 #. TRANSLATORS: Quest Map
-#: Source/levels/setmaps.cpp:29 Source/quests.cpp:99
+#: Source/levels/setmaps.cpp:29 Source/quests.cpp:104
 msgid "Maze"
 msgstr "Labirinto"
 
-#: Source/levels/setmaps.cpp:30 Source/quests.cpp:61
+#: Source/levels/setmaps.cpp:30 Source/quests.cpp:66
 msgid "Poisoned Water Supply"
 msgstr "Reserv. de água envenenado"
 
@@ -4827,86 +3268,86 @@ msgstr "Arena do Inferno"
 msgid "Circle of Life Arena"
 msgstr "Arena do Ciclo da Vida"
 
-#: Source/levels/trigs.cpp:350
+#: Source/levels/trigs.cpp:355
 msgid "Down to dungeon"
 msgstr "Descer para as masmorras"
 
-#: Source/levels/trigs.cpp:359
+#: Source/levels/trigs.cpp:364
 msgid "Down to catacombs"
 msgstr "Descer para as catabumbas"
 
-#: Source/levels/trigs.cpp:369
+#: Source/levels/trigs.cpp:374
 msgid "Down to caves"
 msgstr "Descer para as cavernas"
 
-#: Source/levels/trigs.cpp:379
+#: Source/levels/trigs.cpp:384
 msgid "Down to hell"
 msgstr "Descer para o inferno"
 
-#: Source/levels/trigs.cpp:389
+#: Source/levels/trigs.cpp:394
 msgid "Down to Hive"
 msgstr "Descer para a Colmeia"
 
-#: Source/levels/trigs.cpp:399
+#: Source/levels/trigs.cpp:404
 msgid "Down to Crypt"
 msgstr "Descer para a Cripta"
 
-#: Source/levels/trigs.cpp:414 Source/levels/trigs.cpp:449
-#: Source/levels/trigs.cpp:495 Source/levels/trigs.cpp:547
+#: Source/levels/trigs.cpp:419 Source/levels/trigs.cpp:454
+#: Source/levels/trigs.cpp:500 Source/levels/trigs.cpp:552
 msgid "Up to level {:d}"
 msgstr "Subir para o nível {:d}"
 
-#: Source/levels/trigs.cpp:416 Source/levels/trigs.cpp:478
-#: Source/levels/trigs.cpp:530 Source/levels/trigs.cpp:577
-#: Source/levels/trigs.cpp:639 Source/levels/trigs.cpp:688
-#: Source/levels/trigs.cpp:795
+#: Source/levels/trigs.cpp:421 Source/levels/trigs.cpp:483
+#: Source/levels/trigs.cpp:535 Source/levels/trigs.cpp:582
+#: Source/levels/trigs.cpp:644 Source/levels/trigs.cpp:693
+#: Source/levels/trigs.cpp:800
 msgid "Up to town"
 msgstr "Subir para a cidade"
 
-#: Source/levels/trigs.cpp:427 Source/levels/trigs.cpp:460
-#: Source/levels/trigs.cpp:512 Source/levels/trigs.cpp:559
-#: Source/levels/trigs.cpp:621
+#: Source/levels/trigs.cpp:432 Source/levels/trigs.cpp:465
+#: Source/levels/trigs.cpp:517 Source/levels/trigs.cpp:564
+#: Source/levels/trigs.cpp:626
 msgid "Down to level {:d}"
 msgstr "Descer para o nível {:d}"
 
-#: Source/levels/trigs.cpp:590
+#: Source/levels/trigs.cpp:595
 msgid "Down to Diablo"
 msgstr "Descer para o Diablo"
 
-#: Source/levels/trigs.cpp:608
+#: Source/levels/trigs.cpp:613
 msgid "Up to Nest level {:d}"
 msgstr "Subir para o nível {:d} do Enxame"
 
-#: Source/levels/trigs.cpp:656
+#: Source/levels/trigs.cpp:661
 msgid "Up to Crypt level {:d}"
 msgstr "Subir para o nível {:d} da Cripta"
 
-#: Source/levels/trigs.cpp:666 Source/quests.cpp:70
+#: Source/levels/trigs.cpp:671 Source/quests.cpp:75
 msgid "Cornerstone of the World"
 msgstr "Pedra angular do mundo"
 
-#: Source/levels/trigs.cpp:671
+#: Source/levels/trigs.cpp:676
 msgid "Down to Crypt level {:d}"
 msgstr "Descer para o nível {:d} da Cripta"
 
-#: Source/levels/trigs.cpp:719 Source/levels/trigs.cpp:733
-#: Source/levels/trigs.cpp:747
+#: Source/levels/trigs.cpp:724 Source/levels/trigs.cpp:738
+#: Source/levels/trigs.cpp:752
 msgid "Back to Level {:d}"
 msgstr "Voltar ao Nível {:d}"
 
-#: Source/loadsave.cpp:2095 Source/loadsave.cpp:2627
+#: Source/loadsave.cpp:1927 Source/loadsave.cpp:2364
 msgid "Unable to open save file archive"
 msgstr "Não foi possível abrir o arquivo salvo"
 
-#: Source/loadsave.cpp:2098
+#: Source/loadsave.cpp:2368
 msgid "Invalid save file"
 msgstr "Jogo salvo inválido"
 
-#: Source/loadsave.cpp:2129
+#: Source/loadsave.cpp:2400
 msgid "Player is on a Hellfire only level"
 msgstr "O jogador está em um nível somente Hellfire"
 
-#: Source/loadsave.cpp:2385
+#: Source/loadsave.cpp:2659
 msgid "Invalid game state"
 msgstr "Estado de jogo inválido"
 
@@ -4914,2005 +3355,516 @@ msgstr "Estado de jogo inválido"
 msgid "Unable to display mainmenu"
 msgstr "Não é possível mostrar o menu principal"
 
-#. TRANSLATORS: Monster Block start
-#. MT_NZOMBIE
-#: Source/monstdat.cpp:33
-msgctxt "monster"
-msgid "Zombie"
-msgstr "Zumbi"
-
-#: Source/monstdat.cpp:34
-msgctxt "monster"
-msgid "Ghoul"
-msgstr "Carniçal"
-
-#: Source/monstdat.cpp:35
-msgctxt "monster"
-msgid "Rotting Carcass"
-msgstr "Carcaça Apodrecida"
-
-#: Source/monstdat.cpp:36
-msgctxt "monster"
-msgid "Black Death"
-msgstr "Morte Negra"
-
-#: Source/monstdat.cpp:37 Source/monstdat.cpp:45
-msgctxt "monster"
-msgid "Fallen One"
-msgstr "Caído"
-
-#: Source/monstdat.cpp:38 Source/monstdat.cpp:46
-msgctxt "monster"
-msgid "Carver"
-msgstr "Talhador"
-
-#: Source/monstdat.cpp:39 Source/monstdat.cpp:47
-#, fuzzy
-#| msgid "Devil Kin"
-msgctxt "monster"
-msgid "Devil Kin"
-msgstr "Cria do Diabo"
-
-#: Source/monstdat.cpp:40 Source/monstdat.cpp:48
-msgctxt "monster"
-msgid "Dark One"
-msgstr "Sombrio"
-
-#: Source/monstdat.cpp:41 Source/monstdat.cpp:53
-msgctxt "monster"
-msgid "Skeleton"
-msgstr "Esqueleto"
-
-#: Source/monstdat.cpp:42
-msgctxt "monster"
-msgid "Corpse Axe"
-msgstr "Cadáver de Machado"
-
-#: Source/monstdat.cpp:43 Source/monstdat.cpp:55
-msgctxt "monster"
-msgid "Burning Dead"
-msgstr "Morto Calcinante"
-
-#: Source/monstdat.cpp:44 Source/monstdat.cpp:56
-msgctxt "monster"
-msgid "Horror"
-msgstr "Horror"
-
-#: Source/monstdat.cpp:49
-msgctxt "monster"
-msgid "Scavenger"
-msgstr "Escavador"
-
-#: Source/monstdat.cpp:50
-msgctxt "monster"
-msgid "Plague Eater"
-msgstr "Devorador de Almas"
-
-#: Source/monstdat.cpp:51
-#, fuzzy
-#| msgid "Shadow Beast"
-msgctxt "monster"
-msgid "Shadow Beast"
-msgstr "Fera das Sombras"
-
-#: Source/monstdat.cpp:52
-#, fuzzy
-#| msgid "Bone Gasher"
-msgctxt "monster"
-msgid "Bone Gasher"
-msgstr "Cortaosso"
-
-#: Source/monstdat.cpp:54
-#, fuzzy
-#| msgid "Corpse Bow"
-msgctxt "monster"
-msgid "Corpse Bow"
-msgstr "Cadáver Arqueiro"
-
-#: Source/monstdat.cpp:57
-msgctxt "monster"
-msgid "Skeleton Captain"
-msgstr "Esqueleto Capitão"
-
-#: Source/monstdat.cpp:58
-#, fuzzy
-#| msgid "Corpse Captain"
-msgctxt "monster"
-msgid "Corpse Captain"
-msgstr "Cadáver Capitão"
-
-#: Source/monstdat.cpp:59
-#, fuzzy
-#| msgid "Burning Dead Captain"
-msgctxt "monster"
-msgid "Burning Dead Captain"
-msgstr "Morto Calcinante Capitão "
-
-#: Source/monstdat.cpp:60
-#, fuzzy
-#| msgid "Horror Captain"
-msgctxt "monster"
-msgid "Horror Captain"
-msgstr "Horror Capitão"
-
-#: Source/monstdat.cpp:61
-#, fuzzy
-#| msgid "Invisible Lord"
-msgctxt "monster"
-msgid "Invisible Lord"
-msgstr "Senhor Invisível"
-
-#: Source/monstdat.cpp:62
-msgctxt "monster"
-msgid "Hidden"
-msgstr "Escondido"
-
-#: Source/monstdat.cpp:63
-#, fuzzy
-#| msgid "Stalker"
-msgctxt "monster"
-msgid "Stalker"
-msgstr "Espreitador"
-
-#: Source/monstdat.cpp:64
-#, fuzzy
-#| msgid "Unseen"
-msgctxt "monster"
-msgid "Unseen"
-msgstr "Despercebido"
-
-#: Source/monstdat.cpp:65
-#, fuzzy
-#| msgid "Illusion Weaver"
-msgctxt "monster"
-msgid "Illusion Weaver"
-msgstr "Tecelão de Ilusões"
-
-#: Source/monstdat.cpp:66
-#, fuzzy
-#| msgid "Satyr Lord"
-msgctxt "monster"
-msgid "Satyr Lord"
-msgstr "Senhor Sátiro"
-
-#: Source/monstdat.cpp:67 Source/monstdat.cpp:75
-#, fuzzy
-#| msgid "Flesh Clan"
-msgctxt "monster"
-msgid "Flesh Clan"
-msgstr "Clã Carne Fresca"
-
-#: Source/monstdat.cpp:68 Source/monstdat.cpp:76
-#, fuzzy
-#| msgid "Stone Clan"
-msgctxt "monster"
-msgid "Stone Clan"
-msgstr "Clã de Pedra"
-
-#: Source/monstdat.cpp:69 Source/monstdat.cpp:77
-#, fuzzy
-#| msgid "Fire Clan"
-msgctxt "monster"
-msgid "Fire Clan"
-msgstr "Clã de Fogo"
-
-#: Source/monstdat.cpp:70 Source/monstdat.cpp:78
-#, fuzzy
-#| msgid "Night Clan"
-msgctxt "monster"
-msgid "Night Clan"
-msgstr "Clã da Noite"
-
-#: Source/monstdat.cpp:71
-#, fuzzy
-#| msgid "Fiend"
-msgctxt "monster"
-msgid "Fiend"
-msgstr "Demônio"
-
-#: Source/monstdat.cpp:72
-#, fuzzy
-#| msgid "Blink"
-msgctxt "monster"
-msgid "Blink"
-msgstr "Cintilador"
-
-#: Source/monstdat.cpp:73
-#, fuzzy
-#| msgid "Gloom"
-msgctxt "monster"
-msgid "Gloom"
-msgstr "Melancolia"
-
-#: Source/monstdat.cpp:74
-#, fuzzy
-#| msgid "Familiar"
-msgctxt "monster"
-msgid "Familiar"
-msgstr "Familiar"
-
-#: Source/monstdat.cpp:79
-#, fuzzy
-#| msgid "Acid Beast"
-msgctxt "monster"
-msgid "Acid Beast"
-msgstr "Fera Ácida"
-
-#: Source/monstdat.cpp:80
-#, fuzzy
-#| msgid "Poison Spitter"
-msgctxt "monster"
-msgid "Poison Spitter"
-msgstr "Cospe-Veneno"
-
-#: Source/monstdat.cpp:81
-#, fuzzy
-#| msgid "Pit Beast"
-msgctxt "monster"
-msgid "Pit Beast"
-msgstr "Fera do Poço"
-
-#: Source/monstdat.cpp:82
-#, fuzzy
-#| msgid "Lava Maw"
-msgctxt "monster"
-msgid "Lava Maw"
-msgstr "Gorja de Lava"
-
-#: Source/monstdat.cpp:83 Source/monstdat.cpp:344
-#, fuzzy
-#| msgid "Skeleton King"
-msgctxt "monster"
-msgid "Skeleton King"
-msgstr "Rei Esqueleto"
-
-#: Source/monstdat.cpp:84 Source/monstdat.cpp:352
-msgctxt "monster"
-msgid "The Butcher"
-msgstr "O Açougueiro"
-
-#: Source/monstdat.cpp:85
-#, fuzzy
-#| msgid "Overlord"
-msgctxt "monster"
-msgid "Overlord"
-msgstr "Suserano"
-
-#: Source/monstdat.cpp:86
-#, fuzzy
-#| msgid "Mud Man"
-msgctxt "monster"
-msgid "Mud Man"
-msgstr "Homem-Lama"
-
-#: Source/monstdat.cpp:87
-#, fuzzy
-#| msgid "Toad Demon"
-msgctxt "monster"
-msgid "Toad Demon"
-msgstr "Demônio Sapo"
-
-#: Source/monstdat.cpp:88
-#, fuzzy
-#| msgid "Flayed One"
-msgctxt "monster"
-msgid "Flayed One"
-msgstr "Esfolado"
-
-#: Source/monstdat.cpp:89
-#, fuzzy
-#| msgid "Wyrm"
-msgctxt "monster"
-msgid "Wyrm"
-msgstr "Wyrm"
-
-#: Source/monstdat.cpp:90
-#, fuzzy
-#| msgid "Cave Slug"
-msgctxt "monster"
-msgid "Cave Slug"
-msgstr "Lesma da Caverna"
-
-#: Source/monstdat.cpp:91
-#, fuzzy
-#| msgid "Devil Wyrm"
-msgctxt "monster"
-msgid "Devil Wyrm"
-msgstr "Wyrm Demoníaca"
-
-#: Source/monstdat.cpp:92
-#, fuzzy
-#| msgid "Devourer"
-msgctxt "monster"
-msgid "Devourer"
-msgstr "Devorador"
-
-#: Source/monstdat.cpp:93
-#, fuzzy
-#| msgid "Magma Demon"
-msgctxt "monster"
-msgid "Magma Demon"
-msgstr "Demônio de Magma"
-
-#: Source/monstdat.cpp:94
-msgctxt "monster"
-msgid "Blood Stone"
-msgstr "Pedra Sanguínea"
-
-#: Source/monstdat.cpp:95
-#, fuzzy
-#| msgid "Hell Stone"
-msgctxt "monster"
-msgid "Hell Stone"
-msgstr "Pedra do Inferno"
-
-#: Source/monstdat.cpp:96
-#, fuzzy
-#| msgid "Lava Lord"
-msgctxt "monster"
-msgid "Lava Lord"
-msgstr "Senhor da Lava"
-
-#: Source/monstdat.cpp:97
-#, fuzzy
-#| msgid "Horned Demon"
-msgctxt "monster"
-msgid "Horned Demon"
-msgstr "Demônio com Chifres"
-
-#: Source/monstdat.cpp:98
-#, fuzzy
-#| msgid "Mud Runner"
-msgctxt "monster"
-msgid "Mud Runner"
-msgstr "Trilhador da Lama"
-
-#: Source/monstdat.cpp:99
-#, fuzzy
-#| msgid "Frost Charger"
-msgctxt "monster"
-msgid "Frost Charger"
-msgstr "Suicida Gélido"
-
-#: Source/monstdat.cpp:100
-#, fuzzy
-#| msgid "Obsidian Lord"
-msgctxt "monster"
-msgid "Obsidian Lord"
-msgstr "Senhor da Obsidiana"
-
-#: Source/monstdat.cpp:101
-#, fuzzy
-#| msgid "oldboned"
-msgctxt "monster"
-msgid "oldboned"
-msgstr "Ossovelho"
-
-#: Source/monstdat.cpp:102
-#, fuzzy
-#| msgid "Red Death"
-msgctxt "monster"
-msgid "Red Death"
-msgstr "Morte Vermelha"
-
-#: Source/monstdat.cpp:103
-#, fuzzy
-#| msgid "Litch Demon"
-msgctxt "monster"
-msgid "Litch Demon"
-msgstr "Demônio Litch"
-
-#: Source/monstdat.cpp:104
-#, fuzzy
-#| msgid "Undead Balrog"
-msgctxt "monster"
-msgid "Undead Balrog"
-msgstr "Balrog Morto-vivo"
-
-#: Source/monstdat.cpp:105
-#, fuzzy
-#| msgid "Incinerator"
-msgctxt "monster"
-msgid "Incinerator"
-msgstr "Incinerador"
-
-#: Source/monstdat.cpp:106
-#, fuzzy
-#| msgid "Flame Lord"
-msgctxt "monster"
-msgid "Flame Lord"
-msgstr "Senhor da Chama"
-
-#: Source/monstdat.cpp:107
-#, fuzzy
-#| msgid "Doom Fire"
-msgctxt "monster"
-msgid "Doom Fire"
-msgstr "Fogo da Perdição"
-
-#: Source/monstdat.cpp:108
-#, fuzzy
-#| msgid "Hell Burner"
-msgctxt "monster"
-msgid "Hell Burner"
-msgstr "Queimador do Inferno"
-
-#: Source/monstdat.cpp:109
-#, fuzzy
-#| msgid "Red Storm"
-msgctxt "monster"
-msgid "Red Storm"
-msgstr "Tempestade Vermelha"
-
-#: Source/monstdat.cpp:110
-#, fuzzy
-#| msgid "Storm Rider"
-msgctxt "monster"
-msgid "Storm Rider"
-msgstr "Tempestuoso"
-
-#: Source/monstdat.cpp:111
-#, fuzzy
-#| msgid "Storm Lord"
-msgctxt "monster"
-msgid "Storm Lord"
-msgstr "Senhor da Tempestade"
-
-#: Source/monstdat.cpp:112
-#, fuzzy
-#| msgid "Maelstrom"
-msgctxt "monster"
-msgid "Maelstrom"
-msgstr "Redemoinho"
-
-#: Source/monstdat.cpp:113
-#, fuzzy
-#| msgid "Devil Kin Brute"
-msgctxt "monster"
-msgid "Devil Kin Brute"
-msgstr "Cria do Diabo Bruta"
-
-#: Source/monstdat.cpp:114
-#, fuzzy
-#| msgid "Winged-Demon"
-msgctxt "monster"
-msgid "Winged-Demon"
-msgstr "Demônio Alado"
-
-#: Source/monstdat.cpp:115
-#, fuzzy
-#| msgid "Gargoyle"
-msgctxt "monster"
-msgid "Gargoyle"
-msgstr "Gárgula"
-
-#: Source/monstdat.cpp:116
-#, fuzzy
-#| msgid "Blood Claw"
-msgctxt "monster"
-msgid "Blood Claw"
-msgstr "Garra Sangrenta"
-
-#: Source/monstdat.cpp:117
-#, fuzzy
-#| msgid "Death Wing"
-msgctxt "monster"
-msgid "Death Wing"
-msgstr "Asa da Morte"
-
-#: Source/monstdat.cpp:118
-#, fuzzy
-#| msgid "Slayer"
-msgctxt "monster"
-msgid "Slayer"
-msgstr "Homicida"
-
-#: Source/monstdat.cpp:119
-#, fuzzy
-#| msgid "Guardian"
-msgctxt "monster"
-msgid "Guardian"
-msgstr "Guardião"
-
-#: Source/monstdat.cpp:120
-#, fuzzy
-#| msgid "Vortex Lord"
-msgctxt "monster"
-msgid "Vortex Lord"
-msgstr "Senhor do Vórtice"
-
-#: Source/monstdat.cpp:121
-#, fuzzy
-#| msgid "Balrog"
-msgctxt "monster"
-msgid "Balrog"
-msgstr "Balrog"
-
-#: Source/monstdat.cpp:122
-#, fuzzy
-#| msgid "Cave Viper"
-msgctxt "monster"
-msgid "Cave Viper"
-msgstr "Víbora da Caverna"
-
-#: Source/monstdat.cpp:123
-#, fuzzy
-#| msgid "Fire Drake"
-msgctxt "monster"
-msgid "Fire Drake"
-msgstr "Víbora de Fogo"
-
-#: Source/monstdat.cpp:124
-#, fuzzy
-#| msgid "Gold Viper"
-msgctxt "monster"
-msgid "Gold Viper"
-msgstr "Víbora de Ouro"
-
-#: Source/monstdat.cpp:125
-#, fuzzy
-#| msgid "Azure Drake"
-msgctxt "monster"
-msgid "Azure Drake"
-msgstr "Víbora Azulada"
-
-#: Source/monstdat.cpp:126
-#, fuzzy
-#| msgid "Black Knight"
-msgctxt "monster"
-msgid "Black Knight"
-msgstr "Cavaleiro Negro"
-
-#: Source/monstdat.cpp:127
-#, fuzzy
-#| msgid "Doom Guard"
-msgctxt "monster"
-msgid "Doom Guard"
-msgstr "Guarda da Perdição"
-
-#: Source/monstdat.cpp:128
-#, fuzzy
-#| msgid "Steel Lord"
-msgctxt "monster"
-msgid "Steel Lord"
-msgstr "Senhor de Aço"
-
-#: Source/monstdat.cpp:129
-#, fuzzy
-#| msgid "Blood Knight"
-msgctxt "monster"
-msgid "Blood Knight"
-msgstr "Cavaleiro Sangrento"
-
-#: Source/monstdat.cpp:130
-#, fuzzy
-#| msgid "The Shredded"
-msgctxt "monster"
-msgid "The Shredded"
-msgstr "Desfiador"
-
-#: Source/monstdat.cpp:131
-#, fuzzy
-#| msgid "Hollow One"
-msgctxt "monster"
-msgid "Hollow One"
-msgstr "Oco"
-
-#: Source/monstdat.cpp:132
-#, fuzzy
-#| msgid "Pain Master"
-msgctxt "monster"
-msgid "Pain Master"
-msgstr "Mestre da Dor"
-
-#: Source/monstdat.cpp:133
-#, fuzzy
-#| msgid "Reality Weaver"
-msgctxt "monster"
-msgid "Reality Weaver"
-msgstr "Tecelão de Realidades"
-
-#: Source/monstdat.cpp:134
-#, fuzzy
-#| msgid "Succubus"
-msgctxt "monster"
-msgid "Succubus"
-msgstr "Súcubo"
-
-#: Source/monstdat.cpp:135
-#, fuzzy
-#| msgid "Snow Witch"
-msgctxt "monster"
-msgid "Snow Witch"
-msgstr "Bruxa da Neve"
-
-#: Source/monstdat.cpp:136
-#, fuzzy
-#| msgid "Hell Spawn"
-msgctxt "monster"
-msgid "Hell Spawn"
-msgstr "Cria do Inferno"
-
-#: Source/monstdat.cpp:137
-#, fuzzy
-#| msgid "Soul Burner"
-msgctxt "monster"
-msgid "Soul Burner"
-msgstr "Queimadora de Almas"
-
-#: Source/monstdat.cpp:138
-#, fuzzy
-#| msgid "Counselor"
-msgctxt "monster"
-msgid "Counselor"
-msgstr "Conselheiro"
-
-#: Source/monstdat.cpp:139
-#, fuzzy
-#| msgid "Magistrate"
-msgctxt "monster"
-msgid "Magistrate"
-msgstr "Magistrado"
-
-#: Source/monstdat.cpp:140
-#, fuzzy
-#| msgid "Cabalist"
-msgctxt "monster"
-msgid "Cabalist"
-msgstr "Cabalista"
-
-#: Source/monstdat.cpp:141
-#, fuzzy
-#| msgid "Advocate"
-msgctxt "monster"
-msgid "Advocate"
-msgstr "Defensor"
-
-#: Source/monstdat.cpp:142
-#, fuzzy
-#| msgid "Golem"
-msgctxt "monster"
-msgid "Golem"
-msgstr "Golem"
-
-#: Source/monstdat.cpp:143
-#, fuzzy
-#| msgid "The Dark Lord"
-msgctxt "monster"
-msgid "The Dark Lord"
-msgstr "O Lorde Sombrio"
-
-#: Source/monstdat.cpp:144
-#, fuzzy
-#| msgid "The Arch-Litch Malignus"
-msgctxt "monster"
-msgid "The Arch-Litch Malignus"
-msgstr "O Arce-Litch Malignus"
-
-#: Source/monstdat.cpp:145
-#, fuzzy
-#| msgid "Hellboar"
-msgctxt "monster"
-msgid "Hellboar"
-msgstr "Hellboar"
-
-#: Source/monstdat.cpp:146
-#, fuzzy
-#| msgid "Stinger"
-msgctxt "monster"
-msgid "Stinger"
-msgstr "Ferrão"
-
-#: Source/monstdat.cpp:147
-#, fuzzy
-#| msgid "Psychorb"
-msgctxt "monster"
-msgid "Psychorb"
-msgstr "Psychorb"
-
-#: Source/monstdat.cpp:148
-#, fuzzy
-#| msgid "Arachnon"
-msgctxt "monster"
-msgid "Arachnon"
-msgstr "Arachnon"
-
-#: Source/monstdat.cpp:149
-#, fuzzy
-#| msgid "Felltwin"
-msgctxt "monster"
-msgid "Felltwin"
-msgstr "Felltwin"
-
-#: Source/monstdat.cpp:150
-#, fuzzy
-#| msgid "Hork Spawn"
-msgctxt "monster"
-msgid "Hork Spawn"
-msgstr "Cria de Hork"
-
-#: Source/monstdat.cpp:151
-#, fuzzy
-#| msgid "Venomtail"
-msgctxt "monster"
-msgid "Venomtail"
-msgstr "Venomtail"
-
-#: Source/monstdat.cpp:152
-#, fuzzy
-#| msgid "Necromorb"
-msgctxt "monster"
-msgid "Necromorb"
-msgstr "Necromorb"
-
-#: Source/monstdat.cpp:153
-#, fuzzy
-#| msgid "Spider Lord"
-msgctxt "monster"
-msgid "Spider Lord"
-msgstr "Senhor das Aranhas"
-
-#: Source/monstdat.cpp:154
-#, fuzzy
-#| msgid "Lashworm"
-msgctxt "monster"
-msgid "Lashworm"
-msgstr "Verme-de-chicote"
-
-#: Source/monstdat.cpp:155
-#, fuzzy
-#| msgid "Torchant"
-msgctxt "monster"
-msgid "Torchant"
-msgstr "Torchant"
-
-#: Source/monstdat.cpp:156 Source/monstdat.cpp:353
-#, fuzzy
-#| msgid "Hork Demon"
-msgctxt "monster"
-msgid "Hork Demon"
-msgstr "Demônio Hork"
-
-#: Source/monstdat.cpp:157
-#, fuzzy
-#| msgid "Hell Bug"
-msgctxt "monster"
-msgid "Hell Bug"
-msgstr "Inseto do Inferno"
-
-#: Source/monstdat.cpp:158
-#, fuzzy
-#| msgid "Gravedigger"
-msgctxt "monster"
-msgid "Gravedigger"
-msgstr "Coveiro"
-
-#: Source/monstdat.cpp:159
-#, fuzzy
-#| msgid "Tomb Rat"
-msgctxt "monster"
-msgid "Tomb Rat"
-msgstr "Rato da Tumba"
-
-#: Source/monstdat.cpp:160
-#, fuzzy
-#| msgid "Firebat"
-msgctxt "monster"
-msgid "Firebat"
-msgstr "Morcego de Fogo"
-
-#: Source/monstdat.cpp:161
-#, fuzzy
-#| msgid "Skullwing"
-msgctxt "monster"
-msgid "Skullwing"
-msgstr "Asa Esquelética"
-
-#: Source/monstdat.cpp:162
-#, fuzzy
-#| msgid "Lich"
-msgctxt "monster"
-msgid "Lich"
-msgstr "Lich"
-
-#: Source/monstdat.cpp:163
-#, fuzzy
-#| msgid "Crypt Demon"
-msgctxt "monster"
-msgid "Crypt Demon"
-msgstr "Demônio da Cripta"
-
-#: Source/monstdat.cpp:164
-#, fuzzy
-#| msgid "Hellbat"
-msgctxt "monster"
-msgid "Hellbat"
-msgstr "Morcego Infernal"
-
-#: Source/monstdat.cpp:165
-#, fuzzy
-#| msgid "Bone Demon"
-msgctxt "monster"
-msgid "Bone Demon"
-msgstr "Demônio de Ossos"
-
-#: Source/monstdat.cpp:166
-#, fuzzy
-#| msgid "Arch Lich"
-msgctxt "monster"
-msgid "Arch Lich"
-msgstr "Arque Lich"
-
-#: Source/monstdat.cpp:167
-#, fuzzy
-#| msgid "Biclops"
-msgctxt "monster"
-msgid "Biclops"
-msgstr "Biclops"
-
-#: Source/monstdat.cpp:168
-#, fuzzy
-#| msgid "Flesh Thing"
-msgctxt "monster"
-msgid "Flesh Thing"
-msgstr "Coisa de Carne Fresca"
-
-#: Source/monstdat.cpp:169
-#, fuzzy
-#| msgid "Reaper"
-msgctxt "monster"
-msgid "Reaper"
-msgstr "Ceifador"
-
-#. TRANSLATORS: Monster Block end
-#. MT_NAKRUL
-#: Source/monstdat.cpp:171 Source/monstdat.cpp:355
-msgctxt "monster"
-msgid "Na-Krul"
-msgstr "Na-Krul"
-
-#. TRANSLATORS: Unique Monster Block start
-#: Source/monstdat.cpp:343
-#, fuzzy
-#| msgid "Gharbad the Weak"
-msgctxt "monster"
-msgid "Gharbad the Weak"
-msgstr "Gharbad, o Fraco"
-
-#: Source/monstdat.cpp:345
-msgctxt "monster"
-msgid "Zhar the Mad"
-msgstr "Zhar, o Louco"
-
-#: Source/monstdat.cpp:346
-#, fuzzy
-#| msgid "Snotspill"
-msgctxt "monster"
-msgid "Snotspill"
-msgstr "Kaikatarro"
-
-#: Source/monstdat.cpp:347
-#, fuzzy
-#| msgid "Arch-Bishop Lazarus"
-msgctxt "monster"
-msgid "Arch-Bishop Lazarus"
-msgstr "Arcebispo Lazarus"
-
-#: Source/monstdat.cpp:348
-#, fuzzy
-#| msgid "Red Vex"
-msgctxt "monster"
-msgid "Red Vex"
-msgstr "Apurrinhação Vermelha"
-
-#: Source/monstdat.cpp:349
-#, fuzzy
-#| msgid "Black Jade"
-msgctxt "monster"
-msgid "Black Jade"
-msgstr "Jade Negra"
-
-#: Source/monstdat.cpp:350
-msgctxt "monster"
-msgid "Lachdanan"
-msgstr "Lachdanan"
-
-#: Source/monstdat.cpp:351
-msgctxt "monster"
-msgid "Warlord of Blood"
-msgstr "Senhor da Guerra Sangrenta"
-
-#: Source/monstdat.cpp:354
-msgctxt "monster"
-msgid "The Defiler"
-msgstr "O Profanador"
-
-#: Source/monstdat.cpp:356
-#, fuzzy
-#| msgid "Bonehead Keenaxe"
-msgctxt "monster"
-msgid "Bonehead Keenaxe"
-msgstr "Osteocéfalo Machado"
-
-#: Source/monstdat.cpp:357
-#, fuzzy
-#| msgid "Bladeskin the Slasher"
-msgctxt "monster"
-msgid "Bladeskin the Slasher"
-msgstr "Laminiderme, o Esfaqueador"
-
-#: Source/monstdat.cpp:358
-#, fuzzy
-#| msgid "Soulpus"
-msgctxt "monster"
-msgid "Soulpus"
-msgstr "Pus de Alma"
-
-#: Source/monstdat.cpp:359
-#, fuzzy
-#| msgid "Pukerat the Unclean"
-msgctxt "monster"
-msgid "Pukerat the Unclean"
-msgstr "Vomirrato, o Impuro"
-
-#: Source/monstdat.cpp:360
-#, fuzzy
-#| msgid "Boneripper"
-msgctxt "monster"
-msgid "Boneripper"
-msgstr "Estripa-ossos"
-
-#: Source/monstdat.cpp:361
-#, fuzzy
-#| msgid "Rotfeast the Hungry"
-msgctxt "monster"
-msgid "Rotfeast the Hungry"
-msgstr "Putrefórico, o Faminto"
-
-#: Source/monstdat.cpp:362
-#, fuzzy
-#| msgid "Gutshank the Quick"
-msgctxt "monster"
-msgid "Gutshank the Quick"
-msgstr "Tripernil, o Veloz"
-
-#: Source/monstdat.cpp:363
-#, fuzzy
-#| msgid "Brokenhead Bangshield"
-msgctxt "monster"
-msgid "Brokenhead Bangshield"
-msgstr "Traumocéfalo Bate-Escudos"
-
-#: Source/monstdat.cpp:364
-msgctxt "monster"
-msgid "Bongo"
-msgstr "Bongo"
-
-#: Source/monstdat.cpp:365
-#, fuzzy
-#| msgid "Rotcarnage"
-msgctxt "monster"
-msgid "Rotcarnage"
-msgstr "Putrificina"
-
-#: Source/monstdat.cpp:366
-#, fuzzy
-#| msgid "Shadowbite"
-msgctxt "monster"
-msgid "Shadowbite"
-msgstr "Mordesombra"
-
-#: Source/monstdat.cpp:367
-#, fuzzy
-#| msgid "Deadeye"
-msgctxt "monster"
-msgid "Deadeye"
-msgstr "Olho Morto"
-
-#: Source/monstdat.cpp:368
-#, fuzzy
-#| msgid "Madeye the Dead"
-msgctxt "monster"
-msgid "Madeye the Dead"
-msgstr "Olholouco, o Morto"
-
-#: Source/monstdat.cpp:369
-msgctxt "monster"
-msgid "El Chupacabras"
-msgstr "El Chupacabras"
-
-#: Source/monstdat.cpp:370
-#, fuzzy
-#| msgid "Skullfire"
-msgctxt "monster"
-msgid "Skullfire"
-msgstr "Fogo Cranial"
-
-#: Source/monstdat.cpp:371
-#, fuzzy
-#| msgid "Warpskull"
-msgctxt "monster"
-msgid "Warpskull"
-msgstr "Crânio Torto"
-
-#: Source/monstdat.cpp:372
-#, fuzzy
-#| msgid "Goretongue"
-msgctxt "monster"
-msgid "Goretongue"
-msgstr "Sanguinolíngue"
-
-#: Source/monstdat.cpp:373
-#, fuzzy
-#| msgid "Pulsecrawler"
-msgctxt "monster"
-msgid "Pulsecrawler"
-msgstr "Pulsejador"
-
-#: Source/monstdat.cpp:374
-#, fuzzy
-#| msgid "Moonbender"
-msgctxt "monster"
-msgid "Moonbender"
-msgstr "Verga-Luas"
-
-#: Source/monstdat.cpp:375
-#, fuzzy
-#| msgid "Wrathraven"
-msgctxt "monster"
-msgid "Wrathraven"
-msgstr "Corvo da Cólera"
-
-#: Source/monstdat.cpp:376
-#, fuzzy
-#| msgid "Spineeater"
-msgctxt "monster"
-msgid "Spineeater"
-msgstr "Come-Espinhas"
-
-#: Source/monstdat.cpp:377
-msgctxt "monster"
-msgid "Blackash the Burning"
-msgstr "Cinzascura, o Calcinante"
-
-#: Source/monstdat.cpp:378
-#, fuzzy
-#| msgid "Shadowcrow"
-msgctxt "monster"
-msgid "Shadowcrow"
-msgstr "Corvossombra"
-
-#: Source/monstdat.cpp:379
-#, fuzzy
-#| msgid "Blightstone the Weak"
-msgctxt "monster"
-msgid "Blightstone the Weak"
-msgstr "Pedrapraga, o Fraco"
-
-#: Source/monstdat.cpp:380
-msgctxt "monster"
-msgid "Bilefroth the Pit Master"
-msgstr "Espumabile, o Mestre do Poço"
-
-#: Source/monstdat.cpp:381
-#, fuzzy
-#| msgid "Bloodskin Darkbow"
-msgctxt "monster"
-msgid "Bloodskin Darkbow"
-msgstr "Sanguiderme Arco Negro"
-
-#: Source/monstdat.cpp:382
-#, fuzzy
-#| msgid "Foulwing"
-msgctxt "monster"
-msgid "Foulwing"
-msgstr "Asa Pútrida"
-
-#: Source/monstdat.cpp:383
-#, fuzzy
-#| msgid "Shadowdrinker"
-msgctxt "monster"
-msgid "Shadowdrinker"
-msgstr "Bebedor das Sombras"
-
-#: Source/monstdat.cpp:384
-#, fuzzy
-#| msgid "Hazeshifter"
-msgctxt "monster"
-msgid "Hazeshifter"
-msgstr "Muda-Névoas"
-
-#: Source/monstdat.cpp:385
-#, fuzzy
-#| msgid "Deathspit"
-msgctxt "monster"
-msgid "Deathspit"
-msgstr "Cospe-Morte"
-
-#: Source/monstdat.cpp:386
-#, fuzzy
-#| msgid "Bloodgutter"
-msgctxt "monster"
-msgid "Bloodgutter"
-msgstr "Coagulário"
-
-#: Source/monstdat.cpp:387
-#, fuzzy
-#| msgid "Deathshade Fleshmaul"
-msgctxt "monster"
-msgid "Deathshade Fleshmaul"
-msgstr "Sombra da Morte Rasga-Carne"
-
-#: Source/monstdat.cpp:388
-#, fuzzy
-#| msgid "Warmaggot the Mad"
-msgctxt "monster"
-msgid "Warmaggot the Mad"
-msgstr "Larvaguerra, o Louco"
-
-#: Source/monstdat.cpp:389
-msgctxt "monster"
-msgid "Glasskull the Jagged"
-msgstr "Crânio de Vidro, o Serrilhado"
-
-#: Source/monstdat.cpp:390
-#, fuzzy
-#| msgid "Blightfire"
-msgctxt "monster"
-msgid "Blightfire"
-msgstr "Flagelo de Fogo"
-
-#: Source/monstdat.cpp:391
-#, fuzzy
-#| msgid "Nightwing the Cold"
-msgctxt "monster"
-msgid "Nightwing the Cold"
-msgstr "Asa Noturna, o Gélido"
-
-#: Source/monstdat.cpp:392
-#, fuzzy
-#| msgid "Gorestone"
-msgctxt "monster"
-msgid "Gorestone"
-msgstr "Rochacínio"
-
-#: Source/monstdat.cpp:393
-#, fuzzy
-#| msgid "Bronzefist Firestone"
-msgctxt "monster"
-msgid "Bronzefist Firestone"
-msgstr "Pugibronze Pedra de Fogo"
-
-#: Source/monstdat.cpp:394
-#, fuzzy
-#| msgid "Wrathfire the Doomed"
-msgctxt "monster"
-msgid "Wrathfire the Doomed"
-msgstr "Irígnea, o Condenado"
-
-#: Source/monstdat.cpp:395
-#, fuzzy
-#| msgid "Firewound the Grim"
-msgctxt "monster"
-msgid "Firewound the Grim"
-msgstr "Chaga Ígnea, o Tenebroso"
-
-#: Source/monstdat.cpp:396
-#, fuzzy
-#| msgid "Baron Sludge"
-msgctxt "monster"
-msgid "Baron Sludge"
-msgstr "Barão Lodoso"
-
-#: Source/monstdat.cpp:397
-#, fuzzy
-#| msgid "Blighthorn Steelmace"
-msgctxt "monster"
-msgid "Blighthorn Steelmace"
-msgstr "Guampestífero Maça de Aço"
-
-#: Source/monstdat.cpp:398
-#, fuzzy
-#| msgid "Chaoshowler"
-msgctxt "monster"
-msgid "Chaoshowler"
-msgstr "Berrocaos"
-
-#: Source/monstdat.cpp:399
-#, fuzzy
-#| msgid "Doomgrin the Rotting"
-msgctxt "monster"
-msgid "Doomgrin the Rotting"
-msgstr "Sorrirruína, o Podre"
-
-#: Source/monstdat.cpp:400
-#, fuzzy
-#| msgid "Madburner"
-msgctxt "monster"
-msgid "Madburner"
-msgstr "Queimador Louco"
-
-#: Source/monstdat.cpp:401
-msgctxt "monster"
-msgid "Bonesaw the Litch"
-msgstr "Serra Osso, o Litch"
-
-#: Source/monstdat.cpp:402
-#, fuzzy
-#| msgid "Breakspine"
-msgctxt "monster"
-msgid "Breakspine"
-msgstr "Quebra-Espinha"
-
-#: Source/monstdat.cpp:403
-#, fuzzy
-#| msgid "Devilskull Sharpbone"
-msgctxt "monster"
-msgid "Devilskull Sharpbone"
-msgstr "Demonicrânio Osso Afiado"
-
-#: Source/monstdat.cpp:404
-#, fuzzy
-#| msgid "Brokenstorm"
-msgctxt "monster"
-msgid "Brokenstorm"
-msgstr "Tempestrago"
-
-#: Source/monstdat.cpp:405
-#, fuzzy
-#| msgid "Stormbane"
-msgctxt "monster"
-msgid "Stormbane"
-msgstr "Praguestade"
-
-#: Source/monstdat.cpp:406
-#, fuzzy
-#| msgid "Oozedrool"
-msgctxt "monster"
-msgid "Oozedrool"
-msgstr "Babujador"
-
-#: Source/monstdat.cpp:407
-msgctxt "monster"
-msgid "Goldblight of the Flame"
-msgstr "Pragáurea da Chama"
-
-#: Source/monstdat.cpp:408
-#, fuzzy
-#| msgid "Blackstorm"
-msgctxt "monster"
-msgid "Blackstorm"
-msgstr "Tempestade Negra"
-
-#: Source/monstdat.cpp:409
-#, fuzzy
-#| msgid "Plaguewrath"
-msgctxt "monster"
-msgid "Plaguewrath"
-msgstr "Pestilérico"
-
-#: Source/monstdat.cpp:410
-#, fuzzy
-#| msgid "The Flayer"
-msgctxt "monster"
-msgid "The Flayer"
-msgstr "O Esfolador"
-
-#: Source/monstdat.cpp:411
-#, fuzzy
-#| msgid "Bluehorn"
-msgctxt "monster"
-msgid "Bluehorn"
-msgstr "Chifre Azul"
-
-#: Source/monstdat.cpp:412
-#, fuzzy
-#| msgid "Warpfire Hellspawn"
-msgctxt "monster"
-msgid "Warpfire Hellspawn"
-msgstr "Deformígneo Cria do Inferno"
-
-#: Source/monstdat.cpp:413
-#, fuzzy
-#| msgid "Fangspeir"
-msgctxt "monster"
-msgid "Fangspeir"
-msgstr "Presatroz"
-
-#: Source/monstdat.cpp:414
-#, fuzzy
-#| msgid "Festerskull"
-msgctxt "monster"
-msgid "Festerskull"
-msgstr "Pesticrânio"
-
-#: Source/monstdat.cpp:415
-msgctxt "monster"
-msgid "Lionskull the Bent"
-msgstr "CrânioLeão, o Curvado"
-
-#: Source/monstdat.cpp:416
-#, fuzzy
-#| msgid "Blacktongue"
-msgctxt "monster"
-msgid "Blacktongue"
-msgstr "Língua Negra"
-
-#: Source/monstdat.cpp:417
-#, fuzzy
-#| msgid "Viletouch"
-msgctxt "monster"
-msgid "Viletouch"
-msgstr "Toque Nóxio"
-
-#: Source/monstdat.cpp:418
-#, fuzzy
-#| msgid "Viperflame"
-msgctxt "monster"
-msgid "Viperflame"
-msgstr "Ignofídico"
-
-#: Source/monstdat.cpp:419
-#, fuzzy
-#| msgid "Fangskin"
-msgctxt "monster"
-msgid "Fangskin"
-msgstr "Presiderme"
-
-#: Source/monstdat.cpp:420
-msgctxt "monster"
-msgid "Witchfire the Unholy"
-msgstr "Witchfire, o Pecaminoso"
-
-#: Source/monstdat.cpp:421
-#, fuzzy
-#| msgid "Blackskull"
-msgctxt "monster"
-msgid "Blackskull"
-msgstr "Caveira Negra"
-
-#: Source/monstdat.cpp:422
-#, fuzzy
-#| msgid "Soulslash"
-msgctxt "monster"
-msgid "Soulslash"
-msgstr "Corta-Almas"
-
-#: Source/monstdat.cpp:423
-#, fuzzy
-#| msgid "Windspawn"
-msgctxt "monster"
-msgid "Windspawn"
-msgstr "Ventoso"
-
-#: Source/monstdat.cpp:424
-msgctxt "monster"
-msgid "Lord of the Pit"
-msgstr "Senhor do Poço"
-
-#: Source/monstdat.cpp:425
-#, fuzzy
-#| msgid "Rustweaver"
-msgctxt "monster"
-msgid "Rustweaver"
-msgstr "Ferrecelão"
-
-#: Source/monstdat.cpp:426
-#, fuzzy
-#| msgid "Howlingire the Shade"
-msgctxt "monster"
-msgid "Howlingire the Shade"
-msgstr "Iruivante, a Sombra"
-
-#: Source/monstdat.cpp:427
-#, fuzzy
-#| msgid "Doomcloud"
-msgctxt "monster"
-msgid "Doomcloud"
-msgstr "Nuvem da Desgraça"
-
-#: Source/monstdat.cpp:428
-#, fuzzy
-#| msgid "Bloodmoon Soulfire"
-msgctxt "monster"
-msgid "Bloodmoon Soulfire"
-msgstr "Luassangra Fogo de Alma"
-
-#: Source/monstdat.cpp:429
-#, fuzzy
-#| msgid "Witchmoon"
-msgctxt "monster"
-msgid "Witchmoon"
-msgstr "Bruxa Lunar"
-
-#: Source/monstdat.cpp:430
-#, fuzzy
-#| msgid "Gorefeast"
-msgctxt "monster"
-msgid "Gorefeast"
-msgstr "Banqueticínio"
-
-#: Source/monstdat.cpp:431
-#, fuzzy
-#| msgid "Graywar the Slayer"
-msgctxt "monster"
-msgid "Graywar the Slayer"
-msgstr "Belipardo, o Matador"
-
-#: Source/monstdat.cpp:432
-#, fuzzy
-#| msgid "Dreadjudge"
-msgctxt "monster"
-msgid "Dreadjudge"
-msgstr "Temível Juiz"
-
-#: Source/monstdat.cpp:433
-#, fuzzy
-#| msgid "Stareye the Witch"
-msgctxt "monster"
-msgid "Stareye the Witch"
-msgstr "Estrolha, a Bruxa"
-
-#: Source/monstdat.cpp:434
-#, fuzzy
-#| msgid "Steelskull the Hunter"
-msgctxt "monster"
-msgid "Steelskull the Hunter"
-msgstr "Craniaço, o Caçador"
-
-#: Source/monstdat.cpp:435
-#, fuzzy
-#| msgid "Sir Gorash"
-msgctxt "monster"
-msgid "Sir Gorash"
-msgstr "Sir Gorash"
-
-#: Source/monstdat.cpp:436
-#, fuzzy
-#| msgid "The Vizier"
-msgctxt "monster"
-msgid "The Vizier"
-msgstr "O Vizir"
-
-#: Source/monstdat.cpp:437
-#, fuzzy
-#| msgid "Sapphire"
-msgctxt "monster"
-msgid "Zamphir"
-msgstr "Zamfir"
-
-#: Source/monstdat.cpp:438
-#, fuzzy
-#| msgid "Bloodlust"
-msgctxt "monster"
-msgid "Bloodlust"
-msgstr "Sede de Sangue"
-
-#: Source/monstdat.cpp:439
-msgctxt "monster"
-msgid "Webwidow"
-msgstr "Viúvaranha"
-
-#: Source/monstdat.cpp:440
-#, fuzzy
-#| msgid "Fleshdancer"
-msgctxt "monster"
-msgid "Fleshdancer"
-msgstr "Dançarina da Carne"
-
-#: Source/monstdat.cpp:441
-#, fuzzy
-#| msgid "Grimspike"
-msgctxt "monster"
-msgid "Grimspike"
-msgstr "Espinebroso"
-
-#. TRANSLATORS: Unique Monster Block end
-#: Source/monstdat.cpp:443
-#, fuzzy
-#| msgid "Doomlock"
-msgctxt "monster"
-msgid "Doomlock"
-msgstr "Perdentrave"
-
-#: Source/monster.cpp:2964
+#: Source/monster.cpp:2941
 msgid "Animal"
 msgstr "Animal"
 
-#: Source/monster.cpp:2966
+#: Source/monster.cpp:2943
 msgid "Demon"
 msgstr "Demônio"
 
-#: Source/monster.cpp:2968
+#: Source/monster.cpp:2945
 msgid "Undead"
 msgstr "Morto-vivo"
 
-#: Source/monster.cpp:4214
+#: Source/monster.cpp:4319
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "Tipo: {:s}  Mortos: {:d}"
 
-#: Source/monster.cpp:4216
+#: Source/monster.cpp:4321
 msgid "Total kills: {:d}"
 msgstr "Total de mortos: {:d}"
 
-#: Source/monster.cpp:4248
+#: Source/monster.cpp:4353
 msgid "Hit Points: {:d}-{:d}"
 msgstr "Pontos de vida: {:d}-{:d}"
 
-#: Source/monster.cpp:4253
+#: Source/monster.cpp:4358
 msgid "No magic resistance"
 msgstr "Nenhuma resistência a magia"
 
-#: Source/monster.cpp:4256
+#: Source/monster.cpp:4361
 msgid "Resists:"
 msgstr "Resiste a:"
 
-#: Source/monster.cpp:4258 Source/monster.cpp:4268
+#: Source/monster.cpp:4363 Source/monster.cpp:4373
 msgid " Magic"
 msgstr " Magia"
 
-#: Source/monster.cpp:4260 Source/monster.cpp:4270
+#: Source/monster.cpp:4365 Source/monster.cpp:4375
 msgid " Fire"
 msgstr " Fogo"
 
-#: Source/monster.cpp:4262 Source/monster.cpp:4272
+#: Source/monster.cpp:4367 Source/monster.cpp:4377
 msgid " Lightning"
 msgstr " Raios"
 
-#: Source/monster.cpp:4266
+#: Source/monster.cpp:4371
 msgid "Immune:"
 msgstr "Imune a:"
 
-#: Source/monster.cpp:4283
+#: Source/monster.cpp:4388
 msgid "Type: {:s}"
 msgstr "Tipo: {:s}"
 
-#: Source/monster.cpp:4288 Source/monster.cpp:4294
+#: Source/monster.cpp:4393 Source/monster.cpp:4399
 msgid "No resistances"
 msgstr "Sem resistências"
 
-#: Source/monster.cpp:4289 Source/monster.cpp:4298
+#: Source/monster.cpp:4394 Source/monster.cpp:4403
 msgid "No Immunities"
 msgstr "Sem imunidades"
 
-#: Source/monster.cpp:4292
+#: Source/monster.cpp:4397
 msgid "Some Magic Resistances"
 msgstr "Algumas Resistências à Magia"
 
-#: Source/monster.cpp:4296
+#: Source/monster.cpp:4401
 msgid "Some Magic Immunities"
 msgstr "Algumas Imunidades à Magia"
 
-#: Source/mpq/mpq_writer.cpp:161
+#: Source/mpq/mpq_writer.cpp:172
 msgid "Failed to open archive for writing."
 msgstr "Não foi possível abrir o arquivo para escrita."
 
-#: Source/msg.cpp:770
+#: Source/msg.cpp:857
 msgid "Trying to drop a floor item?"
 msgstr "Gostaria de jogar um item do chão?"
 
-#: Source/msg.cpp:1380
+#: Source/msg.cpp:1459
 msgid "{:s} has cast an invalid spell."
 msgstr "{:s} lançou um feitiço inválido."
 
-#: Source/msg.cpp:1384
+#: Source/msg.cpp:1463
 msgid "{:s} has cast an illegal spell."
 msgstr "{:s} lançou um feitiço ilegal."
 
-#: Source/msg.cpp:2034 Source/multi.cpp:797 Source/multi.cpp:847
+#: Source/msg.cpp:2094 Source/multi.cpp:830 Source/multi.cpp:880
 msgid "Player '{:s}' (level {:d}) just joined the game"
 msgstr "O jogador '{:s}' (nível {:d}) acabou de entrar no jogo"
 
-#: Source/msg.cpp:2395
+#: Source/msg.cpp:2480
 msgid "The game ended"
 msgstr "O jogo terminou"
 
-#: Source/msg.cpp:2401
+#: Source/msg.cpp:2486
 msgid "Unable to get level data"
 msgstr "Não é possível obter dados do nível"
 
-#: Source/multi.cpp:262
+#: Source/multi.cpp:277
 msgid "Player '{:s}' just left the game"
 msgstr "O jogador '{:s}' acabou de sair do jogo"
 
-#: Source/multi.cpp:265
+#: Source/multi.cpp:280
 msgid "Player '{:s}' killed Diablo and left the game!"
 msgstr "O jogador '{:s}' matou Diablo e saiu do jogo!"
 
-#: Source/multi.cpp:269
+#: Source/multi.cpp:284
 msgid "Player '{:s}' dropped due to timeout"
 msgstr "O jogador '{:s}' caiu devido a tempo esgotado"
 
-#: Source/multi.cpp:849
+#: Source/multi.cpp:882
 msgid "Player '{:s}' (level {:d}) is already in the game"
 msgstr "O jogador '{:s}' (nível {:d}) já está no jogo"
 
 #. TRANSLATORS: Shrine Name Block
-#: Source/objects.cpp:120
+#: Source/objects.cpp:127
 msgid "Mysterious"
 msgstr "Misterioso"
 
-#: Source/objects.cpp:121
+#: Source/objects.cpp:128
 msgid "Hidden"
 msgstr "Escondido"
 
-#: Source/objects.cpp:122
+#: Source/objects.cpp:129
 msgid "Gloomy"
 msgstr "Melancólico"
 
-#: Source/objects.cpp:124 Source/objects.cpp:131
+#: Source/objects.cpp:130 Source/translation_dummy.cpp:606
+msgid "Weird"
+msgstr "esquisito(a)"
+
+#: Source/objects.cpp:131 Source/objects.cpp:138
 msgid "Magical"
 msgstr "Mágico"
 
-#: Source/objects.cpp:125
+#: Source/objects.cpp:132
 msgid "Stone"
 msgstr "de pedra"
 
-#: Source/objects.cpp:126
+#: Source/objects.cpp:133
 msgid "Religious"
 msgstr "Religioso"
 
-#: Source/objects.cpp:127
+#: Source/objects.cpp:134
 msgid "Enchanted"
 msgstr "Encantado"
 
-#: Source/objects.cpp:128
+#: Source/objects.cpp:135
 msgid "Thaumaturgic"
 msgstr "Taumatúrgico"
 
-#: Source/objects.cpp:129
+#: Source/objects.cpp:136
 msgid "Fascinating"
 msgstr "Fascinante"
 
-#: Source/objects.cpp:130
+#: Source/objects.cpp:137
 msgid "Cryptic"
 msgstr "Críptico"
 
-#: Source/objects.cpp:132
+#: Source/objects.cpp:139
 msgid "Eldritch"
 msgstr "Insólito"
 
-#: Source/objects.cpp:133
+#: Source/objects.cpp:140
 msgid "Eerie"
 msgstr "Esquisito"
 
-#: Source/objects.cpp:134
+#: Source/objects.cpp:141
 msgid "Divine"
 msgstr "Divino"
 
-#: Source/objects.cpp:136
+#: Source/objects.cpp:142 Source/translation_dummy.cpp:641
+msgid "Holy"
+msgstr "sagrado(a)"
+
+#: Source/objects.cpp:143
 msgid "Sacred"
 msgstr "Sagrado"
 
-#: Source/objects.cpp:137
+#: Source/objects.cpp:144
 msgid "Spiritual"
 msgstr "Espiritual"
 
-#: Source/objects.cpp:138
+#: Source/objects.cpp:145
 msgid "Spooky"
 msgstr "Pavoroso"
 
-#: Source/objects.cpp:139
+#: Source/objects.cpp:146
 msgid "Abandoned"
 msgstr "Abandonado"
 
-#: Source/objects.cpp:140
+#: Source/objects.cpp:147
 msgid "Creepy"
 msgstr "Assustador"
 
-#: Source/objects.cpp:141
+#: Source/objects.cpp:148
 msgid "Quiet"
 msgstr "Quieto"
 
-#: Source/objects.cpp:142
+#: Source/objects.cpp:149
 msgid "Secluded"
 msgstr "Isolado"
 
-#: Source/objects.cpp:143
+#: Source/objects.cpp:150
 msgid "Ornate"
 msgstr "Ornado"
 
-#: Source/objects.cpp:144
+#: Source/objects.cpp:151
 msgid "Glimmering"
 msgstr "Vislumbrante"
 
-#: Source/objects.cpp:145
+#: Source/objects.cpp:152
 msgid "Tainted"
 msgstr "Maculado"
 
-#: Source/objects.cpp:146
+#: Source/objects.cpp:153
 msgid "Oily"
 msgstr "Oleoso"
 
-#: Source/objects.cpp:147
+#: Source/objects.cpp:154
 msgid "Glowing"
 msgstr "Brilhante"
 
-#: Source/objects.cpp:148
+#: Source/objects.cpp:155
 msgid "Mendicant's"
 msgstr "Do Mendicante"
 
-#: Source/objects.cpp:149
+#: Source/objects.cpp:156
 msgid "Sparkling"
 msgstr "Espumante"
 
-#: Source/objects.cpp:151
+#: Source/objects.cpp:158
 msgid "Shimmering"
 msgstr "Cintilante"
 
-#: Source/objects.cpp:152
+#: Source/objects.cpp:159
 msgid "Solar"
 msgstr "Solar"
 
 #. TRANSLATORS: Shrine Name Block end
-#: Source/objects.cpp:154
+#: Source/objects.cpp:161
 msgid "Murphy's"
 msgstr "De Murphy"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:284
+#: Source/objects.cpp:214
 msgid "The Great Conflict"
 msgstr "O Grande Conflito"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:285
+#: Source/objects.cpp:215
 msgid "The Wages of Sin are War"
 msgstr "O Salário do Pecado é a Guerra"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:286
+#: Source/objects.cpp:216
 msgid "The Tale of the Horadrim"
 msgstr "O Conto dos Horadrim"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:287
+#: Source/objects.cpp:217
 msgid "The Dark Exile"
 msgstr "O Exílio Sombrio"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:288
+#: Source/objects.cpp:218
 msgid "The Sin War"
 msgstr "A Guerra do Pecado"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:289
+#: Source/objects.cpp:219
 msgid "The Binding of the Three"
 msgstr "O Aprisionamento dos Três"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:290
+#: Source/objects.cpp:220
 msgid "The Realms Beyond"
 msgstr "Os Reinos Além"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:291
+#: Source/objects.cpp:221
 msgid "Tale of the Three"
 msgstr "Conto dos Três"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:292
+#: Source/objects.cpp:222
 msgid "The Black King"
 msgstr "O Rei Negro"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:293
+#: Source/objects.cpp:223
 msgid "Journal: The Ensorcellment"
 msgstr "Diário: O Enfeitiçado"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:294
+#: Source/objects.cpp:224
 msgid "Journal: The Meeting"
 msgstr "Diário: O Encontro"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:295
+#: Source/objects.cpp:225
 msgid "Journal: The Tirade"
 msgstr "Diário: A Desgraça"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:296
+#: Source/objects.cpp:226
 msgid "Journal: His Power Grows"
 msgstr "Diário: Seu Poder Cresce"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:297
+#: Source/objects.cpp:227
 msgid "Journal: NA-KRUL"
 msgstr "Diário: NA-KRUL"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:298
+#: Source/objects.cpp:228
 msgid "Journal: The End"
 msgstr "Diário: O Fim"
 
 #. TRANSLATORS: Book Title
-#: Source/objects.cpp:299
+#: Source/objects.cpp:229
 msgid "A Spellbook"
 msgstr "Um Livro de Feitiços"
 
-#: Source/objects.cpp:4849
+#: Source/objects.cpp:4780
 msgid "Crucified Skeleton"
 msgstr "Esqueleto Crucificado"
 
-#: Source/objects.cpp:4853
+#: Source/objects.cpp:4784
 msgid "Lever"
 msgstr "Alavanca"
 
-#: Source/objects.cpp:4863
+#: Source/objects.cpp:4794
 msgid "Open Door"
 msgstr "Porta Aberta"
 
-#: Source/objects.cpp:4865
+#: Source/objects.cpp:4796
 msgid "Closed Door"
 msgstr "Porta Fechada"
 
-#: Source/objects.cpp:4867
+#: Source/objects.cpp:4798
 msgid "Blocked Door"
 msgstr "Porta Bloqueada"
 
-#: Source/objects.cpp:4872
+#: Source/objects.cpp:4803
 msgid "Ancient Tome"
 msgstr "Tomo Antigo"
 
-#: Source/objects.cpp:4874
+#: Source/objects.cpp:4805
 msgid "Book of Vileness"
 msgstr "Livro da Vileza"
 
-#: Source/objects.cpp:4879
+#: Source/objects.cpp:4810
 msgid "Skull Lever"
 msgstr "Alavanca de Caveira"
 
-#: Source/objects.cpp:4881
+#: Source/objects.cpp:4812
 msgid "Mythical Book"
 msgstr "Livro Mítico"
 
-#: Source/objects.cpp:4884
+#: Source/objects.cpp:4815
 msgid "Small Chest"
 msgstr "Baú Pequeno"
 
-#: Source/objects.cpp:4887
+#: Source/objects.cpp:4818
 msgid "Chest"
 msgstr "Baú"
 
-#: Source/objects.cpp:4891
+#: Source/objects.cpp:4822
 msgid "Large Chest"
 msgstr "Baú Grande"
 
-#: Source/objects.cpp:4894
+#: Source/objects.cpp:4825
 msgid "Sarcophagus"
 msgstr "Sarcófago"
 
-#: Source/objects.cpp:4896
+#: Source/objects.cpp:4827
 msgid "Bookshelf"
 msgstr "Estante de Livros"
 
-#: Source/objects.cpp:4899
+#: Source/objects.cpp:4830
 msgid "Bookcase"
 msgstr "Estante"
 
-#: Source/objects.cpp:4902
+#: Source/objects.cpp:4833
 msgid "Barrel"
 msgstr "Barril"
 
-#: Source/objects.cpp:4905
+#: Source/objects.cpp:4836
 msgid "Pod"
 msgstr "Ovo"
 
-#: Source/objects.cpp:4908
+#: Source/objects.cpp:4839
 msgid "Urn"
 msgstr "Urna"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:4911
+#: Source/objects.cpp:4842
 msgid "{:s} Shrine"
 msgstr "Altar {:s}"
 
-#: Source/objects.cpp:4913
+#: Source/objects.cpp:4844
 msgid "Skeleton Tome"
 msgstr "Tomo do Esqueleto"
 
-#: Source/objects.cpp:4915
+#: Source/objects.cpp:4846
 msgid "Library Book"
 msgstr "Livro da Biblioteca"
 
-#: Source/objects.cpp:4917
+#: Source/objects.cpp:4848
 msgid "Blood Fountain"
 msgstr "Fonte de Sangue"
 
-#: Source/objects.cpp:4919
+#: Source/objects.cpp:4850
 msgid "Decapitated Body"
 msgstr "Corpo Decapitado"
 
-#: Source/objects.cpp:4921
+#: Source/objects.cpp:4852
 msgid "Book of the Blind"
 msgstr "Livro dos Cegos"
 
-#: Source/objects.cpp:4923
+#: Source/objects.cpp:4854
 msgid "Book of Blood"
 msgstr "Livro de Sangue"
 
-#: Source/objects.cpp:4925
+#: Source/objects.cpp:4856
 msgid "Purifying Spring"
 msgstr "Fonte Purificante"
 
-#: Source/objects.cpp:4930 Source/objects.cpp:4947
+#: Source/objects.cpp:4859 Source/translation_dummy.cpp:316
+#: Source/translation_dummy.cpp:318 Source/translation_dummy.cpp:320
+#: Source/translation_dummy.cpp:322
+msgid "Armor"
+msgstr "Armadura"
+
+#: Source/objects.cpp:4861 Source/objects.cpp:4878
 msgid "Weapon Rack"
 msgstr "Estante de Armas"
 
-#: Source/objects.cpp:4932
+#: Source/objects.cpp:4863
 msgid "Goat Shrine"
 msgstr "Altar Caprino"
 
-#: Source/objects.cpp:4934
+#: Source/objects.cpp:4865
 msgid "Cauldron"
 msgstr "Caldeirão"
 
-#: Source/objects.cpp:4936
+#: Source/objects.cpp:4867
 msgid "Murky Pool"
 msgstr "Poça Turva"
 
-#: Source/objects.cpp:4938
+#: Source/objects.cpp:4869
 msgid "Fountain of Tears"
 msgstr "Fonte de Lágrimas"
 
-#: Source/objects.cpp:4940
+#: Source/objects.cpp:4871
 msgid "Steel Tome"
 msgstr "Tomo do Aço"
 
-#: Source/objects.cpp:4942
+#: Source/objects.cpp:4873
 msgid "Pedestal of Blood"
 msgstr "Pedestal de Sangue"
 
-#: Source/objects.cpp:4949
+#: Source/objects.cpp:4880
 msgid "Mushroom Patch"
 msgstr "Canteiro de Cogumelos"
 
-#: Source/objects.cpp:4951
+#: Source/objects.cpp:4882
 msgid "Vile Stand"
 msgstr "Suporte Vil"
 
-#: Source/objects.cpp:4953
+#: Source/objects.cpp:4884
 msgid "Slain Hero"
 msgstr "Herói Assassinado"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:4965
+#: Source/objects.cpp:4896
 msgid "Trapped {:s}"
 msgstr "{:s} com armadilha"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls lever
-#: Source/objects.cpp:4970
+#: Source/objects.cpp:4901
 msgid "{:s} (disabled)"
 msgstr "{:s} (desativado)"
 
-#: Source/options.cpp:455 Source/options.cpp:580 Source/options.cpp:586
+#: Source/options.cpp:304 Source/options.cpp:441 Source/options.cpp:447
 msgid "ON"
 msgstr "ATIVO"
 
-#: Source/options.cpp:455 Source/options.cpp:578 Source/options.cpp:584
+#: Source/options.cpp:304 Source/options.cpp:439 Source/options.cpp:445
 msgid "OFF"
 msgstr "INATIVO"
 
-#: Source/options.cpp:568
-msgid "Start Up"
-msgstr "Inicialização"
-
-#: Source/options.cpp:568
-msgid "Start Up Settings"
-msgstr "Configurações de Inicialização"
-
-#: Source/options.cpp:569
+#: Source/options.cpp:416 Source/options.cpp:417
 msgid "Game Mode"
 msgstr "Modo de Jogo"
 
-#: Source/options.cpp:569
+#: Source/options.cpp:416
+#, fuzzy
+#| msgid "Gameplay Settings"
+msgid "Game Mode Settings"
+msgstr "Configurações de Gameplay"
+
+#: Source/options.cpp:417
 msgid "Play Diablo or Hellfire."
 msgstr "Jogar Diablo ou Hellfire."
 
-#: Source/options.cpp:575
+#: Source/options.cpp:423
 msgid "Restrict to Shareware"
 msgstr "Restringir ao Shareware"
 
-#: Source/options.cpp:575
+#: Source/options.cpp:423
 msgid ""
 "Makes the game compatible with the demo. Enables multiplayer with friends "
 "who don't own a full copy of Diablo."
@@ -6920,108 +3872,114 @@ msgstr ""
 "Torna o jogo compatível com a demonstração. Habilita multiplayer com amigos "
 "que não possuem a versão completa do Diablo."
 
-#: Source/options.cpp:576 Source/options.cpp:582
+#: Source/options.cpp:436
+msgid "Start Up"
+msgstr "Inicialização"
+
+#: Source/options.cpp:436
+msgid "Start Up Settings"
+msgstr "Configurações de Inicialização"
+
+#: Source/options.cpp:437 Source/options.cpp:443
 msgid "Intro"
 msgstr "Introdução"
 
-#: Source/options.cpp:576 Source/options.cpp:582
+#: Source/options.cpp:437 Source/options.cpp:443
 msgid "Shown Intro cinematic."
 msgstr "Exibe vídeo de Introdução."
 
-#: Source/options.cpp:588
+#: Source/options.cpp:449
 msgid "Splash"
 msgstr "Tela de Abertura"
 
-#: Source/options.cpp:588
+#: Source/options.cpp:449
 msgid "Shown splash screen."
 msgstr "Tela de abertura exibida."
 
-#: Source/options.cpp:590
+#: Source/options.cpp:451
 msgid "Logo and Title Screen"
 msgstr "Tela com logo e título"
 
-#: Source/options.cpp:591
+#: Source/options.cpp:452
 msgid "Title Screen"
 msgstr "Tela do Título"
 
-#: Source/options.cpp:610
+#: Source/options.cpp:467
 msgid "Diablo specific Settings"
 msgstr "Configurações específicas do Diablo"
 
-#: Source/options.cpp:624
+#: Source/options.cpp:481
 msgid "Hellfire specific Settings"
 msgstr "Configurações específicas do Hellfire"
 
-#: Source/options.cpp:638
+#: Source/options.cpp:495
 msgid "Audio"
 msgstr "Áudio"
 
-#: Source/options.cpp:638
+#: Source/options.cpp:495
 msgid "Audio Settings"
 msgstr "Configurações de Áudio"
 
-#: Source/options.cpp:641
+#: Source/options.cpp:498
 msgid "Walking Sound"
 msgstr "Som dos Passos"
 
-#: Source/options.cpp:641
+#: Source/options.cpp:498
 msgid "Player emits sound when walking."
 msgstr "Jogador emite som ao caminhar."
 
-#: Source/options.cpp:642
+#: Source/options.cpp:499
 msgid "Auto Equip Sound"
 msgstr "Som ao Auto-Equipar"
 
-#: Source/options.cpp:642
+#: Source/options.cpp:499
 msgid "Automatically equipping items on pickup emits the equipment sound."
 msgstr ""
 "Equipar os items automaticamente emite o som dos equipamentos ao pegá-los."
 
-#: Source/options.cpp:643
+#: Source/options.cpp:500
 msgid "Item Pickup Sound"
 msgstr "Som ao Pegar Item"
 
-#: Source/options.cpp:643
+#: Source/options.cpp:500
 msgid "Picking up items emits the items pickup sound."
 msgstr "Emite o som dos equipamentos ao pegá-los."
 
-#: Source/options.cpp:644
+#: Source/options.cpp:501
 msgid "Sample Rate"
 msgstr "Taxa de Amostragem"
 
-#: Source/options.cpp:644
+#: Source/options.cpp:501
 msgid "Output sample rate (Hz)."
 msgstr "Taxa de amostragem de saída (Hz)"
 
-#: Source/options.cpp:645
+#: Source/options.cpp:502
 msgid "Channels"
 msgstr "Canais"
 
-#: Source/options.cpp:645
+#: Source/options.cpp:502
 msgid "Number of output channels."
 msgstr "Número de canais de saída."
 
-#: Source/options.cpp:646
+#: Source/options.cpp:503
 msgid "Buffer Size"
 msgstr "Tamanho do Buffer"
 
-#: Source/options.cpp:646
+#: Source/options.cpp:503
 msgid "Buffer size (number of frames per channel)."
 msgstr "Tamanho do Buffer (número de quadros por canal)."
 
-#: Source/options.cpp:647
+#: Source/options.cpp:504
 msgid "Resampling Quality"
 msgstr "Qualidade de resampling"
 
-#: Source/options.cpp:647
-msgid "Quality of the resampler, from 0 (lowest) to 10 (highest)."
+#: Source/options.cpp:504
+#, fuzzy
+#| msgid "Quality of the resampler, from 0 (lowest) to 10 (highest)."
+msgid "Quality of the resampler, from 0 (lowest) to 5 (highest)."
 msgstr "Qualidade do resampler, de 0 (pior) to 10 (melhor)."
 
-#: Source/options.cpp:678
-msgid "Resolution"
-msgstr "Resolução"
-
-#: Source/options.cpp:678
+#: Source/options.cpp:529
 msgid ""
 "Affect the game's internal resolution and determine your view area. Note: "
 "This can differ from screen resolution, when Upscaling, Integer Scaling or "
@@ -7031,43 +3989,43 @@ msgstr ""
 "pode mudar para cada resolução de tela, quando usando Upscaling, Escala de "
 "Inteiros ou Ajustar à Tela."
 
-#: Source/options.cpp:825
+#: Source/options.cpp:568
 msgid "Resampler"
 msgstr "Resampler"
 
-#: Source/options.cpp:825
+#: Source/options.cpp:568
 msgid "Audio resampler"
 msgstr "Resampler de áudio"
 
-#: Source/options.cpp:882
+#: Source/options.cpp:625
 msgid "Device"
 msgstr "Dispositivo"
 
-#: Source/options.cpp:882
+#: Source/options.cpp:625
 msgid "Audio device"
 msgstr "Dipositivo de Áudio"
 
-#: Source/options.cpp:950
+#: Source/options.cpp:682
 msgid "Graphics"
 msgstr "Gráficos"
 
-#: Source/options.cpp:950
+#: Source/options.cpp:682
 msgid "Graphics Settings"
 msgstr "Configurações de Gráficos"
 
-#: Source/options.cpp:951
+#: Source/options.cpp:683
 msgid "Fullscreen"
 msgstr "Tela cheia"
 
-#: Source/options.cpp:951
+#: Source/options.cpp:683
 msgid "Display the game in windowed or fullscreen mode."
 msgstr "Exibe o jogo em modo janela ou tela cheia."
 
-#: Source/options.cpp:953
+#: Source/options.cpp:685
 msgid "Fit to Screen"
 msgstr "Ajustar à Tela"
 
-#: Source/options.cpp:953
+#: Source/options.cpp:685
 msgid ""
 "Automatically adjust the game window to your current desktop screen aspect "
 "ratio and resolution."
@@ -7075,11 +4033,11 @@ msgstr ""
 "Ajusta automaticamente a janela do jogo mantendo a mesma proporção e "
 "resolução da tela de desktop atual."
 
-#: Source/options.cpp:956
+#: Source/options.cpp:688
 msgid "Upscale"
 msgstr "Upscale"
 
-#: Source/options.cpp:956
+#: Source/options.cpp:688
 msgid ""
 "Enables image scaling from the game resolution to your monitor resolution. "
 "Prevents changing the monitor resolution and allows window resizing."
@@ -7088,89 +4046,103 @@ msgstr ""
 "monitor. Previne mudanças na resolução do monitor e permite redimensionar a "
 "janela."
 
-#: Source/options.cpp:963
+#: Source/options.cpp:695
 msgid "Scaling Quality"
 msgstr "Qualidade de Escala"
 
-#: Source/options.cpp:963
+#: Source/options.cpp:695
 msgid "Enables optional filters to the output image when upscaling."
 msgstr ""
 "Habilita filtros opcionais para a image de saída quando utilizando upscaling."
 
-#: Source/options.cpp:965
+#: Source/options.cpp:697
 msgid "Nearest Pixel"
 msgstr "Pixel mais Próximo"
 
-#: Source/options.cpp:966
+#: Source/options.cpp:698
 msgid "Bilinear"
 msgstr "Bilinear"
 
-#: Source/options.cpp:967
+#: Source/options.cpp:699
 msgid "Anisotropic"
 msgstr "Anisotrópico"
 
-#: Source/options.cpp:969
+#: Source/options.cpp:701
 msgid "Integer Scaling"
 msgstr "Escala de Inteiros"
 
-#: Source/options.cpp:969
+#: Source/options.cpp:701
 msgid "Scales the image using whole number pixel ratio."
 msgstr "Escala a imagem usando a proporção de pixel em número inteiro."
 
-#: Source/options.cpp:976
+#: Source/options.cpp:709
+msgid "Frame Rate Control"
+msgstr ""
+
+#: Source/options.cpp:710
+msgid ""
+"Manages frame rate to balance performance, reduce tearing, or save power."
+msgstr ""
+
+#: Source/options.cpp:720
 msgid "Vertical Sync"
 msgstr "Sincronização Vertical"
 
-#: Source/options.cpp:977
-msgid ""
-"Forces waiting for Vertical Sync. Prevents tearing effect when drawing a "
-"frame. Disabling it can help with mouse lag on some systems."
+#: Source/options.cpp:722
+msgid "Limit FPS"
 msgstr ""
-"Força a espera por Sincronização Vertical. Previne efeito de sobreposição de "
-"retalhos ao desenhar quadro. Desabilitá-lo pode ajudar com lag no mouse em "
-"alguns sistemas."
 
-#: Source/options.cpp:986
+#: Source/options.cpp:725
 msgid "Zoom on when enabled."
 msgstr "Zoom quando habilitado."
 
-#: Source/options.cpp:987
+#: Source/options.cpp:726
+#, fuzzy
+#| msgid " Lightning"
+msgid "Per-pixel Lighting"
+msgstr " Raios"
+
+#: Source/options.cpp:726
+msgid "Subtile lighting for smoother light gradients."
+msgstr ""
+
+#: Source/options.cpp:727
 msgid "Color Cycling"
 msgstr "Ciclagem de Cores"
 
-#: Source/options.cpp:987
+#: Source/options.cpp:727
 msgid "Color cycling effect used for water, lava, and acid animation."
 msgstr "Efeito de Ciclagem de Cores usado para animação da água, lava e ácido."
 
-#: Source/options.cpp:988
+#: Source/options.cpp:728
 msgid "Alternate nest art"
 msgstr "Usa paleta alternativa no enxame"
 
-#: Source/options.cpp:988
+#: Source/options.cpp:728
 msgid "The game will use an alternative palette for Hellfire’s nest tileset."
 msgstr "O jogo irá usar a paleta alternativa para o enxame do Hellfire."
 
-#: Source/options.cpp:990
+#: Source/options.cpp:730
 msgid "Hardware Cursor"
 msgstr "Cursor em Hardware"
 
-#: Source/options.cpp:990
+#: Source/options.cpp:730
 msgid "Use a hardware cursor"
 msgstr "Usa um cursor em hardware"
 
-#: Source/options.cpp:991
+#: Source/options.cpp:731
 msgid "Hardware Cursor For Items"
 msgstr "Cursor em Hardware Para Items"
 
-#: Source/options.cpp:991
+#: Source/options.cpp:731
 msgid "Use a hardware cursor for items."
 msgstr "Usa um cursor em hardware para os items."
 
-#: Source/options.cpp:992
+#: Source/options.cpp:732
 msgid "Hardware Cursor Maximum Size"
 msgstr "Tamanho máximo do Cursor em Hardware"
 
-#: Source/options.cpp:992
+#: Source/options.cpp:732
 msgid ""
 "Maximum width / height for the hardware cursor. Larger cursors fall back to "
 "software."
@@ -7178,63 +4150,23 @@ msgstr ""
 "Largura / altura máxima para o cursor em hardware. Cursores maiores são "
 "convertidos para software."
 
-#: Source/options.cpp:994
-msgid "FPS Limiter"
-msgstr "Limitador de FPS"
-
-#: Source/options.cpp:994
-msgid "FPS is limited to avoid high CPU load. Limit considers refresh rate."
-msgstr ""
-"FPS é limitado para evitar alta carga de CPU. O limite considera a taxa de "
-"atualização."
-
-#: Source/options.cpp:995
-msgid "Show Item Graphics in Stores"
-msgstr "Exibir Gráficos de Itens nas Lojas"
-
-#: Source/options.cpp:995
-msgid "Show item graphics to the left of item descriptions in store menus."
-msgstr ""
-"Exibir gráficos de itens à esquerda das descrições de itens nos menus das "
-"lojas."
-
-#: Source/options.cpp:996
+#: Source/options.cpp:734
 msgid "Show FPS"
 msgstr "Exibir FPS"
 
-#: Source/options.cpp:996
+#: Source/options.cpp:734
 msgid "Displays the FPS in the upper left corner of the screen."
 msgstr "Exibe o FPS no canto esquerdo superior da tela."
 
-#: Source/options.cpp:997
-msgid "Show health values"
-msgstr "Exibir valor de pontos de vida"
-
-#: Source/options.cpp:997
-msgid "Displays current / max health value on health globe."
-msgstr "Exibe valor atual e máximo de pontos de vida no orbe da vida."
-
-#: Source/options.cpp:998
-msgid "Show mana values"
-msgstr "Exibir valor de mana"
-
-#: Source/options.cpp:998
-msgid "Displays current / max mana value on mana globe."
-msgstr "Exibe valor atual e máximo de mana no orbe da mana."
-
-#: Source/options.cpp:1049
+#: Source/options.cpp:770
 msgid "Gameplay"
 msgstr "Gameplay"
 
-#: Source/options.cpp:1049
+#: Source/options.cpp:770
 msgid "Gameplay Settings"
 msgstr "Configurações de Gameplay"
 
-#: Source/options.cpp:1051
-msgid "Run in Town"
-msgstr "Correr na Cidade"
-
-#: Source/options.cpp:1051
+#: Source/options.cpp:772
 msgid ""
 "Enable jogging/fast walking in town for Diablo and Hellfire. This option was "
 "introduced in the expansion."
@@ -7242,38 +4174,38 @@ msgstr ""
 "Habilita correr/andar rápido na cidade no Diablo e Hellfire. Essa opção foi "
 "introduzida na expansão."
 
-#: Source/options.cpp:1052
+#: Source/options.cpp:773
 msgid "Grab Input"
 msgstr "Travar Input"
 
-#: Source/options.cpp:1052
+#: Source/options.cpp:773
 msgid "When enabled mouse is locked to the game window."
 msgstr "Quando habilitado, mouse fica travado na janela do jogo."
 
-#: Source/options.cpp:1053
-msgid "Theo Quest"
-msgstr "Missão do Theo"
+#: Source/options.cpp:774
+msgid "Pause Game When Window Loses Focus"
+msgstr ""
 
-#: Source/options.cpp:1053
+#: Source/options.cpp:774
+msgid "When enabled, the game will pause when focus is lost."
+msgstr ""
+
+#: Source/options.cpp:775
 msgid "Enable Little Girl quest."
 msgstr "Habilita missão da Garotinha."
 
-#: Source/options.cpp:1054
-msgid "Cow Quest"
-msgstr "Missão da Vaca"
-
-#: Source/options.cpp:1054
+#: Source/options.cpp:776
 msgid ""
 "Enable Jersey's quest. Lester the farmer is replaced by the Complete Nut."
 msgstr ""
 "Habilitar missão do Jersey. Lester o fazendeiro é substituído pelo "
 "Completamente Louco."
 
-#: Source/options.cpp:1055
+#: Source/options.cpp:777
 msgid "Friendly Fire"
 msgstr "Fogo Amigo"
 
-#: Source/options.cpp:1055
+#: Source/options.cpp:777
 msgid ""
 "Allow arrow/spell damage between players in multiplayer even when the "
 "friendly mode is on."
@@ -7281,151 +4213,133 @@ msgstr ""
 "Permite causar danos por flechas/feitiços entre jogadores no multiplayer "
 "mesmo quando o modo amistoso está habilitado."
 
-#: Source/options.cpp:1056
+#: Source/options.cpp:778
 msgid "Full quests in Multiplayer"
 msgstr "Todas as quests no modo Multijogador"
 
-#: Source/options.cpp:1056
+#: Source/options.cpp:778
 msgid "Enables the full/uncut singleplayer version of quests."
 msgstr "Habilita a versão completa/sem cortes das missões de um jogador."
 
-#: Source/options.cpp:1057
+#: Source/options.cpp:779
 msgid "Test Bard"
 msgstr "Teste Bardo"
 
-#: Source/options.cpp:1057
+#: Source/options.cpp:779
 msgid "Force the Bard character type to appear in the hero selection menu."
 msgstr ""
 "Força a classe de personagem Bardo a aparecer no menu de seleção do herói."
 
-#: Source/options.cpp:1058
+#: Source/options.cpp:780
 msgid "Test Barbarian"
 msgstr "Teste Bárbaro"
 
-#: Source/options.cpp:1058
+#: Source/options.cpp:780
 msgid ""
 "Force the Barbarian character type to appear in the hero selection menu."
 msgstr ""
 "Força a classe de personagem Bárbaro a aparecer no menu de seleção do herói."
 
-#: Source/options.cpp:1059
+#: Source/options.cpp:781
 msgid "Experience Bar"
 msgstr "Barra de Experiência"
 
-#: Source/options.cpp:1059
+#: Source/options.cpp:781
 msgid "Experience Bar is added to the UI at the bottom of the screen."
 msgstr "Barra de Experiência é adicionada à UI na parte inferior da tela."
 
-#: Source/options.cpp:1060
+#: Source/options.cpp:782
+msgid "Show Item Graphics in Stores"
+msgstr "Exibir Gráficos de Itens nas Lojas"
+
+#: Source/options.cpp:782
+msgid "Show item graphics to the left of item descriptions in store menus."
+msgstr ""
+"Exibir gráficos de itens à esquerda das descrições de itens nos menus das "
+"lojas."
+
+#: Source/options.cpp:783
+msgid "Show health values"
+msgstr "Exibir valor de pontos de vida"
+
+#: Source/options.cpp:783
+msgid "Displays current / max health value on health globe."
+msgstr "Exibe valor atual e máximo de pontos de vida no orbe da vida."
+
+#: Source/options.cpp:784
+msgid "Show mana values"
+msgstr "Exibir valor de mana"
+
+#: Source/options.cpp:784
+msgid "Displays current / max mana value on mana globe."
+msgstr "Exibe valor atual e máximo de mana no orbe da mana."
+
+#: Source/options.cpp:785
 msgid "Enemy Health Bar"
 msgstr "Barra de Vida do Inimigo"
 
-#: Source/options.cpp:1060
+#: Source/options.cpp:785
 msgid "Enemy Health Bar is displayed at the top of the screen."
 msgstr "Barra de Vida do Inimigo é exibida na parte superior da tela."
 
-#: Source/options.cpp:1061
-msgid "Auto Gold Pickup"
-msgstr "Pegar Ouro Automaticamente"
-
-#: Source/options.cpp:1061
+#: Source/options.cpp:786
 msgid "Gold is automatically collected when in close proximity to the player."
 msgstr "Ouro é pego automaticamente quando perto do jogador."
 
-#: Source/options.cpp:1062
-msgid "Auto Elixir Pickup"
-msgstr "Pegar Elixir Automaticamente"
-
-#: Source/options.cpp:1062
+#: Source/options.cpp:787
 msgid ""
 "Elixirs are automatically collected when in close proximity to the player."
 msgstr "Elixires são pegos automaticamente quando perto do jogador."
 
-#: Source/options.cpp:1063
-msgid "Auto Oil Pickup"
-msgstr "Pegar Óleo Automaticamente"
-
-#: Source/options.cpp:1063
+#: Source/options.cpp:788
 msgid "Oils are automatically collected when in close proximity to the player."
 msgstr "Óleos são pegos automaticamente quando perto do jogador."
 
-#: Source/options.cpp:1064
-msgid "Auto Pickup in Town"
-msgstr "Pegar itens na Cidade automaticamente"
-
-#: Source/options.cpp:1064
+#: Source/options.cpp:789
 msgid "Automatically pickup items in town."
 msgstr "Itens são pegos automaticamente quando estiver na cidade."
 
-#: Source/options.cpp:1065
-msgid "Adria Refills Mana"
-msgstr "Adria Recupera Mana"
-
-#: Source/options.cpp:1065
+#: Source/options.cpp:790
 msgid "Adria will refill your mana when you visit her shop."
 msgstr "Adria vai encher sua mana quando você visitar a loja dela."
 
-#: Source/options.cpp:1066
-msgid "Auto Equip Weapons"
-msgstr "Auto Equipar Armas"
-
-#: Source/options.cpp:1066
+#: Source/options.cpp:791
 msgid ""
 "Weapons will be automatically equipped on pickup or purchase if enabled."
 msgstr ""
 "Armas são equipadas automaticamente quando pegas ou compradas, se habilitado."
 
-#: Source/options.cpp:1067
-msgid "Auto Equip Armor"
-msgstr "Auto Equipar Armadura"
-
-#: Source/options.cpp:1067
+#: Source/options.cpp:792
 msgid "Armor will be automatically equipped on pickup or purchase if enabled."
 msgstr ""
 "Armadura é equipada automaticamente se pega ou comprada, se habilitado."
 
-#: Source/options.cpp:1068
-msgid "Auto Equip Helms"
-msgstr "Auto Equipar Elmos"
-
-#: Source/options.cpp:1068
+#: Source/options.cpp:793
 msgid "Helms will be automatically equipped on pickup or purchase if enabled."
 msgstr ""
 "Elmos são equipados automaticamente se pegos ou comprados, se habilitado."
 
-#: Source/options.cpp:1069
-msgid "Auto Equip Shields"
-msgstr "Auto Equipar Escudos"
-
-#: Source/options.cpp:1069
+#: Source/options.cpp:794
 msgid ""
 "Shields will be automatically equipped on pickup or purchase if enabled."
 msgstr ""
 "Escudos são equipados automaticamente se pegos ou comprados, se habilitado."
 
-#: Source/options.cpp:1070
-msgid "Auto Equip Jewelry"
-msgstr "Auto Equipar Jóias"
-
-#: Source/options.cpp:1070
+#: Source/options.cpp:795
 msgid ""
 "Jewelry will be automatically equipped on pickup or purchase if enabled."
 msgstr ""
 "Jóias são equipadas automaticamente quando pegas ou compradas, se habilitado."
 
-#: Source/options.cpp:1071
-msgid "Randomize Quests"
-msgstr "Randomizar Missões"
-
-#: Source/options.cpp:1071
+#: Source/options.cpp:796
 msgid "Randomly selecting available quests for new games."
 msgstr "Seleciona missões aleatóriamente para novos jogos."
 
-#: Source/options.cpp:1072
+#: Source/options.cpp:797
 msgid "Show Monster Type"
 msgstr "Exibir Tipo de Monstro"
 
-#: Source/options.cpp:1072
+#: Source/options.cpp:797
 msgid ""
 "Hovering over a monster will display the type of monster in the description "
 "box in the UI."
@@ -7433,40 +4347,33 @@ msgstr ""
 "Quando o cursor estiver sobre o monstro, o seu tipo será exibido na caixa de "
 "descrição da UI."
 
-#: Source/options.cpp:1073
-msgid "Show Item Labels"
-msgstr "Exibir nome dos items"
-
-#: Source/options.cpp:1073
+#: Source/options.cpp:798
 msgid "Show labels for items on the ground when enabled."
 msgstr "Exibir nome dos items no chão quando habilitado."
 
-#: Source/options.cpp:1074
-msgid "Auto Refill Belt"
-msgstr "Auto Abastecer Cinto"
-
-#: Source/options.cpp:1074
+#: Source/options.cpp:799
 msgid "Refill belt from inventory when belt item is consumed."
 msgstr "Abastece cinto pelo inventário quando um item do cinto é consumido."
 
-#: Source/options.cpp:1075
-msgid "Disable Crippling Shrines"
-msgstr "Desabilitar Altares Destrutivos"
-
-#: Source/options.cpp:1075
+#: Source/options.cpp:800
+#, fuzzy
+#| msgid ""
+#| "When enabled Cauldrons, Fascinating Shrines, Goat Shrines, Ornate Shrines "
+#| "and Sacred Shrines are not able to be clicked on and labeled as disabled."
 msgid ""
-"When enabled Cauldrons, Fascinating Shrines, Goat Shrines, Ornate Shrines "
-"and Sacred Shrines are not able to be clicked on and labeled as disabled."
+"When enabled Cauldrons, Fascinating Shrines, Goat Shrines, Ornate Shrines, "
+"Sacred Shrines and Murphy's Shrines are not able to be clicked on and "
+"labeled as disabled."
 msgstr ""
 "Quando habilitado, Caldeirões, Altares Fascinantes, Altares Caprinos, "
 "Altares Ornados e Altares Sagrados não podem ser clicadas e são marcados "
 "como desabilitados."
 
-#: Source/options.cpp:1076
+#: Source/options.cpp:801
 msgid "Quick Cast"
 msgstr "Lançamento Rápido"
 
-#: Source/options.cpp:1076
+#: Source/options.cpp:801
 msgid ""
 "Spell hotkeys instantly cast the spell, rather than switching the readied "
 "spell."
@@ -7474,1004 +4381,800 @@ msgstr ""
 "Teclas de Atalho de feitiços lançam feitiços, ao invés de mudar o fetiço "
 "selecionado."
 
-#: Source/options.cpp:1077
-msgid "Heal Potion Pickup"
-msgstr "Pegar Poção de Cura"
-
-#: Source/options.cpp:1077
+#: Source/options.cpp:802
 msgid "Number of Healing potions to pick up automatically."
 msgstr "Número de poções de cura a serem pegas automaticamente."
 
-#: Source/options.cpp:1078
-msgid "Full Heal Potion Pickup"
-msgstr "Pegar Poção de Cura Completa"
-
-#: Source/options.cpp:1078
+#: Source/options.cpp:803
 msgid "Number of Full Healing potions to pick up automatically."
 msgstr "Número de poções de cura completa a serem pegas automaticamente."
 
-#: Source/options.cpp:1079
-msgid "Mana Potion Pickup"
-msgstr "Pegar Poção de Mana"
-
-#: Source/options.cpp:1079
+#: Source/options.cpp:804
 msgid "Number of Mana potions to pick up automatically."
 msgstr "Número de poções de mana a serem pegas automaticamente."
 
-#: Source/options.cpp:1080
-msgid "Full Mana Potion Pickup"
-msgstr "Pegar Poção de Mana Completa"
-
-#: Source/options.cpp:1080
+#: Source/options.cpp:805
 msgid "Number of Full Mana potions to pick up automatically."
 msgstr "Número de poções de mana completa a serem pegas automaticamente."
 
-#: Source/options.cpp:1081
-msgid "Rejuvenation Potion Pickup"
-msgstr "Pegar Poção de Rejuvenescimento"
-
-#: Source/options.cpp:1081
+#: Source/options.cpp:806
 msgid "Number of Rejuvenation potions to pick up automatically."
 msgstr "Número de poções de Rejuvenecimento a serem pegas automaticamente."
 
-#: Source/options.cpp:1082
-msgid "Full Rejuvenation Potion Pickup"
-msgstr "Pegar Poção de Rejuvenecimento Completo"
-
-#: Source/options.cpp:1082
+#: Source/options.cpp:807
 msgid "Number of Full Rejuvenation potions to pick up automatically."
 msgstr ""
 "Número de poções de Rejuvenecimento Completo a serem pegas automaticamente."
 
-#: Source/options.cpp:1083
+#: Source/options.cpp:808
 msgid "Enable floating numbers"
 msgstr "Habilitar números flutuantes"
 
-#: Source/options.cpp:1083
+#: Source/options.cpp:808
 msgid "Enables floating numbers on gaining XP / dealing damage etc."
 msgstr "Habilita números flutuantes ao ganhar XP / causar dano, etc."
 
-#: Source/options.cpp:1085
+#: Source/options.cpp:810
 msgid "Off"
 msgstr "Desligado"
 
-#: Source/options.cpp:1086
+#: Source/options.cpp:811
 msgid "Random Angles"
 msgstr "Ângulos Aleatórios"
 
-#: Source/options.cpp:1087
+#: Source/options.cpp:812
 msgid "Vertical Only"
 msgstr "Somente Vertical"
 
-#: Source/options.cpp:1135
+#: Source/options.cpp:864
 msgid "Controller"
 msgstr "Controle"
 
-#: Source/options.cpp:1135
+#: Source/options.cpp:864
 msgid "Controller Settings"
 msgstr "Configurações de Controle"
 
-#: Source/options.cpp:1144
+#: Source/options.cpp:873
 msgid "Network"
 msgstr "Rede"
 
-#: Source/options.cpp:1144
+#: Source/options.cpp:873
 msgid "Network Settings"
 msgstr "Configurações de Rede"
 
-#: Source/options.cpp:1156
+#: Source/options.cpp:885
 msgid "Chat"
 msgstr "Chat"
 
-#: Source/options.cpp:1156
+#: Source/options.cpp:885
 msgid "Chat Settings"
 msgstr "Configurações de Chat"
 
-#: Source/options.cpp:1165 Source/options.cpp:1281
+#: Source/options.cpp:894 Source/options.cpp:1012
 msgid "Language"
 msgstr "Idioma"
 
-#: Source/options.cpp:1165
+#: Source/options.cpp:894
 msgid "Define what language to use in game."
 msgstr "Define qual idioma será usado no jogo."
 
-#: Source/options.cpp:1281
+#: Source/options.cpp:1012
 msgid "Language Settings"
 msgstr "Configurações de Idioma"
 
-#: Source/options.cpp:1293
+#: Source/options.cpp:1023
 msgid "Keymapping"
 msgstr "Mapeamento de Teclas"
 
-#: Source/options.cpp:1293
+#: Source/options.cpp:1023
 msgid "Keymapping Settings"
 msgstr "Configurações de Mapeamento de Teclas"
 
-#: Source/options.cpp:1516
+#: Source/options.cpp:1243
 msgid "Padmapping"
 msgstr "Mapeamento de Teclas"
 
-#: Source/options.cpp:1516
+#: Source/options.cpp:1243
 msgid "Padmapping Settings"
 msgstr "Configurações de Mapeamento de Teclas"
 
-#: Source/panels/charpanel.cpp:125
+#: Source/options.cpp:1495
+msgid "Mods"
+msgstr ""
+
+#: Source/options.cpp:1495
+#, fuzzy
+#| msgid "Settings"
+msgid "Mod Settings"
+msgstr "Configurações"
+
+#: Source/panels/charpanel.cpp:133
 msgid "Level"
 msgstr "Nível"
 
-#: Source/panels/charpanel.cpp:127
+#: Source/panels/charpanel.cpp:135
 msgid "Experience"
 msgstr "Experiência"
 
-#: Source/panels/charpanel.cpp:132
+#: Source/panels/charpanel.cpp:139
 msgid "Next level"
 msgstr "Próximo nível"
 
-#: Source/panels/charpanel.cpp:141
+#: Source/panels/charpanel.cpp:148
 msgid "Base"
 msgstr "Base"
 
-#: Source/panels/charpanel.cpp:142
+#: Source/panels/charpanel.cpp:149
 msgid "Now"
 msgstr "Atual"
 
-#: Source/panels/charpanel.cpp:143
+#: Source/panels/charpanel.cpp:150
 msgid "Strength"
 msgstr "Força"
 
-#: Source/panels/charpanel.cpp:147
+#: Source/panels/charpanel.cpp:154
 msgid "Magic"
 msgstr "Magia"
 
-#: Source/panels/charpanel.cpp:151
+#: Source/panels/charpanel.cpp:158
 msgid "Dexterity"
 msgstr "Destreza"
 
-#: Source/panels/charpanel.cpp:154
+#: Source/panels/charpanel.cpp:161
 msgid "Vitality"
 msgstr "Vitalidade"
 
-#: Source/panels/charpanel.cpp:157
+#: Source/panels/charpanel.cpp:164
 msgid "Points to distribute"
 msgstr "Pontos a distribuir"
 
-#: Source/panels/charpanel.cpp:167
+#: Source/panels/charpanel.cpp:170 Source/translation_dummy.cpp:247
+#: Source/translation_dummy.cpp:602
+msgid "Gold"
+msgstr "Ouro"
+
+#: Source/panels/charpanel.cpp:174
 msgid "Armor class"
 msgstr "Armadura"
 
-#: Source/panels/charpanel.cpp:169
-msgid "To hit"
-msgstr "Chance de acerto"
+#: Source/panels/charpanel.cpp:176
+#, fuzzy
+#| msgid "chance to hit"
+msgid "Chance To Hit"
+msgstr "chance de acerto"
 
-#: Source/panels/charpanel.cpp:171
+#: Source/panels/charpanel.cpp:178
 msgid "Damage"
 msgstr "Dano"
 
-#: Source/panels/charpanel.cpp:178
+#: Source/panels/charpanel.cpp:184
 msgid "Life"
 msgstr "Vida"
 
-#: Source/panels/charpanel.cpp:182
+#: Source/panels/charpanel.cpp:188
 msgid "Mana"
 msgstr "Mana"
 
-#: Source/panels/charpanel.cpp:187
+#: Source/panels/charpanel.cpp:193
 msgid "Resist magic"
 msgstr "Resist. à magia"
 
-#: Source/panels/charpanel.cpp:189
+#: Source/panels/charpanel.cpp:195
 msgid "Resist fire"
 msgstr "Resist. a fogo"
 
-#: Source/panels/charpanel.cpp:191
+#: Source/panels/charpanel.cpp:197
 msgid "Resist lightning"
 msgstr "Resist. a raios"
 
-#: Source/panels/mainpanel.cpp:85
+#: Source/panels/mainpanel.cpp:91
 msgid "char"
 msgstr "person."
 
-#: Source/panels/mainpanel.cpp:86
+#: Source/panels/mainpanel.cpp:92
 msgid "quests"
 msgstr "missões"
 
-#: Source/panels/mainpanel.cpp:87
+#: Source/panels/mainpanel.cpp:93
 msgid "map"
 msgstr "mapa"
 
-#: Source/panels/mainpanel.cpp:88
+#: Source/panels/mainpanel.cpp:94
 msgid "menu"
 msgstr "menu"
 
-#: Source/panels/mainpanel.cpp:89
+#: Source/panels/mainpanel.cpp:95
 msgid "inv"
 msgstr "invent."
 
-#: Source/panels/mainpanel.cpp:90
+#: Source/panels/mainpanel.cpp:96
 msgid "spells"
 msgstr "feitiços"
 
-#: Source/panels/mainpanel.cpp:100 Source/panels/mainpanel.cpp:126
-#: Source/panels/mainpanel.cpp:128
+#: Source/panels/mainpanel.cpp:106 Source/panels/mainpanel.cpp:132
+#: Source/panels/mainpanel.cpp:134
 msgid "voice"
 msgstr "voz"
 
-#: Source/panels/mainpanel.cpp:121 Source/panels/mainpanel.cpp:123
-#: Source/panels/mainpanel.cpp:125
+#: Source/panels/mainpanel.cpp:127 Source/panels/mainpanel.cpp:129
+#: Source/panels/mainpanel.cpp:131
 msgid "mute"
 msgstr "mudo"
 
-#: Source/panels/spell_book.cpp:158 Source/panels/spell_list.cpp:150
+#: Source/panels/spell_book.cpp:119
+msgid "Unusable"
+msgstr "Inutilizável"
+
+#. TRANSLATORS: UI constraints, keep short please.
+#: Source/panels/spell_book.cpp:122
+msgid "Dmg: 1/3 target hp"
+msgstr "Dano: 1/3 da vida do alvo"
+
+#. TRANSLATORS: UI constraints, keep short please.
+#: Source/panels/spell_book.cpp:129
+msgid "Heals: {:d} - {:d}"
+msgstr "Cura: {:d} - {:d}"
+
+#. TRANSLATORS: UI constraints, keep short please.
+#: Source/panels/spell_book.cpp:131
+msgid "Damage: {:d} - {:d}"
+msgstr "Dano: {:d} - {:d}"
+
+#: Source/panels/spell_book.cpp:186 Source/panels/spell_list.cpp:152
 msgid "Skill"
 msgstr "Habilidade"
 
-#: Source/panels/spell_book.cpp:162
+#: Source/panels/spell_book.cpp:190
 msgid "Staff ({:d} charge)"
 msgid_plural "Staff ({:d} charges)"
 msgstr[0] "Cajado ({:d} carga)"
 msgstr[1] "Cajado ({:d} cargas)"
 
 #. TRANSLATORS: UI constraints, keep short please.
-#: Source/panels/spell_book.cpp:167
+#: Source/panels/spell_book.cpp:195
 msgctxt "spellbook"
 msgid "Level {:d}"
 msgstr "Nível {:d}"
 
-#: Source/panels/spell_book.cpp:169
-msgid "Unusable"
-msgstr "Inutilizável"
-
 #. TRANSLATORS: UI constraints, keep short please.
-#: Source/panels/spell_book.cpp:177
-msgid "Heals: {:d} - {:d}"
-msgstr "Cura: {:d} - {:d}"
-
-#. TRANSLATORS: UI constraints, keep short please.
-#: Source/panels/spell_book.cpp:179
-msgid "Damage: {:d} - {:d}"
-msgstr "Dano: {:d} - {:d}"
-
-#. TRANSLATORS: UI constraints, keep short please.
-#: Source/panels/spell_book.cpp:183
-msgid "Dmg: 1/3 target hp"
-msgstr "Dano: 1/3 da vida do alvo"
-
-#. TRANSLATORS: UI constraints, keep short please.
-#: Source/panels/spell_book.cpp:185
+#: Source/panels/spell_book.cpp:199
 msgctxt "spellbook"
 msgid "Mana: {:d}"
 msgstr "Mana: {:d}"
 
-#: Source/panels/spell_list.cpp:157
+#: Source/panels/spell_list.cpp:159
 msgid "Spell"
 msgstr "Feitiço"
 
-#: Source/panels/spell_list.cpp:160
+#: Source/panels/spell_list.cpp:162
 msgid "Damages undead only"
 msgstr "Atinge apenas mortos-vivos"
 
-#: Source/panels/spell_list.cpp:171
+#: Source/panels/spell_list.cpp:173
 msgid "Scroll"
 msgstr "Pergaminho"
 
-#: Source/panels/spell_list.cpp:193
+#: Source/panels/spell_list.cpp:184 Source/translation_dummy.cpp:455
+#: Source/translation_dummy.cpp:457 Source/translation_dummy.cpp:459
+#: Source/translation_dummy.cpp:461 Source/translation_dummy.cpp:463
+msgid "Staff"
+msgstr "Cajado"
+
+#: Source/panels/spell_list.cpp:194
 msgid "Spell Hotkey {:s}"
 msgstr "Atalho de feitiço {:s}"
 
-#: Source/pfile.cpp:723
+#: Source/pfile.cpp:761
 msgid "Unable to open archive"
 msgstr "Não é possível abrir o arquivo"
 
-#: Source/pfile.cpp:725
+#: Source/pfile.cpp:763
 msgid "Unable to load character"
 msgstr "Não é possível carregar o personagem"
 
-#: Source/plrmsg.cpp:84 Source/qol/chatlog.cpp:131
+#: Source/plrmsg.cpp:79 Source/qol/chatlog.cpp:128
 msgid "{:s} (lvl {:d}): "
 msgstr "{:s} (nvl {:d}): "
 
-#: Source/qol/chatlog.cpp:160
+#: Source/qol/chatlog.cpp:168
 msgid "Chat History (Messages: {:d})"
 msgstr "Histórico do Chat (Mensagens: {:d})"
 
-#: Source/qol/itemlabels.cpp:105
+#: Source/qol/itemlabels.cpp:113
 msgid "{:s} gold"
 msgstr "{:s} de ouro"
 
-#: Source/qol/stash.cpp:640
+#: Source/qol/stash.cpp:651
 msgid "How many gold pieces do you want to withdraw?"
 msgstr "Quantas peças de ouro você quer retirar?"
 
-#: Source/qol/xpbar.cpp:125
+#: Source/qol/xpbar.cpp:138
 msgid "Level {:d}"
 msgstr "Nível {:d}"
 
-#: Source/qol/xpbar.cpp:131 Source/qol/xpbar.cpp:139
+#: Source/qol/xpbar.cpp:144 Source/qol/xpbar.cpp:152
 msgid "Experience: {:s}"
 msgstr "Experiência: {:s}"
 
-#: Source/qol/xpbar.cpp:132
+#: Source/qol/xpbar.cpp:145
 msgid "Maximum Level"
 msgstr "Nível máximo"
 
-#: Source/qol/xpbar.cpp:140
+#: Source/qol/xpbar.cpp:154
 msgid "Next Level: {:s}"
 msgstr "Próximo nível: {:s}"
 
-#: Source/qol/xpbar.cpp:141
+#: Source/qol/xpbar.cpp:155
 msgid "{:s} to Level {:d}"
 msgstr "{:s} para o nível {:d}"
 
 #. TRANSLATORS: Quest Name Block
-#: Source/quests.cpp:48
+#: Source/quests.cpp:53
 msgid "The Magic Rock"
 msgstr "A Rocha Mágica"
 
-#: Source/quests.cpp:50
+#: Source/quests.cpp:54 Source/translation_dummy.cpp:264
+msgid "Black Mushroom"
+msgstr "Cogumelo negro"
+
+#: Source/quests.cpp:55
 msgid "Gharbad The Weak"
 msgstr "Gharbad, o Fraco"
 
-#: Source/quests.cpp:51
+#: Source/quests.cpp:56
 msgid "Zhar the Mad"
 msgstr "Zhar, o Louco"
 
-#: Source/quests.cpp:52
+#: Source/quests.cpp:57
 msgid "Lachdanan"
 msgstr "Lachdanan"
 
-#: Source/quests.cpp:54
+#: Source/quests.cpp:59
 msgid "The Butcher"
 msgstr "O Açougueiro"
 
-#: Source/quests.cpp:55
+#: Source/quests.cpp:60
 msgid "Ogden's Sign"
 msgstr "A placa de Ogden"
 
-#: Source/quests.cpp:56
+#: Source/quests.cpp:61
 msgid "Halls of the Blind"
 msgstr "Câmara dos cegos"
 
-#: Source/quests.cpp:57
+#: Source/quests.cpp:62
 msgid "Valor"
 msgstr "Bravura"
 
-#: Source/quests.cpp:59
+#: Source/quests.cpp:63 Source/translation_dummy.cpp:263
+msgid "Anvil of Fury"
+msgstr "Bigorna da fúria"
+
+#: Source/quests.cpp:64
 msgid "Warlord of Blood"
 msgstr "Senhor da Guerra Sangrenta"
 
-#: Source/quests.cpp:60
+#: Source/quests.cpp:65
 msgid "The Curse of King Leoric"
 msgstr "A maldição do Rei Leoric"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:62 Source/quests.cpp:98
+#: Source/quests.cpp:67 Source/quests.cpp:103
 msgid "The Chamber of Bone"
 msgstr "A câmara de osso"
 
-#: Source/quests.cpp:63
+#: Source/quests.cpp:68
 msgid "Archbishop Lazarus"
 msgstr "Arcebispo Lázarus"
 
-#: Source/quests.cpp:64
+#: Source/quests.cpp:69
 msgid "Grave Matters"
 msgstr "Assuntos graves"
 
-#: Source/quests.cpp:65
+#: Source/quests.cpp:70
 msgid "Farmer's Orchard"
 msgstr "Pomar do fazendeiro"
 
-#: Source/quests.cpp:66
+#: Source/quests.cpp:71
 msgid "Little Girl"
 msgstr "Garotinha"
 
-#: Source/quests.cpp:67
+#: Source/quests.cpp:72
 msgid "Wandering Trader"
 msgstr "Comerciante errante"
 
-#: Source/quests.cpp:68
+#: Source/quests.cpp:73
 msgid "The Defiler"
 msgstr "O Profanador"
 
-#: Source/quests.cpp:69
+#: Source/quests.cpp:74
 msgid "Na-Krul"
 msgstr "Na-Krul"
 
 #. TRANSLATORS: Quest Name Block end
-#: Source/quests.cpp:71
+#: Source/quests.cpp:76
 msgid "The Jersey's Jersey"
 msgstr "A Fantasia de Jersey"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:97
+#: Source/quests.cpp:102
 msgid "King Leoric's Tomb"
 msgstr "A tumba do Rei Leoric"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:100
+#: Source/quests.cpp:105
 msgid "A Dark Passage"
 msgstr "Uma passagem negra"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:101
+#: Source/quests.cpp:106
 msgid "Unholy Altar"
 msgstr "Altar profano"
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
-#: Source/quests.cpp:400
+#: Source/quests.cpp:379
 msgid "To {:s}"
 msgstr "Para {:s}"
 
-#: Source/spelldat.cpp:24
-msgctxt "spell"
-msgid "Firebolt"
-msgstr "Raio de Fogo"
+#: Source/quick_messages.cpp:10
+#, fuzzy
+#| msgid "I need help! Come Here!"
+msgid "I need help! Come here!"
+msgstr "Preciso de ajuda! Venha aqui!"
 
-#: Source/spelldat.cpp:25
-msgctxt "spell"
-msgid "Healing"
-msgstr "Cura"
+#: Source/quick_messages.cpp:11
+msgid "Follow me."
+msgstr "Siga-me."
 
-#: Source/spelldat.cpp:26
-msgctxt "spell"
-msgid "Lightning"
-msgstr "Relâmpago"
+#: Source/quick_messages.cpp:12
+msgid "Here's something for you."
+msgstr "Tenho algo pra você."
 
-#: Source/spelldat.cpp:27
-msgctxt "spell"
-msgid "Flash"
-msgstr "Lampejo"
+#: Source/quick_messages.cpp:13
+msgid "Now you DIE!"
+msgstr "Agora você MORRE!"
 
-#: Source/spelldat.cpp:28
-msgctxt "spell"
-msgid "Identify"
-msgstr "Identificar"
+#: Source/quick_messages.cpp:14
+msgid "Heal yourself!"
+msgstr ""
 
-#: Source/spelldat.cpp:29
-msgctxt "spell"
-msgid "Fire Wall"
-msgstr "Parede de Fogo"
+#: Source/quick_messages.cpp:15
+msgid "Watch out!"
+msgstr ""
 
-#: Source/spelldat.cpp:30
-msgctxt "spell"
-msgid "Town Portal"
-msgstr "Portal da cidade"
+#: Source/quick_messages.cpp:16
+#, fuzzy
+#| msgid "Thanks To"
+msgid "Thanks."
+msgstr "Agradecimentos a"
 
-#: Source/spelldat.cpp:31
-msgctxt "spell"
-msgid "Stone Curse"
-msgstr "Petrificar"
+#: Source/quick_messages.cpp:17
+msgid "Retreat!"
+msgstr ""
 
-#: Source/spelldat.cpp:32
-msgctxt "spell"
-msgid "Infravision"
-msgstr "Infravisão"
+#: Source/quick_messages.cpp:18
+msgid "Sorry."
+msgstr ""
 
-#: Source/spelldat.cpp:33
-msgctxt "spell"
-msgid "Phasing"
-msgstr "Fasear"
+#: Source/quick_messages.cpp:19
+msgid "I'm waiting."
+msgstr ""
 
-#: Source/spelldat.cpp:34
-msgctxt "spell"
-msgid "Mana Shield"
-msgstr "Escudo de Mana"
-
-#: Source/spelldat.cpp:35
-msgctxt "spell"
-msgid "Fireball"
-msgstr "Bola de Fogo"
-
-#: Source/spelldat.cpp:36
-msgctxt "spell"
-msgid "Guardian"
-msgstr "Guardiã"
-
-#: Source/spelldat.cpp:37
-msgctxt "spell"
-msgid "Chain Lightning"
-msgstr "Relâmpago encadeado"
-
-#: Source/spelldat.cpp:38
-msgctxt "spell"
-msgid "Flame Wave"
-msgstr "Onda de Chamas"
-
-#: Source/spelldat.cpp:39
-msgctxt "spell"
-msgid "Doom Serpents"
-msgstr "Serpentes da Ruína"
-
-#: Source/spelldat.cpp:40
-msgctxt "spell"
-msgid "Blood Ritual"
-msgstr "Ritual Sanguíneo"
-
-#: Source/spelldat.cpp:41
-msgctxt "spell"
-msgid "Nova"
-msgstr "Nova"
-
-#: Source/spelldat.cpp:42
-msgctxt "spell"
-msgid "Invisibility"
-msgstr "Invisibilidade"
-
-#: Source/spelldat.cpp:43
-msgctxt "spell"
-msgid "Inferno"
-msgstr "Inferno"
-
-#: Source/spelldat.cpp:44
-msgctxt "spell"
-msgid "Golem"
-msgstr "Golem"
-
-#: Source/spelldat.cpp:45
-msgctxt "spell"
-msgid "Rage"
-msgstr "Fúria"
-
-#: Source/spelldat.cpp:46
-msgctxt "spell"
-msgid "Teleport"
-msgstr "Teletransporte"
-
-#: Source/spelldat.cpp:47
-msgctxt "spell"
-msgid "Apocalypse"
-msgstr "Apocalipse"
-
-#: Source/spelldat.cpp:48
-msgctxt "spell"
-msgid "Etherealize"
-msgstr "Eterealizar"
-
-#: Source/spelldat.cpp:49
-msgctxt "spell"
-msgid "Item Repair"
-msgstr "Reparar Itens"
-
-#: Source/spelldat.cpp:50
-msgctxt "spell"
-msgid "Staff Recharge"
-msgstr "Recarregar Cajados"
-
-#: Source/spelldat.cpp:51
-msgctxt "spell"
-msgid "Trap Disarm"
-msgstr "Desarmar Armadilha"
-
-#: Source/spelldat.cpp:52
-msgctxt "spell"
-msgid "Elemental"
-msgstr "Elemental"
-
-#: Source/spelldat.cpp:53
-msgctxt "spell"
-msgid "Charged Bolt"
-msgstr "Raio Carregado"
-
-#: Source/spelldat.cpp:54
-msgctxt "spell"
-msgid "Holy Bolt"
-msgstr "Raio Sagrado"
-
-#: Source/spelldat.cpp:55
-msgctxt "spell"
-msgid "Resurrect"
-msgstr "Ressurreição"
-
-#: Source/spelldat.cpp:56
-msgctxt "spell"
-msgid "Telekinesis"
-msgstr "Telecinese"
-
-#: Source/spelldat.cpp:57
-msgctxt "spell"
-msgid "Heal Other"
-msgstr "Curar Outro"
-
-#: Source/spelldat.cpp:58
-msgctxt "spell"
-msgid "Blood Star"
-msgstr "Estrela de Sangue"
-
-#: Source/spelldat.cpp:59
-msgctxt "spell"
-msgid "Bone Spirit"
-msgstr "Espírito de Ossos"
-
-#: Source/spelldat.cpp:60
-msgctxt "spell"
-msgid "Mana"
-msgstr "Mana"
-
-#: Source/spelldat.cpp:61
-msgctxt "spell"
-msgid "the Magi"
-msgstr "de Magi"
-
-#: Source/spelldat.cpp:62
-msgctxt "spell"
-msgid "the Jester"
-msgstr "do Bobo"
-
-#: Source/spelldat.cpp:63
-msgctxt "spell"
-msgid "Lightning Wall"
-msgstr "Parede Relampejante"
-
-#: Source/spelldat.cpp:64
-msgctxt "spell"
-msgid "Immolation"
-msgstr "Imolação"
-
-#: Source/spelldat.cpp:65
-msgctxt "spell"
-msgid "Warp"
-msgstr "Deformação"
-
-#: Source/spelldat.cpp:66
-msgctxt "spell"
-msgid "Reflect"
-msgstr "Refletir"
-
-#: Source/spelldat.cpp:67
-msgctxt "spell"
-msgid "Berserk"
-msgstr "Fúria"
-
-#: Source/spelldat.cpp:68
-msgctxt "spell"
-msgid "Ring of Fire"
-msgstr "Anel de Fogo"
-
-#: Source/spelldat.cpp:69
-msgctxt "spell"
-msgid "Search"
-msgstr "Procurar"
-
-#: Source/spelldat.cpp:70
-msgctxt "spell"
-msgid "Rune of Fire"
-msgstr "Runa de fogo"
-
-#: Source/spelldat.cpp:71
-msgctxt "spell"
-msgid "Rune of Light"
-msgstr "Runa da Luz"
-
-#: Source/spelldat.cpp:72
-msgctxt "spell"
-msgid "Rune of Nova"
-msgstr "Runa de Nova"
-
-#: Source/spelldat.cpp:73
-msgctxt "spell"
-msgid "Rune of Immolation"
-msgstr "Runa Explosiva"
-
-#: Source/spelldat.cpp:74
-msgctxt "spell"
-msgid "Rune of Stone"
-msgstr "Runa de Pedra"
-
-#: Source/stores.cpp:129
+#: Source/stores.cpp:131
 msgid "Griswold"
 msgstr "Griswold"
 
-#: Source/stores.cpp:130
+#: Source/stores.cpp:132
 msgid "Pepin"
 msgstr "Pepin"
 
-#: Source/stores.cpp:132
+#: Source/stores.cpp:134
 msgid "Ogden"
 msgstr "Ogden"
 
-#: Source/stores.cpp:133
+#: Source/stores.cpp:135
 msgid "Cain"
 msgstr "Cain"
 
-#: Source/stores.cpp:134
+#: Source/stores.cpp:136
 msgid "Farnham"
 msgstr "Farnham"
 
-#: Source/stores.cpp:135
+#: Source/stores.cpp:137
 msgid "Adria"
 msgstr "Adria"
 
-#: Source/stores.cpp:136 Source/stores.cpp:1315
+#: Source/stores.cpp:138 Source/stores.cpp:1267
 msgid "Gillian"
 msgstr "Gillian"
 
-#: Source/stores.cpp:137
+#: Source/stores.cpp:139
 msgid "Wirt"
 msgstr "Wirt"
 
-#: Source/stores.cpp:263 Source/stores.cpp:270
+#: Source/stores.cpp:265 Source/stores.cpp:272
 msgid "Back"
 msgstr "Voltar"
 
-#: Source/stores.cpp:292 Source/stores.cpp:298
+#: Source/stores.cpp:294 Source/stores.cpp:300 Source/stores.cpp:326
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:309
+#: Source/stores.cpp:311
 msgid "Damage: {:d}-{:d}  "
 msgstr "Dano: {:d}-{:d}  "
 
-#: Source/stores.cpp:311
+#: Source/stores.cpp:313
 msgid "Armor: {:d}  "
 msgstr "Armadura: {:d}  "
 
-#: Source/stores.cpp:313
-msgid "Dur: {:d}/{:d},  "
+#: Source/stores.cpp:315
+#, fuzzy
+#| msgid "Dur: {:d}/{:d},  "
+msgid "Dur: {:d}/{:d}"
 msgstr "Dur: {:d}/{:d},  "
 
-#: Source/stores.cpp:315
-msgid "Indestructible,  "
-msgstr "Indestrutível,  "
+#: Source/stores.cpp:317
+#, fuzzy
+#| msgid "indestructible"
+msgid "Indestructible"
+msgstr "indestrutível"
 
-#: Source/stores.cpp:323
-msgid "No required attributes"
-msgstr "Nenhum atributo requerido"
-
-#: Source/stores.cpp:355 Source/stores.cpp:1069 Source/stores.cpp:1302
+#: Source/stores.cpp:387 Source/stores.cpp:1035 Source/stores.cpp:1254
 msgid "Welcome to the"
 msgstr "Boas-vindas à"
 
-#: Source/stores.cpp:356
+#: Source/stores.cpp:388
 msgid "Blacksmith's shop"
 msgstr "Loja do ferreiro"
 
-#: Source/stores.cpp:357 Source/stores.cpp:705 Source/stores.cpp:1071
-#: Source/stores.cpp:1128 Source/stores.cpp:1304 Source/stores.cpp:1316
-#: Source/stores.cpp:1329
+#: Source/stores.cpp:389 Source/stores.cpp:686 Source/stores.cpp:1037
+#: Source/stores.cpp:1080 Source/stores.cpp:1256 Source/stores.cpp:1268
+#: Source/stores.cpp:1281
 msgid "Would you like to:"
 msgstr "Você gostaria de:"
 
-#: Source/stores.cpp:358
+#: Source/stores.cpp:390
 msgid "Talk to Griswold"
 msgstr "Falar com Griswold"
 
-#: Source/stores.cpp:359
+#: Source/stores.cpp:391
 msgid "Buy basic items"
 msgstr "Comprar itens básicos"
 
-#: Source/stores.cpp:360
+#: Source/stores.cpp:392
 msgid "Buy premium items"
 msgstr "Comprar itens especiais"
 
-#: Source/stores.cpp:361 Source/stores.cpp:708
+#: Source/stores.cpp:393 Source/stores.cpp:689
 msgid "Sell items"
 msgstr "Vender itens"
 
-#: Source/stores.cpp:362
+#: Source/stores.cpp:394
 msgid "Repair items"
 msgstr "Reparar itens"
 
-#: Source/stores.cpp:363
+#: Source/stores.cpp:395
 msgid "Leave the shop"
 msgstr "Sair da loja"
 
-#: Source/stores.cpp:406 Source/stores.cpp:759 Source/stores.cpp:1105
+#: Source/stores.cpp:423 Source/stores.cpp:725 Source/stores.cpp:1057
 msgid "I have these items for sale:"
 msgstr "Eu tenho estes itens para vender:"
 
-#: Source/stores.cpp:471
+#: Source/stores.cpp:472
 msgid "I have these premium items for sale:"
 msgstr "Eu tenho estes itens especiais para vender:"
 
-#: Source/stores.cpp:590 Source/stores.cpp:852
+#: Source/stores.cpp:568 Source/stores.cpp:818
 msgid "You have nothing I want."
 msgstr "Você não tem nada que eu queira."
 
-#: Source/stores.cpp:601 Source/stores.cpp:864
+#: Source/stores.cpp:579 Source/stores.cpp:830
 msgid "Which item is for sale?"
 msgstr "Qual item está à venda?"
 
-#: Source/stores.cpp:666
+#: Source/stores.cpp:647
 msgid "You have nothing to repair."
 msgstr "Você não tem nada para reparar."
 
-#: Source/stores.cpp:677
+#: Source/stores.cpp:658
 msgid "Repair which item?"
 msgstr "Reparar qual item?"
 
-#: Source/stores.cpp:704
+#: Source/stores.cpp:685
 msgid "Witch's shack"
 msgstr "Cabana da bruxa"
 
-#: Source/stores.cpp:706
+#: Source/stores.cpp:687
 msgid "Talk to Adria"
 msgstr "Falar com Ádria"
 
-#: Source/stores.cpp:707 Source/stores.cpp:1073
+#: Source/stores.cpp:688 Source/stores.cpp:1039
 msgid "Buy items"
 msgstr "Comprar itens"
 
-#: Source/stores.cpp:709
+#: Source/stores.cpp:690
 msgid "Recharge staves"
 msgstr "Recarregar cajados"
 
-#: Source/stores.cpp:710
+#: Source/stores.cpp:691
 msgid "Leave the shack"
 msgstr "Sair da cabana"
 
-#: Source/stores.cpp:926
+#: Source/stores.cpp:892
 msgid "You have nothing to recharge."
 msgstr "Você não tem nada para recarregar."
 
-#: Source/stores.cpp:937
+#: Source/stores.cpp:903
 msgid "Recharge which item?"
 msgstr "Recarregar qual item?"
 
-#: Source/stores.cpp:950
+#: Source/stores.cpp:916
 msgid "You do not have enough gold"
 msgstr "Você não tem ouro o suficiente"
 
-#: Source/stores.cpp:958
+#: Source/stores.cpp:924
 msgid "You do not have enough room in inventory"
 msgstr "Você não tem espaço o suficiente em seu inventário"
 
-#: Source/stores.cpp:976
+#: Source/stores.cpp:942
 msgid "Do we have a deal?"
 msgstr "Negócio fechado?"
 
-#: Source/stores.cpp:979
+#: Source/stores.cpp:945
 msgid "Are you sure you want to identify this item?"
 msgstr "Tem certeza de que quer identificar este item?"
 
-#: Source/stores.cpp:985
+#: Source/stores.cpp:951
 msgid "Are you sure you want to buy this item?"
 msgstr "Tem certeza de que quer comprar este item?"
 
-#: Source/stores.cpp:988
+#: Source/stores.cpp:954
 msgid "Are you sure you want to recharge this item?"
 msgstr "Tem certeza de que quer recarregar este item?"
 
-#: Source/stores.cpp:992
+#: Source/stores.cpp:958
 msgid "Are you sure you want to sell this item?"
 msgstr "Tem certeza de que quer vender este item?"
 
-#: Source/stores.cpp:995
+#: Source/stores.cpp:961
 msgid "Are you sure you want to repair this item?"
 msgstr "Tem certeza de que quer reparar este item?"
 
-#: Source/stores.cpp:1009 Source/towners.cpp:158
+#: Source/stores.cpp:975 Source/towners.cpp:784
 msgid "Wirt the Peg-legged boy"
 msgstr "Wirt, garoto da Perna-de-Pau"
 
-#: Source/stores.cpp:1012 Source/stores.cpp:1019
+#: Source/stores.cpp:978 Source/stores.cpp:985
 msgid "Talk to Wirt"
 msgstr "Falar com Wirt"
 
-#: Source/stores.cpp:1013
+#: Source/stores.cpp:979
 msgid "I have something for sale,"
 msgstr "Eu tenho algo para vender,"
 
-#: Source/stores.cpp:1014
+#: Source/stores.cpp:980
 msgid "but it will cost 50 gold"
 msgstr "mas lhe custará 50 de ouro"
 
-#: Source/stores.cpp:1015
+#: Source/stores.cpp:981
 msgid "just to take a look. "
 msgstr "só para dar uma olhada. "
 
-#: Source/stores.cpp:1016
+#: Source/stores.cpp:982
 msgid "What have you got?"
 msgstr "O que você tem aí?"
 
-#: Source/stores.cpp:1017 Source/stores.cpp:1020 Source/stores.cpp:1131
-#: Source/stores.cpp:1319
+#: Source/stores.cpp:983 Source/stores.cpp:986 Source/stores.cpp:1083
+#: Source/stores.cpp:1271
 msgid "Say goodbye"
 msgstr "Dizer adeus"
 
-#: Source/stores.cpp:1030
+#: Source/stores.cpp:996
 msgid "I have this item for sale:"
 msgstr "Eu tenho este item para vender:"
 
-#: Source/stores.cpp:1047
+#: Source/stores.cpp:1013
 msgid "Leave"
 msgstr "Sair"
 
-#: Source/stores.cpp:1070
+#: Source/stores.cpp:1036
 msgid "Healer's home"
 msgstr "Casa do curandeiro"
 
-#: Source/stores.cpp:1072
+#: Source/stores.cpp:1038
 msgid "Talk to Pepin"
 msgstr "Falar com Pepin"
 
-#: Source/stores.cpp:1074
+#: Source/stores.cpp:1040
 msgid "Leave Healer's home"
 msgstr "Sair da casa do curandeiro"
 
-#: Source/stores.cpp:1127
+#: Source/stores.cpp:1079
 msgid "The Town Elder"
 msgstr "O ancião da cidade"
 
-#: Source/stores.cpp:1129
+#: Source/stores.cpp:1081
 msgid "Talk to Cain"
 msgstr "Falar com Cain"
 
-#: Source/stores.cpp:1130
+#: Source/stores.cpp:1082
 msgid "Identify an item"
 msgstr "Identificar um item"
 
-#: Source/stores.cpp:1223
+#: Source/stores.cpp:1175
 msgid "You have nothing to identify."
 msgstr "Você não tem nada para identificar."
 
-#: Source/stores.cpp:1234
+#: Source/stores.cpp:1186
 msgid "Identify which item?"
 msgstr "Identificar qual item?"
 
-#: Source/stores.cpp:1249
+#: Source/stores.cpp:1201
 msgid "This item is:"
 msgstr "Este item é:"
 
-#: Source/stores.cpp:1252
+#: Source/stores.cpp:1204
 msgid "Done"
 msgstr "Pronto"
 
-#: Source/stores.cpp:1261
+#: Source/stores.cpp:1213
 msgid "Talk to {:s}"
 msgstr "Falar com {:s}"
 
-#: Source/stores.cpp:1264
+#: Source/stores.cpp:1216
 msgid "Talking to {:s}"
 msgstr "Falar com {:s}"
 
-#: Source/stores.cpp:1265
+#: Source/stores.cpp:1217
 msgid "is not available"
 msgstr "não está disponível"
 
-#: Source/stores.cpp:1266
+#: Source/stores.cpp:1218
 msgid "in the shareware"
 msgstr "na versão"
 
-#: Source/stores.cpp:1267
+#: Source/stores.cpp:1219
 msgid "version"
 msgstr "versão"
 
-#: Source/stores.cpp:1294
+#: Source/stores.cpp:1246
 msgid "Gossip"
 msgstr "Boatos"
 
-#: Source/stores.cpp:1303
+#: Source/stores.cpp:1255
 msgid "Rising Sun"
 msgstr "Sol Nascente"
 
-#: Source/stores.cpp:1305
+#: Source/stores.cpp:1257
 msgid "Talk to Ogden"
 msgstr "Falar com Ogden"
 
-#: Source/stores.cpp:1306
+#: Source/stores.cpp:1258
 msgid "Leave the tavern"
 msgstr "Sair da taverna"
 
-#: Source/stores.cpp:1317
+#: Source/stores.cpp:1269
 msgid "Talk to Gillian"
 msgstr "Falar com Gillian"
 
-#: Source/stores.cpp:1318
+#: Source/stores.cpp:1270
 msgid "Access Storage"
 msgstr "Acessar Armazém"
 
-#: Source/stores.cpp:1328 Source/towners.cpp:216
+#: Source/stores.cpp:1280 Source/towners.cpp:781
 msgid "Farnham the Drunk"
 msgstr "Farnham, o Bêbado"
 
-#: Source/stores.cpp:1330
+#: Source/stores.cpp:1282
 msgid "Talk to Farnham"
 msgstr "Falar com Farnham"
 
-#: Source/stores.cpp:1331
+#: Source/stores.cpp:1283
 msgid "Say Goodbye"
 msgstr "Dizer adeus"
 
-#: Source/stores.cpp:2464
+#: Source/stores.cpp:2413
 msgid "Your gold: {:s}"
 msgstr "Seu ouro: {:s}"
 
@@ -9453,7 +6156,7 @@ msgstr ""
 "Eu nunca ouvi falar de um Lachdanan antes. Peço desculpas, mas acho que não "
 "poderei ajudar muito."
 
-#. TRANSLATORS: Quest dialog spoken by Ogden
+#. TRANSLATORS: Quest dialog spoken by Griswold
 #: Source/textdat.cpp:164
 msgid ""
 "If it is actually Lachdanan that you have met, then I would advise that you "
@@ -11462,7 +8165,7 @@ msgstr ""
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:471 Source/textdat.cpp:479 Source/textdat.cpp:487
-#: Source/textdat.cpp:525 Source/textdat.cpp:533
+#: Source/textdat.cpp:517 Source/textdat.cpp:525
 msgid ""
 "Beyond the Hall of Heroes lies the Chamber of Bone. Eternal death awaits any "
 "who would seek to steal the treasures secured within this room. So speaks "
@@ -11474,7 +8177,7 @@ msgstr ""
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:473 Source/textdat.cpp:481 Source/textdat.cpp:489
-#: Source/textdat.cpp:527 Source/textdat.cpp:535
+#: Source/textdat.cpp:519 Source/textdat.cpp:527
 msgid ""
 "...and so, locked beyond the Gateway of Blood and past the Hall of Fire, "
 "Valor awaits for the Hero of Light to awaken..."
@@ -11484,7 +8187,7 @@ msgstr ""
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:475 Source/textdat.cpp:483 Source/textdat.cpp:491
-#: Source/textdat.cpp:529 Source/textdat.cpp:537
+#: Source/textdat.cpp:521 Source/textdat.cpp:529
 msgid ""
 "I can see what you see not.\n"
 "Vision milky then eyes rot.\n"
@@ -11506,7 +8209,7 @@ msgstr ""
 
 #. TRANSLATORS: Quest text spoken aloud from a book by player
 #: Source/textdat.cpp:477 Source/textdat.cpp:485 Source/textdat.cpp:493
-#: Source/textdat.cpp:531 Source/textdat.cpp:539
+#: Source/textdat.cpp:523 Source/textdat.cpp:531
 msgid ""
 "The armories of Hell are home to the Warlord of Blood. In his wake lay the "
 "mutilated bodies of thousands. Angels and men alike have been cut down to "
@@ -11519,7 +8222,7 @@ msgstr ""
 "só coisa - sangue."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:505
+#: Source/textdat.cpp:497
 msgid ""
 "Take heed and bear witness to the truths that lie herein, for they are the "
 "last legacy of the Horadrim. There is a war that rages on even now, beyond "
@@ -11538,7 +8241,7 @@ msgstr ""
 "Luz e das Trevas disputam constantemente pelo controle sobre toda a criação."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:507
+#: Source/textdat.cpp:499
 msgid ""
 "Take heed and bear witness to the truths that lie herein, for they are the "
 "last legacy of the Horadrim. When the Eternal Conflict between the High "
@@ -11557,7 +8260,7 @@ msgstr ""
 "curso da Guerra do Pecado."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:509
+#: Source/textdat.cpp:501
 msgid ""
 "Take heed and bear witness to the truths that lie herein, for they are the "
 "last legacy of the Horadrim. Nearly three hundred years ago, it came to be "
@@ -11599,7 +8302,7 @@ msgstr ""
 "de um velho ou o de uma criança."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:511
+#: Source/textdat.cpp:503
 msgid ""
 "So it came to be that there was a great revolution within the Burning Hells "
 "known as The Dark Exile. The Lesser Evils overthrew the Three Prime Evils "
@@ -11619,7 +8322,7 @@ msgstr ""
 "Inferno."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:513
+#: Source/textdat.cpp:505
 msgid ""
 "Many demons traveled to the mortal realm in search of the Three Brothers. "
 "These demons were followed to the mortal plane by Angels who hunted them "
@@ -11635,7 +8338,7 @@ msgstr ""
 "Inferiores."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:515
+#: Source/textdat.cpp:507
 msgid ""
 "So it came to be that the Three Prime Evils were banished in spirit form to "
 "the mortal realm and after sewing chaos across the East for decades, they "
@@ -11667,7 +8370,7 @@ msgstr ""
 "mais uma vez agitar as chamas da Guerra do Pecado..."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:517
+#: Source/textdat.cpp:509
 msgid ""
 "All praises to Diablo - Lord of Terror and Survivor of The Dark Exile. When "
 "he awakened from his long slumber, my Lord and Master spoke to me of secrets "
@@ -11685,7 +8388,7 @@ msgstr ""
 "Guerra do Pecado."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:519
+#: Source/textdat.cpp:511
 msgid ""
 "Glory and Approbation to Diablo - Lord of Terror and Leader of the Three. My "
 "Lord spoke to me of his two Brothers, Mephisto and Baal, who were banished "
@@ -11702,7 +8405,7 @@ msgstr ""
 "Irmãos, a Guerra do Pecado conhecerá mais uma vez a fúria dos Três."
 
 #. TRANSLATORS: Book read aloud
-#: Source/textdat.cpp:521
+#: Source/textdat.cpp:513
 msgid ""
 "Hail and Sacrifice to Diablo - Lord of Terror and Destroyer of Souls. When I "
 "awoke my Master from his sleep, he attempted to possess a mortal's form. "
@@ -11725,7 +8428,7 @@ msgstr ""
 "seja recompensado quando ele por fim emergir como o Senhor deste mundo."
 
 #. TRANSLATORS: Neutral Text spoken by Ogden
-#: Source/textdat.cpp:523
+#: Source/textdat.cpp:515
 msgid ""
 "Thank goodness you've returned!\n"
 "Much has changed since you lived here, my friend. All was peaceful until the "
@@ -11751,7 +8454,7 @@ msgstr ""
 "Talvez eu possa lhe contar mais se nos falarmos novamente. Boa sorte."
 
 #. TRANSLATORS: Quest text spoken by Adria
-#: Source/textdat.cpp:541
+#: Source/textdat.cpp:533
 msgid ""
 "Maintain your quest.  Finding a treasure that is lost is not easy.  Finding "
 "a treasure that is hidden less so.  I will leave you with this.  Do not let "
@@ -11762,7 +8465,7 @@ msgstr ""
 "tempo confundam sua busca."
 
 #. TRANSLATORS: Quest text spoken by Griswold
-#: Source/textdat.cpp:543
+#: Source/textdat.cpp:535
 msgid ""
 "A what?!  This is foolishness.  There's no treasure buried here in "
 "Tristram.  Let me see that!!  Ah, Look these drawings are inaccurate.  They "
@@ -11775,7 +8478,7 @@ msgstr ""
 "que está sob nossa camada superficial do solo."
 
 #. TRANSLATORS: Quest text spoken by Pepin
-#: Source/textdat.cpp:545
+#: Source/textdat.cpp:537
 msgid ""
 "I really don't have time to discuss some map you are looking for.  I have "
 "many sick people that require my help and yours as well."
@@ -11784,7 +8487,7 @@ msgstr ""
 "Tenho muitas pessoas doentes que precisam da minha ajuda e da sua também."
 
 #. TRANSLATORS: Quest text spoken by Adria
-#: Source/textdat.cpp:547 Source/textdat.cpp:559
+#: Source/textdat.cpp:539 Source/textdat.cpp:551
 msgid ""
 "The once proud Iswall is trapped deep beneath the surface of this world.  "
 "His honor stripped and his visage altered.  He is trapped in immortal "
@@ -11796,7 +8499,7 @@ msgstr ""
 "lo."
 
 #. TRANSLATORS: Quest text spoken by Ogden
-#: Source/textdat.cpp:549
+#: Source/textdat.cpp:541
 msgid ""
 "I'll bet that Wirt saw you coming and put on an act just so he could laugh "
 "at you later when you were running around the town with your nose in the "
@@ -11806,7 +8509,7 @@ msgstr ""
 "tarde, quando você estivesse com o nariz na terra. Eu apenas ignoraria."
 
 #. TRANSLATORS: Quest text spoken by Cain
-#: Source/textdat.cpp:551
+#: Source/textdat.cpp:543
 msgid ""
 "There was a time when this town was a frequent stop for travelers from far "
 "and wide.  Much has changed since then.  But hidden caves and buried "
@@ -11819,7 +8522,7 @@ msgstr ""
 "raramente se entrega a jogos juvenis. Então talvez seja só sua imaginação."
 
 #. TRANSLATORS: Quest text spoken by Farnham
-#: Source/textdat.cpp:553
+#: Source/textdat.cpp:545
 msgid ""
 "Listen here.  Come close.  I don't know if you know what I know, but you've "
 "have really got something here.  That's a map."
@@ -11828,7 +8531,7 @@ msgstr ""
 "tem algo aqui. Isso é um mapa."
 
 #. TRANSLATORS: Quest text spoken by Gillian
-#: Source/textdat.cpp:555
+#: Source/textdat.cpp:547
 msgid ""
 "My grandmother often tells me stories about the strange forces that inhabit "
 "the graveyard outside of the church.  And it may well interest you to hear "
@@ -11845,7 +8548,7 @@ msgstr ""
 "possível hoje em dia."
 
 #. TRANSLATORS: Quest text spoken by Wirt
-#: Source/textdat.cpp:557
+#: Source/textdat.cpp:549
 msgid ""
 "Hmmm.  A vast and mysterious treasure you say.  Mmmm.  Maybe I could be "
 "interested in picking up a few things from you.  Or better yet, don't you "
@@ -11856,7 +8559,7 @@ msgstr ""
 "precisa de alguns suprimentos raros e caros para passar por esse teste?"
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
-#: Source/textdat.cpp:561
+#: Source/textdat.cpp:553
 msgid ""
 "So, you're the hero everyone's been talking about. Perhaps you could help a "
 "poor, simple farmer out of a terrible mess? At the edge of my orchard, just "
@@ -11875,7 +8578,7 @@ msgstr ""
 "faria isso, mas alguém tem que ficar aqui com as vacas..."
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
-#: Source/textdat.cpp:563
+#: Source/textdat.cpp:555
 msgid ""
 "I knew that it couldn't be as simple as that witch made it sound. It's a sad "
 "world when you can't even trust your neighbors."
@@ -11884,7 +8587,7 @@ msgstr ""
 "quando você não pode nem confiar em seus vizinhos."
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
-#: Source/textdat.cpp:565
+#: Source/textdat.cpp:557
 msgid ""
 "Is it gone? Did you send it back to the dark recesses of Hades that spawned "
 "it? You what? Oh, don't tell me you lost it! Those things don't come cheap, "
@@ -11896,7 +8599,7 @@ msgstr ""
 "nossa cidade."
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
-#: Source/textdat.cpp:567
+#: Source/textdat.cpp:559
 msgid ""
 "I heard the explosion from here! Many thanks to you, kind stranger. What "
 "with all these things comin' out of the ground, monsters taking over the "
@@ -11909,7 +8612,7 @@ msgstr ""
 "isso como agradecimento."
 
 #. TRANSLATORS: Neutral text spoken by Farmer (Gossip)
-#: Source/textdat.cpp:569
+#: Source/textdat.cpp:561
 msgid ""
 "Oh, such a trouble I have...maybe...No, I couldn't impose on you, what with "
 "all the other troubles. Maybe after you've cleansed the church of some of "
@@ -11922,12 +8625,12 @@ msgstr ""
 "ajudando um pobre fazendeiro?"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
-#: Source/textdat.cpp:571
+#: Source/textdat.cpp:563
 msgid "Waaaah! (sniff) Waaaah! (sniff)"
 msgstr "Buáááá! (sniff) Buáááá! (sniff)"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
-#: Source/textdat.cpp:572
+#: Source/textdat.cpp:564
 msgid ""
 "I lost Theo!  I lost my best friend!  We were playing over by the river, and "
 "Theo said he wanted to go look at the big green thing.  I said we shouldn't, "
@@ -11940,7 +8643,7 @@ msgstr ""
 "Nós fugimos, mas Theo caiu e o inseto o agarrou e o levou embora!"
 
 #. TRANSLATORS: Quest text spoken by Little Girl
-#: Source/textdat.cpp:574
+#: Source/textdat.cpp:566
 msgid ""
 "Didja find him?  You gotta find Theodore, please!  He's just little.  He "
 "can't take care of himself!  Please!"
@@ -11949,7 +8652,7 @@ msgstr ""
 "pequeno, não consegue se cuidar sozinho!  Por favor!"
 
 #. TRANSLATORS: Quest text spoken by Little Girl (Quest End)
-#: Source/textdat.cpp:576
+#: Source/textdat.cpp:568
 msgid ""
 "You found him!  You found him!  Thank you!  Oh Theo, did those nasty bugs "
 "scare you?  Hey!  Ugh!  There's something stuck to your fur!  Ick!  Come on, "
@@ -11960,7 +8663,7 @@ msgstr ""
 "Theo, vamos para casa! Obrigado novamente, herói!"
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
-#: Source/textdat.cpp:578
+#: Source/textdat.cpp:570
 msgid ""
 "We have long lain dormant, and the time to awaken has come.  After our long "
 "sleep, we are filled with great hunger.  Soon, now, we shall feed..."
@@ -11969,7 +8672,7 @@ msgstr ""
 "longo sonho, estamos com muita fome. Em breve vamos nos alimentar..."
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
-#: Source/textdat.cpp:580
+#: Source/textdat.cpp:572
 msgid ""
 "Have you been enjoying yourself, little mammal?  How pathetic. Your little "
 "world will be no challenge at all."
@@ -11978,7 +8681,7 @@ msgstr ""
 "nenhum desafio."
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
-#: Source/textdat.cpp:582
+#: Source/textdat.cpp:574
 msgid ""
 "These lands shall be defiled, and our brood shall overrun the fields that "
 "men call home.  Our tendrils shall envelop this world, and we will feast on "
@@ -11990,7 +8693,7 @@ msgstr ""
 "nosso bem e sustento."
 
 #. TRANSLATORS: Quest text spoken by Defiler (Hostile)
-#: Source/textdat.cpp:584
+#: Source/textdat.cpp:576
 msgid ""
 "Ah, I can smell you...you are close! Close! Ssss...the scent of blood and "
 "fear...how enticing..."
@@ -11999,7 +8702,7 @@ msgstr ""
 "de sangue e medo... que tentador..."
 
 #. TRANSLATORS: Quest text spoken by Narrator
-#: Source/textdat.cpp:592
+#: Source/textdat.cpp:584
 msgid ""
 "And in the year of the Golden Light, it was so decreed that a great "
 "Cathedral be raised.  The cornerstone of this holy place was to be carved "
@@ -12031,22 +8734,22 @@ msgstr ""
 "desta fundação sagrada, uma unidade de propósito e uma unidade de posse."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:594
+#: Source/textdat.cpp:586
 msgid "Moo."
 msgstr "Mu."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:595
+#: Source/textdat.cpp:587
 msgid "I said, Moo."
 msgstr "Eu disse, Mu."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:596
+#: Source/textdat.cpp:588
 msgid "Look I'm just a cow, OK?"
 msgstr "Olhe, eu só sou uma vaca, certo?"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:597
+#: Source/textdat.cpp:589
 msgid ""
 "All right, all right.  I'm not really a cow.  I don't normally go around "
 "like this; but, I was sitting at home minding my own business and all of a "
@@ -12071,7 +8774,7 @@ msgstr ""
 "crescida."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:599
+#: Source/textdat.cpp:591
 msgid ""
 "What are you wasting time for?  Go get my suit!  And hurry!  That Holstein "
 "over there keeps winking at me!"
@@ -12080,7 +8783,7 @@ msgstr ""
 "Holstein ali não para de piscar para mim!"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:601
+#: Source/textdat.cpp:593
 msgid ""
 "Hey, have you got my suit there?  Quick, pass it over!  These ears itch like "
 "you wouldn't believe!"
@@ -12089,7 +8792,7 @@ msgstr ""
 "de forma inacreditável!"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:603
+#: Source/textdat.cpp:595
 msgid ""
 "No no no no!  This is my GRAY suit!  It's for evening wear!  Formal "
 "occasions!  I can't wear THIS.  What are you, some kind of weirdo?  I need "
@@ -12100,7 +8803,7 @@ msgstr ""
 "Preciso do traje MARROM."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:605
+#: Source/textdat.cpp:597
 msgid ""
 "Ahh, that's MUCH better.  Whew!  At last, some dignity!  Are my antlers on "
 "straight?  Good.  Look, thanks a lot for helping me out.  Here, take this as "
@@ -12115,7 +8818,7 @@ msgstr ""
 "o tema de aventureiro é tão... retrô.  Só um conselho, hein?  Tchau."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:607
+#: Source/textdat.cpp:599
 msgid ""
 "Look.  I'm a cow.  And you, you're monster bait. Get some experience under "
 "your belt!  We'll talk..."
@@ -12124,7 +8827,7 @@ msgstr ""
 "experiência!  E depois nos falamos..."
 
 #. TRANSLATORS: Quest text spoken by Farmer
-#: Source/textdat.cpp:610
+#: Source/textdat.cpp:602
 msgid ""
 "It must truly be a fearsome task I've set before you. If there was just some "
 "way that I could... would a flagon of some nice, fresh milk help?"
@@ -12133,7 +8836,7 @@ msgstr ""
 "houvesse algo que eu pudesse... uma jarra de leite fresco ajudaria?"
 
 #. TRANSLATORS: Quest text spoken by Farmer
-#: Source/textdat.cpp:612
+#: Source/textdat.cpp:604
 msgid ""
 "Oh, I could use your help, but perhaps after you've saved the catacombs from "
 "the desecration of those beasts."
@@ -12142,7 +8845,7 @@ msgstr ""
 "da profanação daquelas bestas."
 
 #. TRANSLATORS: Quest text spoken by Farmer
-#: Source/textdat.cpp:614
+#: Source/textdat.cpp:606
 msgid ""
 "I need something done, but I couldn't impose on a perfect stranger. Perhaps "
 "after you've been here a while I might feel more comfortable asking a favor."
@@ -12152,7 +8855,7 @@ msgstr ""
 "pedindo um favor."
 
 #. TRANSLATORS: Quest text spoken by Farmer
-#: Source/textdat.cpp:616
+#: Source/textdat.cpp:608
 msgid ""
 "I see in you the potential for greatness.  Perhaps sometime while you are "
 "fulfilling your destiny, you could stop by and do a little favor for me?"
@@ -12162,7 +8865,7 @@ msgstr ""
 "para mim?"
 
 #. TRANSLATORS: Quest text spoken by Farmer
-#: Source/textdat.cpp:618
+#: Source/textdat.cpp:610
 msgid ""
 "I think you could probably help me, but perhaps after you've gotten a little "
 "more powerful. I wouldn't want to injure the village's only chance to "
@@ -12173,14 +8876,14 @@ msgstr ""
 "oportunidade da vila de destruir a ameaça na igreja!"
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:620
+#: Source/textdat.cpp:612
 msgid ""
 "Me, I'm a self-made cow.  Make something of yourself, and... then we'll talk."
 msgstr ""
 "Eu sou uma vaca auto-criada.  Faça algo de si mesmo e... depois nos falamos."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:622
+#: Source/textdat.cpp:614
 msgid ""
 "I don't have to explain myself to every tourist that walks by!  Don't you "
 "have some monsters to kill?  Maybe we'll talk later.  If you live..."
@@ -12190,7 +8893,7 @@ msgstr ""
 "tarde.  Se você sobreviver..."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:624
+#: Source/textdat.cpp:616
 msgid ""
 "Quit bugging me.  I'm looking for someone really heroic.  And you're not "
 "it.  I can't trust you, you're going to get eaten by monsters any day now... "
@@ -12201,7 +8904,7 @@ msgstr ""
 "momento... Preciso de alguém que seja um herói experiente."
 
 #. TRANSLATORS: Quest text spoken by Complete Nut
-#: Source/textdat.cpp:626
+#: Source/textdat.cpp:618
 msgid ""
 "All right, I'll cut the bull.  I didn't mean to steer you wrong.  I was "
 "sitting at home, feeling moo-dy, when things got really un-stable; a whole "
@@ -12227,21 +8930,8 @@ msgstr ""
 "achar a minha casa, é ao sul da bifurcação no rio... Você sabe... aquela com "
 "a horta crescida."
 
-#. TRANSLATORS: Quest text spoken by Unknown, Maybe Farmer
-#: Source/textdat.cpp:628
-msgid ""
-"Cloudy and cooler today.  Casting the nets of necromancy across the void "
-"landed two new subspecies of flying horror; a good day's work.  Must "
-"remember to order some more bat guano and black candles from Adria; I'm "
-"running a bit low."
-msgstr ""
-"Está nublado e fresco hoje.  Lançar as redes de necromancia através do vazio "
-"aterrou duas novas subespécies de terror voador; um bom dia de trabalho.  "
-"Tenho de me lembrar de pedir mais guano de morcego e velas pretas para "
-"Ádria; Estou ficando com pouco."
-
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:630
+#: Source/textdat.cpp:621
 msgid ""
 "I have tried spells, threats, abjuration and bargaining with this foul "
 "creature -- to no avail.  My methods of enslaving lesser demons seem to have "
@@ -12252,7 +8942,7 @@ msgstr ""
 "efeito sobre esta besta temível."
 
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:632
+#: Source/textdat.cpp:623
 msgid ""
 "My home is slowly becoming corrupted by the vileness of this unwanted "
 "prisoner.  The crypts are full of shadows that move just beyond the corners "
@@ -12265,7 +8955,7 @@ msgstr ""
 "audição. Eu acho que eles estão procurando por este diário."
 
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:634
+#: Source/textdat.cpp:625
 msgid ""
 "In its ranting, the creature has let slip its name -- Na-Krul.  I have "
 "attempted to research the name, but the smaller demons have somehow "
@@ -12278,7 +8968,7 @@ msgstr ""
 "como 'A Criatura', em vez de refletir sobre seu nome verdadeiro."
 
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:636
+#: Source/textdat.cpp:627
 msgid ""
 "The entrapped creature's howls of fury keep me from gaining much needed "
 "sleep.  It rages against the one who sent it to the Void, and it calls foul "
@@ -12291,7 +8981,7 @@ msgstr ""
 "ainda assim não posso bloquear sua voz."
 
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:638
+#: Source/textdat.cpp:629
 msgid ""
 "My time is quickly running out.  I must record the ways to weaken the demon, "
 "and then conceal that text, lest his minions find some way to use my "
@@ -12304,7 +8994,7 @@ msgstr ""
 "Espero que quem encontrar este diário busque o conhecimento."
 
 #. TRANSLATORS: Quest text read aloud from book
-#: Source/textdat.cpp:640
+#: Source/textdat.cpp:631
 msgid ""
 "Whoever finds this scroll is charged with stopping the demonic creature that "
 "lies within these walls.  My time is over. Even now, its hellish minions "
@@ -12333,75 +9023,3616 @@ msgstr ""
 "grande para ser derrotá-lo."
 
 #. TRANSLATORS: Quest text read aloud from book by player
-#: Source/textdat.cpp:642 Source/textdat.cpp:645 Source/textdat.cpp:648
-#: Source/textdat.cpp:651 Source/textdat.cpp:654
+#: Source/textdat.cpp:633 Source/textdat.cpp:636 Source/textdat.cpp:639
+#: Source/textdat.cpp:642 Source/textdat.cpp:645
 msgid "In Spiritu Sanctum."
 msgstr "In Spiritu Sanctum."
 
 #. TRANSLATORS: Quest text read aloud from book by player
-#: Source/textdat.cpp:643 Source/textdat.cpp:646 Source/textdat.cpp:649
-#: Source/textdat.cpp:652 Source/textdat.cpp:655
+#: Source/textdat.cpp:634 Source/textdat.cpp:637 Source/textdat.cpp:640
+#: Source/textdat.cpp:643 Source/textdat.cpp:646
 msgid "Praedictum Otium."
 msgstr "Praedictum Otium."
 
 #. TRANSLATORS: Quest text read aloud from book by player
-#: Source/textdat.cpp:644 Source/textdat.cpp:647 Source/textdat.cpp:650
-#: Source/textdat.cpp:653 Source/textdat.cpp:656
+#: Source/textdat.cpp:635 Source/textdat.cpp:638 Source/textdat.cpp:641
+#: Source/textdat.cpp:644 Source/textdat.cpp:647
 msgid "Efficio Obitus Ut Inimicus."
 msgstr "Efficio Obitus Ut Inimicus."
 
-#: Source/towners.cpp:83
-msgid "Griswold the Blacksmith"
-msgstr "Griswold, o Ferreiro"
-
-#: Source/towners.cpp:106
-msgid "Ogden the Tavern owner"
-msgstr "Ogden, o Dono da Taverna"
-
-#: Source/towners.cpp:116
-msgid "Wounded Townsman"
-msgstr "Aldeão Ferido"
-
-#: Source/towners.cpp:138
-msgid "Adria the Witch"
-msgstr "Ádria, a Bruxa"
-
-#: Source/towners.cpp:148
-msgid "Gillian the Barmaid"
-msgstr "Gillian, a Atendente"
-
-#: Source/towners.cpp:181
-msgid "Pepin the Healer"
-msgstr "Pepin, o Curandeiro"
-
-#: Source/towners.cpp:199
-msgid "Cain the Elder"
-msgstr "Cain, o Ancião"
-
-#: Source/towners.cpp:228
-msgid "Cow"
-msgstr "Vaca"
-
-#: Source/towners.cpp:252
-msgid "Lester the farmer"
-msgstr "Lester, o fazendeiro"
-
-#: Source/towners.cpp:265
-msgid "Complete Nut"
-msgstr "Completamente Louco"
-
-#: Source/towners.cpp:274
-msgid "Celia"
-msgstr "Celia"
-
-#: Source/towners.cpp:287
+#: Source/towners.cpp:268
 msgid "Slain Townsman"
 msgstr "Aldeão Assassinado"
 
+#: Source/towners.cpp:776
+msgid "Griswold the Blacksmith"
+msgstr "Griswold, o Ferreiro"
+
+#: Source/towners.cpp:777
+msgid "Pepin the Healer"
+msgstr "Pepin, o Curandeiro"
+
+#: Source/towners.cpp:778
+msgid "Wounded Townsman"
+msgstr "Aldeão Ferido"
+
+#: Source/towners.cpp:779
+msgid "Ogden the Tavern owner"
+msgstr "Ogden, o Dono da Taverna"
+
+#: Source/towners.cpp:780
+msgid "Cain the Elder"
+msgstr "Cain, o Ancião"
+
+#: Source/towners.cpp:782
+msgid "Adria the Witch"
+msgstr "Ádria, a Bruxa"
+
+#: Source/towners.cpp:783
+msgid "Gillian the Barmaid"
+msgstr "Gillian, a Atendente"
+
+#: Source/towners.cpp:785
+msgid "Cow"
+msgstr "Vaca"
+
+#: Source/towners.cpp:786
+msgid "Lester the farmer"
+msgstr "Lester, o fazendeiro"
+
+#: Source/towners.cpp:787
+msgid "Celia"
+msgstr "Celia"
+
+#: Source/towners.cpp:788
+msgid "Complete Nut"
+msgstr "Completamente Louco"
+
+#: Source/translation_dummy.cpp:9
+msgctxt "monster"
+msgid "Zombie"
+msgstr "Zumbi"
+
+#: Source/translation_dummy.cpp:10
+msgctxt "monster"
+msgid "Ghoul"
+msgstr "Carniçal"
+
+#: Source/translation_dummy.cpp:11
+msgctxt "monster"
+msgid "Rotting Carcass"
+msgstr "Carcaça Apodrecida"
+
+#: Source/translation_dummy.cpp:12
+msgctxt "monster"
+msgid "Black Death"
+msgstr "Morte Negra"
+
+#: Source/translation_dummy.cpp:13 Source/translation_dummy.cpp:21
+msgctxt "monster"
+msgid "Fallen One"
+msgstr "Caído"
+
+#: Source/translation_dummy.cpp:14 Source/translation_dummy.cpp:22
+msgctxt "monster"
+msgid "Carver"
+msgstr "Talhador"
+
+#: Source/translation_dummy.cpp:15 Source/translation_dummy.cpp:23
+#, fuzzy
+#| msgid "Devil Kin"
+msgctxt "monster"
+msgid "Devil Kin"
+msgstr "Cria do Diabo"
+
+#: Source/translation_dummy.cpp:16 Source/translation_dummy.cpp:24
+msgctxt "monster"
+msgid "Dark One"
+msgstr "Sombrio"
+
+#: Source/translation_dummy.cpp:17 Source/translation_dummy.cpp:29
+msgctxt "monster"
+msgid "Skeleton"
+msgstr "Esqueleto"
+
+#: Source/translation_dummy.cpp:18
+msgctxt "monster"
+msgid "Corpse Axe"
+msgstr "Cadáver de Machado"
+
+#: Source/translation_dummy.cpp:19 Source/translation_dummy.cpp:31
+msgctxt "monster"
+msgid "Burning Dead"
+msgstr "Morto Calcinante"
+
+#: Source/translation_dummy.cpp:20 Source/translation_dummy.cpp:32
+msgctxt "monster"
+msgid "Horror"
+msgstr "Horror"
+
+#: Source/translation_dummy.cpp:25
+msgctxt "monster"
+msgid "Scavenger"
+msgstr "Escavador"
+
+#: Source/translation_dummy.cpp:26
+msgctxt "monster"
+msgid "Plague Eater"
+msgstr "Devorador de Almas"
+
+#: Source/translation_dummy.cpp:27
+#, fuzzy
+#| msgid "Shadow Beast"
+msgctxt "monster"
+msgid "Shadow Beast"
+msgstr "Fera das Sombras"
+
+#: Source/translation_dummy.cpp:28
+#, fuzzy
+#| msgid "Bone Gasher"
+msgctxt "monster"
+msgid "Bone Gasher"
+msgstr "Cortaosso"
+
+#: Source/translation_dummy.cpp:30
+#, fuzzy
+#| msgid "Corpse Bow"
+msgctxt "monster"
+msgid "Corpse Bow"
+msgstr "Cadáver Arqueiro"
+
+#: Source/translation_dummy.cpp:33
+msgctxt "monster"
+msgid "Skeleton Captain"
+msgstr "Esqueleto Capitão"
+
+#: Source/translation_dummy.cpp:34
+#, fuzzy
+#| msgid "Corpse Captain"
+msgctxt "monster"
+msgid "Corpse Captain"
+msgstr "Cadáver Capitão"
+
+#: Source/translation_dummy.cpp:35
+#, fuzzy
+#| msgid "Burning Dead Captain"
+msgctxt "monster"
+msgid "Burning Dead Captain"
+msgstr "Morto Calcinante Capitão "
+
+#: Source/translation_dummy.cpp:36
+#, fuzzy
+#| msgid "Horror Captain"
+msgctxt "monster"
+msgid "Horror Captain"
+msgstr "Horror Capitão"
+
+#: Source/translation_dummy.cpp:37
+#, fuzzy
+#| msgid "Invisible Lord"
+msgctxt "monster"
+msgid "Invisible Lord"
+msgstr "Senhor Invisível"
+
+#: Source/translation_dummy.cpp:38
+msgctxt "monster"
+msgid "Hidden"
+msgstr "Escondido"
+
+#: Source/translation_dummy.cpp:39
+#, fuzzy
+#| msgid "Stalker"
+msgctxt "monster"
+msgid "Stalker"
+msgstr "Espreitador"
+
+#: Source/translation_dummy.cpp:40
+#, fuzzy
+#| msgid "Unseen"
+msgctxt "monster"
+msgid "Unseen"
+msgstr "Despercebido"
+
+#: Source/translation_dummy.cpp:41
+#, fuzzy
+#| msgid "Illusion Weaver"
+msgctxt "monster"
+msgid "Illusion Weaver"
+msgstr "Tecelão de Ilusões"
+
+#: Source/translation_dummy.cpp:42
+#, fuzzy
+#| msgid "Satyr Lord"
+msgctxt "monster"
+msgid "Satyr Lord"
+msgstr "Senhor Sátiro"
+
+#: Source/translation_dummy.cpp:43 Source/translation_dummy.cpp:51
+#, fuzzy
+#| msgid "Flesh Clan"
+msgctxt "monster"
+msgid "Flesh Clan"
+msgstr "Clã Carne Fresca"
+
+#: Source/translation_dummy.cpp:44 Source/translation_dummy.cpp:52
+#, fuzzy
+#| msgid "Stone Clan"
+msgctxt "monster"
+msgid "Stone Clan"
+msgstr "Clã de Pedra"
+
+#: Source/translation_dummy.cpp:45 Source/translation_dummy.cpp:53
+#, fuzzy
+#| msgid "Fire Clan"
+msgctxt "monster"
+msgid "Fire Clan"
+msgstr "Clã de Fogo"
+
+#: Source/translation_dummy.cpp:46 Source/translation_dummy.cpp:54
+#, fuzzy
+#| msgid "Night Clan"
+msgctxt "monster"
+msgid "Night Clan"
+msgstr "Clã da Noite"
+
+#: Source/translation_dummy.cpp:47
+#, fuzzy
+#| msgid "Fiend"
+msgctxt "monster"
+msgid "Fiend"
+msgstr "Demônio"
+
+#: Source/translation_dummy.cpp:48
+#, fuzzy
+#| msgid "Blink"
+msgctxt "monster"
+msgid "Blink"
+msgstr "Cintilador"
+
+#: Source/translation_dummy.cpp:49
+#, fuzzy
+#| msgid "Gloom"
+msgctxt "monster"
+msgid "Gloom"
+msgstr "Melancolia"
+
+#: Source/translation_dummy.cpp:50
+#, fuzzy
+#| msgid "Familiar"
+msgctxt "monster"
+msgid "Familiar"
+msgstr "Familiar"
+
+#: Source/translation_dummy.cpp:55
+#, fuzzy
+#| msgid "Acid Beast"
+msgctxt "monster"
+msgid "Acid Beast"
+msgstr "Fera Ácida"
+
+#: Source/translation_dummy.cpp:56
+#, fuzzy
+#| msgid "Poison Spitter"
+msgctxt "monster"
+msgid "Poison Spitter"
+msgstr "Cospe-Veneno"
+
+#: Source/translation_dummy.cpp:57
+#, fuzzy
+#| msgid "Pit Beast"
+msgctxt "monster"
+msgid "Pit Beast"
+msgstr "Fera do Poço"
+
+#: Source/translation_dummy.cpp:58
+#, fuzzy
+#| msgid "Lava Maw"
+msgctxt "monster"
+msgid "Lava Maw"
+msgstr "Gorja de Lava"
+
+#: Source/translation_dummy.cpp:59 Source/translation_dummy.cpp:148
+#, fuzzy
+#| msgid "Skeleton King"
+msgctxt "monster"
+msgid "Skeleton King"
+msgstr "Rei Esqueleto"
+
+#: Source/translation_dummy.cpp:60 Source/translation_dummy.cpp:156
+msgctxt "monster"
+msgid "The Butcher"
+msgstr "O Açougueiro"
+
+#: Source/translation_dummy.cpp:61
+#, fuzzy
+#| msgid "Overlord"
+msgctxt "monster"
+msgid "Overlord"
+msgstr "Suserano"
+
+#: Source/translation_dummy.cpp:62
+#, fuzzy
+#| msgid "Mud Man"
+msgctxt "monster"
+msgid "Mud Man"
+msgstr "Homem-Lama"
+
+#: Source/translation_dummy.cpp:63
+#, fuzzy
+#| msgid "Toad Demon"
+msgctxt "monster"
+msgid "Toad Demon"
+msgstr "Demônio Sapo"
+
+#: Source/translation_dummy.cpp:64
+#, fuzzy
+#| msgid "Flayed One"
+msgctxt "monster"
+msgid "Flayed One"
+msgstr "Esfolado"
+
+#: Source/translation_dummy.cpp:65
+#, fuzzy
+#| msgid "Wyrm"
+msgctxt "monster"
+msgid "Wyrm"
+msgstr "Wyrm"
+
+#: Source/translation_dummy.cpp:66
+#, fuzzy
+#| msgid "Cave Slug"
+msgctxt "monster"
+msgid "Cave Slug"
+msgstr "Lesma da Caverna"
+
+#: Source/translation_dummy.cpp:67
+#, fuzzy
+#| msgid "Devil Wyrm"
+msgctxt "monster"
+msgid "Devil Wyrm"
+msgstr "Wyrm Demoníaca"
+
+#: Source/translation_dummy.cpp:68
+#, fuzzy
+#| msgid "Devourer"
+msgctxt "monster"
+msgid "Devourer"
+msgstr "Devorador"
+
+#: Source/translation_dummy.cpp:69
+#, fuzzy
+#| msgid "Magma Demon"
+msgctxt "monster"
+msgid "Magma Demon"
+msgstr "Demônio de Magma"
+
+#: Source/translation_dummy.cpp:70
+msgctxt "monster"
+msgid "Blood Stone"
+msgstr "Pedra Sanguínea"
+
+#: Source/translation_dummy.cpp:71
+#, fuzzy
+#| msgid "Hell Stone"
+msgctxt "monster"
+msgid "Hell Stone"
+msgstr "Pedra do Inferno"
+
+#: Source/translation_dummy.cpp:72
+#, fuzzy
+#| msgid "Lava Lord"
+msgctxt "monster"
+msgid "Lava Lord"
+msgstr "Senhor da Lava"
+
+#: Source/translation_dummy.cpp:73
+#, fuzzy
+#| msgid "Horned Demon"
+msgctxt "monster"
+msgid "Horned Demon"
+msgstr "Demônio com Chifres"
+
+#: Source/translation_dummy.cpp:74
+#, fuzzy
+#| msgid "Mud Runner"
+msgctxt "monster"
+msgid "Mud Runner"
+msgstr "Trilhador da Lama"
+
+#: Source/translation_dummy.cpp:75
+#, fuzzy
+#| msgid "Frost Charger"
+msgctxt "monster"
+msgid "Frost Charger"
+msgstr "Suicida Gélido"
+
+#: Source/translation_dummy.cpp:76
+#, fuzzy
+#| msgid "Obsidian Lord"
+msgctxt "monster"
+msgid "Obsidian Lord"
+msgstr "Senhor da Obsidiana"
+
+#: Source/translation_dummy.cpp:77
+#, fuzzy
+#| msgid "oldboned"
+msgctxt "monster"
+msgid "oldboned"
+msgstr "Ossovelho"
+
+#: Source/translation_dummy.cpp:78
+#, fuzzy
+#| msgid "Red Death"
+msgctxt "monster"
+msgid "Red Death"
+msgstr "Morte Vermelha"
+
+#: Source/translation_dummy.cpp:79
+#, fuzzy
+#| msgid "Litch Demon"
+msgctxt "monster"
+msgid "Litch Demon"
+msgstr "Demônio Litch"
+
+#: Source/translation_dummy.cpp:80
+#, fuzzy
+#| msgid "Undead Balrog"
+msgctxt "monster"
+msgid "Undead Balrog"
+msgstr "Balrog Morto-vivo"
+
+#: Source/translation_dummy.cpp:81
+#, fuzzy
+#| msgid "Incinerator"
+msgctxt "monster"
+msgid "Incinerator"
+msgstr "Incinerador"
+
+#: Source/translation_dummy.cpp:82
+#, fuzzy
+#| msgid "Flame Lord"
+msgctxt "monster"
+msgid "Flame Lord"
+msgstr "Senhor da Chama"
+
+#: Source/translation_dummy.cpp:83
+#, fuzzy
+#| msgid "Doom Fire"
+msgctxt "monster"
+msgid "Doom Fire"
+msgstr "Fogo da Perdição"
+
+#: Source/translation_dummy.cpp:84
+#, fuzzy
+#| msgid "Hell Burner"
+msgctxt "monster"
+msgid "Hell Burner"
+msgstr "Queimador do Inferno"
+
+#: Source/translation_dummy.cpp:85
+#, fuzzy
+#| msgid "Red Storm"
+msgctxt "monster"
+msgid "Red Storm"
+msgstr "Tempestade Vermelha"
+
+#: Source/translation_dummy.cpp:86
+#, fuzzy
+#| msgid "Storm Rider"
+msgctxt "monster"
+msgid "Storm Rider"
+msgstr "Tempestuoso"
+
+#: Source/translation_dummy.cpp:87
+#, fuzzy
+#| msgid "Storm Lord"
+msgctxt "monster"
+msgid "Storm Lord"
+msgstr "Senhor da Tempestade"
+
+#: Source/translation_dummy.cpp:88
+#, fuzzy
+#| msgid "Maelstrom"
+msgctxt "monster"
+msgid "Maelstrom"
+msgstr "Redemoinho"
+
+#: Source/translation_dummy.cpp:89
+#, fuzzy
+#| msgid "Devil Kin Brute"
+msgctxt "monster"
+msgid "Devil Kin Brute"
+msgstr "Cria do Diabo Bruta"
+
+#: Source/translation_dummy.cpp:90
+#, fuzzy
+#| msgid "Winged-Demon"
+msgctxt "monster"
+msgid "Winged-Demon"
+msgstr "Demônio Alado"
+
+#: Source/translation_dummy.cpp:91
+#, fuzzy
+#| msgid "Gargoyle"
+msgctxt "monster"
+msgid "Gargoyle"
+msgstr "Gárgula"
+
+#: Source/translation_dummy.cpp:92
+#, fuzzy
+#| msgid "Blood Claw"
+msgctxt "monster"
+msgid "Blood Claw"
+msgstr "Garra Sangrenta"
+
+#: Source/translation_dummy.cpp:93
+#, fuzzy
+#| msgid "Death Wing"
+msgctxt "monster"
+msgid "Death Wing"
+msgstr "Asa da Morte"
+
+#: Source/translation_dummy.cpp:94
+#, fuzzy
+#| msgid "Slayer"
+msgctxt "monster"
+msgid "Slayer"
+msgstr "Homicida"
+
+#: Source/translation_dummy.cpp:95
+#, fuzzy
+#| msgid "Guardian"
+msgctxt "monster"
+msgid "Guardian"
+msgstr "Guardião"
+
+#: Source/translation_dummy.cpp:96
+#, fuzzy
+#| msgid "Vortex Lord"
+msgctxt "monster"
+msgid "Vortex Lord"
+msgstr "Senhor do Vórtice"
+
+#: Source/translation_dummy.cpp:97
+#, fuzzy
+#| msgid "Balrog"
+msgctxt "monster"
+msgid "Balrog"
+msgstr "Balrog"
+
+#: Source/translation_dummy.cpp:98
+#, fuzzy
+#| msgid "Cave Viper"
+msgctxt "monster"
+msgid "Cave Viper"
+msgstr "Víbora da Caverna"
+
+#: Source/translation_dummy.cpp:99
+#, fuzzy
+#| msgid "Fire Drake"
+msgctxt "monster"
+msgid "Fire Drake"
+msgstr "Víbora de Fogo"
+
+#: Source/translation_dummy.cpp:100
+#, fuzzy
+#| msgid "Gold Viper"
+msgctxt "monster"
+msgid "Gold Viper"
+msgstr "Víbora de Ouro"
+
+#: Source/translation_dummy.cpp:101
+#, fuzzy
+#| msgid "Azure Drake"
+msgctxt "monster"
+msgid "Azure Drake"
+msgstr "Víbora Azulada"
+
+#: Source/translation_dummy.cpp:102
+#, fuzzy
+#| msgid "Black Knight"
+msgctxt "monster"
+msgid "Black Knight"
+msgstr "Cavaleiro Negro"
+
+#: Source/translation_dummy.cpp:103
+#, fuzzy
+#| msgid "Doom Guard"
+msgctxt "monster"
+msgid "Doom Guard"
+msgstr "Guarda da Perdição"
+
+#: Source/translation_dummy.cpp:104
+#, fuzzy
+#| msgid "Steel Lord"
+msgctxt "monster"
+msgid "Steel Lord"
+msgstr "Senhor de Aço"
+
+#: Source/translation_dummy.cpp:105
+#, fuzzy
+#| msgid "Blood Knight"
+msgctxt "monster"
+msgid "Blood Knight"
+msgstr "Cavaleiro Sangrento"
+
+#: Source/translation_dummy.cpp:106
+#, fuzzy
+#| msgid "The Shredded"
+msgctxt "monster"
+msgid "The Shredded"
+msgstr "Desfiador"
+
+#: Source/translation_dummy.cpp:107
+#, fuzzy
+#| msgid "Hollow One"
+msgctxt "monster"
+msgid "Hollow One"
+msgstr "Oco"
+
+#: Source/translation_dummy.cpp:108
+#, fuzzy
+#| msgid "Pain Master"
+msgctxt "monster"
+msgid "Pain Master"
+msgstr "Mestre da Dor"
+
+#: Source/translation_dummy.cpp:109
+#, fuzzy
+#| msgid "Reality Weaver"
+msgctxt "monster"
+msgid "Reality Weaver"
+msgstr "Tecelão de Realidades"
+
+#: Source/translation_dummy.cpp:110
+#, fuzzy
+#| msgid "Succubus"
+msgctxt "monster"
+msgid "Succubus"
+msgstr "Súcubo"
+
+#: Source/translation_dummy.cpp:111
+#, fuzzy
+#| msgid "Snow Witch"
+msgctxt "monster"
+msgid "Snow Witch"
+msgstr "Bruxa da Neve"
+
+#: Source/translation_dummy.cpp:112
+#, fuzzy
+#| msgid "Hell Spawn"
+msgctxt "monster"
+msgid "Hell Spawn"
+msgstr "Cria do Inferno"
+
+#: Source/translation_dummy.cpp:113
+#, fuzzy
+#| msgid "Soul Burner"
+msgctxt "monster"
+msgid "Soul Burner"
+msgstr "Queimadora de Almas"
+
+#: Source/translation_dummy.cpp:114
+#, fuzzy
+#| msgid "Counselor"
+msgctxt "monster"
+msgid "Counselor"
+msgstr "Conselheiro"
+
+#: Source/translation_dummy.cpp:115
+#, fuzzy
+#| msgid "Magistrate"
+msgctxt "monster"
+msgid "Magistrate"
+msgstr "Magistrado"
+
+#: Source/translation_dummy.cpp:116
+#, fuzzy
+#| msgid "Cabalist"
+msgctxt "monster"
+msgid "Cabalist"
+msgstr "Cabalista"
+
+#: Source/translation_dummy.cpp:117
+#, fuzzy
+#| msgid "Advocate"
+msgctxt "monster"
+msgid "Advocate"
+msgstr "Defensor"
+
+#: Source/translation_dummy.cpp:118
+#, fuzzy
+#| msgid "Golem"
+msgctxt "monster"
+msgid "Golem"
+msgstr "Golem"
+
+#: Source/translation_dummy.cpp:119
+#, fuzzy
+#| msgid "The Dark Lord"
+msgctxt "monster"
+msgid "The Dark Lord"
+msgstr "O Lorde Sombrio"
+
+#: Source/translation_dummy.cpp:120
+#, fuzzy
+#| msgid "The Arch-Litch Malignus"
+msgctxt "monster"
+msgid "The Arch-Litch Malignus"
+msgstr "O Arce-Litch Malignus"
+
+#: Source/translation_dummy.cpp:121
+#, fuzzy
+#| msgid "Hellboar"
+msgctxt "monster"
+msgid "Hellboar"
+msgstr "Hellboar"
+
+#: Source/translation_dummy.cpp:122
+#, fuzzy
+#| msgid "Stinger"
+msgctxt "monster"
+msgid "Stinger"
+msgstr "Ferrão"
+
+#: Source/translation_dummy.cpp:123
+#, fuzzy
+#| msgid "Psychorb"
+msgctxt "monster"
+msgid "Psychorb"
+msgstr "Psychorb"
+
+#: Source/translation_dummy.cpp:124
+#, fuzzy
+#| msgid "Arachnon"
+msgctxt "monster"
+msgid "Arachnon"
+msgstr "Arachnon"
+
+#: Source/translation_dummy.cpp:125
+#, fuzzy
+#| msgid "Felltwin"
+msgctxt "monster"
+msgid "Felltwin"
+msgstr "Felltwin"
+
+#: Source/translation_dummy.cpp:126
+#, fuzzy
+#| msgid "Hork Spawn"
+msgctxt "monster"
+msgid "Hork Spawn"
+msgstr "Cria de Hork"
+
+#: Source/translation_dummy.cpp:127
+#, fuzzy
+#| msgid "Venomtail"
+msgctxt "monster"
+msgid "Venomtail"
+msgstr "Venomtail"
+
+#: Source/translation_dummy.cpp:128
+#, fuzzy
+#| msgid "Necromorb"
+msgctxt "monster"
+msgid "Necromorb"
+msgstr "Necromorb"
+
+#: Source/translation_dummy.cpp:129
+#, fuzzy
+#| msgid "Spider Lord"
+msgctxt "monster"
+msgid "Spider Lord"
+msgstr "Senhor das Aranhas"
+
+#: Source/translation_dummy.cpp:130
+#, fuzzy
+#| msgid "Lashworm"
+msgctxt "monster"
+msgid "Lashworm"
+msgstr "Verme-de-chicote"
+
+#: Source/translation_dummy.cpp:131
+#, fuzzy
+#| msgid "Torchant"
+msgctxt "monster"
+msgid "Torchant"
+msgstr "Torchant"
+
+#: Source/translation_dummy.cpp:132 Source/translation_dummy.cpp:157
+#, fuzzy
+#| msgid "Hork Demon"
+msgctxt "monster"
+msgid "Hork Demon"
+msgstr "Demônio Hork"
+
+#: Source/translation_dummy.cpp:133
+#, fuzzy
+#| msgid "Hell Bug"
+msgctxt "monster"
+msgid "Hell Bug"
+msgstr "Inseto do Inferno"
+
+#: Source/translation_dummy.cpp:134
+#, fuzzy
+#| msgid "Gravedigger"
+msgctxt "monster"
+msgid "Gravedigger"
+msgstr "Coveiro"
+
+#: Source/translation_dummy.cpp:135
+#, fuzzy
+#| msgid "Tomb Rat"
+msgctxt "monster"
+msgid "Tomb Rat"
+msgstr "Rato da Tumba"
+
+#: Source/translation_dummy.cpp:136
+#, fuzzy
+#| msgid "Firebat"
+msgctxt "monster"
+msgid "Firebat"
+msgstr "Morcego de Fogo"
+
+#: Source/translation_dummy.cpp:137
+#, fuzzy
+#| msgid "Skullwing"
+msgctxt "monster"
+msgid "Skullwing"
+msgstr "Asa Esquelética"
+
+#: Source/translation_dummy.cpp:138
+#, fuzzy
+#| msgid "Lich"
+msgctxt "monster"
+msgid "Lich"
+msgstr "Lich"
+
+#: Source/translation_dummy.cpp:139
+#, fuzzy
+#| msgid "Crypt Demon"
+msgctxt "monster"
+msgid "Crypt Demon"
+msgstr "Demônio da Cripta"
+
+#: Source/translation_dummy.cpp:140
+#, fuzzy
+#| msgid "Hellbat"
+msgctxt "monster"
+msgid "Hellbat"
+msgstr "Morcego Infernal"
+
+#: Source/translation_dummy.cpp:141
+#, fuzzy
+#| msgid "Bone Demon"
+msgctxt "monster"
+msgid "Bone Demon"
+msgstr "Demônio de Ossos"
+
+#: Source/translation_dummy.cpp:142
+#, fuzzy
+#| msgid "Arch Lich"
+msgctxt "monster"
+msgid "Arch Lich"
+msgstr "Arque Lich"
+
+#: Source/translation_dummy.cpp:143
+#, fuzzy
+#| msgid "Biclops"
+msgctxt "monster"
+msgid "Biclops"
+msgstr "Biclops"
+
+#: Source/translation_dummy.cpp:144
+#, fuzzy
+#| msgid "Flesh Thing"
+msgctxt "monster"
+msgid "Flesh Thing"
+msgstr "Coisa de Carne Fresca"
+
+#: Source/translation_dummy.cpp:145
+#, fuzzy
+#| msgid "Reaper"
+msgctxt "monster"
+msgid "Reaper"
+msgstr "Ceifador"
+
+#: Source/translation_dummy.cpp:146 Source/translation_dummy.cpp:159
+msgctxt "monster"
+msgid "Na-Krul"
+msgstr "Na-Krul"
+
+#: Source/translation_dummy.cpp:147
+#, fuzzy
+#| msgid "Gharbad the Weak"
+msgctxt "monster"
+msgid "Gharbad the Weak"
+msgstr "Gharbad, o Fraco"
+
+#: Source/translation_dummy.cpp:149
+msgctxt "monster"
+msgid "Zhar the Mad"
+msgstr "Zhar, o Louco"
+
+#: Source/translation_dummy.cpp:150
+#, fuzzy
+#| msgid "Snotspill"
+msgctxt "monster"
+msgid "Snotspill"
+msgstr "Kaikatarro"
+
+#: Source/translation_dummy.cpp:151
+#, fuzzy
+#| msgid "Arch-Bishop Lazarus"
+msgctxt "monster"
+msgid "Arch-Bishop Lazarus"
+msgstr "Arcebispo Lazarus"
+
+#: Source/translation_dummy.cpp:152
+#, fuzzy
+#| msgid "Red Vex"
+msgctxt "monster"
+msgid "Red Vex"
+msgstr "Apurrinhação Vermelha"
+
+#: Source/translation_dummy.cpp:153
+#, fuzzy
+#| msgid "Black Jade"
+msgctxt "monster"
+msgid "Black Jade"
+msgstr "Jade Negra"
+
+#: Source/translation_dummy.cpp:154
+msgctxt "monster"
+msgid "Lachdanan"
+msgstr "Lachdanan"
+
+#: Source/translation_dummy.cpp:155
+msgctxt "monster"
+msgid "Warlord of Blood"
+msgstr "Senhor da Guerra Sangrenta"
+
+#: Source/translation_dummy.cpp:158
+msgctxt "monster"
+msgid "The Defiler"
+msgstr "O Profanador"
+
+#: Source/translation_dummy.cpp:160
+#, fuzzy
+#| msgid "Bonehead Keenaxe"
+msgctxt "monster"
+msgid "Bonehead Keenaxe"
+msgstr "Osteocéfalo Machado"
+
+#: Source/translation_dummy.cpp:161
+#, fuzzy
+#| msgid "Bladeskin the Slasher"
+msgctxt "monster"
+msgid "Bladeskin the Slasher"
+msgstr "Laminiderme, o Esfaqueador"
+
+#: Source/translation_dummy.cpp:162
+#, fuzzy
+#| msgid "Soulpus"
+msgctxt "monster"
+msgid "Soulpus"
+msgstr "Pus de Alma"
+
+#: Source/translation_dummy.cpp:163
+#, fuzzy
+#| msgid "Pukerat the Unclean"
+msgctxt "monster"
+msgid "Pukerat the Unclean"
+msgstr "Vomirrato, o Impuro"
+
+#: Source/translation_dummy.cpp:164
+#, fuzzy
+#| msgid "Boneripper"
+msgctxt "monster"
+msgid "Boneripper"
+msgstr "Estripa-ossos"
+
+#: Source/translation_dummy.cpp:165
+#, fuzzy
+#| msgid "Rotfeast the Hungry"
+msgctxt "monster"
+msgid "Rotfeast the Hungry"
+msgstr "Putrefórico, o Faminto"
+
+#: Source/translation_dummy.cpp:166
+#, fuzzy
+#| msgid "Gutshank the Quick"
+msgctxt "monster"
+msgid "Gutshank the Quick"
+msgstr "Tripernil, o Veloz"
+
+#: Source/translation_dummy.cpp:167
+#, fuzzy
+#| msgid "Brokenhead Bangshield"
+msgctxt "monster"
+msgid "Brokenhead Bangshield"
+msgstr "Traumocéfalo Bate-Escudos"
+
+#: Source/translation_dummy.cpp:168
+msgctxt "monster"
+msgid "Bongo"
+msgstr "Bongo"
+
+#: Source/translation_dummy.cpp:169
+#, fuzzy
+#| msgid "Rotcarnage"
+msgctxt "monster"
+msgid "Rotcarnage"
+msgstr "Putrificina"
+
+#: Source/translation_dummy.cpp:170
+#, fuzzy
+#| msgid "Shadowbite"
+msgctxt "monster"
+msgid "Shadowbite"
+msgstr "Mordesombra"
+
+#: Source/translation_dummy.cpp:171
+#, fuzzy
+#| msgid "Deadeye"
+msgctxt "monster"
+msgid "Deadeye"
+msgstr "Olho Morto"
+
+#: Source/translation_dummy.cpp:172
+#, fuzzy
+#| msgid "Madeye the Dead"
+msgctxt "monster"
+msgid "Madeye the Dead"
+msgstr "Olholouco, o Morto"
+
+#: Source/translation_dummy.cpp:173
+msgctxt "monster"
+msgid "El Chupacabras"
+msgstr "El Chupacabras"
+
+#: Source/translation_dummy.cpp:174
+#, fuzzy
+#| msgid "Skullfire"
+msgctxt "monster"
+msgid "Skullfire"
+msgstr "Fogo Cranial"
+
+#: Source/translation_dummy.cpp:175
+#, fuzzy
+#| msgid "Warpskull"
+msgctxt "monster"
+msgid "Warpskull"
+msgstr "Crânio Torto"
+
+#: Source/translation_dummy.cpp:176
+#, fuzzy
+#| msgid "Goretongue"
+msgctxt "monster"
+msgid "Goretongue"
+msgstr "Sanguinolíngue"
+
+#: Source/translation_dummy.cpp:177
+#, fuzzy
+#| msgid "Pulsecrawler"
+msgctxt "monster"
+msgid "Pulsecrawler"
+msgstr "Pulsejador"
+
+#: Source/translation_dummy.cpp:178
+#, fuzzy
+#| msgid "Moonbender"
+msgctxt "monster"
+msgid "Moonbender"
+msgstr "Verga-Luas"
+
+#: Source/translation_dummy.cpp:179
+#, fuzzy
+#| msgid "Wrathraven"
+msgctxt "monster"
+msgid "Wrathraven"
+msgstr "Corvo da Cólera"
+
+#: Source/translation_dummy.cpp:180
+#, fuzzy
+#| msgid "Spineeater"
+msgctxt "monster"
+msgid "Spineeater"
+msgstr "Come-Espinhas"
+
+#: Source/translation_dummy.cpp:181
+msgctxt "monster"
+msgid "Blackash the Burning"
+msgstr "Cinzascura, o Calcinante"
+
+#: Source/translation_dummy.cpp:182
+#, fuzzy
+#| msgid "Shadowcrow"
+msgctxt "monster"
+msgid "Shadowcrow"
+msgstr "Corvossombra"
+
+#: Source/translation_dummy.cpp:183
+#, fuzzy
+#| msgid "Blightstone the Weak"
+msgctxt "monster"
+msgid "Blightstone the Weak"
+msgstr "Pedrapraga, o Fraco"
+
+#: Source/translation_dummy.cpp:184
+msgctxt "monster"
+msgid "Bilefroth the Pit Master"
+msgstr "Espumabile, o Mestre do Poço"
+
+#: Source/translation_dummy.cpp:185
+#, fuzzy
+#| msgid "Bloodskin Darkbow"
+msgctxt "monster"
+msgid "Bloodskin Darkbow"
+msgstr "Sanguiderme Arco Negro"
+
+#: Source/translation_dummy.cpp:186
+#, fuzzy
+#| msgid "Foulwing"
+msgctxt "monster"
+msgid "Foulwing"
+msgstr "Asa Pútrida"
+
+#: Source/translation_dummy.cpp:187
+#, fuzzy
+#| msgid "Shadowdrinker"
+msgctxt "monster"
+msgid "Shadowdrinker"
+msgstr "Bebedor das Sombras"
+
+#: Source/translation_dummy.cpp:188
+#, fuzzy
+#| msgid "Hazeshifter"
+msgctxt "monster"
+msgid "Hazeshifter"
+msgstr "Muda-Névoas"
+
+#: Source/translation_dummy.cpp:189
+#, fuzzy
+#| msgid "Deathspit"
+msgctxt "monster"
+msgid "Deathspit"
+msgstr "Cospe-Morte"
+
+#: Source/translation_dummy.cpp:190
+#, fuzzy
+#| msgid "Bloodgutter"
+msgctxt "monster"
+msgid "Bloodgutter"
+msgstr "Coagulário"
+
+#: Source/translation_dummy.cpp:191
+#, fuzzy
+#| msgid "Deathshade Fleshmaul"
+msgctxt "monster"
+msgid "Deathshade Fleshmaul"
+msgstr "Sombra da Morte Rasga-Carne"
+
+#: Source/translation_dummy.cpp:192
+#, fuzzy
+#| msgid "Warmaggot the Mad"
+msgctxt "monster"
+msgid "Warmaggot the Mad"
+msgstr "Larvaguerra, o Louco"
+
+#: Source/translation_dummy.cpp:193
+msgctxt "monster"
+msgid "Glasskull the Jagged"
+msgstr "Crânio de Vidro, o Serrilhado"
+
+#: Source/translation_dummy.cpp:194
+#, fuzzy
+#| msgid "Blightfire"
+msgctxt "monster"
+msgid "Blightfire"
+msgstr "Flagelo de Fogo"
+
+#: Source/translation_dummy.cpp:195
+#, fuzzy
+#| msgid "Nightwing the Cold"
+msgctxt "monster"
+msgid "Nightwing the Cold"
+msgstr "Asa Noturna, o Gélido"
+
+#: Source/translation_dummy.cpp:196
+#, fuzzy
+#| msgid "Gorestone"
+msgctxt "monster"
+msgid "Gorestone"
+msgstr "Rochacínio"
+
+#: Source/translation_dummy.cpp:197
+#, fuzzy
+#| msgid "Bronzefist Firestone"
+msgctxt "monster"
+msgid "Bronzefist Firestone"
+msgstr "Pugibronze Pedra de Fogo"
+
+#: Source/translation_dummy.cpp:198
+#, fuzzy
+#| msgid "Wrathfire the Doomed"
+msgctxt "monster"
+msgid "Wrathfire the Doomed"
+msgstr "Irígnea, o Condenado"
+
+#: Source/translation_dummy.cpp:199
+#, fuzzy
+#| msgid "Firewound the Grim"
+msgctxt "monster"
+msgid "Firewound the Grim"
+msgstr "Chaga Ígnea, o Tenebroso"
+
+#: Source/translation_dummy.cpp:200
+#, fuzzy
+#| msgid "Baron Sludge"
+msgctxt "monster"
+msgid "Baron Sludge"
+msgstr "Barão Lodoso"
+
+#: Source/translation_dummy.cpp:201
+#, fuzzy
+#| msgid "Blighthorn Steelmace"
+msgctxt "monster"
+msgid "Blighthorn Steelmace"
+msgstr "Guampestífero Maça de Aço"
+
+#: Source/translation_dummy.cpp:202
+#, fuzzy
+#| msgid "Chaoshowler"
+msgctxt "monster"
+msgid "Chaoshowler"
+msgstr "Berrocaos"
+
+#: Source/translation_dummy.cpp:203
+#, fuzzy
+#| msgid "Doomgrin the Rotting"
+msgctxt "monster"
+msgid "Doomgrin the Rotting"
+msgstr "Sorrirruína, o Podre"
+
+#: Source/translation_dummy.cpp:204
+#, fuzzy
+#| msgid "Madburner"
+msgctxt "monster"
+msgid "Madburner"
+msgstr "Queimador Louco"
+
+#: Source/translation_dummy.cpp:205
+msgctxt "monster"
+msgid "Bonesaw the Litch"
+msgstr "Serra Osso, o Litch"
+
+#: Source/translation_dummy.cpp:206
+#, fuzzy
+#| msgid "Breakspine"
+msgctxt "monster"
+msgid "Breakspine"
+msgstr "Quebra-Espinha"
+
+#: Source/translation_dummy.cpp:207
+#, fuzzy
+#| msgid "Devilskull Sharpbone"
+msgctxt "monster"
+msgid "Devilskull Sharpbone"
+msgstr "Demonicrânio Osso Afiado"
+
+#: Source/translation_dummy.cpp:208
+#, fuzzy
+#| msgid "Brokenstorm"
+msgctxt "monster"
+msgid "Brokenstorm"
+msgstr "Tempestrago"
+
+#: Source/translation_dummy.cpp:209
+#, fuzzy
+#| msgid "Stormbane"
+msgctxt "monster"
+msgid "Stormbane"
+msgstr "Praguestade"
+
+#: Source/translation_dummy.cpp:210
+#, fuzzy
+#| msgid "Oozedrool"
+msgctxt "monster"
+msgid "Oozedrool"
+msgstr "Babujador"
+
+#: Source/translation_dummy.cpp:211
+msgctxt "monster"
+msgid "Goldblight of the Flame"
+msgstr "Pragáurea da Chama"
+
+#: Source/translation_dummy.cpp:212
+#, fuzzy
+#| msgid "Blackstorm"
+msgctxt "monster"
+msgid "Blackstorm"
+msgstr "Tempestade Negra"
+
+#: Source/translation_dummy.cpp:213
+#, fuzzy
+#| msgid "Plaguewrath"
+msgctxt "monster"
+msgid "Plaguewrath"
+msgstr "Pestilérico"
+
+#: Source/translation_dummy.cpp:214
+#, fuzzy
+#| msgid "The Flayer"
+msgctxt "monster"
+msgid "The Flayer"
+msgstr "O Esfolador"
+
+#: Source/translation_dummy.cpp:215
+#, fuzzy
+#| msgid "Bluehorn"
+msgctxt "monster"
+msgid "Bluehorn"
+msgstr "Chifre Azul"
+
+#: Source/translation_dummy.cpp:216
+#, fuzzy
+#| msgid "Warpfire Hellspawn"
+msgctxt "monster"
+msgid "Warpfire Hellspawn"
+msgstr "Deformígneo Cria do Inferno"
+
+#: Source/translation_dummy.cpp:217
+#, fuzzy
+#| msgid "Fangspeir"
+msgctxt "monster"
+msgid "Fangspeir"
+msgstr "Presatroz"
+
+#: Source/translation_dummy.cpp:218
+#, fuzzy
+#| msgid "Festerskull"
+msgctxt "monster"
+msgid "Festerskull"
+msgstr "Pesticrânio"
+
+#: Source/translation_dummy.cpp:219
+msgctxt "monster"
+msgid "Lionskull the Bent"
+msgstr "CrânioLeão, o Curvado"
+
+#: Source/translation_dummy.cpp:220
+#, fuzzy
+#| msgid "Blacktongue"
+msgctxt "monster"
+msgid "Blacktongue"
+msgstr "Língua Negra"
+
+#: Source/translation_dummy.cpp:221
+#, fuzzy
+#| msgid "Viletouch"
+msgctxt "monster"
+msgid "Viletouch"
+msgstr "Toque Nóxio"
+
+#: Source/translation_dummy.cpp:222
+#, fuzzy
+#| msgid "Viperflame"
+msgctxt "monster"
+msgid "Viperflame"
+msgstr "Ignofídico"
+
+#: Source/translation_dummy.cpp:223
+#, fuzzy
+#| msgid "Fangskin"
+msgctxt "monster"
+msgid "Fangskin"
+msgstr "Presiderme"
+
+#: Source/translation_dummy.cpp:224
+msgctxt "monster"
+msgid "Witchfire the Unholy"
+msgstr "Witchfire, o Pecaminoso"
+
+#: Source/translation_dummy.cpp:225
+#, fuzzy
+#| msgid "Blackskull"
+msgctxt "monster"
+msgid "Blackskull"
+msgstr "Caveira Negra"
+
+#: Source/translation_dummy.cpp:226
+#, fuzzy
+#| msgid "Soulslash"
+msgctxt "monster"
+msgid "Soulslash"
+msgstr "Corta-Almas"
+
+#: Source/translation_dummy.cpp:227
+#, fuzzy
+#| msgid "Windspawn"
+msgctxt "monster"
+msgid "Windspawn"
+msgstr "Ventoso"
+
+#: Source/translation_dummy.cpp:228
+msgctxt "monster"
+msgid "Lord of the Pit"
+msgstr "Senhor do Poço"
+
+#: Source/translation_dummy.cpp:229
+#, fuzzy
+#| msgid "Rustweaver"
+msgctxt "monster"
+msgid "Rustweaver"
+msgstr "Ferrecelão"
+
+#: Source/translation_dummy.cpp:230
+#, fuzzy
+#| msgid "Howlingire the Shade"
+msgctxt "monster"
+msgid "Howlingire the Shade"
+msgstr "Iruivante, a Sombra"
+
+#: Source/translation_dummy.cpp:231
+#, fuzzy
+#| msgid "Doomcloud"
+msgctxt "monster"
+msgid "Doomcloud"
+msgstr "Nuvem da Desgraça"
+
+#: Source/translation_dummy.cpp:232
+#, fuzzy
+#| msgid "Bloodmoon Soulfire"
+msgctxt "monster"
+msgid "Bloodmoon Soulfire"
+msgstr "Luassangra Fogo de Alma"
+
+#: Source/translation_dummy.cpp:233
+#, fuzzy
+#| msgid "Witchmoon"
+msgctxt "monster"
+msgid "Witchmoon"
+msgstr "Bruxa Lunar"
+
+#: Source/translation_dummy.cpp:234
+#, fuzzy
+#| msgid "Gorefeast"
+msgctxt "monster"
+msgid "Gorefeast"
+msgstr "Banqueticínio"
+
+#: Source/translation_dummy.cpp:235
+#, fuzzy
+#| msgid "Graywar the Slayer"
+msgctxt "monster"
+msgid "Graywar the Slayer"
+msgstr "Belipardo, o Matador"
+
+#: Source/translation_dummy.cpp:236
+#, fuzzy
+#| msgid "Dreadjudge"
+msgctxt "monster"
+msgid "Dreadjudge"
+msgstr "Temível Juiz"
+
+#: Source/translation_dummy.cpp:237
+#, fuzzy
+#| msgid "Stareye the Witch"
+msgctxt "monster"
+msgid "Stareye the Witch"
+msgstr "Estrolha, a Bruxa"
+
+#: Source/translation_dummy.cpp:238
+#, fuzzy
+#| msgid "Steelskull the Hunter"
+msgctxt "monster"
+msgid "Steelskull the Hunter"
+msgstr "Craniaço, o Caçador"
+
+#: Source/translation_dummy.cpp:239
+#, fuzzy
+#| msgid "Sir Gorash"
+msgctxt "monster"
+msgid "Sir Gorash"
+msgstr "Sir Gorash"
+
+#: Source/translation_dummy.cpp:240
+#, fuzzy
+#| msgid "The Vizier"
+msgctxt "monster"
+msgid "The Vizier"
+msgstr "O Vizir"
+
+#: Source/translation_dummy.cpp:241
+#, fuzzy
+#| msgid "Sapphire"
+msgctxt "monster"
+msgid "Zamphir"
+msgstr "Zamfir"
+
+#: Source/translation_dummy.cpp:242
+#, fuzzy
+#| msgid "Bloodlust"
+msgctxt "monster"
+msgid "Bloodlust"
+msgstr "Sede de Sangue"
+
+#: Source/translation_dummy.cpp:243
+msgctxt "monster"
+msgid "Webwidow"
+msgstr "Viúvaranha"
+
+#: Source/translation_dummy.cpp:244
+#, fuzzy
+#| msgid "Fleshdancer"
+msgctxt "monster"
+msgid "Fleshdancer"
+msgstr "Dançarina da Carne"
+
+#: Source/translation_dummy.cpp:245
+#, fuzzy
+#| msgid "Grimspike"
+msgctxt "monster"
+msgid "Grimspike"
+msgstr "Espinebroso"
+
+#: Source/translation_dummy.cpp:246
+#, fuzzy
+#| msgid "Doomlock"
+msgctxt "monster"
+msgid "Doomlock"
+msgstr "Perdentrave"
+
+#: Source/translation_dummy.cpp:248 Source/translation_dummy.cpp:390
+msgid "Short Sword"
+msgstr "Espada Curta"
+
+#: Source/translation_dummy.cpp:249 Source/translation_dummy.cpp:341
+msgid "Buckler"
+msgstr "Broquel"
+
+#: Source/translation_dummy.cpp:250 Source/translation_dummy.cpp:431
+#: Source/translation_dummy.cpp:432 Source/translation_dummy.cpp:433
+msgid "Club"
+msgstr "Clava"
+
+#: Source/translation_dummy.cpp:251 Source/translation_dummy.cpp:438
+msgid "Short Bow"
+msgstr "Arco curto"
+
+#: Source/translation_dummy.cpp:252
+msgid "Short Staff of Mana"
+msgstr "Cajado curto de mana"
+
+#: Source/translation_dummy.cpp:253
+msgid "Cleaver"
+msgstr "Cutelo"
+
+#: Source/translation_dummy.cpp:254 Source/translation_dummy.cpp:487
+msgid "The Undead Crown"
+msgstr "Coroa dos mortos-vivos"
+
+#: Source/translation_dummy.cpp:255 Source/translation_dummy.cpp:488
+msgid "Empyrean Band"
+msgstr "Anel empíreo"
+
+#: Source/translation_dummy.cpp:256
+msgid "Magic Rock"
+msgstr "Rocha mágica"
+
+#: Source/translation_dummy.cpp:257 Source/translation_dummy.cpp:489
+msgid "Optic Amulet"
+msgstr "Amuleto óptico"
+
+#: Source/translation_dummy.cpp:258 Source/translation_dummy.cpp:490
+msgid "Ring of Truth"
+msgstr "Anel da verdade"
+
+#: Source/translation_dummy.cpp:259
+msgid "Tavern Sign"
+msgstr "Placa da taverna"
+
+#: Source/translation_dummy.cpp:260 Source/translation_dummy.cpp:491
+msgid "Harlequin Crest"
+msgstr "Brasão do arlequim"
+
+#: Source/translation_dummy.cpp:261 Source/translation_dummy.cpp:492
+msgid "Veil of Steel"
+msgstr "Véu de aço"
+
+#: Source/translation_dummy.cpp:262
+msgid "Golden Elixir"
+msgstr "Elixir dourado"
+
+#: Source/translation_dummy.cpp:265
+msgid "Brain"
+msgstr "Cérebro"
+
+#: Source/translation_dummy.cpp:266
+msgid "Fungal Tome"
+msgstr "Tomo fungoso"
+
+#: Source/translation_dummy.cpp:267
+msgid "Spectral Elixir"
+msgstr "Elixir espectral"
+
+#: Source/translation_dummy.cpp:268
+msgid "Blood Stone"
+msgstr "Pedra sanguínea"
+
+#: Source/translation_dummy.cpp:269
+msgid "Cathedral Map"
+msgstr "Mapa da catedral"
+
+#: Source/translation_dummy.cpp:270
+msgid "Heart"
+msgstr "Coração"
+
+#: Source/translation_dummy.cpp:271 Source/translation_dummy.cpp:353
+msgid "Potion of Healing"
+msgstr "Poção de cura"
+
+#: Source/translation_dummy.cpp:272 Source/translation_dummy.cpp:355
+msgid "Potion of Mana"
+msgstr "Poção de mana"
+
+#: Source/translation_dummy.cpp:273 Source/translation_dummy.cpp:370
+msgid "Scroll of Identify"
+msgstr "Pergaminho de identificar"
+
+#: Source/translation_dummy.cpp:274 Source/translation_dummy.cpp:374
+msgid "Scroll of Town Portal"
+msgstr "Pergaminho de portal da cidade"
+
+#: Source/translation_dummy.cpp:275 Source/translation_dummy.cpp:493
+msgid "Arkaine's Valor"
+msgstr "Bravura de Arkaine"
+
+#: Source/translation_dummy.cpp:276 Source/translation_dummy.cpp:354
+msgid "Potion of Full Healing"
+msgstr "Poção de cura completa"
+
+#: Source/translation_dummy.cpp:277 Source/translation_dummy.cpp:356
+msgid "Potion of Full Mana"
+msgstr "Poção de mana completa"
+
+#: Source/translation_dummy.cpp:278 Source/translation_dummy.cpp:494
+msgid "Griswold's Edge"
+msgstr "Gume de Griswold"
+
+#: Source/translation_dummy.cpp:279 Source/translation_dummy.cpp:495
+msgid "Bovine Plate"
+msgstr "Placa bovina"
+
+#: Source/translation_dummy.cpp:280
+msgid "Staff of Lazarus"
+msgstr "Cajado de Lázarus"
+
+#: Source/translation_dummy.cpp:281 Source/translation_dummy.cpp:371
+msgid "Scroll of Resurrect"
+msgstr "Pergaminho de ressuscitar"
+
+#: Source/translation_dummy.cpp:283 Source/translation_dummy.cpp:454
+msgid "Short Staff"
+msgstr "Cajado curto"
+
+#: Source/translation_dummy.cpp:284 Source/translation_dummy.cpp:391
+#: Source/translation_dummy.cpp:393 Source/translation_dummy.cpp:395
+#: Source/translation_dummy.cpp:397 Source/translation_dummy.cpp:403
+#: Source/translation_dummy.cpp:405 Source/translation_dummy.cpp:407
+#: Source/translation_dummy.cpp:409 Source/translation_dummy.cpp:411
+msgid "Sword"
+msgstr "Espada"
+
+#: Source/translation_dummy.cpp:285 Source/translation_dummy.cpp:388
+#: Source/translation_dummy.cpp:389
+msgid "Dagger"
+msgstr "Adaga"
+
+#: Source/translation_dummy.cpp:286
+msgid "Rune Bomb"
+msgstr "Runa explosiva"
+
+#: Source/translation_dummy.cpp:287
+msgid "Theodore"
+msgstr "Theodore"
+
+#: Source/translation_dummy.cpp:288
+msgid "Auric Amulet"
+msgstr "Amuleto áurico"
+
+#: Source/translation_dummy.cpp:289
+msgid "Torn Note 1"
+msgstr "Nota rasgada 1"
+
+#: Source/translation_dummy.cpp:290
+msgid "Torn Note 2"
+msgstr "Nota rasgada 2"
+
+#: Source/translation_dummy.cpp:291
+msgid "Torn Note 3"
+msgstr "Nota rasgada 3"
+
+#: Source/translation_dummy.cpp:292
+msgid "Reconstructed Note"
+msgstr "Nota reconstruída"
+
+#: Source/translation_dummy.cpp:293
+msgid "Brown Suit"
+msgstr "Traje marrom"
+
+#: Source/translation_dummy.cpp:294
+msgid "Grey Suit"
+msgstr "Traje cinza"
+
+#: Source/translation_dummy.cpp:295 Source/translation_dummy.cpp:296
+#: Source/translation_dummy.cpp:298
+msgid "Cap"
+msgstr "Quepe"
+
+#: Source/translation_dummy.cpp:297
+msgid "Skull Cap"
+msgstr "Cervelliere"
+
+#: Source/translation_dummy.cpp:299 Source/translation_dummy.cpp:300
+#: Source/translation_dummy.cpp:302 Source/translation_dummy.cpp:306
+msgid "Helm"
+msgstr "Elmo"
+
+#: Source/translation_dummy.cpp:301
+msgid "Full Helm"
+msgstr "Elmo Completo"
+
+#: Source/translation_dummy.cpp:303 Source/translation_dummy.cpp:304
+msgid "Crown"
+msgstr "Coroa"
+
+#: Source/translation_dummy.cpp:305
+msgid "Great Helm"
+msgstr "Grande Elmo"
+
+#: Source/translation_dummy.cpp:307 Source/translation_dummy.cpp:308
+msgid "Cape"
+msgstr "Capa"
+
+#: Source/translation_dummy.cpp:309 Source/translation_dummy.cpp:310
+msgid "Rags"
+msgstr "Trapo"
+
+#: Source/translation_dummy.cpp:311 Source/translation_dummy.cpp:312
+msgid "Cloak"
+msgstr "Manto"
+
+#: Source/translation_dummy.cpp:313 Source/translation_dummy.cpp:314
+msgid "Robe"
+msgstr "Túnica"
+
+#: Source/translation_dummy.cpp:315
+msgid "Quilted Armor"
+msgstr "Armadura Acolchoada"
+
+#: Source/translation_dummy.cpp:317
+msgid "Leather Armor"
+msgstr "Armadura de Couro"
+
+#: Source/translation_dummy.cpp:319
+msgid "Hard Leather Armor"
+msgstr "Armadura de Couro Duro"
+
+#: Source/translation_dummy.cpp:321
+msgid "Studded Leather Armor"
+msgstr "Armad. de Couro Cravejado"
+
+#: Source/translation_dummy.cpp:323
+msgid "Ring Mail"
+msgstr "Malha de Anéis"
+
+#: Source/translation_dummy.cpp:324 Source/translation_dummy.cpp:326
+#: Source/translation_dummy.cpp:328 Source/translation_dummy.cpp:332
+msgid "Mail"
+msgstr "Malha"
+
+#: Source/translation_dummy.cpp:325
+msgid "Chain Mail"
+msgstr "Cota de Malha"
+
+#: Source/translation_dummy.cpp:327
+msgid "Scale Mail"
+msgstr "Malha em Escamas"
+
+#: Source/translation_dummy.cpp:329
+msgid "Breast Plate"
+msgstr "Armadura Peitoral"
+
+#: Source/translation_dummy.cpp:330 Source/translation_dummy.cpp:334
+#: Source/translation_dummy.cpp:336 Source/translation_dummy.cpp:338
+#: Source/translation_dummy.cpp:340
+msgid "Plate"
+msgstr "Armadura de Placas"
+
+#: Source/translation_dummy.cpp:331
+msgid "Splint Mail"
+msgstr "Cota de Talas"
+
+#: Source/translation_dummy.cpp:333
+msgid "Plate Mail"
+msgstr "Malha de Placas"
+
+#: Source/translation_dummy.cpp:335
+msgid "Field Plate"
+msgstr "Placa de Campo"
+
+#: Source/translation_dummy.cpp:337
+msgid "Gothic Plate"
+msgstr "Placa Gótica"
+
+#: Source/translation_dummy.cpp:339
+msgid "Full Plate Mail"
+msgstr "Malha de Placas Completa"
+
+#: Source/translation_dummy.cpp:342 Source/translation_dummy.cpp:344
+#: Source/translation_dummy.cpp:346 Source/translation_dummy.cpp:348
+#: Source/translation_dummy.cpp:350 Source/translation_dummy.cpp:352
+msgid "Shield"
+msgstr "Escudo"
+
+#: Source/translation_dummy.cpp:343
+msgid "Small Shield"
+msgstr "Escudo Pequeno"
+
+#: Source/translation_dummy.cpp:345
+msgid "Large Shield"
+msgstr "Escudo Grande"
+
+#: Source/translation_dummy.cpp:347
+msgid "Kite Shield"
+msgstr "Escudo Gota"
+
+#: Source/translation_dummy.cpp:349
+msgid "Tower Shield"
+msgstr "Escudo Torre"
+
+#: Source/translation_dummy.cpp:351
+msgid "Gothic Shield"
+msgstr "Escudo Gótico"
+
+#: Source/translation_dummy.cpp:357
+msgid "Potion of Rejuvenation"
+msgstr "Poção de Rejuvenescimento"
+
+#: Source/translation_dummy.cpp:358
+msgid "Potion of Full Rejuvenation"
+msgstr "Poção de Rejuvenescimento Completo"
+
+#: Source/translation_dummy.cpp:362
+msgid "Oil"
+msgstr "Óleo"
+
+#: Source/translation_dummy.cpp:363
+msgid "Elixir of Strength"
+msgstr "Elixir da Força"
+
+#: Source/translation_dummy.cpp:364
+msgid "Elixir of Magic"
+msgstr "Elixir da Magia"
+
+#: Source/translation_dummy.cpp:365
+msgid "Elixir of Dexterity"
+msgstr "Elixir da Destreza"
+
+#: Source/translation_dummy.cpp:366
+msgid "Elixir of Vitality"
+msgstr "Elixir da Vitalidade"
+
+#: Source/translation_dummy.cpp:367
+msgid "Scroll of Healing"
+msgstr "Pergaminho de Cura"
+
+#: Source/translation_dummy.cpp:368
+msgid "Scroll of Search"
+msgstr "Pergaminho de Busca"
+
+#: Source/translation_dummy.cpp:369
+msgid "Scroll of Lightning"
+msgstr "Pergaminho de Raio"
+
+#: Source/translation_dummy.cpp:372
+msgid "Scroll of Fire Wall"
+msgstr "Pergaminho de Parede de Fogo"
+
+#: Source/translation_dummy.cpp:373
+msgid "Scroll of Inferno"
+msgstr "Pergaminho de Inferno"
+
+#: Source/translation_dummy.cpp:375
+msgid "Scroll of Flash"
+msgstr "Pergaminho de Lampejo"
+
+#: Source/translation_dummy.cpp:376
+msgid "Scroll of Infravision"
+msgstr "Pergaminho de Infravisão"
+
+#: Source/translation_dummy.cpp:377
+msgid "Scroll of Phasing"
+msgstr "Pergaminho de Fasear"
+
+#: Source/translation_dummy.cpp:378
+msgid "Scroll of Mana Shield"
+msgstr "Pergaminho de Escudo de Mana"
+
+#: Source/translation_dummy.cpp:379
+msgid "Scroll of Flame Wave"
+msgstr "Pergaminho de Onda de Chamas"
+
+#: Source/translation_dummy.cpp:380
+msgid "Scroll of Fireball"
+msgstr "Pergaminho de Bola de Fogo"
+
+#: Source/translation_dummy.cpp:381
+msgid "Scroll of Stone Curse"
+msgstr "Pergaminho de Maldição de Pedra"
+
+#: Source/translation_dummy.cpp:382
+msgid "Scroll of Chain Lightning"
+msgstr "Pergaminho de Relâmp. Encadeado"
+
+#: Source/translation_dummy.cpp:383
+msgid "Scroll of Guardian"
+msgstr "Pergaminho de Guardião"
+
+#: Source/translation_dummy.cpp:384
+msgid "Scroll of Nova"
+msgstr "Pergaminho de Nova"
+
+#: Source/translation_dummy.cpp:385
+msgid "Scroll of Golem"
+msgstr "Pergaminho de Golem"
+
+#: Source/translation_dummy.cpp:386
+msgid "Scroll of Teleport"
+msgstr "Pergaminho de Teletransporte"
+
+#: Source/translation_dummy.cpp:387
+msgid "Scroll of Apocalypse"
+msgstr "Pergaminho de Apocalipse"
+
+#: Source/translation_dummy.cpp:392
+msgid "Falchion"
+msgstr "Alfanje"
+
+#: Source/translation_dummy.cpp:394
+msgid "Scimitar"
+msgstr "Cimitarra"
+
+#: Source/translation_dummy.cpp:396
+msgid "Claymore"
+msgstr "Espada Escocesa"
+
+#: Source/translation_dummy.cpp:398 Source/translation_dummy.cpp:399
+msgid "Blade"
+msgstr "Lâmina"
+
+#: Source/translation_dummy.cpp:400 Source/translation_dummy.cpp:401
+msgid "Sabre"
+msgstr "Sabre"
+
+#: Source/translation_dummy.cpp:402
+msgid "Long Sword"
+msgstr "Espada Longa"
+
+#: Source/translation_dummy.cpp:404
+msgid "Broad Sword"
+msgstr "Espada Larga"
+
+#: Source/translation_dummy.cpp:406
+msgid "Bastard Sword"
+msgstr "Espada Bastarda"
+
+#: Source/translation_dummy.cpp:408
+msgid "Two-Handed Sword"
+msgstr "Espada de Duas Mãos"
+
+#: Source/translation_dummy.cpp:410
+msgid "Great Sword"
+msgstr "Espada Montante"
+
+#: Source/translation_dummy.cpp:412
+msgid "Small Axe"
+msgstr "Machado Pequeno"
+
+#: Source/translation_dummy.cpp:413 Source/translation_dummy.cpp:414
+#: Source/translation_dummy.cpp:415 Source/translation_dummy.cpp:417
+#: Source/translation_dummy.cpp:419 Source/translation_dummy.cpp:421
+#: Source/translation_dummy.cpp:423
+msgid "Axe"
+msgstr "Machado"
+
+#: Source/translation_dummy.cpp:416
+msgid "Large Axe"
+msgstr "Machado Grande"
+
+#: Source/translation_dummy.cpp:418
+msgid "Broad Axe"
+msgstr "Machado Largo"
+
+#: Source/translation_dummy.cpp:420
+msgid "Battle Axe"
+msgstr "Machado de Batalha"
+
+#: Source/translation_dummy.cpp:422
+msgid "Great Axe"
+msgstr "Grão-machado"
+
+#: Source/translation_dummy.cpp:424 Source/translation_dummy.cpp:425
+#: Source/translation_dummy.cpp:427
+msgid "Mace"
+msgstr "Maça"
+
+#: Source/translation_dummy.cpp:426
+msgid "Morning Star"
+msgstr "Chicote de Roldão"
+
+#: Source/translation_dummy.cpp:428
+msgid "War Hammer"
+msgstr "Martelo de Guerra"
+
+#: Source/translation_dummy.cpp:429
+msgid "Hammer"
+msgstr "Martelo"
+
+#: Source/translation_dummy.cpp:430
+msgid "Spiked Club"
+msgstr "Clava Cravada"
+
+#: Source/translation_dummy.cpp:434 Source/translation_dummy.cpp:435
+msgid "Flail"
+msgstr "Mangual"
+
+#: Source/translation_dummy.cpp:436 Source/translation_dummy.cpp:437
+msgid "Maul"
+msgstr "Malho"
+
+#: Source/translation_dummy.cpp:439 Source/translation_dummy.cpp:441
+#: Source/translation_dummy.cpp:443 Source/translation_dummy.cpp:445
+#: Source/translation_dummy.cpp:447 Source/translation_dummy.cpp:449
+#: Source/translation_dummy.cpp:451 Source/translation_dummy.cpp:453
+msgid "Bow"
+msgstr "Arco"
+
+#: Source/translation_dummy.cpp:440
+msgid "Hunter's Bow"
+msgstr "Arco de Caçador"
+
+#: Source/translation_dummy.cpp:442
+msgid "Long Bow"
+msgstr "Arco Longo"
+
+#: Source/translation_dummy.cpp:444
+msgid "Composite Bow"
+msgstr "Arco Composto"
+
+#: Source/translation_dummy.cpp:446
+msgid "Short Battle Bow"
+msgstr "Arco de Batalha Curto"
+
+#: Source/translation_dummy.cpp:448
+msgid "Long Battle Bow"
+msgstr "Arco de Batalha Longo"
+
+#: Source/translation_dummy.cpp:450
+msgid "Short War Bow"
+msgstr "Arco de Guerra Curto"
+
+#: Source/translation_dummy.cpp:452
+msgid "Long War Bow"
+msgstr "Arco de Guerra Longo"
+
+#: Source/translation_dummy.cpp:456
+msgid "Long Staff"
+msgstr "Cajado longo"
+
+#: Source/translation_dummy.cpp:458
+msgid "Composite Staff"
+msgstr "Cajado composto"
+
+#: Source/translation_dummy.cpp:460
+msgid "Quarter Staff"
+msgstr "Cajado de combate"
+
+#: Source/translation_dummy.cpp:462
+msgid "War Staff"
+msgstr "Cajado de guerra"
+
+#: Source/translation_dummy.cpp:464 Source/translation_dummy.cpp:465
+#: Source/translation_dummy.cpp:466 Source/translation_dummy.cpp:467
+#: Source/translation_dummy.cpp:468 Source/translation_dummy.cpp:469
+msgid "Ring"
+msgstr "Anel"
+
+#: Source/translation_dummy.cpp:470 Source/translation_dummy.cpp:471
+#: Source/translation_dummy.cpp:472 Source/translation_dummy.cpp:473
+msgid "Amulet"
+msgstr "Amuleto"
+
+#: Source/translation_dummy.cpp:474
+msgid "Rune of Fire"
+msgstr "Runa de Fogo"
+
+#: Source/translation_dummy.cpp:475 Source/translation_dummy.cpp:477
+#: Source/translation_dummy.cpp:479 Source/translation_dummy.cpp:481
+#: Source/translation_dummy.cpp:483
+msgid "Rune"
+msgstr "Runa"
+
+#: Source/translation_dummy.cpp:476
+msgid "Rune of Lightning"
+msgstr "Runa de Relâmpago"
+
+#: Source/translation_dummy.cpp:478
+msgid "Greater Rune of Fire"
+msgstr "Grande Runa de Fogo"
+
+#: Source/translation_dummy.cpp:480
+msgid "Greater Rune of Lightning"
+msgstr "Grande Runa de Relâmpago"
+
+#: Source/translation_dummy.cpp:482
+msgid "Rune of Stone"
+msgstr "Runa de Pedra"
+
+#: Source/translation_dummy.cpp:484
+msgid "Short Staff of Charged Bolt"
+msgstr "Cajado Curto de Raio Carregado"
+
+#: Source/translation_dummy.cpp:485
+msgid "Arena Potion"
+msgstr "Poção de Arena"
+
+#: Source/translation_dummy.cpp:486
+msgid "The Butcher's Cleaver"
+msgstr "Cutelo do Açougueiro"
+
+#: Source/translation_dummy.cpp:496
+msgid "The Rift Bow"
+msgstr "Arco da ruptura"
+
+#: Source/translation_dummy.cpp:497
+msgid "The Needler"
+msgstr "O agulheiro"
+
+#: Source/translation_dummy.cpp:498
+msgid "The Celestial Bow"
+msgstr "O arco celestial"
+
+#: Source/translation_dummy.cpp:499
+msgid "Deadly Hunter"
+msgstr "Caçador mortal"
+
+#: Source/translation_dummy.cpp:500
+msgid "Bow of the Dead"
+msgstr "Arco dos mortos"
+
+#: Source/translation_dummy.cpp:501
+msgid "The Blackoak Bow"
+msgstr "Arco do carvalho negro"
+
+#: Source/translation_dummy.cpp:502
+msgid "Flamedart"
+msgstr "Dardo das chamas"
+
+#: Source/translation_dummy.cpp:503
+msgid "Fleshstinger"
+msgstr "Ferroa-carne"
+
+#: Source/translation_dummy.cpp:504
+msgid "Windforce"
+msgstr "Força do vento"
+
+#: Source/translation_dummy.cpp:505
+msgid "Eaglehorn"
+msgstr "Chifre de águia"
+
+#: Source/translation_dummy.cpp:506
+msgid "Gonnagal's Dirk"
+msgstr "Punhal de Gonnagal"
+
+#: Source/translation_dummy.cpp:507
+msgid "The Defender"
+msgstr "O defensor"
+
+#: Source/translation_dummy.cpp:508
+msgid "Gryphon's Claw"
+msgstr "Garra do Grifo"
+
+#: Source/translation_dummy.cpp:509
+msgid "Black Razor"
+msgstr "Navalha negra"
+
+#: Source/translation_dummy.cpp:510
+msgid "Gibbous Moon"
+msgstr "Lua crescente"
+
+#: Source/translation_dummy.cpp:511
+msgid "Ice Shank"
+msgstr "Haste de gelo"
+
+#: Source/translation_dummy.cpp:512
+msgid "The Executioner's Blade"
+msgstr "Lâmina do carrasco"
+
+#: Source/translation_dummy.cpp:513
+msgid "The Bonesaw"
+msgstr "A serra de osso"
+
+#: Source/translation_dummy.cpp:514
+msgid "Shadowhawk"
+msgstr "Gavião das sombras"
+
+#: Source/translation_dummy.cpp:515
+msgid "Wizardspike"
+msgstr "Espinho arcano"
+
+#: Source/translation_dummy.cpp:516
+msgid "Lightsabre"
+msgstr "Sabre de luz"
+
+#: Source/translation_dummy.cpp:517
+msgid "The Falcon's Talon"
+msgstr "Garra do falcão"
+
+#: Source/translation_dummy.cpp:518
+msgid "Inferno"
+msgstr "Inferno"
+
+#: Source/translation_dummy.cpp:519
+msgid "Doombringer"
+msgstr "Ruinosa"
+
+#: Source/translation_dummy.cpp:520
+msgid "The Grizzly"
+msgstr "O Urso Pardo"
+
+#: Source/translation_dummy.cpp:521
+msgid "The Grandfather"
+msgstr "O Avô"
+
+#: Source/translation_dummy.cpp:522
+msgid "The Mangler"
+msgstr "O Estraçalhador"
+
+#: Source/translation_dummy.cpp:523
+msgid "Sharp Beak"
+msgstr "Bico afiado"
+
+#: Source/translation_dummy.cpp:524
+msgid "BloodSlayer"
+msgstr "Assassino sangrento"
+
+#: Source/translation_dummy.cpp:525
+msgid "The Celestial Axe"
+msgstr "O machado celestial"
+
+#: Source/translation_dummy.cpp:526
+msgid "Wicked Axe"
+msgstr "Machado maligno"
+
+#: Source/translation_dummy.cpp:527
+msgid "Stonecleaver"
+msgstr "Cutelo de pedra"
+
+#: Source/translation_dummy.cpp:528
+msgid "Aguinara's Hatchet"
+msgstr "Machadinha de Aguinara"
+
+#: Source/translation_dummy.cpp:529
+msgid "Hellslayer"
+msgstr "Assassino infernal"
+
+#: Source/translation_dummy.cpp:530
+msgid "Messerschmidt's Reaver"
+msgstr "Ceifador de Messerschmidt"
+
+#: Source/translation_dummy.cpp:531
+msgid "Crackrust"
+msgstr "Racharrugem"
+
+#: Source/translation_dummy.cpp:532
+msgid "Hammer of Jholm"
+msgstr "Martelo de Jholm"
+
+#: Source/translation_dummy.cpp:533
+msgid "Civerb's Cudgel"
+msgstr "Tacape de Civerb"
+
+#: Source/translation_dummy.cpp:534
+msgid "The Celestial Star"
+msgstr "A estrela celestial"
+
+#: Source/translation_dummy.cpp:535
+msgid "Baranar's Star"
+msgstr "Estrela de Baranar"
+
+#: Source/translation_dummy.cpp:536
+msgid "Gnarled Root"
+msgstr "Raiz nodosa"
+
+#: Source/translation_dummy.cpp:537
+msgid "The Cranium Basher"
+msgstr "O amassador de crânios"
+
+#: Source/translation_dummy.cpp:538
+msgid "Schaefer's Hammer"
+msgstr "Martelo de Schaefer"
+
+#: Source/translation_dummy.cpp:539
+msgid "Dreamflange"
+msgstr "Flange onírico"
+
+#: Source/translation_dummy.cpp:540
+msgid "Staff of Shadows"
+msgstr "Cajado das sombras"
+
+#: Source/translation_dummy.cpp:541
+msgid "Immolator"
+msgstr "Imolador"
+
+#: Source/translation_dummy.cpp:542
+msgid "Storm Spire"
+msgstr "Ápice da tempestade"
+
+#: Source/translation_dummy.cpp:543
+msgid "Gleamsong"
+msgstr "Canção do vislumbre"
+
+#: Source/translation_dummy.cpp:544
+msgid "Thundercall"
+msgstr "Chamado do trovão"
+
+#: Source/translation_dummy.cpp:545
+msgid "The Protector"
+msgstr "O protetor"
+
+#: Source/translation_dummy.cpp:546
+msgid "Naj's Puzzler"
+msgstr "Enigma de Naj"
+
+#: Source/translation_dummy.cpp:547
+msgid "Mindcry"
+msgstr "Grito da mente"
+
+#: Source/translation_dummy.cpp:548
+msgid "Rod of Onan"
+msgstr "Vara de Onan"
+
+#: Source/translation_dummy.cpp:549
+msgid "Helm of Spirits"
+msgstr "Elmo dos Espíritos"
+
+#: Source/translation_dummy.cpp:550
+msgid "Thinking Cap"
+msgstr "Quepe de reflexão"
+
+#: Source/translation_dummy.cpp:551
+msgid "OverLord's Helm"
+msgstr "Elmo do Suserano"
+
+#: Source/translation_dummy.cpp:552
+msgid "Fool's Crest"
+msgstr "Brasão do bobo"
+
+#: Source/translation_dummy.cpp:553
+msgid "Gotterdamerung"
+msgstr "Götterdämerung"
+
+#: Source/translation_dummy.cpp:554
+msgid "Royal Circlet"
+msgstr "Diadema real"
+
+#: Source/translation_dummy.cpp:555
+msgid "Torn Flesh of Souls"
+msgstr "Carne rasgada de almas"
+
+#: Source/translation_dummy.cpp:556
+msgid "The Gladiator's Bane"
+msgstr "Flagelo do gladiador"
+
+#: Source/translation_dummy.cpp:557
+msgid "The Rainbow Cloak"
+msgstr "O manto arco-íris"
+
+#: Source/translation_dummy.cpp:558
+msgid "Leather of Aut"
+msgstr "Couro de Aut"
+
+#: Source/translation_dummy.cpp:559
+msgid "Wisdom's Wrap"
+msgstr "Xale da sabedoria"
+
+#: Source/translation_dummy.cpp:560
+msgid "Sparking Mail"
+msgstr "Malha faiscante"
+
+#: Source/translation_dummy.cpp:561
+msgid "Scavenger Carapace"
+msgstr "Carapaça do Vorazgo"
+
+#: Source/translation_dummy.cpp:562
+msgid "Nightscape"
+msgstr "Paisagem da noite"
+
+#: Source/translation_dummy.cpp:563
+msgid "Naj's Light Plate"
+msgstr "Placa leve de Naj"
+
+#: Source/translation_dummy.cpp:564
+msgid "Demonspike Coat"
+msgstr "Casaco de demonispeto"
+
+#: Source/translation_dummy.cpp:565
+msgid "The Deflector"
+msgstr "O defletor"
+
+#: Source/translation_dummy.cpp:566
+msgid "Split Skull Shield"
+msgstr "Escudo de crânio partido"
+
+#: Source/translation_dummy.cpp:567
+msgid "Dragon's Breach"
+msgstr "Fenda do dragão"
+
+#: Source/translation_dummy.cpp:568
+msgid "Blackoak Shield"
+msgstr "Escudo do carvalho negro"
+
+#: Source/translation_dummy.cpp:569
+msgid "Holy Defender"
+msgstr "Defensor santo"
+
+#: Source/translation_dummy.cpp:570
+msgid "Stormshield"
+msgstr "Escudo da tempestade"
+
+#: Source/translation_dummy.cpp:571
+msgid "Bramble"
+msgstr "Silveira"
+
+#: Source/translation_dummy.cpp:572
+msgid "Ring of Regha"
+msgstr "Anel de Regha"
+
+#: Source/translation_dummy.cpp:573
+msgid "The Bleeder"
+msgstr "O sangrador"
+
+#: Source/translation_dummy.cpp:574
+msgid "Constricting Ring"
+msgstr "Anel constringente"
+
+#: Source/translation_dummy.cpp:575
+msgid "Ring of Engagement"
+msgstr "Anel de noivado"
+
+#: Source/translation_dummy.cpp:576
+msgid "Giant's Knuckle"
+msgstr "Junta do gigante"
+
+#: Source/translation_dummy.cpp:577
+msgid "Mercurial Ring"
+msgstr "Anel mercurial"
+
+#: Source/translation_dummy.cpp:578
+msgid "Xorine's Ring"
+msgstr "Anel de Xorine"
+
+#: Source/translation_dummy.cpp:579
+msgid "Karik's Ring"
+msgstr "Anel de Karik"
+
+#: Source/translation_dummy.cpp:580
+msgid "Ring of Magma"
+msgstr "Anel de magma"
+
+#: Source/translation_dummy.cpp:581
+msgid "Ring of the Mystics"
+msgstr "Anel dos místicos"
+
+#: Source/translation_dummy.cpp:582
+msgid "Ring of Thunder"
+msgstr "Anel do trovão"
+
+#: Source/translation_dummy.cpp:583
+msgid "Amulet of Warding"
+msgstr "Amuleto de proteção"
+
+#: Source/translation_dummy.cpp:584
+msgid "Gnat Sting"
+msgstr "Picada de mosquito"
+
+#: Source/translation_dummy.cpp:585
+msgid "Flambeau"
+msgstr "Tocha"
+
+#: Source/translation_dummy.cpp:586
+msgid "Armor of Gloom"
+msgstr "Armadura da penumbra"
+
+#: Source/translation_dummy.cpp:587
+msgid "Blitzen"
+msgstr "Blitzen"
+
+#: Source/translation_dummy.cpp:588
+msgid "Thunderclap"
+msgstr "Trovoada"
+
+#: Source/translation_dummy.cpp:589
+msgid "Shirotachi"
+msgstr "Shirotachi"
+
+#: Source/translation_dummy.cpp:590
+msgid "Eater of Souls"
+msgstr "Devorador de almas"
+
+#: Source/translation_dummy.cpp:591
+msgid "Diamondedge"
+msgstr "Diamondedge"
+
+#: Source/translation_dummy.cpp:592
+msgid "Bone Chain Armor"
+msgstr "Armadura de cadeias de ossos"
+
+#: Source/translation_dummy.cpp:593
+msgid "Demon Plate Armor"
+msgstr "Armadura de placas de demônio"
+
+#: Source/translation_dummy.cpp:594
+msgid "Acolyte's Amulet"
+msgstr "Amuleto de acólito"
+
+#: Source/translation_dummy.cpp:595
+msgid "Gladiator's Ring"
+msgstr "Anel do gladiador"
+
+#: Source/translation_dummy.cpp:596
+msgid "Tin"
+msgstr "de lata"
+
+#: Source/translation_dummy.cpp:597
+msgid "Brass"
+msgstr "de latão"
+
+#: Source/translation_dummy.cpp:598
+msgid "Bronze"
+msgstr "de bronze"
+
+#: Source/translation_dummy.cpp:599
+msgid "Iron"
+msgstr "de ferro"
+
+#: Source/translation_dummy.cpp:600
+msgid "Steel"
+msgstr "de aço"
+
+#: Source/translation_dummy.cpp:601
+msgid "Silver"
+msgstr "de prata"
+
+#: Source/translation_dummy.cpp:603
+msgid "Platinum"
+msgstr "de platina"
+
+#: Source/translation_dummy.cpp:604
+msgid "Mithril"
+msgstr "de mithril"
+
+#: Source/translation_dummy.cpp:605
+msgid "Meteoric"
+msgstr "meteórico(a)"
+
+#: Source/translation_dummy.cpp:607
+msgid "Strange"
+msgstr "estranho(a)"
+
+#: Source/translation_dummy.cpp:608
+msgid "Useless"
+msgstr "inútil"
+
+#: Source/translation_dummy.cpp:609
+msgid "Bent"
+msgstr "envergado(a)"
+
+#: Source/translation_dummy.cpp:610
+msgid "Weak"
+msgstr "fraco(a)"
+
+#: Source/translation_dummy.cpp:611
+msgid "Jagged"
+msgstr "serrilhado(a)"
+
+#: Source/translation_dummy.cpp:612
+msgid "Deadly"
+msgstr "mortal"
+
+#: Source/translation_dummy.cpp:613
+msgid "Heavy"
+msgstr "pesado(a)"
+
+#: Source/translation_dummy.cpp:614
+msgid "Vicious"
+msgstr "vicioso(a)"
+
+#: Source/translation_dummy.cpp:615
+msgid "Brutal"
+msgstr "brutal"
+
+#: Source/translation_dummy.cpp:616
+msgid "Massive"
+msgstr "imenso(a)"
+
+#: Source/translation_dummy.cpp:617
+msgid "Savage"
+msgstr "selvagem"
+
+#: Source/translation_dummy.cpp:618
+msgid "Ruthless"
+msgstr "implacável"
+
+#: Source/translation_dummy.cpp:619
+msgid "Merciless"
+msgstr "impiedoso(a)"
+
+#: Source/translation_dummy.cpp:620
+msgid "Clumsy"
+msgstr "desajeitado(a)"
+
+#: Source/translation_dummy.cpp:621
+msgid "Dull"
+msgstr "enfadonho(a)"
+
+#: Source/translation_dummy.cpp:622
+msgid "Sharp"
+msgstr "afiado(a)"
+
+#: Source/translation_dummy.cpp:623 Source/translation_dummy.cpp:633
+msgid "Fine"
+msgstr "fino(a)"
+
+#: Source/translation_dummy.cpp:624
+msgid "Warrior's"
+msgstr "de guerreiro"
+
+#: Source/translation_dummy.cpp:625
+msgid "Soldier's"
+msgstr "de soldado"
+
+#: Source/translation_dummy.cpp:626
+msgid "Lord's"
+msgstr "do senhor"
+
+#: Source/translation_dummy.cpp:627
+msgid "Knight's"
+msgstr "de cavaleiro"
+
+#: Source/translation_dummy.cpp:628
+msgid "Master's"
+msgstr "de mestre"
+
+#: Source/translation_dummy.cpp:629
+msgid "Champion's"
+msgstr "de campeão"
+
+#: Source/translation_dummy.cpp:630
+msgid "King's"
+msgstr "de rei"
+
+#: Source/translation_dummy.cpp:631
+msgid "Vulnerable"
+msgstr "vulnerável"
+
+#: Source/translation_dummy.cpp:632
+msgid "Rusted"
+msgstr "enferrujado(a)"
+
+#: Source/translation_dummy.cpp:634
+msgid "Strong"
+msgstr "forte"
+
+#: Source/translation_dummy.cpp:635
+msgid "Grand"
+msgstr "grandioso(a)"
+
+#: Source/translation_dummy.cpp:636
+msgid "Valiant"
+msgstr "valente"
+
+#: Source/translation_dummy.cpp:637
+msgid "Glorious"
+msgstr "glorioso(a)"
+
+#: Source/translation_dummy.cpp:638
+msgid "Blessed"
+msgstr "abençoado(a)"
+
+#: Source/translation_dummy.cpp:639
+msgid "Saintly"
+msgstr "santo(a)"
+
+#: Source/translation_dummy.cpp:640
+msgid "Awesome"
+msgstr "impressionante"
+
+#: Source/translation_dummy.cpp:642
+msgid "Godly"
+msgstr "divino(a)"
+
+#: Source/translation_dummy.cpp:643
+msgid "Red"
+msgstr "vermelho(a)"
+
+#: Source/translation_dummy.cpp:644 Source/translation_dummy.cpp:645
+msgid "Crimson"
+msgstr "carmesim"
+
+#: Source/translation_dummy.cpp:646
+msgid "Garnet"
+msgstr "granada"
+
+#: Source/translation_dummy.cpp:647
+msgid "Ruby"
+msgstr "rubi"
+
+#: Source/translation_dummy.cpp:648
+msgid "Blue"
+msgstr "azul"
+
+#: Source/translation_dummy.cpp:649
+msgid "Azure"
+msgstr "lazúli"
+
+#: Source/translation_dummy.cpp:650
+msgid "Lapis"
+msgstr "lápis-lazúli"
+
+#: Source/translation_dummy.cpp:651
+msgid "Cobalt"
+msgstr "cobalto"
+
+#: Source/translation_dummy.cpp:652
+msgid "Sapphire"
+msgstr "safira"
+
+#: Source/translation_dummy.cpp:653
+msgid "White"
+msgstr "branco(a)"
+
+#: Source/translation_dummy.cpp:654
+msgid "Pearl"
+msgstr "de pérola"
+
+#: Source/translation_dummy.cpp:655
+msgid "Ivory"
+msgstr "de marfim"
+
+#: Source/translation_dummy.cpp:656
+msgid "Crystal"
+msgstr "de cristal"
+
+#: Source/translation_dummy.cpp:657
+msgid "Diamond"
+msgstr "de diamante"
+
+#: Source/translation_dummy.cpp:658
+msgid "Topaz"
+msgstr "de topázio"
+
+#: Source/translation_dummy.cpp:659
+msgid "Amber"
+msgstr "de âmbar"
+
+#: Source/translation_dummy.cpp:660
+msgid "Jade"
+msgstr "de jade"
+
+#: Source/translation_dummy.cpp:661
+msgid "Obsidian"
+msgstr "de obsidiana"
+
+#: Source/translation_dummy.cpp:662
+msgid "Emerald"
+msgstr "de esmeralda"
+
+#: Source/translation_dummy.cpp:663
+msgid "Hyena's"
+msgstr "de hienas"
+
+#: Source/translation_dummy.cpp:664
+msgid "Frog's"
+msgstr "de sapos"
+
+#: Source/translation_dummy.cpp:665
+msgid "Spider's"
+msgstr "de aranhas"
+
+#: Source/translation_dummy.cpp:666
+msgid "Raven's"
+msgstr "de corvos"
+
+#: Source/translation_dummy.cpp:667
+msgid "Snake's"
+msgstr "de cobras"
+
+#: Source/translation_dummy.cpp:668
+msgid "Serpent's"
+msgstr "de serpentes"
+
+#: Source/translation_dummy.cpp:669
+msgid "Drake's"
+msgstr "de draco"
+
+#: Source/translation_dummy.cpp:670
+msgid "Dragon's"
+msgstr "de dragão"
+
+#: Source/translation_dummy.cpp:671
+msgid "Wyrm's"
+msgstr "de serpe"
+
+#: Source/translation_dummy.cpp:672
+msgid "Hydra's"
+msgstr "de hidra"
+
+#: Source/translation_dummy.cpp:673
+msgid "Angel's"
+msgstr "de anjo"
+
+#: Source/translation_dummy.cpp:674
+msgid "Arch-Angel's"
+msgstr "de arcanjo"
+
+#: Source/translation_dummy.cpp:675
+msgid "Plentiful"
+msgstr "farto(a)"
+
+#: Source/translation_dummy.cpp:676
+msgid "Bountiful"
+msgstr "abundante"
+
+#: Source/translation_dummy.cpp:677
+msgid "Flaming"
+msgstr "flamejante"
+
+#: Source/translation_dummy.cpp:678
+msgid "Lightning"
+msgstr "relampejante"
+
+#: Source/translation_dummy.cpp:679
+msgid "Jester's"
+msgstr "do Bobo"
+
+#: Source/translation_dummy.cpp:680
+msgid "Crystalline"
+msgstr "Cristalino"
+
+#: Source/translation_dummy.cpp:681
+msgid "Doppelganger's"
+msgstr "do Impostor"
+
+#: Source/translation_dummy.cpp:682
+msgid "quality"
+msgstr "de qualidade"
+
+#: Source/translation_dummy.cpp:683
+msgid "maiming"
+msgstr "do aleijamento"
+
+#: Source/translation_dummy.cpp:684
+msgid "slaying"
+msgstr "do homicídio"
+
+#: Source/translation_dummy.cpp:685
+msgid "gore"
+msgstr "da ultra-violência"
+
+#: Source/translation_dummy.cpp:686
+msgid "carnage"
+msgstr "da carnificina"
+
+#: Source/translation_dummy.cpp:687
+msgid "slaughter"
+msgstr "do massacre"
+
+#: Source/translation_dummy.cpp:688
+msgid "pain"
+msgstr "da dor"
+
+#: Source/translation_dummy.cpp:689
+msgid "tears"
+msgstr "das lágrimas"
+
+#: Source/translation_dummy.cpp:690
+msgid "health"
+msgstr "da saúde"
+
+#: Source/translation_dummy.cpp:691
+msgid "protection"
+msgstr "da proteção"
+
+#: Source/translation_dummy.cpp:692
+msgid "absorption"
+msgstr "da absorção"
+
+#: Source/translation_dummy.cpp:693
+msgid "deflection"
+msgstr "da deflexão"
+
+#: Source/translation_dummy.cpp:694
+msgid "osmosis"
+msgstr "da osmose"
+
+#: Source/translation_dummy.cpp:695
+msgid "frailty"
+msgstr "da fragilidade"
+
+#: Source/translation_dummy.cpp:696
+msgid "weakness"
+msgstr "da fraqueza"
+
+#: Source/translation_dummy.cpp:697
+msgid "strength"
+msgstr "da força"
+
+#: Source/translation_dummy.cpp:698
+msgid "might"
+msgstr "do poder"
+
+#: Source/translation_dummy.cpp:699
+msgid "power"
+msgstr "da potência"
+
+#: Source/translation_dummy.cpp:700
+msgid "giants"
+msgstr "dos gigantes"
+
+#: Source/translation_dummy.cpp:701
+msgid "titans"
+msgstr "dos titãs"
+
+#: Source/translation_dummy.cpp:702
+msgid "paralysis"
+msgstr "da paralisia"
+
+#: Source/translation_dummy.cpp:703
+msgid "atrophy"
+msgstr "da atrofia"
+
+#: Source/translation_dummy.cpp:704
+msgid "dexterity"
+msgstr "da destreza"
+
+#: Source/translation_dummy.cpp:705
+msgid "skill"
+msgstr "da habilidade"
+
+#: Source/translation_dummy.cpp:706
+msgid "accuracy"
+msgstr "da acurácia"
+
+#: Source/translation_dummy.cpp:707
+msgid "precision"
+msgstr "da precisão"
+
+#: Source/translation_dummy.cpp:708
+msgid "perfection"
+msgstr "da perfeição"
+
+#: Source/translation_dummy.cpp:709
+msgid "the fool"
+msgstr "do tolo"
+
+#: Source/translation_dummy.cpp:710
+msgid "dyslexia"
+msgstr "da dislexia"
+
+#: Source/translation_dummy.cpp:711
+msgid "magic"
+msgstr "da magia"
+
+#: Source/translation_dummy.cpp:712
+msgid "the mind"
+msgstr "da mente"
+
+#: Source/translation_dummy.cpp:713
+msgid "brilliance"
+msgstr "do brilhantismo"
+
+#: Source/translation_dummy.cpp:714
+msgid "sorcery"
+msgstr "da feitiçaria"
+
+#: Source/translation_dummy.cpp:715
+msgid "wizardry"
+msgstr "da bruxaria"
+
+#: Source/translation_dummy.cpp:716
+msgid "illness"
+msgstr "da enfermidade"
+
+#: Source/translation_dummy.cpp:717
+msgid "disease"
+msgstr "da doença"
+
+#: Source/translation_dummy.cpp:718
+msgid "vitality"
+msgstr "da vitalidade"
+
+#: Source/translation_dummy.cpp:719
+msgid "zest"
+msgstr "do ânimo"
+
+#: Source/translation_dummy.cpp:720
+msgid "vim"
+msgstr "do afinco"
+
+#: Source/translation_dummy.cpp:721
+msgid "vigor"
+msgstr "do vigor"
+
+#: Source/translation_dummy.cpp:722
+msgid "life"
+msgstr "da vida"
+
+#: Source/translation_dummy.cpp:723
+msgid "trouble"
+msgstr "da encrenca"
+
+#: Source/translation_dummy.cpp:724
+msgid "the pit"
+msgstr "do poço"
+
+#: Source/translation_dummy.cpp:725
+msgid "the sky"
+msgstr "do céu"
+
+#: Source/translation_dummy.cpp:726
+msgid "the moon"
+msgstr "da lua"
+
+#: Source/translation_dummy.cpp:727
+msgid "the stars"
+msgstr "das estrelas"
+
+#: Source/translation_dummy.cpp:728
+msgid "the heavens"
+msgstr "do paraíso"
+
+#: Source/translation_dummy.cpp:729
+msgid "the zodiac"
+msgstr "do zodíaco"
+
+#: Source/translation_dummy.cpp:730
+msgid "the vulture"
+msgstr "do abutre"
+
+#: Source/translation_dummy.cpp:731
+msgid "the jackal"
+msgstr "do chacal"
+
+#: Source/translation_dummy.cpp:732
+msgid "the fox"
+msgstr "da raposa"
+
+#: Source/translation_dummy.cpp:733
+msgid "the jaguar"
+msgstr "do jaguar"
+
+#: Source/translation_dummy.cpp:734
+msgid "the eagle"
+msgstr "da águia"
+
+#: Source/translation_dummy.cpp:735
+msgid "the wolf"
+msgstr "do lobo"
+
+#: Source/translation_dummy.cpp:736
+msgid "the tiger"
+msgstr "do tigre"
+
+#: Source/translation_dummy.cpp:737
+msgid "the lion"
+msgstr "do leão"
+
+#: Source/translation_dummy.cpp:738
+msgid "the mammoth"
+msgstr "do mamute"
+
+#: Source/translation_dummy.cpp:739
+msgid "the whale"
+msgstr "da baleia"
+
+#: Source/translation_dummy.cpp:740
+msgid "fragility"
+msgstr "da debilidade"
+
+#: Source/translation_dummy.cpp:741
+msgid "brittleness"
+msgstr "da ruptilidade"
+
+#: Source/translation_dummy.cpp:742
+msgid "sturdiness"
+msgstr "da firmeza"
+
+#: Source/translation_dummy.cpp:743
+msgid "craftsmanship"
+msgstr "da competência"
+
+#: Source/translation_dummy.cpp:744
+msgid "structure"
+msgstr "da estrutura"
+
+#: Source/translation_dummy.cpp:745
+msgid "the ages"
+msgstr "das eras"
+
+#: Source/translation_dummy.cpp:746
+msgid "the dark"
+msgstr "do escuro"
+
+#: Source/translation_dummy.cpp:747
+msgid "the night"
+msgstr "da noite"
+
+#: Source/translation_dummy.cpp:748
+msgid "light"
+msgstr "da luz"
+
+#: Source/translation_dummy.cpp:749
+msgid "radiance"
+msgstr "da radiância"
+
+#: Source/translation_dummy.cpp:750
+msgid "flame"
+msgstr "da chama"
+
+#: Source/translation_dummy.cpp:751
+msgid "fire"
+msgstr "do fogo"
+
+#: Source/translation_dummy.cpp:752
+msgid "burning"
+msgstr "calcinante"
+
+#: Source/translation_dummy.cpp:753
+msgid "shock"
+msgstr "do choque"
+
+#: Source/translation_dummy.cpp:754
+msgid "lightning"
+msgstr "do relâmpago"
+
+#: Source/translation_dummy.cpp:755
+msgid "thunder"
+msgstr "do trovão"
+
+#: Source/translation_dummy.cpp:756
+msgid "many"
+msgstr "dos muitos"
+
+#: Source/translation_dummy.cpp:757
+msgid "plenty"
+msgstr "da abundância"
+
+#: Source/translation_dummy.cpp:758
+msgid "thorns"
+msgstr "dos espinhos"
+
+#: Source/translation_dummy.cpp:759
+msgid "corruption"
+msgstr "da corrupção"
+
+#: Source/translation_dummy.cpp:760
+msgid "thieves"
+msgstr "dos ladrões"
+
+#: Source/translation_dummy.cpp:761
+msgid "the bear"
+msgstr "do urso"
+
+#: Source/translation_dummy.cpp:762
+msgid "the bat"
+msgstr "do morcego"
+
+#: Source/translation_dummy.cpp:763
+msgid "vampires"
+msgstr "dos vampiros"
+
+#: Source/translation_dummy.cpp:764
+msgid "the leech"
+msgstr "do sanguessuga"
+
+#: Source/translation_dummy.cpp:765
+msgid "blood"
+msgstr "do sangue"
+
+#: Source/translation_dummy.cpp:766
+msgid "piercing"
+msgstr "da perfuração"
+
+#: Source/translation_dummy.cpp:767
+msgid "puncturing"
+msgstr "da punção"
+
+#: Source/translation_dummy.cpp:768
+msgid "bashing"
+msgstr "do esmagamento"
+
+#: Source/translation_dummy.cpp:769
+msgid "readiness"
+msgstr "da prontidão"
+
+#: Source/translation_dummy.cpp:770
+msgid "swiftness"
+msgstr "da presteza"
+
+#: Source/translation_dummy.cpp:771
+msgid "speed"
+msgstr "da velocidade"
+
+#: Source/translation_dummy.cpp:772
+msgid "haste"
+msgstr "da pressa"
+
+#: Source/translation_dummy.cpp:773
+msgid "balance"
+msgstr "do equilíbrio"
+
+#: Source/translation_dummy.cpp:774
+msgid "stability"
+msgstr "da estabilidade"
+
+#: Source/translation_dummy.cpp:775
+msgid "harmony"
+msgstr "da harmonia"
+
+#: Source/translation_dummy.cpp:776
+msgid "blocking"
+msgstr "do bloqueio"
+
+#: Source/translation_dummy.cpp:777
+msgid "devastation"
+msgstr "da devastação"
+
+#: Source/translation_dummy.cpp:778
+msgid "decay"
+msgstr "declínio"
+
+#: Source/translation_dummy.cpp:779
+msgid "peril"
+msgstr "perigo"
+
+#: Source/translation_dummy.cpp:780
+msgctxt "spell"
+msgid "Firebolt"
+msgstr "Raio de Fogo"
+
+#: Source/translation_dummy.cpp:781
+msgctxt "spell"
+msgid "Healing"
+msgstr "Cura"
+
+#: Source/translation_dummy.cpp:782
+msgctxt "spell"
+msgid "Lightning"
+msgstr "Relâmpago"
+
+#: Source/translation_dummy.cpp:783
+msgctxt "spell"
+msgid "Flash"
+msgstr "Lampejo"
+
+#: Source/translation_dummy.cpp:784
+msgctxt "spell"
+msgid "Identify"
+msgstr "Identificar"
+
+#: Source/translation_dummy.cpp:785
+msgctxt "spell"
+msgid "Fire Wall"
+msgstr "Parede de Fogo"
+
+#: Source/translation_dummy.cpp:786
+msgctxt "spell"
+msgid "Town Portal"
+msgstr "Portal da cidade"
+
+#: Source/translation_dummy.cpp:787
+msgctxt "spell"
+msgid "Stone Curse"
+msgstr "Petrificar"
+
+#: Source/translation_dummy.cpp:788
+msgctxt "spell"
+msgid "Infravision"
+msgstr "Infravisão"
+
+#: Source/translation_dummy.cpp:789
+msgctxt "spell"
+msgid "Phasing"
+msgstr "Fasear"
+
+#: Source/translation_dummy.cpp:790
+msgctxt "spell"
+msgid "Mana Shield"
+msgstr "Escudo de Mana"
+
+#: Source/translation_dummy.cpp:791
+msgctxt "spell"
+msgid "Fireball"
+msgstr "Bola de Fogo"
+
+#: Source/translation_dummy.cpp:792
+msgctxt "spell"
+msgid "Guardian"
+msgstr "Guardiã"
+
+#: Source/translation_dummy.cpp:793
+msgctxt "spell"
+msgid "Chain Lightning"
+msgstr "Relâmpago encadeado"
+
+#: Source/translation_dummy.cpp:794
+msgctxt "spell"
+msgid "Flame Wave"
+msgstr "Onda de Chamas"
+
+#: Source/translation_dummy.cpp:795
+msgctxt "spell"
+msgid "Doom Serpents"
+msgstr "Serpentes da Ruína"
+
+#: Source/translation_dummy.cpp:796
+msgctxt "spell"
+msgid "Blood Ritual"
+msgstr "Ritual Sanguíneo"
+
+#: Source/translation_dummy.cpp:797
+msgctxt "spell"
+msgid "Nova"
+msgstr "Nova"
+
+#: Source/translation_dummy.cpp:798
+msgctxt "spell"
+msgid "Invisibility"
+msgstr "Invisibilidade"
+
+#: Source/translation_dummy.cpp:799
+msgctxt "spell"
+msgid "Inferno"
+msgstr "Inferno"
+
+#: Source/translation_dummy.cpp:800
+msgctxt "spell"
+msgid "Golem"
+msgstr "Golem"
+
+#: Source/translation_dummy.cpp:801
+msgctxt "spell"
+msgid "Rage"
+msgstr "Fúria"
+
+#: Source/translation_dummy.cpp:802
+msgctxt "spell"
+msgid "Teleport"
+msgstr "Teletransporte"
+
+#: Source/translation_dummy.cpp:803
+msgctxt "spell"
+msgid "Apocalypse"
+msgstr "Apocalipse"
+
+#: Source/translation_dummy.cpp:804
+msgctxt "spell"
+msgid "Etherealize"
+msgstr "Eterealizar"
+
+#: Source/translation_dummy.cpp:805
+msgctxt "spell"
+msgid "Item Repair"
+msgstr "Reparar Itens"
+
+#: Source/translation_dummy.cpp:806
+msgctxt "spell"
+msgid "Staff Recharge"
+msgstr "Recarregar Cajados"
+
+#: Source/translation_dummy.cpp:807
+msgctxt "spell"
+msgid "Trap Disarm"
+msgstr "Desarmar Armadilha"
+
+#: Source/translation_dummy.cpp:808
+msgctxt "spell"
+msgid "Elemental"
+msgstr "Elemental"
+
+#: Source/translation_dummy.cpp:809
+msgctxt "spell"
+msgid "Charged Bolt"
+msgstr "Raio Carregado"
+
+#: Source/translation_dummy.cpp:810
+msgctxt "spell"
+msgid "Holy Bolt"
+msgstr "Raio Sagrado"
+
+#: Source/translation_dummy.cpp:811
+msgctxt "spell"
+msgid "Resurrect"
+msgstr "Ressurreição"
+
+#: Source/translation_dummy.cpp:812
+msgctxt "spell"
+msgid "Telekinesis"
+msgstr "Telecinese"
+
+#: Source/translation_dummy.cpp:813
+msgctxt "spell"
+msgid "Heal Other"
+msgstr "Curar Outro"
+
+#: Source/translation_dummy.cpp:814
+msgctxt "spell"
+msgid "Blood Star"
+msgstr "Estrela de Sangue"
+
+#: Source/translation_dummy.cpp:815
+msgctxt "spell"
+msgid "Bone Spirit"
+msgstr "Espírito de Ossos"
+
+#: Source/translation_dummy.cpp:816
+msgctxt "spell"
+msgid "Mana"
+msgstr "Mana"
+
+#: Source/translation_dummy.cpp:817
+msgctxt "spell"
+msgid "the Magi"
+msgstr "de Magi"
+
+#: Source/translation_dummy.cpp:818
+msgctxt "spell"
+msgid "the Jester"
+msgstr "do Bobo"
+
+#: Source/translation_dummy.cpp:819
+msgctxt "spell"
+msgid "Lightning Wall"
+msgstr "Parede Relampejante"
+
+#: Source/translation_dummy.cpp:820
+msgctxt "spell"
+msgid "Immolation"
+msgstr "Imolação"
+
+#: Source/translation_dummy.cpp:821
+msgctxt "spell"
+msgid "Warp"
+msgstr "Deformação"
+
+#: Source/translation_dummy.cpp:822
+msgctxt "spell"
+msgid "Reflect"
+msgstr "Refletir"
+
+#: Source/translation_dummy.cpp:823
+msgctxt "spell"
+msgid "Berserk"
+msgstr "Fúria"
+
+#: Source/translation_dummy.cpp:824
+msgctxt "spell"
+msgid "Ring of Fire"
+msgstr "Anel de Fogo"
+
+#: Source/translation_dummy.cpp:825
+msgctxt "spell"
+msgid "Search"
+msgstr "Procurar"
+
+#: Source/translation_dummy.cpp:826
+msgctxt "spell"
+msgid "Rune of Fire"
+msgstr "Runa de fogo"
+
+#: Source/translation_dummy.cpp:827
+msgctxt "spell"
+msgid "Rune of Light"
+msgstr "Runa da Luz"
+
+#: Source/translation_dummy.cpp:828
+msgctxt "spell"
+msgid "Rune of Nova"
+msgstr "Runa de Nova"
+
+#: Source/translation_dummy.cpp:829
+msgctxt "spell"
+msgid "Rune of Immolation"
+msgstr "Runa Explosiva"
+
+#: Source/translation_dummy.cpp:830
+msgctxt "spell"
+msgid "Rune of Stone"
+msgstr "Runa de Pedra"
+
 #. TRANSLATORS: Thousands separator
-#: Source/utils/format_int.cpp:26
+#: Source/utils/format_int.cpp:28 Source/utils/format_int.cpp:64
 msgid ","
 msgstr ","
+
+#~ msgid "/help"
+#~ msgstr "/help"
+
+#~ msgid "/arena"
+#~ msgstr "/arena"
+
+#~ msgid "/arenapot"
+#~ msgstr "/arenapot"
+
+#~ msgid "/inspect"
+#~ msgstr "/inspect"
+
+#~ msgid "/seedinfo"
+#~ msgstr "/seedinfo"
+
+#~ msgid "Command \""
+#~ msgstr "Comando \""
+
+#~ msgid "Decrease Gamma"
+#~ msgstr "Diminuir Gama"
+
+#~ msgid "Increase Gamma"
+#~ msgstr "Aumentar Gama"
+
+#~ msgid "No automap available in town"
+#~ msgstr "Automapa indisponível na cidade"
+
+#~ msgid "Restart In Town"
+#~ msgstr "Reiniciar na cidade"
+
+#~ msgid ""
+#~ "Forces waiting for Vertical Sync. Prevents tearing effect when drawing a "
+#~ "frame. Disabling it can help with mouse lag on some systems."
+#~ msgstr ""
+#~ "Força a espera por Sincronização Vertical. Previne efeito de sobreposição "
+#~ "de retalhos ao desenhar quadro. Desabilitá-lo pode ajudar com lag no "
+#~ "mouse em alguns sistemas."
+
+#~ msgid "FPS Limiter"
+#~ msgstr "Limitador de FPS"
+
+#~ msgid "FPS is limited to avoid high CPU load. Limit considers refresh rate."
+#~ msgstr ""
+#~ "FPS é limitado para evitar alta carga de CPU. O limite considera a taxa "
+#~ "de atualização."
+
+#~ msgid "To hit"
+#~ msgstr "Chance de acerto"
+
+#~ msgid "Indestructible,  "
+#~ msgstr "Indestrutível,  "
+
+#~ msgid "No required attributes"
+#~ msgstr "Nenhum atributo requerido"
+
+#~ msgid ""
+#~ "Cloudy and cooler today.  Casting the nets of necromancy across the void "
+#~ "landed two new subspecies of flying horror; a good day's work.  Must "
+#~ "remember to order some more bat guano and black candles from Adria; I'm "
+#~ "running a bit low."
+#~ msgstr ""
+#~ "Está nublado e fresco hoje.  Lançar as redes de necromancia através do "
+#~ "vazio aterrou duas novas subespécies de terror voador; um bom dia de "
+#~ "trabalho.  Tenho de me lembrar de pedir mais guano de morcego e velas "
+#~ "pretas para Ádria; Estou ficando com pouco."
 
 #~ msgid "Options:"
 #~ msgstr "Opções:"

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2025-04-18 23:03+0200\n"
-"PO-Revision-Date: 2025-04-18 23:03+0200\n"
+"POT-Creation-Date: 2025-04-18 23:04+0200\n"
+"PO-Revision-Date: 2025-04-18 23:04+0200\n"
 "Last-Translator: Altieres Lima da Silva <altieres.lima@gmail.com>\n"
 "Language-Team: \n"
 "Language: pt_BR\n"
@@ -27,11 +27,11 @@ msgstr "Design do Jogo"
 
 #: Source/DiabloUI/credits_lines.cpp:10
 msgid "Senior Designers"
-msgstr "Projetistas Sêniores"
+msgstr "Designers Sêniores"
 
 #: Source/DiabloUI/credits_lines.cpp:13 Source/DiabloUI/credits_lines.cpp:232
 msgid "Additional Design"
-msgstr "Projeto Adicional"
+msgstr "Design Adicional"
 
 #: Source/DiabloUI/credits_lines.cpp:16 Source/DiabloUI/credits_lines.cpp:215
 msgid "Lead Programmer"
@@ -503,9 +503,8 @@ msgid "Client-Server (TCP)"
 msgstr "Cliente-Servidor (TCP)"
 
 #: Source/DiabloUI/multi/selconn.cpp:17
-#, fuzzy
 msgid "Offline"
-msgstr "Loopback"
+msgstr "Offline"
 
 #: Source/DiabloUI/multi/selconn.cpp:58 Source/DiabloUI/multi/selgame.cpp:648
 #: Source/DiabloUI/multi/selgame.cpp:674
@@ -953,9 +952,8 @@ msgid "Game: "
 msgstr "Jogo: "
 
 #: Source/automap.cpp:1424
-#, fuzzy
 msgid "Offline Game"
-msgstr "Loopback"
+msgstr "Partida Offline"
 
 #: Source/automap.cpp:1426
 msgid "Password: "
@@ -2965,7 +2963,7 @@ msgstr "{:+d} a todos os atributos"
 
 #: Source/items.cpp:3959
 msgid "{:+d} damage from enemies"
-msgstr "{:+d} de dano a inimigos"
+msgstr "{:+d} de dano dos inimigos"
 
 #: Source/items.cpp:3962
 msgid "Hit Points: {:+d}"
@@ -9119,8 +9117,6 @@ msgid "Carver"
 msgstr "Talhador"
 
 #: Source/translation_dummy.cpp:15 Source/translation_dummy.cpp:23
-#, fuzzy
-#| msgid "Devil Kin"
 msgctxt "monster"
 msgid "Devil Kin"
 msgstr "Cria do Diabo"
@@ -9161,22 +9157,16 @@ msgid "Plague Eater"
 msgstr "Devorador de Almas"
 
 #: Source/translation_dummy.cpp:27
-#, fuzzy
-#| msgid "Shadow Beast"
 msgctxt "monster"
 msgid "Shadow Beast"
 msgstr "Fera das Sombras"
 
 #: Source/translation_dummy.cpp:28
-#, fuzzy
-#| msgid "Bone Gasher"
 msgctxt "monster"
 msgid "Bone Gasher"
 msgstr "Cortaosso"
 
 #: Source/translation_dummy.cpp:30
-#, fuzzy
-#| msgid "Corpse Bow"
 msgctxt "monster"
 msgid "Corpse Bow"
 msgstr "Cadáver Arqueiro"
@@ -9187,32 +9177,24 @@ msgid "Skeleton Captain"
 msgstr "Esqueleto Capitão"
 
 #: Source/translation_dummy.cpp:34
-#, fuzzy
-#| msgid "Corpse Captain"
 msgctxt "monster"
 msgid "Corpse Captain"
 msgstr "Cadáver Capitão"
 
 #: Source/translation_dummy.cpp:35
-#, fuzzy
-#| msgid "Burning Dead Captain"
 msgctxt "monster"
 msgid "Burning Dead Captain"
 msgstr "Morto Calcinante Capitão "
 
 #: Source/translation_dummy.cpp:36
-#, fuzzy
-#| msgid "Horror Captain"
 msgctxt "monster"
 msgid "Horror Captain"
 msgstr "Horror Capitão"
 
 #: Source/translation_dummy.cpp:37
-#, fuzzy
-#| msgid "Invisible Lord"
 msgctxt "monster"
 msgid "Invisible Lord"
-msgstr "Senhor Invisível"
+msgstr "Lorde Invisível"
 
 #: Source/translation_dummy.cpp:38
 msgctxt "monster"
@@ -9220,120 +9202,86 @@ msgid "Hidden"
 msgstr "Escondido"
 
 #: Source/translation_dummy.cpp:39
-#, fuzzy
-#| msgid "Stalker"
 msgctxt "monster"
 msgid "Stalker"
 msgstr "Espreitador"
 
 #: Source/translation_dummy.cpp:40
-#, fuzzy
-#| msgid "Unseen"
 msgctxt "monster"
 msgid "Unseen"
 msgstr "Despercebido"
 
 #: Source/translation_dummy.cpp:41
-#, fuzzy
-#| msgid "Illusion Weaver"
 msgctxt "monster"
 msgid "Illusion Weaver"
 msgstr "Tecelão de Ilusões"
 
 #: Source/translation_dummy.cpp:42
-#, fuzzy
-#| msgid "Satyr Lord"
 msgctxt "monster"
 msgid "Satyr Lord"
-msgstr "Senhor Sátiro"
+msgstr "Lorde Sátiro"
 
 #: Source/translation_dummy.cpp:43 Source/translation_dummy.cpp:51
-#, fuzzy
-#| msgid "Flesh Clan"
 msgctxt "monster"
 msgid "Flesh Clan"
 msgstr "Clã Carne Fresca"
 
 #: Source/translation_dummy.cpp:44 Source/translation_dummy.cpp:52
-#, fuzzy
-#| msgid "Stone Clan"
 msgctxt "monster"
 msgid "Stone Clan"
 msgstr "Clã de Pedra"
 
 #: Source/translation_dummy.cpp:45 Source/translation_dummy.cpp:53
-#, fuzzy
-#| msgid "Fire Clan"
 msgctxt "monster"
 msgid "Fire Clan"
 msgstr "Clã de Fogo"
 
 #: Source/translation_dummy.cpp:46 Source/translation_dummy.cpp:54
-#, fuzzy
-#| msgid "Night Clan"
 msgctxt "monster"
 msgid "Night Clan"
 msgstr "Clã da Noite"
 
 #: Source/translation_dummy.cpp:47
-#, fuzzy
-#| msgid "Fiend"
 msgctxt "monster"
 msgid "Fiend"
 msgstr "Demônio"
 
 #: Source/translation_dummy.cpp:48
-#, fuzzy
-#| msgid "Blink"
 msgctxt "monster"
 msgid "Blink"
 msgstr "Cintilador"
 
 #: Source/translation_dummy.cpp:49
-#, fuzzy
-#| msgid "Gloom"
 msgctxt "monster"
 msgid "Gloom"
 msgstr "Melancolia"
 
 #: Source/translation_dummy.cpp:50
-#, fuzzy
-#| msgid "Familiar"
 msgctxt "monster"
 msgid "Familiar"
 msgstr "Familiar"
 
 #: Source/translation_dummy.cpp:55
-#, fuzzy
-#| msgid "Acid Beast"
 msgctxt "monster"
 msgid "Acid Beast"
 msgstr "Fera Ácida"
 
 #: Source/translation_dummy.cpp:56
-#, fuzzy
-#| msgid "Poison Spitter"
 msgctxt "monster"
 msgid "Poison Spitter"
 msgstr "Cospe-Veneno"
 
 #: Source/translation_dummy.cpp:57
-#, fuzzy
-#| msgid "Pit Beast"
 msgctxt "monster"
 msgid "Pit Beast"
 msgstr "Fera do Poço"
 
 #: Source/translation_dummy.cpp:58
-#, fuzzy
-#| msgid "Lava Maw"
 msgctxt "monster"
 msgid "Lava Maw"
 msgstr "Gorja de Lava"
 
 #: Source/translation_dummy.cpp:59 Source/translation_dummy.cpp:148
-#, fuzzy
-#| msgid "Skeleton King"
 msgctxt "monster"
 msgid "Skeleton King"
 msgstr "Rei Esqueleto"
@@ -9344,64 +9292,46 @@ msgid "The Butcher"
 msgstr "O Açougueiro"
 
 #: Source/translation_dummy.cpp:61
-#, fuzzy
-#| msgid "Overlord"
 msgctxt "monster"
 msgid "Overlord"
 msgstr "Suserano"
 
 #: Source/translation_dummy.cpp:62
-#, fuzzy
-#| msgid "Mud Man"
 msgctxt "monster"
 msgid "Mud Man"
 msgstr "Homem-Lama"
 
 #: Source/translation_dummy.cpp:63
-#, fuzzy
-#| msgid "Toad Demon"
 msgctxt "monster"
 msgid "Toad Demon"
 msgstr "Demônio Sapo"
 
 #: Source/translation_dummy.cpp:64
-#, fuzzy
-#| msgid "Flayed One"
 msgctxt "monster"
 msgid "Flayed One"
 msgstr "Esfolado"
 
 #: Source/translation_dummy.cpp:65
-#, fuzzy
-#| msgid "Wyrm"
 msgctxt "monster"
 msgid "Wyrm"
 msgstr "Wyrm"
 
 #: Source/translation_dummy.cpp:66
-#, fuzzy
-#| msgid "Cave Slug"
 msgctxt "monster"
 msgid "Cave Slug"
 msgstr "Lesma da Caverna"
 
 #: Source/translation_dummy.cpp:67
-#, fuzzy
-#| msgid "Devil Wyrm"
 msgctxt "monster"
 msgid "Devil Wyrm"
 msgstr "Wyrm Demoníaca"
 
 #: Source/translation_dummy.cpp:68
-#, fuzzy
-#| msgid "Devourer"
 msgctxt "monster"
 msgid "Devourer"
 msgstr "Devorador"
 
 #: Source/translation_dummy.cpp:69
-#, fuzzy
-#| msgid "Magma Demon"
 msgctxt "monster"
 msgid "Magma Demon"
 msgstr "Demônio de Magma"
@@ -9412,526 +9342,376 @@ msgid "Blood Stone"
 msgstr "Pedra Sanguínea"
 
 #: Source/translation_dummy.cpp:71
-#, fuzzy
-#| msgid "Hell Stone"
 msgctxt "monster"
 msgid "Hell Stone"
 msgstr "Pedra do Inferno"
 
 #: Source/translation_dummy.cpp:72
-#, fuzzy
-#| msgid "Lava Lord"
 msgctxt "monster"
 msgid "Lava Lord"
-msgstr "Senhor da Lava"
+msgstr "Lorde da Lava"
 
 #: Source/translation_dummy.cpp:73
-#, fuzzy
-#| msgid "Horned Demon"
 msgctxt "monster"
 msgid "Horned Demon"
 msgstr "Demônio com Chifres"
 
 #: Source/translation_dummy.cpp:74
-#, fuzzy
-#| msgid "Mud Runner"
 msgctxt "monster"
 msgid "Mud Runner"
 msgstr "Trilhador da Lama"
 
 #: Source/translation_dummy.cpp:75
-#, fuzzy
-#| msgid "Frost Charger"
 msgctxt "monster"
 msgid "Frost Charger"
 msgstr "Suicida Gélido"
 
 #: Source/translation_dummy.cpp:76
-#, fuzzy
-#| msgid "Obsidian Lord"
 msgctxt "monster"
 msgid "Obsidian Lord"
-msgstr "Senhor da Obsidiana"
+msgstr "Lorde da Obsidiana"
 
 #: Source/translation_dummy.cpp:77
-#, fuzzy
-#| msgid "oldboned"
 msgctxt "monster"
 msgid "oldboned"
 msgstr "Ossovelho"
 
 #: Source/translation_dummy.cpp:78
-#, fuzzy
-#| msgid "Red Death"
 msgctxt "monster"
 msgid "Red Death"
-msgstr "Morte Vermelha"
+msgstr "Morte Rubra"
 
 #: Source/translation_dummy.cpp:79
-#, fuzzy
-#| msgid "Litch Demon"
 msgctxt "monster"
 msgid "Litch Demon"
 msgstr "Demônio Litch"
 
 #: Source/translation_dummy.cpp:80
-#, fuzzy
-#| msgid "Undead Balrog"
 msgctxt "monster"
 msgid "Undead Balrog"
 msgstr "Balrog Morto-vivo"
 
 #: Source/translation_dummy.cpp:81
-#, fuzzy
-#| msgid "Incinerator"
 msgctxt "monster"
 msgid "Incinerator"
 msgstr "Incinerador"
 
 #: Source/translation_dummy.cpp:82
-#, fuzzy
-#| msgid "Flame Lord"
 msgctxt "monster"
 msgid "Flame Lord"
-msgstr "Senhor da Chama"
+msgstr "Lorde da Chama"
 
 #: Source/translation_dummy.cpp:83
-#, fuzzy
-#| msgid "Doom Fire"
 msgctxt "monster"
 msgid "Doom Fire"
 msgstr "Fogo da Perdição"
 
 #: Source/translation_dummy.cpp:84
-#, fuzzy
-#| msgid "Hell Burner"
 msgctxt "monster"
 msgid "Hell Burner"
 msgstr "Queimador do Inferno"
 
 #: Source/translation_dummy.cpp:85
-#, fuzzy
-#| msgid "Red Storm"
 msgctxt "monster"
 msgid "Red Storm"
-msgstr "Tempestade Vermelha"
+msgstr "Tempestade Rubra"
 
 #: Source/translation_dummy.cpp:86
-#, fuzzy
-#| msgid "Storm Rider"
 msgctxt "monster"
 msgid "Storm Rider"
 msgstr "Tempestuoso"
 
 #: Source/translation_dummy.cpp:87
-#, fuzzy
-#| msgid "Storm Lord"
 msgctxt "monster"
 msgid "Storm Lord"
-msgstr "Senhor da Tempestade"
+msgstr "Lorde da Tempestade"
 
 #: Source/translation_dummy.cpp:88
-#, fuzzy
-#| msgid "Maelstrom"
 msgctxt "monster"
 msgid "Maelstrom"
 msgstr "Redemoinho"
 
 #: Source/translation_dummy.cpp:89
-#, fuzzy
-#| msgid "Devil Kin Brute"
 msgctxt "monster"
 msgid "Devil Kin Brute"
 msgstr "Cria do Diabo Bruta"
 
 #: Source/translation_dummy.cpp:90
-#, fuzzy
-#| msgid "Winged-Demon"
 msgctxt "monster"
 msgid "Winged-Demon"
 msgstr "Demônio Alado"
 
 #: Source/translation_dummy.cpp:91
-#, fuzzy
-#| msgid "Gargoyle"
 msgctxt "monster"
 msgid "Gargoyle"
 msgstr "Gárgula"
 
 #: Source/translation_dummy.cpp:92
-#, fuzzy
-#| msgid "Blood Claw"
 msgctxt "monster"
 msgid "Blood Claw"
 msgstr "Garra Sangrenta"
 
 #: Source/translation_dummy.cpp:93
-#, fuzzy
-#| msgid "Death Wing"
 msgctxt "monster"
 msgid "Death Wing"
 msgstr "Asa da Morte"
 
 #: Source/translation_dummy.cpp:94
-#, fuzzy
-#| msgid "Slayer"
 msgctxt "monster"
 msgid "Slayer"
 msgstr "Homicida"
 
 #: Source/translation_dummy.cpp:95
-#, fuzzy
-#| msgid "Guardian"
 msgctxt "monster"
 msgid "Guardian"
 msgstr "Guardião"
 
 #: Source/translation_dummy.cpp:96
-#, fuzzy
-#| msgid "Vortex Lord"
 msgctxt "monster"
 msgid "Vortex Lord"
-msgstr "Senhor do Vórtice"
+msgstr "Lorde do Vórtice"
 
 #: Source/translation_dummy.cpp:97
-#, fuzzy
-#| msgid "Balrog"
 msgctxt "monster"
 msgid "Balrog"
 msgstr "Balrog"
 
 #: Source/translation_dummy.cpp:98
-#, fuzzy
-#| msgid "Cave Viper"
 msgctxt "monster"
 msgid "Cave Viper"
 msgstr "Víbora da Caverna"
 
 #: Source/translation_dummy.cpp:99
-#, fuzzy
-#| msgid "Fire Drake"
 msgctxt "monster"
 msgid "Fire Drake"
 msgstr "Víbora de Fogo"
 
 #: Source/translation_dummy.cpp:100
-#, fuzzy
-#| msgid "Gold Viper"
 msgctxt "monster"
 msgid "Gold Viper"
 msgstr "Víbora de Ouro"
 
 #: Source/translation_dummy.cpp:101
-#, fuzzy
-#| msgid "Azure Drake"
 msgctxt "monster"
 msgid "Azure Drake"
 msgstr "Víbora Azulada"
 
 #: Source/translation_dummy.cpp:102
-#, fuzzy
-#| msgid "Black Knight"
 msgctxt "monster"
 msgid "Black Knight"
 msgstr "Cavaleiro Negro"
 
 #: Source/translation_dummy.cpp:103
-#, fuzzy
-#| msgid "Doom Guard"
 msgctxt "monster"
 msgid "Doom Guard"
 msgstr "Guarda da Perdição"
 
 #: Source/translation_dummy.cpp:104
-#, fuzzy
-#| msgid "Steel Lord"
 msgctxt "monster"
 msgid "Steel Lord"
-msgstr "Senhor de Aço"
+msgstr "Lorde de Aço"
 
 #: Source/translation_dummy.cpp:105
-#, fuzzy
-#| msgid "Blood Knight"
 msgctxt "monster"
 msgid "Blood Knight"
 msgstr "Cavaleiro Sangrento"
 
 #: Source/translation_dummy.cpp:106
-#, fuzzy
-#| msgid "The Shredded"
 msgctxt "monster"
 msgid "The Shredded"
 msgstr "Desfiador"
 
 #: Source/translation_dummy.cpp:107
-#, fuzzy
-#| msgid "Hollow One"
 msgctxt "monster"
 msgid "Hollow One"
 msgstr "Oco"
 
 #: Source/translation_dummy.cpp:108
-#, fuzzy
-#| msgid "Pain Master"
 msgctxt "monster"
 msgid "Pain Master"
 msgstr "Mestre da Dor"
 
 #: Source/translation_dummy.cpp:109
-#, fuzzy
-#| msgid "Reality Weaver"
 msgctxt "monster"
 msgid "Reality Weaver"
 msgstr "Tecelão de Realidades"
 
 #: Source/translation_dummy.cpp:110
-#, fuzzy
-#| msgid "Succubus"
 msgctxt "monster"
 msgid "Succubus"
 msgstr "Súcubo"
 
 #: Source/translation_dummy.cpp:111
-#, fuzzy
-#| msgid "Snow Witch"
 msgctxt "monster"
 msgid "Snow Witch"
 msgstr "Bruxa da Neve"
 
 #: Source/translation_dummy.cpp:112
-#, fuzzy
-#| msgid "Hell Spawn"
 msgctxt "monster"
 msgid "Hell Spawn"
 msgstr "Cria do Inferno"
 
 #: Source/translation_dummy.cpp:113
-#, fuzzy
-#| msgid "Soul Burner"
 msgctxt "monster"
 msgid "Soul Burner"
 msgstr "Queimadora de Almas"
 
 #: Source/translation_dummy.cpp:114
-#, fuzzy
-#| msgid "Counselor"
 msgctxt "monster"
 msgid "Counselor"
 msgstr "Conselheiro"
 
 #: Source/translation_dummy.cpp:115
-#, fuzzy
-#| msgid "Magistrate"
 msgctxt "monster"
 msgid "Magistrate"
 msgstr "Magistrado"
 
 #: Source/translation_dummy.cpp:116
-#, fuzzy
-#| msgid "Cabalist"
 msgctxt "monster"
 msgid "Cabalist"
 msgstr "Cabalista"
 
 #: Source/translation_dummy.cpp:117
-#, fuzzy
-#| msgid "Advocate"
 msgctxt "monster"
 msgid "Advocate"
 msgstr "Defensor"
 
 #: Source/translation_dummy.cpp:118
-#, fuzzy
-#| msgid "Golem"
 msgctxt "monster"
 msgid "Golem"
 msgstr "Golem"
 
 #: Source/translation_dummy.cpp:119
-#, fuzzy
-#| msgid "The Dark Lord"
 msgctxt "monster"
 msgid "The Dark Lord"
 msgstr "O Lorde Sombrio"
 
 #: Source/translation_dummy.cpp:120
-#, fuzzy
-#| msgid "The Arch-Litch Malignus"
 msgctxt "monster"
 msgid "The Arch-Litch Malignus"
 msgstr "O Arce-Litch Malignus"
 
 #: Source/translation_dummy.cpp:121
-#, fuzzy
-#| msgid "Hellboar"
 msgctxt "monster"
 msgid "Hellboar"
 msgstr "Hellboar"
 
 #: Source/translation_dummy.cpp:122
-#, fuzzy
-#| msgid "Stinger"
 msgctxt "monster"
 msgid "Stinger"
-msgstr "Ferrão"
+msgstr "Ferroador"
 
 #: Source/translation_dummy.cpp:123
-#, fuzzy
-#| msgid "Psychorb"
 msgctxt "monster"
 msgid "Psychorb"
-msgstr "Psychorb"
+msgstr "Psicorbe"
 
 #: Source/translation_dummy.cpp:124
-#, fuzzy
-#| msgid "Arachnon"
 msgctxt "monster"
 msgid "Arachnon"
 msgstr "Arachnon"
 
 #: Source/translation_dummy.cpp:125
-#, fuzzy
-#| msgid "Felltwin"
 msgctxt "monster"
 msgid "Felltwin"
-msgstr "Felltwin"
+msgstr "Geminígio"
 
 #: Source/translation_dummy.cpp:126
-#, fuzzy
-#| msgid "Hork Spawn"
 msgctxt "monster"
 msgid "Hork Spawn"
 msgstr "Cria de Hork"
 
 #: Source/translation_dummy.cpp:127
-#, fuzzy
-#| msgid "Venomtail"
 msgctxt "monster"
 msgid "Venomtail"
 msgstr "Venomtail"
 
 #: Source/translation_dummy.cpp:128
-#, fuzzy
-#| msgid "Necromorb"
 msgctxt "monster"
 msgid "Necromorb"
 msgstr "Necromorb"
 
 #: Source/translation_dummy.cpp:129
-#, fuzzy
-#| msgid "Spider Lord"
 msgctxt "monster"
 msgid "Spider Lord"
-msgstr "Senhor das Aranhas"
+msgstr "Lorde das Aranhas"
 
 #: Source/translation_dummy.cpp:130
-#, fuzzy
-#| msgid "Lashworm"
 msgctxt "monster"
 msgid "Lashworm"
 msgstr "Verme-de-chicote"
 
 #: Source/translation_dummy.cpp:131
-#, fuzzy
-#| msgid "Torchant"
 msgctxt "monster"
 msgid "Torchant"
 msgstr "Torchant"
 
 #: Source/translation_dummy.cpp:132 Source/translation_dummy.cpp:157
-#, fuzzy
-#| msgid "Hork Demon"
 msgctxt "monster"
 msgid "Hork Demon"
 msgstr "Demônio Hork"
 
 #: Source/translation_dummy.cpp:133
-#, fuzzy
-#| msgid "Hell Bug"
 msgctxt "monster"
 msgid "Hell Bug"
 msgstr "Inseto do Inferno"
 
 #: Source/translation_dummy.cpp:134
-#, fuzzy
-#| msgid "Gravedigger"
 msgctxt "monster"
 msgid "Gravedigger"
 msgstr "Coveiro"
 
 #: Source/translation_dummy.cpp:135
-#, fuzzy
-#| msgid "Tomb Rat"
 msgctxt "monster"
 msgid "Tomb Rat"
 msgstr "Rato da Tumba"
 
 #: Source/translation_dummy.cpp:136
-#, fuzzy
-#| msgid "Firebat"
 msgctxt "monster"
 msgid "Firebat"
 msgstr "Morcego de Fogo"
 
 #: Source/translation_dummy.cpp:137
-#, fuzzy
-#| msgid "Skullwing"
 msgctxt "monster"
 msgid "Skullwing"
 msgstr "Asa Esquelética"
 
 #: Source/translation_dummy.cpp:138
-#, fuzzy
-#| msgid "Lich"
 msgctxt "monster"
 msgid "Lich"
 msgstr "Lich"
 
 #: Source/translation_dummy.cpp:139
-#, fuzzy
-#| msgid "Crypt Demon"
 msgctxt "monster"
 msgid "Crypt Demon"
 msgstr "Demônio da Cripta"
 
 #: Source/translation_dummy.cpp:140
-#, fuzzy
-#| msgid "Hellbat"
 msgctxt "monster"
 msgid "Hellbat"
 msgstr "Morcego Infernal"
 
 #: Source/translation_dummy.cpp:141
-#, fuzzy
-#| msgid "Bone Demon"
 msgctxt "monster"
 msgid "Bone Demon"
 msgstr "Demônio de Ossos"
 
 #: Source/translation_dummy.cpp:142
-#, fuzzy
-#| msgid "Arch Lich"
 msgctxt "monster"
 msgid "Arch Lich"
 msgstr "Arque Lich"
 
 #: Source/translation_dummy.cpp:143
-#, fuzzy
-#| msgid "Biclops"
 msgctxt "monster"
 msgid "Biclops"
 msgstr "Biclops"
 
 #: Source/translation_dummy.cpp:144
-#, fuzzy
-#| msgid "Flesh Thing"
 msgctxt "monster"
 msgid "Flesh Thing"
 msgstr "Coisa de Carne Fresca"
 
 #: Source/translation_dummy.cpp:145
-#, fuzzy
-#| msgid "Reaper"
 msgctxt "monster"
 msgid "Reaper"
 msgstr "Ceifador"
@@ -9942,8 +9722,6 @@ msgid "Na-Krul"
 msgstr "Na-Krul"
 
 #: Source/translation_dummy.cpp:147
-#, fuzzy
-#| msgid "Gharbad the Weak"
 msgctxt "monster"
 msgid "Gharbad the Weak"
 msgstr "Gharbad, o Fraco"
@@ -9954,29 +9732,21 @@ msgid "Zhar the Mad"
 msgstr "Zhar, o Louco"
 
 #: Source/translation_dummy.cpp:150
-#, fuzzy
-#| msgid "Snotspill"
 msgctxt "monster"
 msgid "Snotspill"
 msgstr "Kaikatarro"
 
 #: Source/translation_dummy.cpp:151
-#, fuzzy
-#| msgid "Arch-Bishop Lazarus"
 msgctxt "monster"
 msgid "Arch-Bishop Lazarus"
 msgstr "Arcebispo Lazarus"
 
 #: Source/translation_dummy.cpp:152
-#, fuzzy
-#| msgid "Red Vex"
 msgctxt "monster"
 msgid "Red Vex"
 msgstr "Apurrinhação Vermelha"
 
 #: Source/translation_dummy.cpp:153
-#, fuzzy
-#| msgid "Black Jade"
 msgctxt "monster"
 msgid "Black Jade"
 msgstr "Jade Negra"
@@ -9997,57 +9767,41 @@ msgid "The Defiler"
 msgstr "O Profanador"
 
 #: Source/translation_dummy.cpp:160
-#, fuzzy
-#| msgid "Bonehead Keenaxe"
 msgctxt "monster"
 msgid "Bonehead Keenaxe"
 msgstr "Osteocéfalo Machado"
 
 #: Source/translation_dummy.cpp:161
-#, fuzzy
-#| msgid "Bladeskin the Slasher"
 msgctxt "monster"
 msgid "Bladeskin the Slasher"
 msgstr "Laminiderme, o Esfaqueador"
 
 #: Source/translation_dummy.cpp:162
-#, fuzzy
-#| msgid "Soulpus"
 msgctxt "monster"
 msgid "Soulpus"
 msgstr "Pus de Alma"
 
 #: Source/translation_dummy.cpp:163
-#, fuzzy
-#| msgid "Pukerat the Unclean"
 msgctxt "monster"
 msgid "Pukerat the Unclean"
 msgstr "Vomirrato, o Impuro"
 
 #: Source/translation_dummy.cpp:164
-#, fuzzy
-#| msgid "Boneripper"
 msgctxt "monster"
 msgid "Boneripper"
 msgstr "Estripa-ossos"
 
 #: Source/translation_dummy.cpp:165
-#, fuzzy
-#| msgid "Rotfeast the Hungry"
 msgctxt "monster"
 msgid "Rotfeast the Hungry"
 msgstr "Putrefórico, o Faminto"
 
 #: Source/translation_dummy.cpp:166
-#, fuzzy
-#| msgid "Gutshank the Quick"
 msgctxt "monster"
 msgid "Gutshank the Quick"
 msgstr "Tripernil, o Veloz"
 
 #: Source/translation_dummy.cpp:167
-#, fuzzy
-#| msgid "Brokenhead Bangshield"
 msgctxt "monster"
 msgid "Brokenhead Bangshield"
 msgstr "Traumocéfalo Bate-Escudos"
@@ -10058,29 +9812,21 @@ msgid "Bongo"
 msgstr "Bongo"
 
 #: Source/translation_dummy.cpp:169
-#, fuzzy
-#| msgid "Rotcarnage"
 msgctxt "monster"
 msgid "Rotcarnage"
 msgstr "Putrificina"
 
 #: Source/translation_dummy.cpp:170
-#, fuzzy
-#| msgid "Shadowbite"
 msgctxt "monster"
 msgid "Shadowbite"
 msgstr "Mordesombra"
 
 #: Source/translation_dummy.cpp:171
-#, fuzzy
-#| msgid "Deadeye"
 msgctxt "monster"
 msgid "Deadeye"
 msgstr "Olho Morto"
 
 #: Source/translation_dummy.cpp:172
-#, fuzzy
-#| msgid "Madeye the Dead"
 msgctxt "monster"
 msgid "Madeye the Dead"
 msgstr "Olholouco, o Morto"
@@ -10091,50 +9837,36 @@ msgid "El Chupacabras"
 msgstr "El Chupacabras"
 
 #: Source/translation_dummy.cpp:174
-#, fuzzy
-#| msgid "Skullfire"
 msgctxt "monster"
 msgid "Skullfire"
 msgstr "Fogo Cranial"
 
 #: Source/translation_dummy.cpp:175
-#, fuzzy
-#| msgid "Warpskull"
 msgctxt "monster"
 msgid "Warpskull"
 msgstr "Crânio Torto"
 
 #: Source/translation_dummy.cpp:176
-#, fuzzy
-#| msgid "Goretongue"
 msgctxt "monster"
 msgid "Goretongue"
 msgstr "Sanguinolíngue"
 
 #: Source/translation_dummy.cpp:177
-#, fuzzy
-#| msgid "Pulsecrawler"
 msgctxt "monster"
 msgid "Pulsecrawler"
 msgstr "Pulsejador"
 
 #: Source/translation_dummy.cpp:178
-#, fuzzy
-#| msgid "Moonbender"
 msgctxt "monster"
 msgid "Moonbender"
 msgstr "Verga-Luas"
 
 #: Source/translation_dummy.cpp:179
-#, fuzzy
-#| msgid "Wrathraven"
 msgctxt "monster"
 msgid "Wrathraven"
 msgstr "Corvo da Cólera"
 
 #: Source/translation_dummy.cpp:180
-#, fuzzy
-#| msgid "Spineeater"
 msgctxt "monster"
 msgid "Spineeater"
 msgstr "Come-Espinhas"
@@ -10145,15 +9877,11 @@ msgid "Blackash the Burning"
 msgstr "Cinzascura, o Calcinante"
 
 #: Source/translation_dummy.cpp:182
-#, fuzzy
-#| msgid "Shadowcrow"
 msgctxt "monster"
 msgid "Shadowcrow"
 msgstr "Corvossombra"
 
 #: Source/translation_dummy.cpp:183
-#, fuzzy
-#| msgid "Blightstone the Weak"
 msgctxt "monster"
 msgid "Blightstone the Weak"
 msgstr "Pedrapraga, o Fraco"
@@ -10164,57 +9892,41 @@ msgid "Bilefroth the Pit Master"
 msgstr "Espumabile, o Mestre do Poço"
 
 #: Source/translation_dummy.cpp:185
-#, fuzzy
-#| msgid "Bloodskin Darkbow"
 msgctxt "monster"
 msgid "Bloodskin Darkbow"
 msgstr "Sanguiderme Arco Negro"
 
 #: Source/translation_dummy.cpp:186
-#, fuzzy
-#| msgid "Foulwing"
 msgctxt "monster"
 msgid "Foulwing"
 msgstr "Asa Pútrida"
 
 #: Source/translation_dummy.cpp:187
-#, fuzzy
-#| msgid "Shadowdrinker"
 msgctxt "monster"
 msgid "Shadowdrinker"
 msgstr "Bebedor das Sombras"
 
 #: Source/translation_dummy.cpp:188
-#, fuzzy
-#| msgid "Hazeshifter"
 msgctxt "monster"
 msgid "Hazeshifter"
 msgstr "Muda-Névoas"
 
 #: Source/translation_dummy.cpp:189
-#, fuzzy
-#| msgid "Deathspit"
 msgctxt "monster"
 msgid "Deathspit"
 msgstr "Cospe-Morte"
 
 #: Source/translation_dummy.cpp:190
-#, fuzzy
-#| msgid "Bloodgutter"
 msgctxt "monster"
 msgid "Bloodgutter"
 msgstr "Coagulário"
 
 #: Source/translation_dummy.cpp:191
-#, fuzzy
-#| msgid "Deathshade Fleshmaul"
 msgctxt "monster"
 msgid "Deathshade Fleshmaul"
 msgstr "Sombra da Morte Rasga-Carne"
 
 #: Source/translation_dummy.cpp:192
-#, fuzzy
-#| msgid "Warmaggot the Mad"
 msgctxt "monster"
 msgid "Warmaggot the Mad"
 msgstr "Larvaguerra, o Louco"
@@ -10225,78 +9937,56 @@ msgid "Glasskull the Jagged"
 msgstr "Crânio de Vidro, o Serrilhado"
 
 #: Source/translation_dummy.cpp:194
-#, fuzzy
-#| msgid "Blightfire"
 msgctxt "monster"
 msgid "Blightfire"
 msgstr "Flagelo de Fogo"
 
 #: Source/translation_dummy.cpp:195
-#, fuzzy
-#| msgid "Nightwing the Cold"
 msgctxt "monster"
 msgid "Nightwing the Cold"
 msgstr "Asa Noturna, o Gélido"
 
 #: Source/translation_dummy.cpp:196
-#, fuzzy
-#| msgid "Gorestone"
 msgctxt "monster"
 msgid "Gorestone"
 msgstr "Rochacínio"
 
 #: Source/translation_dummy.cpp:197
-#, fuzzy
-#| msgid "Bronzefist Firestone"
 msgctxt "monster"
 msgid "Bronzefist Firestone"
 msgstr "Pugibronze Pedra de Fogo"
 
 #: Source/translation_dummy.cpp:198
-#, fuzzy
-#| msgid "Wrathfire the Doomed"
 msgctxt "monster"
 msgid "Wrathfire the Doomed"
 msgstr "Irígnea, o Condenado"
 
 #: Source/translation_dummy.cpp:199
-#, fuzzy
-#| msgid "Firewound the Grim"
 msgctxt "monster"
 msgid "Firewound the Grim"
 msgstr "Chaga Ígnea, o Tenebroso"
 
 #: Source/translation_dummy.cpp:200
-#, fuzzy
-#| msgid "Baron Sludge"
 msgctxt "monster"
 msgid "Baron Sludge"
 msgstr "Barão Lodoso"
 
 #: Source/translation_dummy.cpp:201
-#, fuzzy
-#| msgid "Blighthorn Steelmace"
 msgctxt "monster"
 msgid "Blighthorn Steelmace"
 msgstr "Guampestífero Maça de Aço"
 
 #: Source/translation_dummy.cpp:202
-#, fuzzy
-#| msgid "Chaoshowler"
 msgctxt "monster"
 msgid "Chaoshowler"
 msgstr "Berrocaos"
 
 #: Source/translation_dummy.cpp:203
-#, fuzzy
-#| msgid "Doomgrin the Rotting"
 msgctxt "monster"
 msgid "Doomgrin the Rotting"
 msgstr "Sorrirruína, o Podre"
 
 #: Source/translation_dummy.cpp:204
-#, fuzzy
-#| msgid "Madburner"
 msgctxt "monster"
 msgid "Madburner"
 msgstr "Queimador Louco"
@@ -10307,36 +9997,26 @@ msgid "Bonesaw the Litch"
 msgstr "Serra Osso, o Litch"
 
 #: Source/translation_dummy.cpp:206
-#, fuzzy
-#| msgid "Breakspine"
 msgctxt "monster"
 msgid "Breakspine"
 msgstr "Quebra-Espinha"
 
 #: Source/translation_dummy.cpp:207
-#, fuzzy
-#| msgid "Devilskull Sharpbone"
 msgctxt "monster"
 msgid "Devilskull Sharpbone"
 msgstr "Demonicrânio Osso Afiado"
 
 #: Source/translation_dummy.cpp:208
-#, fuzzy
-#| msgid "Brokenstorm"
 msgctxt "monster"
 msgid "Brokenstorm"
 msgstr "Tempestrago"
 
 #: Source/translation_dummy.cpp:209
-#, fuzzy
-#| msgid "Stormbane"
 msgctxt "monster"
 msgid "Stormbane"
 msgstr "Praguestade"
 
 #: Source/translation_dummy.cpp:210
-#, fuzzy
-#| msgid "Oozedrool"
 msgctxt "monster"
 msgid "Oozedrool"
 msgstr "Babujador"
@@ -10347,50 +10027,36 @@ msgid "Goldblight of the Flame"
 msgstr "Pragáurea da Chama"
 
 #: Source/translation_dummy.cpp:212
-#, fuzzy
-#| msgid "Blackstorm"
 msgctxt "monster"
 msgid "Blackstorm"
 msgstr "Tempestade Negra"
 
 #: Source/translation_dummy.cpp:213
-#, fuzzy
-#| msgid "Plaguewrath"
 msgctxt "monster"
 msgid "Plaguewrath"
 msgstr "Pestilérico"
 
 #: Source/translation_dummy.cpp:214
-#, fuzzy
-#| msgid "The Flayer"
 msgctxt "monster"
 msgid "The Flayer"
 msgstr "O Esfolador"
 
 #: Source/translation_dummy.cpp:215
-#, fuzzy
-#| msgid "Bluehorn"
 msgctxt "monster"
 msgid "Bluehorn"
 msgstr "Chifre Azul"
 
 #: Source/translation_dummy.cpp:216
-#, fuzzy
-#| msgid "Warpfire Hellspawn"
 msgctxt "monster"
 msgid "Warpfire Hellspawn"
 msgstr "Deformígneo Cria do Inferno"
 
 #: Source/translation_dummy.cpp:217
-#, fuzzy
-#| msgid "Fangspeir"
 msgctxt "monster"
 msgid "Fangspeir"
 msgstr "Presatroz"
 
 #: Source/translation_dummy.cpp:218
-#, fuzzy
-#| msgid "Festerskull"
 msgctxt "monster"
 msgid "Festerskull"
 msgstr "Pesticrânio"
@@ -10401,29 +10067,21 @@ msgid "Lionskull the Bent"
 msgstr "CrânioLeão, o Curvado"
 
 #: Source/translation_dummy.cpp:220
-#, fuzzy
-#| msgid "Blacktongue"
 msgctxt "monster"
 msgid "Blacktongue"
 msgstr "Língua Negra"
 
 #: Source/translation_dummy.cpp:221
-#, fuzzy
-#| msgid "Viletouch"
 msgctxt "monster"
 msgid "Viletouch"
 msgstr "Toque Nóxio"
 
 #: Source/translation_dummy.cpp:222
-#, fuzzy
-#| msgid "Viperflame"
 msgctxt "monster"
 msgid "Viperflame"
 msgstr "Ignofídico"
 
 #: Source/translation_dummy.cpp:223
-#, fuzzy
-#| msgid "Fangskin"
 msgctxt "monster"
 msgid "Fangskin"
 msgstr "Presiderme"
@@ -10434,22 +10092,16 @@ msgid "Witchfire the Unholy"
 msgstr "Witchfire, o Pecaminoso"
 
 #: Source/translation_dummy.cpp:225
-#, fuzzy
-#| msgid "Blackskull"
 msgctxt "monster"
 msgid "Blackskull"
 msgstr "Caveira Negra"
 
 #: Source/translation_dummy.cpp:226
-#, fuzzy
-#| msgid "Soulslash"
 msgctxt "monster"
 msgid "Soulslash"
 msgstr "Corta-Almas"
 
 #: Source/translation_dummy.cpp:227
-#, fuzzy
-#| msgid "Windspawn"
 msgctxt "monster"
 msgid "Windspawn"
 msgstr "Ventoso"
@@ -10460,99 +10112,71 @@ msgid "Lord of the Pit"
 msgstr "Senhor do Poço"
 
 #: Source/translation_dummy.cpp:229
-#, fuzzy
-#| msgid "Rustweaver"
 msgctxt "monster"
 msgid "Rustweaver"
 msgstr "Ferrecelão"
 
 #: Source/translation_dummy.cpp:230
-#, fuzzy
-#| msgid "Howlingire the Shade"
 msgctxt "monster"
 msgid "Howlingire the Shade"
 msgstr "Iruivante, a Sombra"
 
 #: Source/translation_dummy.cpp:231
-#, fuzzy
-#| msgid "Doomcloud"
 msgctxt "monster"
 msgid "Doomcloud"
 msgstr "Nuvem da Desgraça"
 
 #: Source/translation_dummy.cpp:232
-#, fuzzy
-#| msgid "Bloodmoon Soulfire"
 msgctxt "monster"
 msgid "Bloodmoon Soulfire"
 msgstr "Luassangra Fogo de Alma"
 
 #: Source/translation_dummy.cpp:233
-#, fuzzy
-#| msgid "Witchmoon"
 msgctxt "monster"
 msgid "Witchmoon"
 msgstr "Bruxa Lunar"
 
 #: Source/translation_dummy.cpp:234
-#, fuzzy
-#| msgid "Gorefeast"
 msgctxt "monster"
 msgid "Gorefeast"
 msgstr "Banqueticínio"
 
 #: Source/translation_dummy.cpp:235
-#, fuzzy
-#| msgid "Graywar the Slayer"
 msgctxt "monster"
 msgid "Graywar the Slayer"
 msgstr "Belipardo, o Matador"
 
 #: Source/translation_dummy.cpp:236
-#, fuzzy
-#| msgid "Dreadjudge"
 msgctxt "monster"
 msgid "Dreadjudge"
 msgstr "Temível Juiz"
 
 #: Source/translation_dummy.cpp:237
-#, fuzzy
-#| msgid "Stareye the Witch"
 msgctxt "monster"
 msgid "Stareye the Witch"
 msgstr "Estrolha, a Bruxa"
 
 #: Source/translation_dummy.cpp:238
-#, fuzzy
-#| msgid "Steelskull the Hunter"
 msgctxt "monster"
 msgid "Steelskull the Hunter"
 msgstr "Craniaço, o Caçador"
 
 #: Source/translation_dummy.cpp:239
-#, fuzzy
-#| msgid "Sir Gorash"
 msgctxt "monster"
 msgid "Sir Gorash"
 msgstr "Sir Gorash"
 
 #: Source/translation_dummy.cpp:240
-#, fuzzy
-#| msgid "The Vizier"
 msgctxt "monster"
 msgid "The Vizier"
 msgstr "O Vizir"
 
 #: Source/translation_dummy.cpp:241
-#, fuzzy
-#| msgid "Sapphire"
 msgctxt "monster"
 msgid "Zamphir"
 msgstr "Zamfir"
 
 #: Source/translation_dummy.cpp:242
-#, fuzzy
-#| msgid "Bloodlust"
 msgctxt "monster"
 msgid "Bloodlust"
 msgstr "Sede de Sangue"
@@ -10563,22 +10187,16 @@ msgid "Webwidow"
 msgstr "Viúvaranha"
 
 #: Source/translation_dummy.cpp:244
-#, fuzzy
-#| msgid "Fleshdancer"
 msgctxt "monster"
 msgid "Fleshdancer"
 msgstr "Dançarina da Carne"
 
 #: Source/translation_dummy.cpp:245
-#, fuzzy
-#| msgid "Grimspike"
 msgctxt "monster"
 msgid "Grimspike"
 msgstr "Espinebroso"
 
 #: Source/translation_dummy.cpp:246
-#, fuzzy
-#| msgid "Doomlock"
 msgctxt "monster"
 msgid "Doomlock"
 msgstr "Perdentrave"


### PR DESCRIPTION
Summary:

Fixed "Damage to Enemy" translation #7824

Replaced all the enemies with Lord in their names from "Senhor" to "Lorde" so it matches Diablo's name "O Lorde Sombrio".

I also Replaced all the enemies with Red in their names from "Vermelho(a)" to "Rubro(a)" I think it sounds better for ~an older~ a medieval game.

I also tweaked a few monster names:

Stinger -> ~Ferrão~ Ferroador
Psychorb -> Psicorbe
Felltwin -> Geminígio


Closes #7824