### PR TITLE
[1.5] Fix CI building

### DIFF
--- a/.github/workflows/Linux_aarch64.yml
+++ b/.github/workflows/Linux_aarch64.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/Linux_aarch64.yml
+++ b/.github/workflows/Linux_aarch64.yml
@@ -31,9 +31,6 @@ jobs:
 
     - name: Create Build Environment
       run: |
-        # Work around the somewhat broken packages in the GitHub Actions Ubuntu 20.04 image.
-        # https://github.com/actions/runner-images/issues/4620#issuecomment-981333260
-        sudo apt-get -y install --allow-downgrades libpcre2-8-0=10.34-7
         Packaging/nix/debian-cross-aarch64-prep.sh
 
     - name: Cache CMake build folder

--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/Linux_x86.yml
+++ b/.github/workflows/Linux_x86.yml
@@ -31,9 +31,6 @@ jobs:
 
     - name: Create Build Environment
       run: |
-        # Work around the somewhat broken packages in the GitHub Actions Ubuntu 20.04 image.
-        # https://github.com/actions/runner-images/issues/4620#issuecomment-981333260
-        sudo apt-get -y install --allow-downgrades libpcre2-8-0=10.34-7
         Packaging/nix/debian-cross-i386-prep.sh
 
     - name: Cache CMake build folder

--- a/.github/workflows/Linux_x86_64.yml
+++ b/.github/workflows/Linux_x86_64.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/3rdParty/libzt/CMakeLists.txt
+++ b/3rdParty/libzt/CMakeLists.txt
@@ -5,7 +5,7 @@ set(BUILD_HOST_SELFTEST OFF)
 include(FetchContent)
 FetchContent_Declare(libzt
   GIT_REPOSITORY https://github.com/diasurgical/libzt.git
-  GIT_TAG d6c6a069a5041a3e89594c447ced3f15d77618b8)
+  GIT_TAG 72a518bcf7d87e32f718ca612ce2c8303ceedd12)
 FetchContent_MakeAvailableExcludeFromAll(libzt)
 
 if(NOT ANDROID)


### PR DESCRIPTION
This turned out to be more than just a one-liner:

* Upgrades Linux CI runners to 22.04, 20.04 was deprecated and removed, see: https://github.com/actions/runner-images/issues/11101
* Removes unneeded workaround
* Backports https://github.com/diasurgical/libzt/commit/72a518bcf7d87e32f718ca612ce2c8303ceedd12 since CI updated CMake to 4.0 and CMake 3.5 compatibility was removed

Required for https://github.com/diasurgical/DevilutionX/pull/7936