### PR TITLE
3rdParty/googletest: Remove unneeded add_library

### DIFF
--- a/3rdParty/googletest/CMakeLists.txt
+++ b/3rdParty/googletest/CMakeLists.txt
@@ -12,5 +12,3 @@ set(INSTALL_GTEST OFF)
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable_ExcludeFromAll(googletest)
-
-add_library(GTest::gtest ALIAS gmock)


### PR DESCRIPTION
This is not needed since https://github.com/google/googletest/commit/2292b6d856335b6c1ee352e9cb97d7a5b193c989