### PR TITLE
Simplify palette handling

### DIFF
--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -21,6 +21,7 @@
 #include "engine/clx_sprite.hpp"
 #include "engine/dx.h"
 #include "engine/load_pcx.hpp"
+#include "engine/palette.h"
 #include "engine/render/clx_render.hpp"
 #include "engine/render/text_render.hpp"
 #include "engine/ticks.hpp"
@@ -89,9 +90,6 @@ bool UiItemsWraps;
 std::optional<TextInputState> UiTextInputState;
 bool allowEmptyTextInput = false;
 
-uint32_t fadeTc;
-int fadeValue = 0;
-
 struct ScrollBarState {
 	bool upArrowPressed;
 	bool downArrowPressed;
@@ -109,6 +107,49 @@ void AdjustListOffset(std::size_t itemIndex)
 		listOffset = itemIndex - (ListViewportSize - 1);
 	if (itemIndex < listOffset)
 		listOffset = itemIndex;
+}
+
+uint32_t fadeTc;
+int fadeValue;
+
+void StartUiFadeIn()
+{
+	fadeValue = 0;
+	fadeTc = 0;
+}
+
+void UiUpdateFadePalette()
+{
+	if (fadeValue == 256) return;
+	if (fadeValue == 0 && fadeTc == 0) {
+		// Start the fade-in.
+		fadeTc = SDL_GetTicks();
+		fadeValue = 0;
+		BlackPalette();
+		// We can skip hardware cursor update for fade level 0 (everything is black).
+		return;
+	}
+
+	const int prevFadeValue = fadeValue;
+	fadeValue = static_cast<int>((SDL_GetTicks() - fadeTc) / 2.083); // 32 frames @ 60hz
+	if (fadeValue == prevFadeValue) return;
+
+	if (fadeValue >= 256) {
+		// Finish the fade-in:
+		fadeValue = 256;
+		fadeTc = 0;
+		ApplyGlobalBrightness(system_palette.data(), logical_palette.data());
+		SystemPaletteUpdated();
+		if (IsHardwareCursor()) ReinitializeHardwareCursor();
+		return;
+	}
+
+	SDL_Color palette[256];
+	ApplyGlobalBrightness(palette, logical_palette.data());
+	ApplyFadeLevel(fadeValue, system_palette.data(), palette);
+
+	SystemPaletteUpdated();
+	if (IsHardwareCursor()) ReinitializeHardwareCursor();
 }
 
 } // namespace
