### PR TITLE
Remove bzip2 backup repo

### DIFF
--- a/3rdParty/bzip2/CMakeLists.txt
+++ b/3rdParty/bzip2/CMakeLists.txt
@@ -4,7 +4,6 @@ include(FetchContent)
 
 FetchContent_Declare_ExcludeFromAll(bzip2
     GIT_REPOSITORY https://sourceware.org/git/bzip2
-    GIT_REPOSITORY https://gitlab.com/bzip2/bzip2
     GIT_TAG bzip2-1.0.8
 )
 FetchContent_MakeAvailable_ExcludeFromAll(bzip2)


### PR DESCRIPTION
Turns out CMake doesn't like 2 repos in one FetchContent