### PR TITLE
Palette kd-tree: Store color values in leaves

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -409,6 +409,7 @@ add_devilutionx_object_library(libdevilutionx_palette_blending
 )
 target_link_dependencies(libdevilutionx_palette_blending PUBLIC
   DevilutionX::SDL
+  fmt::fmt
   libdevilutionx_strings
 )
 


### PR DESCRIPTION
Storing color values directly in leaves improves lookup speed, at the cost of a bit more space and a slightly slower `BuildTree`.

Tree size: 360 bytes -> 1119 bytes.

```
Benchmark                                              Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------------------------
BM_GenerateBlendedLookupTable_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_GenerateBlendedLookupTable_mean                  +0.0116         +0.0117       2245830       2271969       2245300       2271555
BM_GenerateBlendedLookupTable_median                +0.0115         +0.0116       2245978       2271854       2245441       2271588
BM_GenerateBlendedLookupTable_stddev                -0.3436         -0.6455           659           433           505           179
BM_GenerateBlendedLookupTable_cv                    -0.3512         -0.6496             0             0             0             0
BM_BuildTree_pvalue                                  0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_BuildTree_mean                                   +0.0636         +0.0649          6382          6788          6372          6786
BM_BuildTree_median                                 +0.0649         +0.0652          6375          6788          6371          6787
BM_BuildTree_stddev                                 -0.8562         +0.4121            23             3             2             3
BM_BuildTree_cv                                     -0.8648         +0.3260             0             0             0             0
BM_FindNearestNeighbor_pvalue                        0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_FindNearestNeighbor_mean                         -0.1665         -0.1662    2555103647    2129742669    2553963618    2129377560
BM_FindNearestNeighbor_median                       -0.1663         -0.1663    2554516344    2129730092    2553962695    2129360650
BM_FindNearestNeighbor_stddev                       -0.7871         +0.6518       1986207        422943        254256        419979
BM_FindNearestNeighbor_cv                           -0.7445         +0.9812             0             0             0             0
OVERALL_GEOMEAN                                     -0.0356         -0.0351             0             0             0             0
```
![palette dot](https://github.com/user-attachments/assets/ccedc142-2a54-4eb8-84c2-724d97b052ee)

