### PR TITLE
Fix errors where Monster::enemy references garbage memory

### DIFF
--- a/Source/monster.h
+++ b/Source/monster.h
@@ -534,6 +534,7 @@ void PrepDoEnding();
 bool Walk(Monster &monster, Direction md);
 void GolumAi(Monster &monster);
 void DeleteMonsterList();
+void RemoveEnemyReferences(const Player &player);
 void ProcessMonsters();
 void FreeMonsters();
 bool DirOK(const Monster &monster, Direction mdir);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -34,6 +34,7 @@
 #include "levels/trigs.h"
 #include "lighting.h"
 #include "missiles.h"
+#include "monster.h"
 #include "monsters/validation.hpp"
 #include "nthread.h"
 #include "objects.h"
@@ -2280,6 +2281,11 @@ size_t OnPlayerJoinLevel(const TCmdLocParam2 &message, Player &player)
 	}
 
 	if (player.plractive && &player != MyPlayer) {
+		if (player.isOnActiveLevel()) {
+			RemoveEnemyReferences(player);
+			RemovePlrMissiles(player);
+			FixPlrWalkTags(player);
+		}
 		player.position.tile = position;
 		SetPlayerOld(player);
 		if (isSetLevel)

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -21,6 +21,7 @@
 #include "engine/random.hpp"
 #include "engine/world_tile.hpp"
 #include "menu.h"
+#include "monster.h"
 #include "msg.h"
 #include "nthread.h"
 #include "options.h"
@@ -275,6 +276,7 @@ void PlayerLeftMsg(Player &player, bool left)
 	RemovePortalMissile(player);
 	DeactivatePortal(player);
 	delta_close_portal(player);
+	RemoveEnemyReferences(player);
 	RemovePlrMissiles(player);
 	if (left) {
 		std::string_view pszFmt = _("Player '{:s}' just left the game");

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -36,6 +36,7 @@
 #include "loadsave.h"
 #include "minitext.h"
 #include "missiles.h"
+#include "monster.h"
 #include "nthread.h"
 #include "objects.h"
 #include "options.h"
@@ -358,6 +359,7 @@ void InitLevelChange(Player &player)
 {
 	Player &myPlayer = *MyPlayer;
 
+	RemoveEnemyReferences(player);
 	RemovePlrMissiles(player);
 	player.pManaShield = false;
 	player.wReflections = 0;


### PR DESCRIPTION
When a monster puts a remote player into hit recovery while that player is in the middle of warping between the dungeon and Tristram, it's possible to encounter the following error.

![image](https://github.com/user-attachments/assets/e790aab6-059f-424a-b084-d079cbc8a28c)

This is possible because `monster.enemy` still has a reference to the ID of a player that uses a town portal. The monster doesn't change targets mid-swing, so it's possible for the monster to hit the player despite the fact that they are no longer referenced in the `dPlayer` array. If the monster puts the player into hit recovery, the remote player will reappear in the `dPlayer` array and eventually crash the local client when their graphics are unloaded.