@@ -338,15 +379,17 @@ bool HandleMenuAction(MenuAction menuAction)
 
 void UiOnBackgroundChange()
 {
-	fadeTc = 0;
-	fadeValue = 0;
-
-	BlackPalette();
+	StartUiFadeIn();
 
 	if (IsHardwareCursorEnabled() && ArtCursor && ControlDevice == ControlTypes::KeyboardAndMouse && GetCurrentCursorInfo().type() != CursorType::UserInterface) {
 		SetHardwareCursor(CursorInfo::UserInterfaceCursor());
 	}
 
+	// It may take some time to get to the first `UiFadeIn()` call from here
+	// if there is non-trivial initialization work, such as loading the list
+	// of single-player characters.
+	//
+	// Black out the screen immediately to make it appear more smooth.
 	SDL_FillRect(DiabloUiSurface(), nullptr, 0x000000);
 	if (DiabloUiSurface() == PalSurface)
 		BltFast(nullptr, nullptr);
@@ -652,8 +695,8 @@ Sint16 GetCenterOffset(Sint16 w, Sint16 bw)
 
 void UiLoadDefaultPalette()
 {
-	LoadPalette("ui_art\\diablo.pal", /*blend=*/false);
-	ApplyToneMapping(logical_palette, orig_palette);
+	LoadPalette("ui_art\\diablo.pal");
+	UpdateSystemPalette(logical_palette);
 }
 
 bool UiLoadBlackBackground()
@@ -667,13 +710,11 @@ bool UiLoadBlackBackground()
 void LoadBackgroundArt(const char *pszFile, int frames)
 {
 	ArtBackground = std::nullopt;
-	SDL_Color pPal[256];
-	ArtBackground = LoadPcxSpriteList(pszFile, static_cast<uint16_t>(frames), /*transparentColor=*/std::nullopt, pPal);
+	ArtBackground = LoadPcxSpriteList(pszFile, static_cast<uint16_t>(frames), /*transparentColor=*/std::nullopt, logical_palette.data());
 	if (!ArtBackground)
 		return;
 
-	LoadPalInMem(pPal);
-	ApplyToneMapping(logical_palette, orig_palette);
+	UpdateSystemPalette(logical_palette);
 	UiOnBackgroundChange();
 }
 
@@ -696,23 +737,11 @@ void UiAddLogo(std::vector<std::unique_ptr<UiItemBase>> *vecDialog, int y)
 
 void UiFadeIn()
 {
-	if (fadeValue < 256) {
-		if (fadeValue == 0 && fadeTc == 0)
-			fadeTc = SDL_GetTicks();
-		const int prevFadeValue = fadeValue;
-		fadeValue = static_cast<int>((SDL_GetTicks() - fadeTc) / 2.083); // 32 frames @ 60hz
-		if (fadeValue > 256) {
-			fadeValue = 256;
-			fadeTc = 0;
-		}
-		if (fadeValue != prevFadeValue) {
-			// We can skip hardware cursor update for fade level 0 (everything is black).
-			SetFadeLevel(fadeValue, /*updateHardwareCursor=*/fadeValue != 0);
-		}
-	}
-
-	if (DiabloUiSurface() == PalSurface)
+	if (HeadlessMode) return;
+	UiUpdateFadePalette();
+	if (DiabloUiSurface() == PalSurface) {
 		BltFast(nullptr, nullptr);
+	}
 	RenderPresent();
 }
 
@@ -765,7 +794,7 @@ void UiPollAndRender(std::optional<tl::function_ref<bool(SDL_Event &)>> eventHan
 	UiFadeIn();
 
 	// Must happen after at least one call to `UiFadeIn` with non-zero fadeValue.
-	// `UiFadeIn` calls `SetFadeLevel` which reinitializes the hardware cursor.
+	// `UiFadeIn` reinitializes the hardware cursor only for fadeValue > 0.
 	if (IsHardwareCursor() && fadeValue != 0)
 		SetHardwareCursorVisible(ControlDevice == ControlTypes::KeyboardAndMouse);
 
@@ -1009,13 +1038,6 @@ bool HandleMouseEvent(const SDL_Event &event, UiItemBase *item)
 }
 
 } // namespace
-
-void LoadPalInMem(const SDL_Color *pPal)
-{
-	for (int i = 0; i < 256; i++) {
-		orig_palette[i] = pPal[i];
-	}
-}
 
 void UiRenderItem(const UiItemBase &item)
 {

--- a/Source/DiabloUI/diabloui.h
+++ b/Source/DiabloUI/diabloui.h
@@ -97,7 +97,6 @@ void UiHandleEvents(SDL_Event *event);
 bool UiItemMouseEvents(SDL_Event *event, const std::vector<UiItemBase *> &items);
 bool UiItemMouseEvents(SDL_Event *event, const std::vector<std::unique_ptr<UiItemBase>> &items);
 Sint16 GetCenterOffset(Sint16 w, Sint16 bw = 0);
-void LoadPalInMem(const SDL_Color *pPal);
 void DrawMouse();
 void UiLoadDefaultPalette();
 bool UiLoadBlackBackground();

--- a/Source/DiabloUI/progress.cpp
+++ b/Source/DiabloUI/progress.cpp
@@ -93,8 +93,6 @@ void ProgressRenderForeground(int progress)
 
 bool UiProgressDialog(int (*fnfunc)())
 {
-	SetFadeLevel(256);
-
 	// Blit the background once and then free it.
 	ProgressLoadBackground();
 

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -66,7 +66,7 @@ void RedPalette()
 		system_palette[i].g = 0;
 		system_palette[i].b = 0;
 	}
-	palette_update();
+	SystemPaletteUpdated();
 	BltFast(nullptr, nullptr);
 	RenderPresent();
 }
@@ -75,7 +75,6 @@ void RedPalette()
 
 void CaptureScreen()
 {
-	SDL_Color palette[256];
 	std::string fileName;
 	const uint32_t startTime = SDL_GetTicks();
 
@@ -86,12 +85,12 @@ void CaptureScreen()
 		return;
 	}
 	DrawAndBlit();
