### PR TITLE
Benchmarks: Use `state.iterations()`

### DIFF
--- a/test/clx_render_benchmark.cpp
+++ b/test/clx_render_benchmark.cpp
@@ -25,20 +25,15 @@ void BM_RenderSmallClx(benchmark::State &state)
 	OwnedClxSpriteList sprites = LoadClx("data\\resistance.clx");
 
 	const size_t numSprites = sprites.numSprites();
-	const size_t dataSize = sprites.dataSize();
-	size_t numBytesProcessed = 0;
-	size_t numItemsProcessed = 0;
 	for (auto _ : state) {
 		for (size_t i = 0; i < numSprites; ++i) {
 			RenderClxSprite(out, sprites[i], Point { static_cast<int>(i * 100), static_cast<int>(i * 60) });
 		}
 		uint8_t color = out[Point { 120, 120 }];
 		benchmark::DoNotOptimize(color);
-		numItemsProcessed += numSprites;
-		numBytesProcessed += dataSize;
 	}
-	state.SetBytesProcessed(numBytesProcessed);
-	state.SetItemsProcessed(numItemsProcessed);
+	state.SetBytesProcessed(state.iterations() * sprites.dataSize());
+	state.SetItemsProcessed(state.iterations() * numSprites);
 }
 
 void BM_RenderLargeClx(benchmark::State &state)
@@ -52,18 +47,13 @@ void BM_RenderLargeClx(benchmark::State &state)
 	Surface out = Surface(sdl_surface.get());
 	OwnedClxSpriteList sprites = LoadClx("ui_art\\dvl_lrpopup.clx");
 
-	const size_t dataSize = sprites.dataSize();
-	size_t numBytesProcessed = 0;
-	size_t numItemsProcessed = 0;
 	for (auto _ : state) {
 		RenderClxSprite(out, sprites[0], Point { 100, 100 });
 		uint8_t color = out[Point { 120, 120 }];
 		benchmark::DoNotOptimize(color);
-		numBytesProcessed += dataSize;
-		++numItemsProcessed;
 	}
-	state.SetBytesProcessed(numBytesProcessed);
-	state.SetItemsProcessed(numItemsProcessed);
+	state.SetBytesProcessed(state.iterations() * sprites.dataSize());
+	state.SetItemsProcessed(state.iterations());
 }
 
 BENCHMARK(BM_RenderSmallClx);

--- a/test/dun_render_benchmark.cpp
+++ b/test/dun_render_benchmark.cpp
@@ -58,6 +58,7 @@ void InitOnce()
 				}
 			}
 		}
+		GetOptions().Graphics.perPixelLighting.SetValue(false);
 		return true;
 	}();
 }
@@ -66,7 +67,6 @@ void RunForTileMaskLight(benchmark::State &state, TileType tileType, MaskType ma
 {
 	Surface out = Surface(SdlSurface.get());
 	Lightmap lightmap(nullptr, {}, 1, nullptr, 0);
-	size_t numItemsProcessed = 0;
 	const std::span<const LevelCelBlock> tiles = Tiles[tileType];
 	for (auto _ : state) {
 		for (const LevelCelBlock &levelCelBlock : tiles) {
@@ -74,9 +74,8 @@ void RunForTileMaskLight(benchmark::State &state, TileType tileType, MaskType ma
 			uint8_t color = out[Point { 310, 200 }];
 			benchmark::DoNotOptimize(color);
 		}
-		numItemsProcessed += tiles.size();
 	}
-	state.SetItemsProcessed(numItemsProcessed);
+	state.SetItemsProcessed(state.iterations() * tiles.size());
 }
 
 using GetLightTableFn = const uint8_t *();
@@ -122,14 +121,12 @@ void BM_RenderBlackTile(benchmark::State &state)
 {
 	InitOnce();
 	Surface out = Surface(SdlSurface.get());
-	size_t numItemsProcessed = 0;
 	for (auto _ : state) {
 		world_draw_black_tile(out, 320, 240);
 		uint8_t color = out[Point { 310, 200 }];
 		benchmark::DoNotOptimize(color);
-		++numItemsProcessed;
 	}
-	state.SetItemsProcessed(numItemsProcessed);
+	state.SetItemsProcessed(state.iterations());
 }
 BENCHMARK(BM_RenderBlackTile);
 

--- a/test/palette_blending_benchmark.cpp
+++ b/test/palette_blending_benchmark.cpp
@@ -56,8 +56,6 @@ void BM_FindNearestNeighbor(benchmark::State &state)
 	GeneratePalette(palette);
 	PaletteKdTree tree(palette, -1, -1);
 
-	std::vector<std::array<uint8_t, 3>> queries;
-	int64_t itemsProcessed = 0;
 	for (auto _ : state) {
 		for (int r = 0; r < 256; ++r) {
 			for (int g = 0; g < 256; ++g) {
@@ -67,9 +65,8 @@ void BM_FindNearestNeighbor(benchmark::State &state)
 				}
 			}
 		}
-		itemsProcessed += 256 * 256 * 256;
 	}
-	state.SetItemsProcessed(itemsProcessed);
+	state.SetItemsProcessed(state.iterations() * 256 * 256 * 256);
 }
 
 BENCHMARK(BM_GenerateBlendedLookupTable);


### PR DESCRIPTION
This is a simpler way to calculate items/bytes per second. Also fixes `dun_render_benchmark`.