### PR TITLE
static_vector.hpp: Use `std::destroy_n` in the destructor

### DIFF
--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -103,9 +103,7 @@ public:
 
 	~StaticVector()
 	{
-		for (std::size_t pos = 0; pos < size_; ++pos) {
-			std::destroy_at(data_[pos].ptr());
-		}
+		std::destroy_n(begin(), size_);
 	}
 
 private:

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -103,7 +103,7 @@ public:
 
 	~StaticVector()
 	{
-		std::destroy_n(begin(), size_);
+		std::destroy_n(data(), size_);
 	}
 
 private:


### PR DESCRIPTION
A bit less code now that we're C++17 everywhere.