### PR TITLE
[1.5] Filter Chat

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -6,6 +6,7 @@ set(libdevilutionx_SRCS
   appfat.cpp
   automap.cpp
   capture.cpp
+  bannedwords.cpp
   codec.cpp
   control.cpp
   cursor.cpp

--- a/Source/bannedwords.cpp
+++ b/Source/bannedwords.cpp
@@ -1,0 +1,83 @@
+// bannedwords.cpp
+
+#include "bannedwords.hpp"
+
+#include "utils/file_util.h"
+#include "utils/log.hpp"
+#include "utils/paths.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace devilution {
+
+std::vector<std::string> BannedWords;
+
+void LoadBannedWords()
+{
+	BannedWords.clear();
+	const std::string path = paths::ConfigPath() + "bannedwords.txt";
+
+	// Create file if it doesn't exist
+	if (!FileExists(path.c_str())) {
+		if (FILE *file = OpenFile(path.c_str(), "wb")) {
+			const char *comment = "# Enter each word to be censored on its own line\n";
+			std::fwrite(comment, std::strlen(comment), 1, file);
+			std::fclose(file);
+		} else {
+			LogError("Failed to create bannedwords.txt at {}", path);
+		}
+		return;
+	}
+
+	// Read file contents
+	std::vector<char> buffer;
+	uintmax_t size = 0;
+	if (GetFileSize(path.c_str(), &size) && size > 0) {
+		buffer.resize(size);
+		if (FILE *file = OpenFile(path.c_str(), "rb")) {
+			if (std::fread(buffer.data(), size, 1, file) == 1) {
+				std::string_view content(buffer.data(), size);
+				std::string line;
+				for (size_t i = 0, start = 0; i <= content.size(); ++i) {
+					if (i == content.size() || content[i] == '\n' || content[i] == '\r') {
+						size_t end = i;
+						if (start < end) {
+							line.assign(content.substr(start, end - start));
+							if (!line.empty() && line[0] != '#') {
+								std::transform(line.begin(), line.end(), line.begin(), [](unsigned char c) { return std::tolower(c); });
+								BannedWords.push_back(line);
+							}
+						}
+						if (i + 1 < content.size() && content[i] == '\r' && content[i + 1] == '\n')
+							i++;
+						start = i + 1;
+					}
+				}
+			} else {
+				LogError("Failed to read bannedwords.txt at {}", path);
+			}
+			std::fclose(file);
+		}
+	}
+}
+
+std::string CensorMessage(const std::string &original)
+{
+	std::string result = original;
+	std::string lowered = original;
+	std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) { return std::tolower(c); });
+
+	for (const std::string &word : BannedWords) {
+		size_t pos = 0;
+		while ((pos = lowered.find(word, pos)) != std::string::npos) {
+			result.replace(pos, word.size(), word.size(), '*');
+			lowered.replace(pos, word.size(), word.size(), '*'); // keep lowered in sync
+			pos += word.size();
+		}
+	}
+
+	return result;
+}
+
+} // namespace devilution

--- a/Source/bannedwords.hpp
+++ b/Source/bannedwords.hpp
@@ -1,0 +1,13 @@
+// bannedwords.hpp
+
+#include <string>
+#include <vector>
+
+namespace devilution {
+
+void LoadBannedWords();
+std::string CensorMessage(const std::string &original);
+
+extern std::vector<std::string> BannedWords;
+
+} // namespace devilution

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -12,6 +12,7 @@
 #define SI_NO_CONVERSION
 #include <SimpleIni.h>
 
+#include "bannedwords.hpp"
 #include "control.h"
 #include "controls/controller.h"
 #include "controls/game_controls.h"
@@ -375,6 +376,8 @@ void LoadOptions()
 
 	if (demo::IsRunning())
 		demo::OverrideOptions();
+
+	LoadBannedWords();
 }
 
 void SaveOptions()
@@ -825,10 +828,10 @@ void OptionEntryResolution::SetActiveListIndex(size_t index)
 
 OptionEntryResampler::OptionEntryResampler()
     : OptionEntryListBase("Resampler", OptionEntryFlags::CantChangeInGame
-            // When there are exactly 2 options there is no submenu, so we need to recreate the UI
-            // to reflect the change in the "Resampling quality" setting visibility.
-            | (NumResamplers == 2 ? OptionEntryFlags::RecreateUI : OptionEntryFlags::None),
-        N_("Resampler"), N_("Audio resampler"))
+              // When there are exactly 2 options there is no submenu, so we need to recreate the UI
+              // to reflect the change in the "Resampling quality" setting visibility.
+              | (NumResamplers == 2 ? OptionEntryFlags::RecreateUI : OptionEntryFlags::None),
+          N_("Resampler"), N_("Audio resampler"))
 {
 }
 void OptionEntryResampler::LoadFromIni(string_view category)

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -10,6 +10,7 @@
 
 #include <fmt/format.h>
 
+#include "bannedwords.hpp"
 #include "control.h"
 #include "engine/render/text_render.hpp"
 #include "inv.h"
@@ -85,7 +86,7 @@ void SendPlrMsg(Player &player, string_view text)
 
 	message.style = UiFlags::ColorWhite;
 	message.time = SDL_GetTicks();
-	message.text = from + std::string(text);
+	message.text = from + CensorMessage(std::string(text));
 	message.from = string_view(message.text.data(), from.size());
 	message.lineHeight = GetLineHeight(message.text, GameFont12) + 3;
 	AddMessageToChatLog(text, &player);


### PR DESCRIPTION
Adds a new file in the config directory `bannedwords.txt`. This file accepts a word on each line to be filtered in Multiplayer chat.

Fixes: https://github.com/diasurgical/DevilutionX/issues/7964