### PR TITLE
Implement skipFrom/To for the k-d tree

### DIFF
--- a/Source/utils/palette_blending.cpp
+++ b/Source/utils/palette_blending.cpp
@@ -59,7 +59,7 @@ void SetPaletteTransparencyLookupBlack16(unsigned i, unsigned j)
 
 void GenerateBlendedLookupTable(SDL_Color palette[256], int skipFrom, int skipTo)
 {
-	const PaletteKdTree kdTree { palette };
+	const PaletteKdTree kdTree { palette, skipFrom, skipTo };
 	for (unsigned i = 0; i < 256; i++) {
 		paletteTransparencyLookup[i][i] = i;
 		unsigned j = 0;


### PR DESCRIPTION
I forgot to do this in #8025. No performance impact.

The skipFrom/To arguments are used to avoid mapping to colors that get palette-swapped (poison water)