### PR TITLE
Validation of network packet lengths and deltas

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -152,6 +152,8 @@ set(libdevilutionx_SRCS
   qol/stash.cpp
   qol/xpbar.cpp
 
+  quests/validation.cpp
+
   storm/storm_net.cpp
   storm/storm_svid.cpp
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -130,6 +130,8 @@ set(libdevilutionx_SRCS
   lua/modules/towners.cpp
   lua/repl.cpp
 
+  monsters/validation.cpp
+
   panels/charpanel.cpp
   panels/console.cpp
   panels/info_box.cpp

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -142,6 +142,8 @@ set(libdevilutionx_SRCS
 
   platform/locale.cpp
 
+  portals/validation.cpp
+
   qol/autopickup.cpp
   qol/chatlog.cpp
   qol/floatingnumbers.cpp

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -422,12 +422,6 @@ void AppendArenaOverview(std::string &ret)
 	}
 }
 
-const dungeon_type DungeonTypeForArena[] = {
-	dungeon_type::DTYPE_CATHEDRAL, // SL_ARENA_CHURCH
-	dungeon_type::DTYPE_HELL,      // SL_ARENA_HELL
-	dungeon_type::DTYPE_HELL,      // SL_ARENA_CIRCLE_OF_LIFE
-};
-
 std::string TextCmdArena(const std::string_view parameter)
 {
 	std::string ret;
@@ -455,7 +449,7 @@ std::string TextCmdArena(const std::string_view parameter)
 		return ret;
 	}
 
-	setlvltype = DungeonTypeForArena[arenaLevel - SL_FIRST_ARENA];
+	setlvltype = GetArenaLevelType(arenaLevel);
 	StartNewLvl(*MyPlayer, WM_DIABSETLVL, arenaLevel);
 	return ret;
 }

--- a/Source/encrypt.h
+++ b/Source/encrypt.h
@@ -11,6 +11,6 @@
 namespace devilution {
 
 uint32_t PkwareCompress(std::byte *srcData, uint32_t size);
-void PkwareDecompress(std::byte *inBuff, uint32_t recvSize, int maxBytes);
+uint32_t PkwareDecompress(std::byte *inBuff, uint32_t recvSize, size_t maxBytes);
 
 } // namespace devilution

--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -10,6 +10,7 @@
 
 #include "items.h"
 #include "monstdat.h"
+#include "msg.h"
 #include "player.h"
 #include "spells.h"
 #include "utils/is_of.hpp"
@@ -173,6 +174,24 @@ bool IsItemValid(const Player &player, const Item &item)
 		return IsHellfireSpellBookValid(item);
 
 	return IsDungeonItemValid(item._iCreateInfo, item.dwBuff);
+}
+
+bool IsItemDeltaValid(const TCmdPItem &itemDelta)
+{
+	if (itemDelta.bCmd == CMD_INVALID)
+		return true;
+	if (IsNoneOf(itemDelta.bCmd, TCmdPItem::FloorItem, TCmdPItem::PickedUpItem, TCmdPItem::DroppedItem))
+		return false;
+	if (!InDungeonBounds({ itemDelta.x, itemDelta.y }))
+		return false;
+	_item_indexes idx = static_cast<_item_indexes>(SDL_SwapLE16(itemDelta.def.wIndx));
+	if (idx == IDI_EAR)
+		return true;
+	if (!IsItemAvailable(idx))
+		return false;
+	Item item = {};
+	RecreateItem(*MyPlayer, itemDelta.item, item);
+	return IsItemValid(*MyPlayer, item);
 }
 
 } // namespace devilution

--- a/Source/items/validation.h
+++ b/Source/items/validation.h
@@ -7,11 +7,12 @@
 
 #include <cstdint>
 
