### PR TITLE
GitHub CI: Update 3DS and Switch configs

### DIFF
--- a/.github/workflows/3ds.yml
+++ b/.github/workflows/3ds.yml
@@ -33,9 +33,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get install -t bullseye -y --no-install-recommends --no-install-suggests \
-            ffmpeg \
-            gettext
+          apt-get install -y --no-install-recommends --no-install-suggests \
+            ffmpeg
 
       - name: Get external dependencies
         run: |

--- a/.github/workflows/switch.yml
+++ b/.github/workflows/switch.yml
@@ -31,11 +31,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install dependencies
-        run: |
-          apt-get install -y --no-install-recommends --no-install-suggests \
-            gettext
-
       - name: Configure CMake
         run: |
           cmake \


### PR DESCRIPTION
1. Debian has been updated to bookworm.
2. gettext is now part of the image, no need to install it.