### PR TITLE
Adjust MP Tick Rates

### DIFF
--- a/Source/DiabloUI/multi/selgame.cpp
+++ b/Source/DiabloUI/multi/selgame.cpp
@@ -247,13 +247,13 @@ void selgame_GameSelection_Focus(size_t value)
 			case 20:
 				infoString.append(_("Speed: Normal"));
 				break;
-			case 30:
+			case 25:
 				infoString.append(_("Speed: Fast"));
 				break;
-			case 40:
+			case 30:
 				infoString.append(_("Speed: Faster"));
 				break;
-			case 50:
+			case 35:
 				infoString.append(_("Speed: Fastest"));
 				break;
 			default:


### PR DESCRIPTION
Adjusts the MP Tick Rates to being 5 apart instead of 10 apart. Allows for more granular game speed changes rather than huge noticeable changes. Additionally, having a lower maximum provides options to players that are less likely to cause desync hourglass in games.

Current MP Speed options:
100%, 150%, 200%, 250%

Proposed MP Speed options:
100%, 125%, 150%, 175%