### PR TITLE
nix/*.desktop: add Keywords fields

### DIFF
--- a/Packaging/nix/devilutionx-hellfire.desktop
+++ b/Packaging/nix/devilutionx-hellfire.desktop
@@ -14,3 +14,4 @@ Type=Application
 X-DCOP-ServiceType=Multi
 X-KDE-StartupNotify=true
 Categories=Game;RolePlaying;
+Keywords=Game;Diablo;Hellfire;Action;RPG;DevilutionX;

--- a/Packaging/nix/devilutionx.6
+++ b/Packaging/nix/devilutionx.6
@@ -1,11 +1,11 @@
 .TH DEVILUTIONX 6 "May 2025" "1.5.4" "DevilutionX Community"
 .SH NAME
-devilutionx \- A source port of Diablo and Hellfire
+devilutionx \- A port of Diablo and Hellfire
 .SH SYNOPSIS
 devilutionx [OPTION]
 .SH DESCRIPTION
 .I DevilutionX
-is a source port of
+is a port of
 .B Diablo
 and
 .B Hellfire

--- a/Packaging/nix/devilutionx.6
+++ b/Packaging/nix/devilutionx.6
@@ -1,0 +1,134 @@
+.TH DEVILUTIONX 6 "May 2025" "1.5.4" "DevilutionX Community"
+.SH NAME
+devilutionx \- A source port of Diablo and Hellfire
+.SH SYNOPSIS
+devilutionx [OPTION]
+.SH DESCRIPTION
+.I DevilutionX
+is a source port of
+.B Diablo
+and
+.B Hellfire
+that strives to make it simple to run the game while providing engine improvements, bugfixes, and some optional quality of life features.
+.SH OPTIONS
+.TP
+.B \-h, \-\-help
+Print this message and exit.
+.TP
+.B \-\-version
+Print the version and exit.
+.TP
+.B \-\-data\-dir
+Specify the folder of
+.I diabdat.mpq.
+.TP
+.B \-\-save\-dir
+Specify the folder of save files.
+.TP
+.B \-\-config\-dir
+Specify the location of
+.I diablo.ini.
+.TP
+.B \-\-lang
+Specify the language code (e.g.
+.I en
+or
+.I pt_BR
+).
+.TP
+.B \-n
+Skip startup videos.
+.TP
+.B \-f
+Display frames per second.
+.TP
+.B \-\-verbose
+Enable verbose logging.
+.TP
+.B \-\-record \fI<#>\fR
+Record a demo file.
+.TP
+.B \-\-demo \fI<#>\fR
+Play a demo file.
+.TP
+.B \-\-timedemo
+Disable all frame limiting during demo playback.
+.SH GAME SELECTION
+.TP
+.B \-\-spawn
+Force Shareware mode.
+.TP
+.B \-\-diablo
+Force Diablo mode.
+.TP
+.B \-\-hellfire
+Force Hellfire mode.
+.SH HELLFIRE OPTIONS
+Refer to the official documentation for more details on Hellfire options.
+.SH MULTI-PLAYER
+TCP/IP requires the host to expose port 6112. All games are encrypted and password protected.
+.SH SAVE GAMES AND CONFIGURATIONS
+The configurations and save games are located in:
+.I ~/.local/share/diasurgical/devilution
+.SH INSTALLATION
+To install
+.B DevilutionX:
+.IP 1.
+Extract the files in the archive.
+.IP 2.
+Install
+.B libsdl2.
+.IP 3.
+Copy
+.I DIABDAT.MPQ
+from the CD or GOG-installation (or extract it from the GoG installer) to the DevilutionX folder.
+.IP 4.
+To run the Diablo: Hellfire expansion you will need to also copy
+.I hellfire.mpq, hfmonk.mpq, hfmusic.mpq, hfvoice.mpq.
+.IP 5.
+For Chinese, Japanese, and Korean text support download
+.UR https://github.com/diasurgical/devilutionx-assets/releases/latest/download/fonts.mpq
+and add it to the game folder.
+.IP 6.
+For the Polish voice pack download
+.UR https://github.com/diasurgical/devilutionx-assets/releases/latest/download/pl.mpq.
+.IP 7.
+For the Russian voice pack download
+.UR https://github.com/diasurgical/devilutionx-assets/releases/latest/download/ru.mpq.
+.IP 8.
+Run
+.B ./devilutionx
+.SH REPORTING BUGS
+Report bugs at
+.B https://github.com/diasurgical/devilutionX/
+
+.SH SEE ALSO
+Discord:
+.B https://discord.gg/devilutionx
+.RE
+
+.PP
+GitHub:
+.B https://github.com/diasurgical/devilutionX
+.RE
+
+.PP
+Manual:
+.B https://github.com/diasurgical/devilutionX/wiki
+.RE
+
+.PP
+Changelog:
+.B https://github.com/diasurgical/devilutionX/blob/master/docs/CHANGELOG.md
+.RE
+
+.SH AUTHOR
+Written by the DevilutionX community.
+.SH COPYRIGHT
+This software is being released to the Public Domain. No assets of Diablo are being provided. You must own a copy of Diablo and have access to the assets beforehand in order to use this software.
+.P
+Battle.net® - Copyright © 1996 Blizzard Entertainment, Inc. All rights reserved. Battle.net and Blizzard Entertainment are trademarks or registered trademarks of Blizzard Entertainment, Inc. in the U.S. and/or other countries.
+.P
+Diablo® - Copyright © 1996 Blizzard Entertainment, Inc. All rights reserved. Diablo and Blizzard Entertainment are trademarks or registered trademarks of Blizzard Entertainment, Inc. in the U.S. and/or other countries.
+.P
+This software is in no way associated with or endorsed by Blizzard Entertainment®.

--- a/Packaging/nix/devilutionx.6
+++ b/Packaging/nix/devilutionx.6
@@ -84,42 +84,48 @@ from the CD or GOG-installation (or extract it from the GOG installer) to the De
 To run the Diablo: Hellfire expansion you will need to also copy
 .I hellfire.mpq, hfmonk.mpq, hfmusic.mpq, hfvoice.mpq.
 .IP 5.
-For Chinese, Japanese, and Korean text support download
-.UR https://github.com/diasurgical/devilutionx-assets/releases/latest/download/fonts.mpq
+For Chinese, Japanese, and Korean text support download:
+
+.B https://github.com/diasurgical/devilutionx-assets/releases/latest/download/fonts.mpq
+
 and add it to the game folder.
+.RE
+
 .IP 6.
-For the Polish voice pack download
-.UR https://github.com/diasurgical/devilutionx-assets/releases/latest/download/pl.mpq.
+For the Polish voice pack download:
+
+.B https://github.com/diasurgical/devilutionx-assets/releases/latest/download/pl.mpq
 .IP 7.
-For the Russian voice pack download
-.UR https://github.com/diasurgical/devilutionx-assets/releases/latest/download/ru.mpq.
+For the Russian voice pack download:
+
+.B https://github.com/diasurgical/devilutionx-assets/releases/latest/download/ru.mpq
+
+.IP 8.
+For the Spanish voice pack download:
+
+.B https://github.com/diasurgical/devilutionx-assets/releases/latest/download/es.mpq
 .IP 8.
 Run
 .B ./devilutionx
 .SH REPORTING BUGS
 Report bugs at
 .B https://github.com/diasurgical/devilutionX/
-
 .SH SEE ALSO
 Discord:
 .B https://discord.gg/devilutionx
 .RE
-
 .PP
 GitHub:
 .B https://github.com/diasurgical/devilutionX
 .RE
-
 .PP
 Manual:
 .B https://github.com/diasurgical/devilutionX/wiki
 .RE
-
 .PP
 Changelog:
 .B https://github.com/diasurgical/devilutionX/blob/master/docs/CHANGELOG.md
 .RE
-
 .SH AUTHOR
 Written by the DevilutionX community.
 .SH COPYRIGHT

--- a/Packaging/nix/devilutionx.6
+++ b/Packaging/nix/devilutionx.6
@@ -129,10 +129,12 @@ Changelog:
 .SH AUTHOR
 Written by the DevilutionX community.
 .SH COPYRIGHT
-This software is being released to the Public Domain. No assets of Diablo are being provided. You must own a copy of Diablo and have access to the assets beforehand in order to use this software.
+DevilutionX is made publicly available and released under the Sustainable Use License (see LICENSE).
+
+.B https://github.com/diasurgical/DevilutionX/blob/master/LICENSE.md
 .P
-Battle.net® - Copyright © 1996 Blizzard Entertainment, Inc. All rights reserved. Battle.net and Blizzard Entertainment are trademarks or registered trademarks of Blizzard Entertainment, Inc. in the U.S. and/or other countries.
+The source code in this repository is for non-commercial use only. If you use the source code, you may not charge others for access to it or any derivative work thereof.
 .P
 Diablo® - Copyright © 1996 Blizzard Entertainment, Inc. All rights reserved. Diablo and Blizzard Entertainment are trademarks or registered trademarks of Blizzard Entertainment, Inc. in the U.S. and/or other countries.
 .P
-This software is in no way associated with or endorsed by Blizzard Entertainment®.
+DevilutionX and any of its maintainers are in no way associated with or endorsed by Blizzard Entertainment®.

--- a/Packaging/nix/devilutionx.6
+++ b/Packaging/nix/devilutionx.6
@@ -63,8 +63,6 @@ Force Diablo mode.
 .TP
 .B \-\-hellfire
 Force Hellfire mode.
-.SH HELLFIRE OPTIONS
-Refer to the official documentation for more details on Hellfire options.
 .SH MULTI-PLAYER
 TCP/IP requires the host to expose port 6112. All games are encrypted and password protected.
 .SH SAVE GAMES AND CONFIGURATIONS

--- a/Packaging/nix/devilutionx.6
+++ b/Packaging/nix/devilutionx.6
@@ -13,7 +13,7 @@ that strives to make it simple to run the game while providing engine improvemen
 .SH OPTIONS
 .TP
 .B \-h, \-\-help
-Print this message and exit.
+This lists all command line options and exit.
 .TP
 .B \-\-version
 Print the version and exit.

--- a/Packaging/nix/devilutionx.6
+++ b/Packaging/nix/devilutionx.6
@@ -64,7 +64,7 @@ Force Diablo mode.
 .B \-\-hellfire
 Force Hellfire mode.
 .SH MULTI-PLAYER
-TCP/IP requires the host to expose port 6112. All games are encrypted and password protected.
+TCP/IP requires the host to expose the port the game is listening on, 6112 by default. Private games are encrypted and password protected.
 .SH SAVE GAMES AND CONFIGURATIONS
 The configurations and save games are located in:
 .I ~/.local/share/diasurgical/devilution

--- a/Packaging/nix/devilutionx.6
+++ b/Packaging/nix/devilutionx.6
@@ -66,7 +66,7 @@ Force Hellfire mode.
 .SH MULTI-PLAYER
 TCP/IP requires the host to expose the port the game is listening on, 6112 by default. Private games are encrypted and password protected.
 .SH SAVE GAMES AND CONFIGURATIONS
-The configurations and save games are located in:
+By default the configurations and save games are located in:
 .I ~/.local/share/diasurgical/devilution
 .SH INSTALLATION
 To install

--- a/Packaging/nix/devilutionx.6
+++ b/Packaging/nix/devilutionx.6
@@ -79,7 +79,7 @@ Install
 .IP 3.
 Copy
 .I DIABDAT.MPQ
-from the CD or GOG-installation (or extract it from the GoG installer) to the DevilutionX folder.
+from the CD or GOG-installation (or extract it from the GOG installer) to the DevilutionX folder.
 .IP 4.
 To run the Diablo: Hellfire expansion you will need to also copy
 .I hellfire.mpq, hfmonk.mpq, hfmusic.mpq, hfvoice.mpq.

--- a/Packaging/nix/devilutionx.desktop
+++ b/Packaging/nix/devilutionx.desktop
@@ -14,3 +14,4 @@ Type=Application
 X-DCOP-ServiceType=Multi
 X-KDE-StartupNotify=true
 Categories=Game;RolePlaying;
+Keywords=Game;Diablo;Action;RPG;DevilutionX;


### PR DESCRIPTION
1. desktop-entry-lacks-keywords-entry

This .desktop file is either missing a Keywords entry, or it does not contain keywords above and beyond those already present in the Name or GenericName entries.

2. no-manual-page

Each binary in /usr/bin, /usr/sbin, /bin, /sbin or /usr/games should have a manual page.

Could you write a manual for the devilutionx binary? I see the description of the devilutionx --help options, but I don't see a manual. That would be cool!

These tasks from:
https://github.com/diasurgical/DevilutionX/issues/7971

Please check the text from `devilutionx.6` carefully, is it correct?

You can read it:
`$ man ./devilutionx.6 `