### PR TITLE
Fix a bug in `palette_update`

### DIFF
--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -139,7 +139,7 @@ void palette_update(int first, int ncolor)
 		return;
 
 	assert(Palette);
-	if (SDLC_SetSurfaceAndPaletteColors(PalSurface, Palette.get(), system_palette.data(), first, ncolor) < 0) {
+	if (SDLC_SetSurfaceAndPaletteColors(PalSurface, Palette.get(), system_palette.data() + first, first, ncolor) < 0) {
 		ErrSdl();
 	}
 	pal_surface_palette_version++;


### PR DESCRIPTION
PR #8027 exposed a bug in `palette_update`.

The `first` argument in SDL palette functions always refers to the first target index (the first source index is always 0).

Fixes poison water following #8027.