### PR TITLE
[Debug] Keep trying when unique item fails to generate

### DIFF
--- a/Source/lua/modules/dev/items.cpp
+++ b/Source/lua/modules/dev/items.cpp
@@ -179,7 +179,6 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 		const std::string tmp = AsciiStrToLower(testItem._iIName);
 		if (tmp.find(itemName) != std::string::npos)
 			break;
-		return "Impossible to generate!";
 	}
 
 	int ii = AllocateItem();


### PR DESCRIPTION
The new logic makes it possible for all unique items to generate so this return statement is no longer accurate or necessary.