### PR TITLE
Various of fixes for the HeadlessMode and more

### DIFF
--- a/Source/controls/input.h
+++ b/Source/controls/input.h
@@ -7,15 +7,20 @@
 
 namespace devilution {
 
-inline int PollEvent(SDL_Event *event)
+inline int PollEventCustom(SDL_Event *event, int (*poll)(SDL_Event *event))
 {
-	int result = SDL_PollEvent(event);
+	int result = poll(event);
 	if (result != 0) {
 		UnlockControllerState(*event);
 		ProcessControllerMotion(*event);
 	}
 
 	return result;
+}
+
+inline int PollEvent(SDL_Event *event)
+{
+	return PollEventCustom(event, SDL_PollEvent);
 }
 
 } // namespace devilution

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -235,7 +235,7 @@ void VirtualDirectionPadRenderer::LoadArt()
 
 void VirtualGamepadRenderer::Render(RenderFunction renderFunction)
 {
-	if (CurrentEventHandler == DisableInputEventHandler)
+	if (CurrentEventHandler.handle == DisableInputEventHandler)
 		return;
 
 	primaryActionButtonRenderer.Render(renderFunction, buttonArt);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -841,7 +841,8 @@ void RunGameLoop(interface_mode uMsg)
 	nthread_ignore_mutex(true);
 	StartGame(uMsg);
 	assert(HeadlessMode || ghMainWnd);
-	EventHandler previousHandler = SetEventHandler(GameEventHandler);
+	EventHandler newHandler = { GameEventHandler, SDL_PollEvent };
+	EventHandler previousHandler = SetEventHandler(newHandler);
 	run_delta_info();
 	gbRunGame = true;
 	gbProcessPlayers = IsDiabloAlive(true);
@@ -937,7 +938,7 @@ void RunGameLoop(interface_mode uMsg)
 	RedrawEverything();
 	scrollrt_draw_game_screen();
 	previousHandler = SetEventHandler(previousHandler);
-	assert(HeadlessMode || previousHandler == GameEventHandler);
+	assert(HeadlessMode || previousHandler.handle == GameEventHandler);
 	FreeGame();
 
 	if (cineflag) {

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1180,8 +1180,17 @@ void ApplicationInit()
 	if (*GetOptions().Graphics.showFPS)
 		EnableFrameCount();
 
-	init_create_window();
-	was_window_init = true;
+	if (!HeadlessMode) {
+		init_create_window();
+		was_window_init = true;
+	} else {
+#ifdef USE_SDL1
+		// Unfortunately no way to init only events queue for SDL1.2
+		SDL_Init(SDL_INIT_VIDEO);
+#else
+		SDL_Init(SDL_INIT_EVENTS);
+#endif
+	}
 
 	InitializeScreenReader();
 	LanguageInitialize();
@@ -1237,9 +1246,10 @@ void DiabloInit()
 
 	DiabloInitScreen();
 
-	snd_init();
-
-	ui_sound_init();
+	if (!HeadlessMode) {
+		snd_init();
+		ui_sound_init();
+	}
 
 	// Item graphics are loaded early, they already get touched during hero selection.
 	InitItemGFX();

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -312,6 +312,10 @@ void effects_play_sound(SfxID id)
 
 int GetSFXLength(SfxID nSFX)
 {
+	if (!gbSndInited || !gbSoundOn) {
+		return 0;
+	}
+
 	TSFX &sfx = sgSFX[static_cast<int16_t>(nSFX)];
 	if (sfx.pSnd == nullptr)
 		sfx.pSnd = sound_file_load(sfx.pszName.c_str(),

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -683,13 +683,13 @@ bool GetRunGameLoop(bool &drawGame, bool &processInput)
 	return isGameTick;
 }
 
-bool FetchMessage(SDL_Event *event, uint16_t *modState)
+bool FetchMessage(SDL_Event *event, uint16_t *modState, int (*poll)(SDL_Event *event))
 {
-	if (CurrentEventHandler == DisableInputEventHandler)
+	if (CurrentEventHandler.handle == DisableInputEventHandler)
 		return false;
 
 	SDL_Event e;
-	if (SDL_PollEvent(&e) != 0) {
+	if (poll(&e) != 0) {
 		if (e.type == SDL_QUIT) {
 			*event = e;
 			return true;
@@ -741,7 +741,7 @@ void RecordMessage(const SDL_Event &event, uint16_t modState)
 {
 	if (!gbRunGame || DemoRecording == nullptr)
 		return;
-	if (CurrentEventHandler == DisableInputEventHandler)
+	if (CurrentEventHandler.handle == DisableInputEventHandler)
 		return;
 	switch (event.type) {
 	case SDL_MOUSEMOTION:

--- a/Source/engine/demomode.h
+++ b/Source/engine/demomode.h
@@ -22,7 +22,7 @@ bool IsRunning();
 bool IsRecording();
 
 bool GetRunGameLoop(bool &drawGame, bool &processInput);
-bool FetchMessage(SDL_Event *event, uint16_t *modState);
+bool FetchMessage(SDL_Event *event, uint16_t *modState, int (*poll)(SDL_Event *event));
 void RecordGameLoopResult(bool runGameLoop);
 void RecordMessage(const SDL_Event &event, uint16_t modState);
 
@@ -46,7 +46,7 @@ inline bool GetRunGameLoop(bool &, bool &)
 {
 	return false;
 }
-inline bool FetchMessage(SDL_Event *, uint16_t *)
+inline bool FetchMessage(SDL_Event *, uint16_t *, int (*poll)(SDL_Event *event))
 {
 	return false;
 }

--- a/Source/engine/events.cpp
+++ b/Source/engine/events.cpp
@@ -39,14 +39,15 @@ bool FalseAvail(const char *name, int value)
 	return true;
 }
 
-bool FetchMessage_Real(SDL_Event *event, uint16_t *modState)
+static bool FetchMessage_Real(SDL_Event *event, uint16_t *modState,
+    int (*poll)(SDL_Event *event))
 {
 #ifdef __SWITCH__
 	HandleDocking();
 #endif
 
 	SDL_Event e;
-	if (PollEvent(&e) == 0) {
+	if (PollEventCustom(&e, poll) == 0) {
 		return false;
 	}
 
@@ -151,9 +152,9 @@ EventHandler SetEventHandler(EventHandler eventHandler)
 	return previousHandler;
 }
 
-bool FetchMessage(SDL_Event *event, uint16_t *modState)
+bool FetchMessage(SDL_Event *event, uint16_t *modState, int (*poll)(SDL_Event *event))
 {
-	const bool available = demo::IsRunning() ? demo::FetchMessage(event, modState) : FetchMessage_Real(event, modState);
+	const bool available = demo::IsRunning() ? demo::FetchMessage(event, modState, poll) : FetchMessage_Real(event, modState, poll);
 
 	if (available && demo::IsRecording())
 		demo::RecordMessage(*event, *modState);
@@ -163,9 +164,9 @@ bool FetchMessage(SDL_Event *event, uint16_t *modState)
 
 void HandleMessage(const SDL_Event &event, uint16_t modState)
 {
-	assert(CurrentEventHandler != nullptr);
+	assert(CurrentEventHandler.handle != nullptr);
 
-	CurrentEventHandler(event, modState);
+	CurrentEventHandler.handle(event, modState);
 }
 
 } // namespace devilution

--- a/Source/engine/events.hpp
+++ b/Source/engine/events.hpp
@@ -12,14 +12,18 @@
 
 namespace devilution {
 
-using EventHandler = void (*)(const SDL_Event &event, uint16_t modState);
+struct EventHandler {
+	void (*handle)(const SDL_Event &event, uint16_t modState);
+	int (*poll)(SDL_Event *event);
+};
 
 /** @brief The current input handler function */
 extern EventHandler CurrentEventHandler;
 
-EventHandler SetEventHandler(EventHandler NewProc);
+EventHandler SetEventHandler(EventHandler NewHandler);
 
-bool FetchMessage(SDL_Event *event, uint16_t *modState);
+bool FetchMessage(SDL_Event *event, uint16_t *modState,
+    int (*poll)(SDL_Event *event) = SDL_PollEvent);
 
 void HandleMessage(const SDL_Event &event, uint16_t modState);
 

--- a/Source/engine/sound.cpp
+++ b/Source/engine/sound.cpp
@@ -152,6 +152,8 @@ int CapVolume(int volume)
 
 void OptionAudioChanged()
 {
+	if (HeadlessMode)
+		return;
 	effects_cleanup_sfx();
 	music_stop();
 	snd_deinit();
@@ -288,6 +290,9 @@ void music_stop()
 void music_start(_music_id nTrack)
 {
 	const char *trackPath;
+
+	if (HeadlessMode)
+		return;
 
 	assert(nTrack < NUM_MUSIC);
 	music_stop();

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -291,7 +291,8 @@ void gamemenu_quit_game(bool bActivate)
 
 void gamemenu_load_game(bool /*bActivate*/)
 {
-	EventHandler saveProc = SetEventHandler(DisableInputEventHandler);
+	EventHandler newHandler = { DisableInputEventHandler, SDL_PollEvent };
+	EventHandler prevHandler = SetEventHandler(newHandler);
 	gamemenu_off();
 	ClearFloatingNumbers();
 	NewCursor(CURSOR_NONE);
@@ -321,7 +322,7 @@ void gamemenu_load_game(bool /*bActivate*/)
 	PaletteFadeIn(8);
 	NewCursor(CURSOR_HAND);
 	interface_msg_pump();
-	SetEventHandler(saveProc);
+	SetEventHandler(prevHandler);
 }
 
 void gamemenu_save_game(bool /*bActivate*/)
@@ -335,7 +336,8 @@ void gamemenu_save_game(bool /*bActivate*/)
 		return;
 	}
 
-	EventHandler saveProc = SetEventHandler(DisableInputEventHandler);
+	EventHandler newHandler = { DisableInputEventHandler, SDL_PollEvent };
+	EventHandler prevHandler = SetEventHandler(newHandler);
 	NewCursor(CURSOR_NONE);
 	gamemenu_off();
 	InitDiabloMsg(EMSG_SAVING);
@@ -352,7 +354,7 @@ void gamemenu_save_game(bool /*bActivate*/)
 		if (!demo::IsRunning()) SaveOptions();
 	}
 	interface_msg_pump();
-	SetEventHandler(saveProc);
+	SetEventHandler(prevHandler);
 }
 
 void gamemenu_on()

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -299,8 +299,10 @@ bool gmenu_presskeys(SDL_Keycode vkey)
 		GmenuUpDown(true);
 		break;
 	default:
-		break;
+		// Key was not handled by the gmenu
+		return false;
 	}
+	// Key was handled
 	return true;
 }
 

--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -16,6 +16,7 @@
 #include "engine/clx_sprite.hpp"
 #include "engine/render/clx_render.hpp"
 #include "engine/surface.hpp"
+#include "headless_mode.hpp"
 #include "utils/display.h"
 #include "utils/sdl_bilinear_scale.hpp"
 #include "utils/sdl_wrap.h"
@@ -164,6 +165,8 @@ void SetHardwareCursor(CursorInfo cursorInfo)
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	CurrentCursorInfo = cursorInfo;
 	CurrentCursorInfo.setNeedsReinitialization(false);
+	if (HeadlessMode)
+		return;
 	switch (cursorInfo.type()) {
 	case CursorType::Game:
 #if LOG_HWCURSOR

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -453,6 +453,28 @@ void CheckShouldSkipRendering()
 	if (!HeadlessMode) InitRendering();
 }
 
+static int PeepEvents(SDL_Event *event, unsigned evType)
+{
+#ifdef USE_SDL1
+	return SDL_PeepEvents(event, 1, SDL_GETEVENT, SDL_EVENTMASK(evType));
+#else
+	return SDL_PeepEvents(event, 1, SDL_GETEVENT, evType, evType + 1);
+#endif
+}
+
+static int ProgressEventPoll(SDL_Event *event)
+{
+	int ret;
+
+	// SDL_QUIT event has higher priority
+	ret = PeepEvents(event, SDL_QUIT);
+	if (ret)
+		return ret;
+
+	// Peek only custom events, leaving others in the queue
+	return PeepEvents(event, CustomEventType);
+}
+
 void ProgressEventHandler(const SDL_Event &event, uint16_t modState)
 {
 	DisableInputEventHandler(event, modState);
@@ -596,7 +618,7 @@ void ShowProgress(interface_mode uMsg)
 	gbSomebodyWonGameKludge = false;
 
 	ProgressEventHandlerState.loadStartedAt = SDL_GetTicks();
-	EventHandler newHandler = { ProgressEventHandler, SDL_PollEvent };
+	EventHandler newHandler = { ProgressEventHandler, ProgressEventPoll };
 	ProgressEventHandlerState.prevHandler = SetEventHandler(newHandler);
 	ProgressEventHandlerState.skipRendering = true;
 	ProgressEventHandlerState.done = false;
@@ -653,7 +675,7 @@ void ShowProgress(interface_mode uMsg)
 		SDL_Event event;
 		// We use the real `PollEventCustom` here instead of `FetchMessage`
 		// to process real events rather than the recorded ones in demo mode.
-		while (PollEventCustom(&event, SDL_PollEvent)) {
+		while (PollEventCustom(&event, ProgressEventPoll)) {
 			if (!processEvent(event)) return;
 		}
 	}

--- a/Source/menu.cpp
+++ b/Source/menu.cpp
@@ -151,7 +151,7 @@ void mainmenu_loop()
 
 	do {
 		_mainmenu_selections menu = MAINMENU_NONE;
-		if (demo::IsRunning())
+		if (demo::IsRunning() || HeadlessMode)
 			menu = MAINMENU_SINGLE_PLAYER;
 		else if (!UiMainMenuDialog(gszProductName, &menu, 30))
 			app_fatal(_("Unable to display mainmenu"));

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -17,6 +17,7 @@
 #include "engine/render/clx_render.hpp"
 #include "engine/render/primitive_render.hpp"
 #include "engine/render/text_render.hpp"
+#include "headless_mode.hpp"
 #include "playerdat.hpp"
 #include "textdat.h"
 #include "utils/language.h"
@@ -162,7 +163,7 @@ void InitQTextMsg(_speech_id m)
 	default:
 		break;
 	}
-	if (Speeches[m].scrlltxt) {
+	if (!HeadlessMode && Speeches[m].scrlltxt) {
 		QuestLogIsOpen = false;
 		LoadText(_(Speeches[m].txtstr));
 		qtextflag = true;

--- a/Source/utils/log.hpp
+++ b/Source/utils/log.hpp
@@ -59,6 +59,7 @@ std::string format(std::string_view fmt, Args &&...args)
 		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "%s", error.c_str());
 		app_fatal(error);
 #endif
+		return "";
 	}
 }
 


### PR DESCRIPTION
This PR addresses various crashes in HeadlessMode and lost keystrokes caused by the game menu or incorrect event polling. These issues were observed during AI agent training, and commits targeting them are part of the RFC #7974 PR. I decided to split the original RFC on several PRs because it is unnecessarily complex and has an unclear status. This PR includes the following commits for easier review:

- Ensured keystrokes are not dropped in game menu or during progress events:
- ShowProgress now preserves non-custom SDL events, ensuring no events are lost
- Fixed crashes in HeadlessMode by avoiding SDL or audio access
- Resolved a GCC warning in logging utility by ensuring a return value in all cases