-	PaletteGetEntries(256, palette);
+
+	std::array<SDL_Color, 256> origSystemPalette = system_palette;
 	RedPalette();
-	for (int i = 0; i < 256; i++) {
-		system_palette[i] = palette[i];
-	}
-	palette_update();
+
+	system_palette = origSystemPalette;
+	SystemPaletteUpdated();
 
 	const tl::expected<void, std::string> result =
 #if DEVILUTIONX_SCREENSHOT_FORMAT == DEVILUTIONX_SCREENSHOT_FORMAT_PCX

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -126,10 +126,10 @@ void LoadPotionArt(ButtonTexture *potionArt)
 	    SDL_PIXELFORMAT_INDEX8);
 
 	auto palette = SDLWrap::AllocPalette();
-	if (SDLC_SetSurfaceAndPaletteColors(surface.get(), palette.get(), orig_palette.data(), 0, 256) < 0)
+	if (SDLC_SetSurfaceAndPaletteColors(surface.get(), palette.get(), logical_palette.data(), 0, 256) < 0)
 		ErrSdl();
 
-	Uint32 bgColor = SDL_MapRGB(surface->format, orig_palette[1].r, orig_palette[1].g, orig_palette[1].b);
+	Uint32 bgColor = SDL_MapRGB(surface->format, logical_palette[1].r, logical_palette[1].g, logical_palette[1].b);
 	if (SDL_FillRect(surface.get(), nullptr, bgColor) < 0)
 		ErrSdl();
 	if (SDL_SetColorKey(surface.get(), SDL_TRUE, bgColor) < 0)

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -697,6 +697,19 @@ void HandleMouseButtonUp(Uint8 button, uint16_t modState)
 	LogVerbose("Unhandled SDL event: {} {}", name, value);
 }
 
+void PrepareForFadeIn()
+{
+	if (HeadlessMode) return;
+	BlackPalette();
+
+	// Render the game to the buffer(s) with a fully black palette.
+	// Palette fade-in will gradually make it visible.
+	RedrawEverything();
+	while (IsRedrawEverything()) {
+		DrawAndBlit();
+	}
+}
+
 void GameEventHandler(const SDL_Event &event, uint16_t modState)
 {
 	[[maybe_unused]] Options &options = GetOptions();
@@ -813,15 +826,7 @@ void GameEventHandler(const SDL_Event &event, uint16_t modState)
 			sound_stop();
 			ShowProgress(GetCustomEvent(event));
 
-			RedrawEverything();
-			if (!HeadlessMode) {
-				while (IsRedrawEverything()) {
-					// In direct rendering mode with double/triple buffering, we need
-					// to prepare all buffers before fading in.
-					DrawAndBlit();
-				}
-			}
-
+			PrepareForFadeIn();
 			LoadPWaterPalette();
 			if (gbRunGame)
 				PaletteFadeIn(8);
@@ -847,15 +852,7 @@ void RunGameLoop(interface_mode uMsg)
 	gbProcessPlayers = IsDiabloAlive(true);
 	gbRunGameResult = true;
 
-	RedrawEverything();
-	if (!HeadlessMode) {
-		while (IsRedrawEverything()) {
-			// In direct rendering mode with double/triple buffering, we need
-			// to prepare all buffers before fading in.
-			DrawAndBlit();
-		}
-	}
-
+	PrepareForFadeIn();
 	LoadPWaterPalette();
 	PaletteFadeIn(8);
 	InitBackbufferState();

--- a/Source/engine/dx.cpp
+++ b/Source/engine/dx.cpp
@@ -36,7 +36,6 @@ SDLTextureUniquePtr texture;
 
 /** Currently active palette */
 SDLPaletteUniquePtr Palette;
-unsigned int pal_surface_palette_version = 0;
 
 /** 24-bit renderer texture surface */
 SDLSurfaceUniquePtr RendererTextureSurface;
@@ -94,9 +93,9 @@ void dx_init()
 	SDL_ShowWindow(ghMainWnd);
 #endif
 
+	Palette = SDLWrap::AllocPalette();
 	palette_init();
 	CreateBackBuffer();
-	pal_surface_palette_version = 1;
 }
 
 Surface GlobalBackBuffer()
