### PR TITLE
Fix freezing the screen when changing the resolution by not recreating the renderer

### DIFF
--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -557,22 +557,17 @@ void ReinitializeRenderer()
 	}
 	AdjustToScreenGeometry(Size(surface->w, surface->h));
 #else
-	if (texture)
-		texture.reset();
-
-	FreeRenderer();
 
 	if (*GetOptions().Graphics.upscale) {
-		Uint32 rendererFlags = 0;
-
-		if (*GetOptions().Graphics.frameRateControl == FrameRateControl::VerticalSync) {
-			rendererFlags |= SDL_RENDERER_PRESENTVSYNC;
-		}
-
-		renderer = SDL_CreateRenderer(ghMainWnd, -1, rendererFlags);
+		// We don't recreate the renderer, because this can result in a freezing (not refreshing) rendering
 		if (renderer == nullptr) {
-			ErrSdl();
+			renderer = SDL_CreateRenderer(ghMainWnd, -1, 0);
+			if (renderer == nullptr) {
+				ErrSdl();
+			}
 		}
+
+		SDL_RenderSetVSync(renderer, *GetOptions().Graphics.frameRateControl == FrameRateControl::VerticalSync ? 1 : 0);
 
 		ReinitializeTexture();
 

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -567,7 +567,9 @@ void ReinitializeRenderer()
 			}
 		}
 
+#if SDL_VERSION_ATLEAST(2, 0, 18)
 		SDL_RenderSetVSync(renderer, *GetOptions().Graphics.frameRateControl == FrameRateControl::VerticalSync ? 1 : 0);
+#endif
 
 		ReinitializeTexture();
 


### PR DESCRIPTION
Fixes (at least on my machine) #7776

I could reproduce #7776 when vsync is enabled and switching resolution or fit to screen.

It looks like SDL2 doesn't like it when the renderer is recreated.
But since #7443 is merged, we don't need to recreate the renderer anymore (it will always stay be there if upscale is true). The only flag we passed to `SDL_CreateRenderer` (vsync) can be replaced by a separate function call (`SDL_RenderSetVSync`).

Tested changing: resolution, fit to screen, vsync, integer scaling.

It would be great if someone else who had errors changing one of the settings and someone else on another device (e.g. linux) could test this PR.