+namespace devilution {
+
 // Forward declared structs to avoid circular dependencies
 struct Item;
+struct TCmdPItem;
 struct Player;
-
-namespace devilution {
 
 bool IsCreationFlagComboValid(uint16_t iCreateInfo);
 bool IsTownItemValid(uint16_t iCreateInfo, const Player &player);
@@ -19,5 +20,6 @@ bool IsShopPriceValid(const Item &item);
 bool IsUniqueMonsterItemValid(uint16_t iCreateInfo, uint32_t dwBuff);
 bool IsDungeonItemValid(uint16_t iCreateInfo, uint32_t dwBuff);
 bool IsItemValid(const Player &player, const Item &item);
+bool IsItemDeltaValid(const TCmdPItem &itemDelta);
 
 } // namespace devilution

--- a/Source/levels/setmaps.h
+++ b/Source/levels/setmaps.h
@@ -5,7 +5,25 @@
  */
 #pragma once
 
+#include "levels/gendung.h"
+
 namespace devilution {
+
+/**
+ * @brief Get the tile type used to render the given arena level
+ */
+inline dungeon_type GetArenaLevelType(_setlevels arenaLevel)
+{
+	constexpr dungeon_type DungeonTypeForArena[] = {
+		dungeon_type::DTYPE_CATHEDRAL, // SL_ARENA_CHURCH
+		dungeon_type::DTYPE_HELL,      // SL_ARENA_HELL
+		dungeon_type::DTYPE_HELL,      // SL_ARENA_CIRCLE_OF_LIFE
+	};
+
+	constexpr size_t arenaCount = sizeof(DungeonTypeForArena) / sizeof(dungeon_type);
+	const size_t index = arenaLevel - SL_FIRST_ARENA;
+	return index < arenaCount ? DungeonTypeForArena[index] : DTYPE_NONE;
+}
 
 /**
  * @brief Load a quest map, the given map is specified via the global setlvlnum

--- a/Source/monsters/validation.cpp
+++ b/Source/monsters/validation.cpp
@@ -1,0 +1,42 @@
+/**
+ * @file monsters/validation.cpp
+ *
+ * Implementation of functions for validation of monster data.
+ */
+
+#include "monsters/validation.hpp"
+
+#include <cstddef>
+
+#include "monster.h"
+#include "player.h"
+
+namespace devilution {
+
+namespace {
+
+bool IsEnemyValid(size_t enemyId, bool checkMonsterTable)
+{
+	if (enemyId < MaxMonsters)
+		return !checkMonsterTable || Monsters[enemyId].hitPoints > 0;
+	const size_t playerId = enemyId - MaxMonsters;
+	return playerId < Players.size() && Players[playerId].plractive;
+}
+
+} // namespace
+
+bool IsEnemyIdValid(size_t enemyId)
+{
+	return IsEnemyValid(enemyId, false);
+}
+
+bool IsEnemyValid(size_t monsterId, size_t enemyId)
+{
+	if (monsterId >= MaxMonsters)
+		return false;
+	if (monsterId == enemyId)
+		return false;
+	return IsEnemyValid(enemyId, true);
+}
+
+} // namespace devilution

--- a/Source/monsters/validation.hpp
+++ b/Source/monsters/validation.hpp
@@ -1,0 +1,15 @@
+/**
+ * @file monsters/validation.hpp
+ *
+ * Interface of functions for validation of monster data.
+ */
+#pragma once
+
+#include <cstddef>
+
+namespace devilution {
+
+bool IsEnemyIdValid(size_t enemyId);
+bool IsEnemyValid(size_t monsterId, size_t enemyId);
+
+} // namespace devilution

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -618,13 +618,13 @@ const std::byte *DeltaImportMonster(const std::byte *src, const std::byte *end, 
 
 std::byte *DeltaExportSpawnedMonsters(std::byte *dst, const ankerl::unordered_dense::map<size_t, DSpawnedMonster> &spawnedMonsters)
 {
-	auto &size = *reinterpret_cast<uint16_t *>(dst);
-	size = static_cast<uint16_t>(spawnedMonsters.size());
+	uint16_t size = SDL_SwapLE16(static_cast<uint16_t>(spawnedMonsters.size()));
+	memcpy(dst, &size, sizeof(uint16_t));
 	dst += sizeof(uint16_t);
 
 	for (const auto &deltaSpawnedMonster : spawnedMonsters) {
-		auto &monsterId = *reinterpret_cast<uint16_t *>(dst);
-		monsterId = static_cast<uint16_t>(deltaSpawnedMonster.first);
+		uint16_t monsterId = SDL_SwapLE16(static_cast<uint16_t>(deltaSpawnedMonster.first));
+		memcpy(dst, &monsterId, sizeof(uint16_t));
 		dst += sizeof(uint16_t);
 
 		memcpy(dst, &deltaSpawnedMonster.second, sizeof(DSpawnedMonster));
@@ -639,7 +639,10 @@ const std::byte *DeltaImportSpawnedMonsters(const std::byte *src, const std::byt
 	if (src == nullptr || src + sizeof(uint16_t) > end)
 		return nullptr;
 
-	uint16_t size = *reinterpret_cast<const uint16_t *>(src);
+	uint16_t size;
+	memcpy(&size, src, sizeof(uint16_t));
+	size = SDL_SwapLE16(size);
+	src += sizeof(uint16_t);
 	if (size > MaxMonsters)
 		return nullptr;
 
@@ -647,11 +650,12 @@ const std::byte *DeltaImportSpawnedMonsters(const std::byte *src, const std::byt
 	if (src + requiredBytes > end)
 		return nullptr;
 
-	src += sizeof(uint16_t);
-
 	for (size_t i = 0; i < size; i++) {
-		uint16_t monsterId = *reinterpret_cast<const uint16_t *>(src);
+		uint16_t monsterId;
+		memcpy(&monsterId, src, sizeof(uint16_t));
+		monsterId = SDL_SwapLE16(monsterId);
 		src += sizeof(uint16_t);
+
 		DSpawnedMonster spawnedMonster;
 		memcpy(&spawnedMonster, src, sizeof(DSpawnedMonster));
 		src += sizeof(DSpawnedMonster);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -685,7 +685,7 @@ std::byte *DeltaExportJunk(std::byte *dst)
 		sgJunk.quests[q].qstate = quest._qactive;
 		sgJunk.quests[q].qvar1 = quest._qvar1;
 		sgJunk.quests[q].qvar2 = quest._qvar2;
-		sgJunk.quests[q].qmsg = static_cast<int16_t>(quest._qmsg);
+		sgJunk.quests[q].qmsg = SDL_SwapLE16(static_cast<int16_t>(quest._qmsg));
 		memcpy(dst, &sgJunk.quests[q], sizeof(MultiQuests));
 		dst += sizeof(MultiQuests);
 		q++;
@@ -2285,7 +2285,7 @@ size_t OnSyncQuest(const TCmdQuest &message, Player &player)
 		SendPacket(player, &message, sizeof(message));
 	} else {
 		if (&player != MyPlayer && message.q < MAXQUESTS && message.qstate <= QUEST_HIVE_DONE)
-			SetMultiQuest(message.q, message.qstate, message.qlog != 0, message.qvar1, message.qvar2, message.qmsg);
+			SetMultiQuest(message.q, message.qstate, message.qlog != 0, message.qvar1, message.qvar2, SDL_SwapLE16(message.qmsg));
 	}
 
 	return sizeof(message);
@@ -2671,7 +2671,7 @@ void DeltaSyncJunk()
 			quest._qactive = sgJunk.quests[q].qstate;
 			quest._qvar1 = sgJunk.quests[q].qvar1;
 			quest._qvar2 = sgJunk.quests[q].qvar2;
-			quest._qmsg = static_cast<_speech_id>(sgJunk.quests[q].qmsg);
+			quest._qmsg = static_cast<_speech_id>(SDL_SwapLE16(sgJunk.quests[q].qmsg));
 		}
 		q++;
 	}
@@ -3071,7 +3071,7 @@ void NetSendCmdQuest(bool bHiPri, const Quest &quest)
 	cmd.qlog = quest._qlog ? 1 : 0;
 	cmd.qvar1 = quest._qvar1;
 	cmd.qvar2 = quest._qvar2;
-	cmd.qmsg = quest._qmsg;
+	cmd.qmsg = SDL_SwapLE16(quest._qmsg);
 
 	if (bHiPri)
 		NetSendHiPri(MyPlayerId, (std::byte *)&cmd, sizeof(cmd));

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -39,6 +39,7 @@
 #include "pack.h"
 #include "pfile.h"
 #include "plrmsg.h"
+#include "portals/validation.hpp"
 #include "spells.h"
 #include "storm/storm_net.hpp"
 #include "sync.h"
@@ -288,6 +289,12 @@ Item ItemLimbo;
 
 /** @brief Last sent player command for the local player. */
 TCmdLocParam5 lastSentPlayerCmd;
+
+bool IsPortalDeltaValid(const DPortal &portal)
+{
+	const WorldTilePosition position { portal.x, portal.y };
+	return IsPortalDeltaValid(position, portal.level, portal.ltype, portal.setlvl);
+}
 
 uint8_t GetLevelForMultiplayer(uint8_t level, bool isSetLevel)
 {
@@ -689,6 +696,8 @@ const std::byte *DeltaImportJunk(const std::byte *src, const std::byte *end)
 			if (src + sizeof(DPortal) > end)
 				return nullptr;
 			memcpy(&sgJunk.portal[i], src, sizeof(DPortal));
+			if (!IsPortalDeltaValid(sgJunk.portal[i]))
+				memset(&sgJunk.portal[i], 0xFF, sizeof(DPortal));
 			src += sizeof(DPortal);
 		}
 	}

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -499,6 +499,8 @@ size_t DeltaImportItem(const std::byte *src, TCmdPItem *dst)
 			size++;
 		} else {
 			memcpy(dst, &src[size], sizeof(TCmdPItem));
+			if (!IsItemDeltaValid(*dst))
+				memset(dst, 0xFF, sizeof(TCmdPItem));
 			size += sizeof(TCmdPItem);
 		}
 	}

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -26,6 +26,7 @@
 #include "engine/random.hpp"
 #include "engine/world_tile.hpp"
 #include "gamemenu.h"
+#include "items/validation.h"
 #include "levels/crypt.h"
 #include "levels/town.h"
 #include "levels/trigs.h"

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1842,7 +1842,7 @@ size_t OnRequestSpawnGolem(const TCmdLocParam1 &message, const Player &player)
 
 	const WorldTilePosition position { message.x, message.y };
 
-	if (player.isLevelOwnedByLocalClient() && InDungeonBounds(position))
+	if (player.plrlevel > 0 && player.isLevelOwnedByLocalClient() && InDungeonBounds(position))
 		SpawnGolem(player, position, static_cast<uint8_t>(message.wParam1));
 
 	return sizeof(message);
@@ -2390,6 +2390,8 @@ size_t OnOpenGrave(const TCmd &cmd)
 size_t OnSpawnMonster(const TCmdSpawnMonster &message, const Player &player)
 {
 	if (gbBufferMsgs == 1)
+		return sizeof(message);
+	if (player.plrlevel == 0)
 		return sizeof(message);
 
 	const WorldTilePosition position { message.x, message.y };

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -40,6 +40,7 @@
 #include "pfile.h"
 #include "plrmsg.h"
 #include "portals/validation.hpp"
+#include "quests/validation.hpp"
 #include "spells.h"
 #include "storm/storm_net.hpp"
 #include "sync.h"
@@ -294,6 +295,11 @@ bool IsPortalDeltaValid(const DPortal &portal)
 {
 	const WorldTilePosition position { portal.x, portal.y };
 	return IsPortalDeltaValid(position, portal.level, portal.ltype, portal.setlvl);
+}
+
+bool IsQuestDeltaValid(quest_id qidx, const MultiQuests &quest)
+{
+	return IsQuestDeltaValid(qidx, quest.qstate, quest.qlog, quest.qmsg);
 }
 
 uint8_t GetLevelForMultiplayer(uint8_t level, bool isSetLevel)
@@ -711,6 +717,9 @@ const std::byte *DeltaImportJunk(const std::byte *src, const std::byte *end)
 			return nullptr;
 		}
 		memcpy(&sgJunk.quests[q], src, sizeof(MultiQuests));
+		if (!IsQuestDeltaValid(static_cast<quest_id>(qidx), sgJunk.quests[q])) {
+			sgJunk.quests[q].qstate = QUEST_INVALID;
+		}
 		src += sizeof(MultiQuests);
 		q++;
 	}

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -756,6 +756,7 @@ void NetSendCmdDamage(bool bHiPri, const Player &player, uint32_t dwDam, DamageT
 void NetSendCmdMonDmg(bool bHiPri, uint16_t wMon, uint32_t dwDam);
 void NetSendCmdString(uint32_t pmask, const char *pszStr);
 void delta_close_portal(const Player &player);
-size_t ParseCmd(uint8_t pnum, const TCmd *pCmd);
+bool ValidateCmdSize(size_t requiredCmdSize, size_t maxCmdSize, size_t playerId);
+size_t ParseCmd(uint8_t pnum, const TCmd *pCmd, size_t maxCmdSize);
 
 } // namespace devilution

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -342,7 +342,7 @@ void BeginTimeout()
 void HandleAllPackets(uint8_t pnum, const std::byte *data, size_t size)
 {
 	for (size_t offset = 0; offset < size;) {
-		size_t messageSize = ParseCmd(pnum, reinterpret_cast<const TCmd *>(&data[offset]));
+		size_t messageSize = ParseCmd(pnum, reinterpret_cast<const TCmd *>(&data[offset]), size - offset);
 		if (messageSize == 0) {
 			break;
 		}

--- a/Source/portals/validation.cpp
+++ b/Source/portals/validation.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file portals/validation.cpp
+ *
+ * Implementation of functions for validation of portal data.
+ */
+
+#include "portals/validation.hpp"
+
+#include <cstdint>
+
+#include "engine/world_tile.hpp"
+#include "levels/gendung.h"
+#include "levels/setmaps.h"
+#include "quests.h"
+
+namespace devilution {
+
+namespace {
+
+dungeon_type GetQuestLevelType(_setlevels questLevel)
+{
+	for (const Quest &quest : Quests) {
+		if (quest._qslvl == questLevel)
+			return quest._qlvltype;
+	}
+	return DTYPE_NONE;
+}
+
+dungeon_type GetSetLevelType(_setlevels setLevel)
+{
+	bool isArenaLevel = setLevel >= SL_FIRST_ARENA && setLevel <= SL_LAST;
+	return isArenaLevel ? GetArenaLevelType(setLevel) : GetQuestLevelType(setLevel);
+}
+
+} // namespace
+
+bool IsPortalDeltaValid(WorldTilePosition location, uint8_t level, uint8_t ltype, bool isOnSetLevel)
+{
+	if (!InDungeonBounds(location))
+		return false;
+	dungeon_type levelType = static_cast<dungeon_type>(ltype);
+	if (levelType == DTYPE_NONE)
+		return false;
+	if (isOnSetLevel)
+		return levelType == GetSetLevelType(static_cast<_setlevels>(level));
+	return levelType == GetLevelType(level);
+}
+
+} // namespace devilution

--- a/Source/portals/validation.hpp
+++ b/Source/portals/validation.hpp
@@ -1,0 +1,16 @@
+/**
+ * @file portals/validation.hpp
+ *
+ * Interface of functions for validation of portal data.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "engine/world_tile.hpp"
+
+namespace devilution {
+
+bool IsPortalDeltaValid(WorldTilePosition location, uint8_t level, uint8_t levelType, bool isOnSetLevel);
+
+} // namespace devilution

--- a/Source/quests/validation.cpp
+++ b/Source/quests/validation.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file quests/validation.cpp
+ *
+ * Implementation of functions for validation of quest data.
+ */
+
+#include "quests/validation.hpp"
+
+#include <cstdint>
+
+#include "objdat.h"
+#include "quests.h"
+#include "textdat.h"
+#include "utils/is_of.hpp"
+
+namespace devilution {
+
+bool IsQuestDeltaValid(quest_id qidx, quest_state qstate, uint8_t qlog, int16_t qmsg)
+{
+	if (IsNoneOf(qlog, 0, 1))
+		return false;
+
+	if (qmsg < 0 || static_cast<size_t>(qmsg) >= SpeechCount)
+		return false;
+
+	switch (qstate) {
+	case QUEST_NOTAVAIL:
+	case QUEST_INIT:
+	case QUEST_ACTIVE:
+	case QUEST_DONE:
+		return true;
+
+	case QUEST_HIVE_TEASE1:
+	case QUEST_HIVE_TEASE2:
+	case QUEST_HIVE_ACTIVE:
+		return qidx == Q_JERSEY;
+
+	case QUEST_HIVE_DONE:
+		return IsAnyOf(qidx, Q_FARMER, Q_JERSEY);
+
+	default:
+		return false;
+	}
+}
+
+} // namespace devilution

--- a/Source/quests/validation.hpp
+++ b/Source/quests/validation.hpp
@@ -1,0 +1,17 @@
+/**
+ * @file quests/validation.hpp
+ *
+ * Interface of functions for validation of quest data.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "objdat.h"
+#include "quests.h"
+
+namespace devilution {
+
+bool IsQuestDeltaValid(quest_id qidx, quest_state qstate, uint8_t qlog, int16_t qmsg);
+
+} // namespace devilution

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -273,10 +273,12 @@ size_t sync_all_monsters(std::byte *pbBuf, size_t dwMaxLen)
 	return dwMaxLen;
 }
 
-uint32_t OnSyncData(const TCmd *pCmd, const Player &player)
+size_t OnSyncData(const TSyncHeader &header, size_t maxCmdSize, const Player &player)
 {
-	const auto &header = *reinterpret_cast<const TSyncHeader *>(pCmd);
 	const uint16_t wLen = SDL_SwapLE16(header.wLen);
+
+	if (!ValidateCmdSize(wLen + sizeof(header), maxCmdSize, player.getId()))
+		return maxCmdSize;
 
 	assert(gbBufferMsgs != 2);
 
@@ -294,7 +296,7 @@ uint32_t OnSyncData(const TCmd *pCmd, const Player &player)
 	bool syncLocalLevel = !MyPlayer->_pLvlChanging && GetLevelForMultiplayer(*MyPlayer) == level;
 
 	if (IsValidLevelForMultiplayer(level)) {
-		const auto *monsterSyncs = reinterpret_cast<const TSyncMonster *>(pCmd + sizeof(header));
+		const auto *monsterSyncs = reinterpret_cast<const TSyncMonster *>(&header + sizeof(header));
 		bool isOwner = player.getId() > MyPlayerId;
 
 		for (int i = 0; i < monsterCount; i++) {

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -10,6 +10,7 @@
 #include "levels/gendung.h"
 #include "lighting.h"
 #include "monster.h"
+#include "monsters/validation.hpp"
 #include "player.h"
 #include "utils/is_of.hpp"
 
@@ -205,17 +206,6 @@ void SyncMonster(bool isOwner, const TSyncMonster &monsterSync)
 	monster.whoHit |= monsterSync.mWhoHit;
 }
 
-bool IsEnemyIdValid(uint8_t enemyId)
-{
-	if (enemyId < MaxMonsters)
-		return true;
-
-	enemyId -= MaxMonsters;
-	if (enemyId >= Players.size())
-		return false;
-	return Players[enemyId].plractive;
-}
-
 bool IsTSyncMonsterValid(const TSyncMonster &monsterSync)
 {
 	const size_t monsterId = monsterSync._mndx;
@@ -234,16 +224,7 @@ bool IsTSyncMonsterValid(const TSyncMonster &monsterSync)
 
 bool IsTSyncEnemyValid(const TSyncMonster &monsterSync)
 {
-	const size_t enemyId = monsterSync._menemy;
-	if (enemyId >= MaxMonsters)
-		return true;
-
-	const size_t monsterId = monsterSync._mndx;
-	if (enemyId == monsterId)
-		return false;
-
-	const Monster &enemy = Monsters[enemyId];
-	return enemy.hitPoints > 0;
+	return IsEnemyValid(monsterSync._mndx, monsterSync._menemy);
 }
 
 } // namespace

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -11,7 +11,7 @@
 namespace devilution {
 
 size_t sync_all_monsters(std::byte *pbBuf, size_t dwMaxLen);
-uint32_t OnSyncData(const TCmd *pCmd, const Player &player);
+size_t OnSyncData(const TSyncHeader &header, size_t maxCmdSize, const Player &player);
 void sync_init();
 
 } // namespace devilution

--- a/Source/textdat.cpp
+++ b/Source/textdat.cpp
@@ -916,4 +916,7 @@ const Speech Speeches[] = {
 	    1, 5, SfxID::Adria48 },
 */
 };
+
+const size_t SpeechCount = sizeof(Speeches) / sizeof(Speech);
+
 } // namespace devilution

--- a/Source/textdat.h
+++ b/Source/textdat.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 #include "sound_effect_enums.h"
@@ -430,6 +431,7 @@ struct Speech {
 	SfxID sfxnr;
 };
 
+extern const size_t SpeechCount;
 extern const Speech Speeches[];
 
 } // namespace devilution


### PR DESCRIPTION
Some of the more noteworthy fixes...

* The use of `reinterpret_cast<uint16_t *>(...)` on unaligned data when exporting and importing spawned monster deltas triggered ASAN errors. Switched to `memcpy()` to resolve them.
* Spawned monster deltas and quest deltas were both using native endian encoding.
* The `CMD_STRING` message was doing absolutely no validation and assuming a well formed null terminated string.
* When receiving `CMD_DLEVEL` messages, bytes are copied to `sgRecvBuf`, which wasn't made large enough to match the sender's buffer size, let alone the largest possible `DLevel` struct.
* Various fatal errors could theoretically be triggered by malformed packets so they were converted to nonfatal errors.
* Most nonfatal errors when decoding packets will result in dropping the player who sent them.
* Spawning monsters in town could bring the townsfolk together for a party, or just crash the client.

![image](https://github.com/user-attachments/assets/9f50a010-52db-417f-9188-fe0fb9e2fc49)