### PR TITLE
Fix crash due to text selection in chat box

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1692,6 +1692,7 @@ void ResetChat()
 {
 	ChatFlag = false;
 	SDL_StopTextInput();
+	ChatCursor = {};
 	ChatInputState = std::nullopt;
 	sgbPlrTalkTbl = 0;
 	RedrawEverything();


### PR DESCRIPTION
This PR clears the text selection in the chat box when the chat box is dismissed using the `Esc` key.

To reproduce the crash:
1. Build in debug mode (not sure if it crashes in release mode).
2. Start a Multiplayer game.
3. Press `Enter` and type `a` into the chat box.
4. Use `Shift+Left` to select the `a`.
5. Press `Esc` to dismiss the chat box.
6. Press `Enter` and type `a` into the chat box.

The logic will try to replace the selection with the character you typed in step 6, but since the chat box was dismissed in step 5, the text that was selected is no longer there.