### PR TITLE
Fix rendering issues with health/mana flasks

### DIFF
--- a/Source/control.h
+++ b/Source/control.h
@@ -100,7 +100,7 @@ void DrawLifeFlaskUpper(const Surface &out);
  * First sets the fill amount then draws the empty flask cel portion then the filled
  * flask portion.
  */
-void DrawLifeFlaskLower(const Surface &out);
+void DrawLifeFlaskLower(const Surface &out, bool drawFilledPortion);
 
 /**
  * Draws the top dome of the mana flask (that part that protrudes out of the control panel).
@@ -112,7 +112,7 @@ void DrawManaFlaskUpper(const Surface &out);
 /**
  * Controls the drawing of the area of the mana flask within the control panel.
  */
-void DrawManaFlaskLower(const Surface &out);
+void DrawManaFlaskLower(const Surface &out, bool drawFilledPortion);
 
 /**
  * Controls drawing of current / max values (health, mana) within the control panel.

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1700,7 +1700,7 @@ void DrawAndBlit()
 
 	const Rectangle &mainPanel = GetMainPanel();
 
-	if (gnScreenWidth > mainPanel.size.width || IsRedrawEverything()) {
+	if (gnScreenWidth > mainPanel.size.width || IsRedrawEverything() || *GetOptions().Gameplay.enableFloatingNumbers != FloatingNumbers::Off) {
 		drawHealth = true;
 		drawMana = true;
 		drawControlButtons = true;

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1724,10 +1724,10 @@ void DrawAndBlit()
 		DrawMainPanel(out);
 	}
 	if (drawHealth) {
-		DrawLifeFlaskLower(out);
+		DrawLifeFlaskLower(out, !drawCtrlPan);
 	}
 	if (drawMana) {
-		DrawManaFlaskLower(out);
+		DrawManaFlaskLower(out, !drawCtrlPan);
 
 		DrawSpell(out);
 	}


### PR DESCRIPTION
The first issue was introduced in #7417 when the code that draws the filled part of the lower portion of each flask was removed from the drawing function for the flasks. Before that, there was a comment introduced in #2291 questioning the need for that code, and I believe the reason it was deemed unnecessary is because `DrawMainPanel()` usually draws the filled part anyway so drawing it again would be largely redundant. However, the issue makes it clear that sometimes the flasks get drawn without calling `DrawMainPanel()`. Instead, I've chosen to pass a boolean value into `DrawLifeFlaskLower()` and `DrawManaFlaskLower()` indicating whether we need to draw the filled part of the flask, based on whether `DrawMainPanel()` was called in the same frame.

The second issue is pretty self-explanatory. I just force the whole UI to redraw so long as floating numbers are enabled. I didn't need to do anything for `showHealthValues`/`showManaValues` because those numbers will only change when the player's health or mana is changed, and that should cause the flasks to be redrawn. The only reason that wasn't happening is because of the first issue, where the filled part of the flask wasn't being redrawn.

This resolves #7835
This resolves #7990