@@ -149,11 +148,6 @@ void CreateBackBuffer()
 	// time the global `palette` is changed. No need to do anything here as
 	// the global `palette` doesn't have any colors set yet.
 #endif
-}
-
-void InitPalette()
-{
-	Palette = SDLWrap::AllocPalette();
 }
 
 void BltFast(SDL_Rect *srcRect, SDL_Rect *dstRect)
@@ -272,10 +266,4 @@ void RenderPresent()
 #endif
 }
 
-void PaletteGetEntries(int dwNumEntries, SDL_Color *lpEntries)
-{
-	for (int i = 0; i < dwNumEntries; i++) {
-		lpEntries[i] = system_palette[i];
-	}
-}
 } // namespace devilution

--- a/Source/engine/dx.h
+++ b/Source/engine/dx.h
@@ -21,10 +21,8 @@ Surface GlobalBackBuffer();
 void dx_init();
 void dx_cleanup();
 void CreateBackBuffer();
-void InitPalette();
 void BltFast(SDL_Rect *srcRect, SDL_Rect *dstRect);
 void Blit(SDL_Surface *src, SDL_Rect *srcRect, SDL_Rect *dstRect);
 void RenderPresent();
-void PaletteGetEntries(int dwNumEntries, SDL_Color *lpEntries);
 
 } // namespace devilution

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -298,6 +298,8 @@ void gamemenu_load_game(bool /*bActivate*/)
 	InitDiabloMsg(EMSG_LOADING);
 	RedrawEverything();
 	DrawAndBlit();
+
+	std::array<SDL_Color, 256> prevPalette = logical_palette;
 #ifndef USE_SDL1
 	DeactivateVirtualGamepad();
 	FreeVirtualGamepadTextures();
@@ -310,14 +312,15 @@ void gamemenu_load_game(bool /*bActivate*/)
 		InitVirtualGamepadTextures(*renderer);
 	}
 #endif
-	NewCursor(CURSOR_HAND);
 	ClrDiabloMsg();
+	PaletteFadeOut(8, prevPalette);
+
+	LoadPWaterPalette();
+	NewCursor(CURSOR_HAND);
 	CornerStone.activated = false;
-	PaletteFadeOut(8);
 	MyPlayerIsDead = false;
 	RedrawEverything();
 	DrawAndBlit();
-	LoadPWaterPalette();
 	PaletteFadeIn(8);
 	NewCursor(CURSOR_HAND);
 	interface_msg_pump();

--- a/Source/levels/setmaps.cpp
+++ b/Source/levels/setmaps.cpp
@@ -117,7 +117,7 @@ void LoadSetMap()
 		LoadPreL1Dungeon("levels\\l1data\\sklkng1.dun");
 		LoadL1Dungeon("levels\\l1data\\sklkng2.dun", { 83, 44 });
 		SetMapTransparency("levels\\l1data\\sklkngt.dun");
-		LoadPalette("levels\\l1data\\l1_2.pal");
+		LoadPaletteAndInitBlending("levels\\l1data\\l1_2.pal");
 		AddSKingObjs();
 		InitSKingTriggers();
 		break;
@@ -125,7 +125,7 @@ void LoadSetMap()
 		LoadPreL2Dungeon("levels\\l2data\\bonecha2.dun");
 		LoadL2Dungeon("levels\\l2data\\bonecha1.dun", { 70, 40 });
 		SetMapTransparency("levels\\l2data\\bonechat.dun");
-		LoadPalette("levels\\l2data\\l2_2.pal");
+		LoadPaletteAndInitBlending("levels\\l2data\\l2_2.pal");
 		AddSChamObjs();
 		InitSChambTriggers();
 		break;
@@ -135,7 +135,7 @@ void LoadSetMap()
 		if (Quests[Q_PWATER]._qactive == QUEST_INIT)
 			Quests[Q_PWATER]._qactive = QUEST_ACTIVE;
 		LoadL3Dungeon("levels\\l3data\\foulwatr.dun", { 31, 83 });
-		LoadPalette("levels\\l3data\\l3pfoul.pal");
+		LoadPaletteAndInitBlending("levels\\l3data\\l3pfoul.pal");
 		InitPWaterTriggers();
 		break;
 	case SL_VILEBETRAYER:
