### PR TITLE
Amiga workflow: Add ccache

### DIFF
--- a/.github/workflows/amiga-m68k.yml
+++ b/.github/workflows/amiga-m68k.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+
       - name: Run prep.sh script
         run: ./Packaging/amiga/prep.sh
 
@@ -62,4 +65,3 @@ jobs:
           asset_name: devilutionx-amiga-m68k
           file: ./build/devilutionx
           overwrite: true
-...


### PR DESCRIPTION
Amiga builds have recently been taking ~50 minutes, most of the time spent compiling lua/modules/items.cpp.
Adding ccache should mitigate this a bit, as we rarely change that file.