### PR TITLE
Use paths::GetBasePath() so it can be freed

### DIFF
--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -491,7 +491,7 @@ void LoadModArchives(std::span<const std::string_view> modnames)
 		if (FileExists(targetPath)) {
 			OverridePaths.emplace_back(targetPath);
 		}
-		targetPath = StrCat(SDL_GetBasePath(), "mods" DIRECTORY_SEPARATOR_STR, modname, DIRECTORY_SEPARATOR_STR);
+		targetPath = StrCat(paths::BasePath(), "mods" DIRECTORY_SEPARATOR_STR, modname, DIRECTORY_SEPARATOR_STR);
 		if (FileExists(targetPath)) {
 			OverridePaths.emplace_back(targetPath);
 		}


### PR DESCRIPTION
Fixes the following ASAN error.

```
==24753==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 54 byte(s) in 1 object(s) allocated from:
    #0 0x7fe12c6f3b58 in realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:85
    #1 0x7fe12c488c45  (/lib/x86_64-linux-gnu/libSDL2-2.0.so.0+0xa8c45) (BuildId: ba11ec6cc627e78ef7103144630792da02ed18b6)
    #2 0x7fe12893bd27  (<unknown module>)
    #3 0x7fe12893bedf  (<unknown module>)
    #4 0x562c1ec81c7d in devilution::LuaReloadActiveMods() .../DevilutionX/Source/lua/lua.cpp:219
    #5 0x562c1ec84657 in devilution::LuaInitialize() .../DevilutionX/Source/lua/lua.cpp:284
    #6 0x562c1e566412 in devilution::DiabloMain(int, char**) .../DevilutionX/Source/diablo.cpp:2608
    #7 0x562c1dbfef35 in main .../DevilutionX/Source/main.cpp:52
    #8 0x7fe12b633ca7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 54 byte(s) leaked in 1 allocation(s).
```