@@ -147,7 +147,7 @@ void LoadSetMap()
 		LoadPreL1Dungeon("levels\\l1data\\vile1.dun");
 		LoadL1Dungeon("levels\\l1data\\vile2.dun", { 35, 36 });
 		SetMapTransparency("levels\\l1data\\vile1.dun");
-		LoadPalette("levels\\l1data\\l1_2.pal");
+		LoadPaletteAndInitBlending("levels\\l1data\\l1_2.pal");
 		AddVileObjs();
 		InitNoTriggers();
 		break;

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -208,10 +208,12 @@ void PrintQLString(const Surface &out, int x, int y, std::string_view str, bool 
 	}
 }
 
+std::array<Color, 32> PureWaterPalette;
+
 void StartPWaterPurify()
 {
 	PlaySfxLoc(SfxID::QuestDone, MyPlayer->position.tile);
-	LoadPalette("levels\\l3data\\l3pwater.pal", false);
+	LoadFileInMem("levels\\l3data\\l3pwater.pal", PureWaterPalette);
 	UpdatePWaterPalette();
 	WaterDone = 32;
 }
@@ -524,15 +526,17 @@ void LoadPWaterPalette()
 		return;
 
 	if (Quests[Q_PWATER]._qactive == QUEST_DONE)
-		LoadPalette("levels\\l3data\\l3pwater.pal");
+		LoadPaletteAndInitBlending("levels\\l3data\\l3pwater.pal");
 	else
-		LoadPalette("levels\\l3data\\l3pfoul.pal");
+		LoadPaletteAndInitBlending("levels\\l3data\\l3pfoul.pal");
 }
 
 void UpdatePWaterPalette()
 {
 	if (WaterDone > 0) {
-		palette_update_quest_palette(WaterDone);
+		// `WaterDone` is in [1, 32], so `colorIndex` is in [0, 31].
+		const unsigned colorIndex = 32 - WaterDone;
+		SetLogicalPaletteColor(colorIndex, PureWaterPalette[colorIndex].toSDL());
 		WaterDone--;
 		return;
 	}

--- a/Source/utils/attributes.h
+++ b/Source/utils/attributes.h
@@ -72,8 +72,10 @@
 #endif
 
 #if ((defined(__GNUC__) || defined(__clang__)) && !defined(__EXCEPTIONS)) || defined(_MSC_VER) && !_HAS_EXCEPTIONS
+// NOLINTNEXTLINE(modernize-macro-to-enum)
 #define DVL_EXCEPTIONS 0
 #else
+// NOLINTNEXTLINE(modernize-macro-to-enum)
 #define DVL_EXCEPTIONS 1
 #endif
 

--- a/Source/utils/display.h
+++ b/Source/utils/display.h
@@ -26,7 +26,6 @@ extern SDLTextureUniquePtr texture;
 
 extern SDLPaletteUniquePtr Palette;
 extern SDL_Surface *PalSurface;
-extern unsigned int pal_surface_palette_version;
 extern DVL_API_FOR_TEST Size forceResolution;
 
 #ifdef USE_SDL1

--- a/Source/utils/palette_blending.hpp
+++ b/Source/utils/palette_blending.hpp
@@ -6,28 +6,32 @@
 
 namespace devilution {
 
-/** Lookup table for transparency */
+/**
+ * @brief Lookup table for the average of two colors in `logical_palette`.
+ */
 extern uint8_t paletteTransparencyLookup[256][256];
 
 /**
- * @brief Generate lookup table for transparency
+ * @brief Generates `paletteTransparencyLookup` table.
  *
  * This is based of the same technique found in Quake2.
  *
  * To mimic 50% transparency we figure out what colors in the existing palette are the best match for the combination of any 2 colors.
  * We save this into a lookup table for use during rendering.
  *
- * @param palette The colors to operate on
  * @param skipFrom Do not use colors between this index and skipTo
  * @param skipTo Do not use colors between skipFrom and this index
  */
-void GenerateBlendedLookupTable(SDL_Color palette[256], int skipFrom, int skipTo);
+void GenerateBlendedLookupTable(int skipFrom = -1, int skipTo = -1);
 
-void UpdateBlendedLookupTableSingleColor(unsigned i, SDL_Color palette[256], int skipFrom, int skipTo);
+/**
+ * @brief Updates the transparency lookup table for a single color.
+ */
+void UpdateBlendedLookupTableSingleColor(unsigned i);
 
 #if DEVILUTIONX_PALETTE_TRANSPARENCY_BLACK_16_LUT
 /**
- * A lookup table from black for a pair of colors.
+ * A lookup table from black for a pair of colors in `logical_palette`.
  *
  * For a pair of colors i and j, the index `i | (j << 8)` contains
  * `paletteTransparencyLookup[0][i] | (paletteTransparencyLookup[0][j] << 8)`.

--- a/Source/utils/palette_kd_tree.hpp
+++ b/Source/utils/palette_kd_tree.hpp
@@ -99,6 +99,8 @@ private:
 	using RGB = std::array<uint8_t, 3>;
 
 public:
+	PaletteKdTree() = default;
+
 	/**
 	 * @brief Constructs a PaletteKdTree
 	 *

--- a/Source/utils/static_vector.hpp
+++ b/Source/utils/static_vector.hpp
@@ -110,12 +110,12 @@ private:
 	struct AlignedStorage {
 		alignas(alignof(T)) std::byte data[sizeof(T)];
 
-		const T *ptr() const
+		[[nodiscard]] const T *ptr() const
 		{
 			return std::launder(reinterpret_cast<const T *>(data));
 		}
 
-		T *ptr()
+		[[nodiscard]] T *ptr()
 		{
 			return std::launder(reinterpret_cast<T *>(data));
 		}

--- a/test/palette_blending_benchmark.cpp
+++ b/test/palette_blending_benchmark.cpp
@@ -1,9 +1,14 @@
 #include "utils/palette_blending.hpp"
 
+#include <array>
+
 #include <SDL.h>
 #include <benchmark/benchmark.h>
 
 namespace devilution {
+
+std::array<SDL_Color, 256> logical_palette;
+
 namespace {
 
 void GeneratePalette(SDL_Color palette[256])
@@ -22,10 +27,10 @@ void GeneratePalette(SDL_Color palette[256])
 
 void BM_GenerateBlendedLookupTable(benchmark::State &state)
 {
-	SDL_Color palette[256];
+	SDL_Color *palette = logical_palette.data();
 	GeneratePalette(palette);
 	for (auto _ : state) {
-		GenerateBlendedLookupTable(palette, /*skipFrom=*/-1, /*skipTo=*/-1);
+		GenerateBlendedLookupTable();
 		int result = paletteTransparencyLookup[17][98];
 		benchmark::DoNotOptimize(result);
 	}

