### PR TITLE
Reload SFX when changing language setting

### DIFF
--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -391,6 +391,7 @@ void LoadCoreArchives()
 
 void LoadLanguageArchive()
 {
+	MpqArchives.erase(LangMpqPriority);
 	const std::string_view code = GetLanguageCode();
 	if (code != "en") {
 		LoadMPQ(GetMPQSearchPaths(), code, LangMpqPriority);

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -496,6 +496,11 @@ void OptionLanguageCodeChanged()
 	UnloadFonts();
 	LanguageInitialize();
 	LoadLanguageArchive();
+	effects_cleanup_sfx();
+	if (gbRunGame)
+		sound_init();
+	else
+		ui_sound_init();
 }
 
 const auto OptionChangeHandlerResolution = (GetOptions().Language.code.SetValueChangedCallback(OptionLanguageCodeChanged), true);


### PR DESCRIPTION
This PR fixes an issue where changing the `Language` setting doesn't reload SFX. So following these steps would cause the game to end up with the wrong audio.

1. Install `pl.mpq` in the data folder.
2. Start the game client and switch to Polish.
3. Enter a game and trigger an audio cue. The game should be using Polish audio.
4. Go back to the main menu without exiting the game client.
5. Switch language back to English.
6. Enter a game and trigger an audio cue. The game should still be using Polish audio.

The issue here was twofold. First, the `sgSFX` vector caches sound effects in memory, and `OptionLanguageCodeChanged()` didn't flush/reload them. Second, the `pl.mpq` archive would only be removed if there was another audio pack to replace it. English doesn't have an explicit audio pack, so even if you flush/reload the SFX vector, the game would just load the Polish audio files anyway because it is still getting assets from `pl.mpq`.