### PR TITLE
fix hellfire crash on pCursCels2

### DIFF
--- a/CMake/Mods.cmake
+++ b/CMake/Mods.cmake
@@ -21,7 +21,7 @@ set(hellfire_mod
   ui_art/mainmenuw.clx)
 
 if(NOT UNPACKED_MPQS)
-  list(APPEND devilutionx_assets
+  list(APPEND hellfire_mod
     data/inv/objcurs2-widths.txt)
 endif()
 


### PR DESCRIPTION
data/inv/objcurs2-widths.txt wasn't getting copied to mods/Hellfire on build