### PR TITLE
Fix custom event logic in interfac.cpp

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -811,7 +811,7 @@ void GameEventHandler(const SDL_Event &event, uint16_t modState)
 			nthread_ignore_mutex(true);
 			PaletteFadeOut(8);
 			sound_stop();
-			ShowProgress(GetCustomEvent(event.type));
+			ShowProgress(GetCustomEvent(event));
 
 			RedrawEverything();
 			if (!HeadlessMode) {

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -280,7 +280,7 @@ bool CreateSdlEvent(const DemoMsg &dmsg, SDL_Event &event, uint16_t &modState)
 		return true;
 	default:
 		if (type >= DemoMsg::MinCustomEvent) {
-			event.type = CustomEventToSdlEvent(static_cast<interface_mode>(type - DemoMsg::MinCustomEvent));
+			CustomEventToSdlEvent(event, static_cast<interface_mode>(type - DemoMsg::MinCustomEvent));
 			return true;
 		}
 		event.type = static_cast<SDL_EventType>(0);
@@ -377,7 +377,7 @@ bool CreateSdlEvent(const DemoMsg &dmsg, SDL_Event &event, uint16_t &modState)
 		return true;
 	default:
 		if (type >= DemoMsg::MinCustomEvent) {
-			event.type = CustomEventToSdlEvent(static_cast<interface_mode>(type - DemoMsg::MinCustomEvent));
+			CustomEventToSdlEvent(event, static_cast<interface_mode>(type - DemoMsg::MinCustomEvent));
 			return true;
 		}
 		event.type = static_cast<SDL_EventType>(0);
@@ -802,7 +802,7 @@ void RecordMessage(const SDL_Event &event, uint16_t modState)
 	default:
 		if (IsCustomEvent(event.type)) {
 			WriteDemoMsgHeader(static_cast<DemoMsg::EventType>(
-			    DemoMsg::MinCustomEvent + static_cast<uint8_t>(GetCustomEvent(event.type))));
+			    DemoMsg::MinCustomEvent + static_cast<uint8_t>(GetCustomEvent(event))));
 		}
 		break;
 	}

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -40,7 +40,7 @@ namespace devilution {
 
 namespace {
 
-#if (defined(__APPLE__) || defined(__3DS__)) && defined(USE_SDL1)
+#if defined(__APPLE__) && defined(USE_SDL1)
 // On Tiger PPC, SDL_PushEvent from a background thread appears to do nothing.
 #define SDL_PUSH_EVENT_BG_THREAD_WORKS 0
 #else

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -7,6 +7,8 @@
 
 #include <cstdint>
 
+#include <SDL.h>
+
 #include "utils/ui_fwd.h"
 
 namespace devilution {
@@ -45,9 +47,9 @@ using SdlEventType = uint8_t;
 
 bool IsCustomEvent(SdlEventType eventType);
 
-interface_mode GetCustomEvent(SdlEventType eventType);
+interface_mode GetCustomEvent(const SDL_Event &event);
 
-SdlEventType CustomEventToSdlEvent(interface_mode eventType);
+void CustomEventToSdlEvent(SDL_Event &event, interface_mode eventType);
 
 enum Cutscenes : uint8_t {
 	CutStart,

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2861,7 +2861,7 @@ StartNewLvl(Player &player, interface_mode fom, int lvl)
 		player._pmode = PM_NEWLVL;
 		player._pInvincible = true;
 		SDL_Event event;
-		event.type = CustomEventToSdlEvent(fom);
+		CustomEventToSdlEvent(event, fom);
 		SDL_PushEvent(&event);
 		if (gbIsMultiplayer) {
 			NetSendCmdParam2(true, CMD_NEWLVL, fom, lvl);
@@ -2887,7 +2887,7 @@ void RestartTownLvl(Player &player)
 	if (&player == MyPlayer) {
 		player._pInvincible = true;
 		SDL_Event event;
-		event.type = CustomEventToSdlEvent(WM_DIABRETOWN);
+		CustomEventToSdlEvent(event, WM_DIABRETOWN);
 		SDL_PushEvent(&event);
 	}
 }
@@ -2912,7 +2912,7 @@ void StartWarpLvl(Player &player, size_t pidx)
 		player._pmode = PM_NEWLVL;
 		player._pInvincible = true;
 		SDL_Event event;
-		event.type = CustomEventToSdlEvent(WM_DIABWARPLVL);
+		CustomEventToSdlEvent(event, WM_DIABWARPLVL);
 		SDL_PushEvent(&event);
 	}
 }


### PR DESCRIPTION
We use `SDL_UserEvent::code` instead of `SDL_Event::type` to indicate the `interface_mode` of the custom event. This avoids overrunning the number of event types on SDL1, which is limited to just 8 custom events.

Implemented as described in https://github.com/diasurgical/DevilutionX/pull/8011#issuecomment-2905853863.

This also resolves the issue that 3DS had when running `SDL_PushEvent()` from a background thread.