--- a/test/palette_blending_test.cpp
+++ b/test/palette_blending_test.cpp
@@ -1,6 +1,7 @@
 #include "utils/palette_blending.hpp"
 
 #include <algorithm>
+#include <array>
 #include <iostream>
 
 #include <SDL.h>
@@ -18,6 +19,9 @@ void PrintTo(const SDL_Color &color, std::ostream *os)
 }
 
 namespace devilution {
+
+std::array<SDL_Color, 256> logical_palette;
+
 namespace {
 
 MATCHER_P3(ColorIs, r, g, b,
@@ -42,10 +46,10 @@ void GeneratePalette(SDL_Color palette[256])
 
 TEST(GenerateBlendedLookupTableTest, BasicTest)
 {
-	SDL_Color palette[256];
+	SDL_Color *palette = logical_palette.data();
 	GeneratePalette(palette);
 
-	GenerateBlendedLookupTable(palette, /*skipFrom=*/-1, /*skipTo=*/-1);
+	GenerateBlendedLookupTable();
 
 	EXPECT_EQ(paletteTransparencyLookup[100][100], 100);
 


### PR DESCRIPTION
Gets rid of `orig_palette`, we now always have only 2 palettes:

1. `logical_palette` - This palette has color cycling / swapping applied but no global effects such as brightness / fade-in.

2. `system_palette` - This palette is the palette that will be used for rendering.
   It is usually `logical_palette` with the global brightness setting and fade-in/out applied.

Additionally, we now keep the k-d tree around and use it to update single colors. The colors that are color-cycled / swapped are never included in the k-d tree, so the tree does not need updating on color cycles/swaps.