### PR TITLE
Don't apply brightness twice in PaletteFadeIn()

### DIFF
--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <span>
 
 #include <fmt/core.h>
@@ -291,7 +292,9 @@ void PaletteFadeIn(int fr, const std::array<SDL_Color, 256> &srcPalette)
 			RenderPresent();
 		}
 	}
-	UpdateSystemPalette(palette);
+	memcpy(system_palette.data(), palette, system_palette.size());
+	SystemPaletteUpdated();
+	RedrawEverything();
 	if (IsHardwareCursor()) ReinitializeHardwareCursor();
 
 	if (fr <= 0) {


### PR DESCRIPTION
This resolves an issue reported by FireIceTalon on Discord.

https://github.com/user-attachments/assets/223ff51f-200e-4593-9fa3-25e0f02e01c4

---

A little ways up on line 269, we apply the brightness to `srcPalette` and write the result in the `palette` array.

https://github.com/diasurgical/DevilutionX/blob/87c5b333c99132ff22d19a73f9a61d3411afcc48/Source/engine/palette.cpp#L268-L269

The `UpdateSystemPalette()` function also applies brightness to the palette we pass in and writes the result to `system_palette`. By passing `palette` as the parameter to `UpdateSystemPalette()`, we effectively apply brightness twice to the data in `srcPalette`. So we should use `srcPalette` instead to apply the brightness only once.