### PR TITLE
[Bugfix] Fix Life Crash/Death Loop

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2951,10 +2951,7 @@ void RestartTownLvl(Player &player)
 	player._pManaBase = player._pMana - (player._pMaxMana - player._pMaxManaBase);
 
 	CalcPlrInv(player, false);
-
-	if ((player._pHitPoints >> 6) <= 0)
-		SetPlayerHitPoints(player, 1 << 6);
-
+	SetPlayerHitPoints(player, 1 << 6);
 	player._pmode = PM_NEWLVL;
 
 	if (&player == MyPlayer) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2947,12 +2947,14 @@ void RestartTownLvl(Player &player)
 	player.setLevel(0);
 	player._pInvincible = false;
 
-	SetPlayerHitPoints(player, 64);
-
 	player._pMana = 0;
 	player._pManaBase = player._pMana - (player._pMaxMana - player._pMaxManaBase);
 
 	CalcPlrInv(player, false);
+
+	if (player._pHitPoints <= 0)
+		SetPlayerHitPoints(player, 1 << 6);
+
 	player._pmode = PM_NEWLVL;
 
 	if (&player == MyPlayer) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2952,7 +2952,7 @@ void RestartTownLvl(Player &player)
 
 	CalcPlrInv(player, false);
 
-	if (player._pHitPoints <= 0)
+	if ((player._pHitPoints >> 6) <= 0)
 		SetPlayerHitPoints(player, 1 << 6);
 
 	player._pmode = PM_NEWLVL;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Bug Fixes
+
+#### Multiplayer
+
+- Cursed items are able to lock the player in a death loop
+
 ## DevilutionX 1.5.2
 
 ### Bug Fixes


### PR DESCRIPTION
Patches a bug that causes strange behavior when respawning in town with items that bring Life to 0 or lower. Instead of giving the player 1 Life, and then recalculating their Life via item bonuses, we first recalculate item bonuses and then set Life to 1.