### PR TITLE
Make `dun_render` a standalone library

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -84,7 +84,6 @@ set(libdevilutionx_SRCS
   engine/trn.cpp
 
   engine/render/automap_render.cpp
-  engine/render/dun_render.cpp
   engine/render/scrollrt.cpp
 
   items/validation.cpp
@@ -289,6 +288,18 @@ target_link_dependencies(libdevilutionx_crawl PUBLIC
 
 add_devilutionx_object_library(libdevilutionx_direction
   engine/direction.cpp
+)
+
+add_devilutionx_object_library(libdevilutionx_dun_render
+  engine/render/dun_render.cpp
+)
+target_link_libraries(libdevilutionx_dun_render
+  PUBLIC
+  DevilutionX::SDL
+  libdevilutionx_light_render
+  libdevilutionx_surface
+  PRIVATE
+  libdevilutionx_options
 )
 
 add_library(libdevilutionx_endian_write INTERFACE)
@@ -851,6 +862,7 @@ target_link_dependencies(libdevilutionx PUBLIC
   libdevilutionx_control_mode
   libdevilutionx_crawl
   libdevilutionx_direction
+  libdevilutionx_dun_render
   libdevilutionx_surface
   libdevilutionx_file_util
   libdevilutionx_format_int

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -3246,7 +3246,7 @@ tl::expected<void, std::string> LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	IncProgress();
 
 	RETURN_IF_ERROR(LoadLvlGFX());
-	SetDungeonMicros();
+	SetDungeonMicros(pDungeonCels, MicroTileLen);
 	ClearClxDrawCache();
 
 	IncProgress();

--- a/Source/engine/render/light_render.cpp
+++ b/Source/engine/render/light_render.cpp
@@ -491,12 +491,15 @@ void BuildLightmap(Point tilePosition, Point targetBufferPosition, uint16_t view
 
 Lightmap::Lightmap(const uint8_t *outBuffer, uint16_t outPitch,
     std::span<const uint8_t> lightmapBuffer, uint16_t lightmapPitch,
-    std::span<const std::array<uint8_t, LightTableSize>, NumLightingLevels> lightTables)
+    std::span<const std::array<uint8_t, LightTableSize>, NumLightingLevels> lightTables,
+    const uint8_t *fullyLitLightTable, const uint8_t *fullyDarkLightTable)
     : outBuffer(outBuffer)
     , outPitch(outPitch)
     , lightmapBuffer(lightmapBuffer)
     , lightmapPitch(lightmapPitch)
     , lightTables(lightTables)
+    , fullyLitLightTable_(fullyLitLightTable)
+    , fullyDarkLightTable_(fullyDarkLightTable)
 {
 }
 
@@ -504,13 +507,14 @@ Lightmap Lightmap::build(bool perPixelLighting, Point tilePosition, Point target
     int viewportWidth, int viewportHeight, int rows, int columns,
     const uint8_t *outBuffer, uint16_t outPitch,
     std::span<const std::array<uint8_t, LightTableSize>, NumLightingLevels> lightTables,
+    const uint8_t *fullyLitLightTable, const uint8_t *fullyDarkLightTable,
     const uint8_t tileLights[MAXDUNX][MAXDUNY],
     uint_fast8_t microTileLen)
 {
 	if (perPixelLighting) {
 		BuildLightmap(tilePosition, targetBufferPosition, viewportWidth, viewportHeight, rows, columns, tileLights, microTileLen);
 	}
-	return Lightmap(outBuffer, outPitch, LightmapBuffer, viewportWidth, lightTables);
+	return Lightmap(outBuffer, outPitch, LightmapBuffer, viewportWidth, lightTables, fullyLitLightTable, fullyDarkLightTable);
 }
 
 Lightmap Lightmap::bleedUp(bool perPixelLighting, const Lightmap &source, Point targetBufferPosition, std::span<uint8_t> lightmapBuffer)
@@ -565,7 +569,7 @@ Lightmap Lightmap::bleedUp(bool perPixelLighting, const Lightmap &source, Point 
 
 	return Lightmap(outBuffer, source.outPitch,
 	    lightmapBuffer, lightmapPitch,
-	    source.lightTables);
+	    source.lightTables, source.fullyLitLightTable_, source.fullyDarkLightTable_);
 }
 
 } // namespace devilution

--- a/Source/engine/render/light_render.hpp
+++ b/Source/engine/render/light_render.hpp
@@ -13,14 +13,17 @@ namespace devilution {
 
 class Lightmap {
 public:
-	explicit Lightmap(const uint8_t *outBuffer, std::span<const uint8_t> lightmapBuffer, uint16_t pitch, std::span<const std::array<uint8_t, LightTableSize>, NumLightingLevels> lightTables)
-	    : Lightmap(outBuffer, pitch, lightmapBuffer, pitch, lightTables)
+	explicit Lightmap(const uint8_t *outBuffer, std::span<const uint8_t> lightmapBuffer, uint16_t pitch,
+	    std::span<const std::array<uint8_t, LightTableSize>, NumLightingLevels> lightTables,
+	    const uint8_t *fullyLitLightTable, const uint8_t *fullyDarkLightTable)
+	    : Lightmap(outBuffer, pitch, lightmapBuffer, pitch, lightTables, fullyLitLightTable, fullyDarkLightTable)
 	{
 	}
 
 	explicit Lightmap(const uint8_t *outBuffer, uint16_t outPitch,
 	    std::span<const uint8_t> lightmapBuffer, uint16_t lightmapPitch,
-	    std::span<const std::array<uint8_t, LightTableSize>, NumLightingLevels> lightTables);
+	    std::span<const std::array<uint8_t, LightTableSize>, NumLightingLevels> lightTables,
+	    const uint8_t *fullyLitLightTable, const uint8_t *fullyDarkLightTable);
 
 	[[nodiscard]] uint8_t adjustColor(uint8_t color, uint8_t lightLevel) const
 	{
@@ -43,10 +46,14 @@ public:
 		return lightmapBuffer.data() + row * lightmapPitch + rowOffset;
 	}
 
+	[[nodiscard]] bool isFullyLitLightTable(const uint8_t *lightTable) const { return lightTable == fullyLitLightTable_; }
+	[[nodiscard]] bool isFullyDarkLightTable(const uint8_t *lightTable) const { return lightTable == fullyDarkLightTable_; }
+
 	static Lightmap build(bool perPixelLighting, Point tilePosition, Point targetBufferPosition,
 	    int viewportWidth, int viewportHeight, int rows, int columns,
 	    const uint8_t *outBuffer, uint16_t outPitch,
 	    std::span<const std::array<uint8_t, LightTableSize>, NumLightingLevels> lightTables,
+	    const uint8_t *fullyLitLightTable, const uint8_t *fullyDarkLightTable,
 	    const uint8_t tileLights[MAXDUNX][MAXDUNY],
 	    uint_fast8_t microTileLen);
 
@@ -60,6 +67,8 @@ private:
 	const uint16_t lightmapPitch;
 
 	std::span<const std::array<uint8_t, LightTableSize>, NumLightingLevels> lightTables;
+	const uint8_t *fullyLitLightTable_;
+	const uint8_t *fullyDarkLightTable_;
 };
 
 } // namespace devilution

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -578,9 +578,11 @@ void DrawCell(const Surface &out, const Lightmap lightmap, Point tilePosition, P
 		const TileType tileType = levelCelBlock.type();
 		if (!isFloor || tileType == TileType::TransparentSquare) {
 			if (isFloor && tileType == TileType::TransparentSquare) {
-				RenderTileFoliage(out, bleedLightmap, targetBufferPosition, levelCelBlock, foliageTbl);
+				RenderTileFoliage(out, bleedLightmap, targetBufferPosition,
+				    pDungeonCels.get(), levelCelBlock, foliageTbl);
 			} else {
-				RenderTile(out, bleedLightmap, targetBufferPosition, levelCelBlock, getFirstTileMaskLeft(tileType), tbl);
+				RenderTile(out, bleedLightmap, targetBufferPosition,
+				    pDungeonCels.get(), levelCelBlock, getFirstTileMaskLeft(tileType), tbl);
 			}
 		}
 	}
@@ -588,10 +590,11 @@ void DrawCell(const Surface &out, const Lightmap lightmap, Point tilePosition, P
 		const TileType tileType = levelCelBlock.type();
 		if (!isFloor || tileType == TileType::TransparentSquare) {
 			if (isFloor && tileType == TileType::TransparentSquare) {
-				RenderTileFoliage(out, bleedLightmap, targetBufferPosition + RightFrameDisplacement, levelCelBlock, foliageTbl);
+				RenderTileFoliage(out, bleedLightmap, targetBufferPosition + RightFrameDisplacement,
+				    pDungeonCels.get(), levelCelBlock, foliageTbl);
 			} else {
 				RenderTile(out, bleedLightmap, targetBufferPosition + RightFrameDisplacement,
-				    levelCelBlock, getFirstTileMaskRight(tileType), tbl);
+				    pDungeonCels.get(), levelCelBlock, getFirstTileMaskRight(tileType), tbl);
 			}
 		}
 	}
@@ -602,7 +605,7 @@ void DrawCell(const Surface &out, const Lightmap lightmap, Point tilePosition, P
 			const LevelCelBlock levelCelBlock { pMap->mt[i] };
 			if (levelCelBlock.hasValue()) {
 				RenderTile(out, bleedLightmap, targetBufferPosition,
-				    levelCelBlock,
+				    pDungeonCels.get(), levelCelBlock,
 				    transparency ? MaskType::Transparent : MaskType::Solid, foliageTbl);
 			}
 		}
@@ -610,7 +613,7 @@ void DrawCell(const Surface &out, const Lightmap lightmap, Point tilePosition, P
 			const LevelCelBlock levelCelBlock { pMap->mt[i + 1] };
 			if (levelCelBlock.hasValue()) {
 				RenderTile(out, bleedLightmap, targetBufferPosition + RightFrameDisplacement,
-				    levelCelBlock,
+				    pDungeonCels.get(), levelCelBlock,
 				    transparency ? MaskType::Transparent : MaskType::Solid, foliageTbl);
 			}
 		}
@@ -650,14 +653,14 @@ void DrawFloorTile(const Surface &out, const Lightmap &lightmap, Point tilePosit
 		const LevelCelBlock levelCelBlock { DPieceMicros[levelPieceId].mt[0] };
 		if (levelCelBlock.hasValue()) {
 			RenderTileFrame(out, lightmap, targetBufferPosition, TileType::LeftTriangle,
-			    GetDunFrame(levelCelBlock.frame()), DunFrameTriangleHeight, MaskType::Solid, tbl);
+			    GetDunFrame(pDungeonCels.get(), levelCelBlock.frame()), DunFrameTriangleHeight, MaskType::Solid, tbl);
 		}
 	}
 	{
 		const LevelCelBlock levelCelBlock { DPieceMicros[levelPieceId].mt[1] };
 		if (levelCelBlock.hasValue()) {
 			RenderTileFrame(out, lightmap, targetBufferPosition + RightFrameDisplacement, TileType::RightTriangle,
-			    GetDunFrame(levelCelBlock.frame()), DunFrameTriangleHeight, MaskType::Solid, tbl);
+			    GetDunFrame(pDungeonCels.get(), levelCelBlock.frame()), DunFrameTriangleHeight, MaskType::Solid, tbl);
 		}
 	}
 }
@@ -1164,7 +1167,7 @@ void DrawGame(const Surface &fullOut, Point position, Displacement offset)
 
 	Lightmap lightmap = Lightmap::build(*GetOptions().Graphics.perPixelLighting, position, Point {} + offset,
 	    gnScreenWidth, gnViewportHeight, rows, columns,
-	    out.at(0, 0), out.pitch(), LightTables,
+	    out.at(0, 0), out.pitch(), LightTables, FullyLitLightTable, FullyDarkLightTable,
 	    dLight, MicroTileLen);
 
 	DrawFloor(out, lightmap, position, Point {} + offset, rows, columns);

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -504,16 +504,16 @@ tl::expected<void, std::string> LoadLevelSOLData()
 	return {};
 }
 
-void SetDungeonMicros()
+void SetDungeonMicros(std::unique_ptr<std::byte[]> &dungeonCels, uint_fast8_t &microTileLen)
 {
-	MicroTileLen = 10;
+	microTileLen = 10;
 	size_t blocks = 10;
 
 	if (leveltype == DTYPE_TOWN) {
-		MicroTileLen = 16;
+		microTileLen = 16;
 		blocks = 16;
 	} else if (leveltype == DTYPE_HELL) {
-		MicroTileLen = 12;
+		microTileLen = 12;
 		blocks = 16;
 	}
 
@@ -539,7 +539,7 @@ void SetDungeonMicros()
 	c_sort(frameToTypeList, [](const std::pair<uint16_t, DunFrameInfo> &a, const std::pair<uint16_t, DunFrameInfo> &b) {
 		return a.first < b.first;
 	});
-	ReencodeDungeonCels(pDungeonCels, frameToTypeList);
+	ReencodeDungeonCels(dungeonCels, frameToTypeList);
 
 	std::vector<std::pair<uint16_t, uint16_t>> celBlockAdjustments = ComputeCelBlockAdjustments(frameToTypeList);
 	if (celBlockAdjustments.size() == 0) return;

--- a/Source/levels/gendung.h
+++ b/Source/levels/gendung.h
@@ -5,13 +5,13 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
 
-#include <SDL_endian.h>
 #include <expected.hpp>
 
 #include "engine/clx_sprite.hpp"
@@ -298,7 +298,7 @@ struct Miniset {
 }
 
 tl::expected<void, std::string> LoadLevelSOLData();
-void SetDungeonMicros();
+void SetDungeonMicros(std::unique_ptr<std::byte[]> &dungeonCels, uint_fast8_t &microTileLen);
 void DRLG_InitTrans();
 void DRLG_MRectTrans(WorldTilePosition origin, WorldTilePosition extent);
 void DRLG_MRectTrans(WorldTileRectangle area);
@@ -330,16 +330,5 @@ void DRLG_LPass3(int lv);
 bool IsNearThemeRoom(WorldTilePosition position);
 void InitLevels();
 void FloodTransparencyValues(uint8_t floorID);
-
-DVL_ALWAYS_INLINE const uint8_t *GetDunFrame(uint32_t frame)
-{
-	const auto *pFrameTable = reinterpret_cast<const uint32_t *>(pDungeonCels.get());
-	return reinterpret_cast<const uint8_t *>(&pDungeonCels[SDL_SwapLE32(pFrameTable[frame])]);
-}
-
-DVL_ALWAYS_INLINE const uint8_t *GetDunFrameFoliage(uint32_t frame)
-{
-	return GetDunFrame(frame) + ReencodedTriangleFrameSize;
-}
 
 } // namespace devilution

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,7 +138,6 @@ if(DEVILUTIONX_SCREENSHOT_FORMAT STREQUAL DEVILUTIONX_SCREENSHOT_FORMAT_PNG AND 
     language_for_testing
     libdevilutionx_primitive_render
     libdevilutionx_strings
-    libdevilutionx_strings
     libdevilutionx_surface
     libdevilutionx_surface_to_png
     libdevilutionx_text_render

--- a/test/light_render_benchmark.cpp
+++ b/test/light_render_benchmark.cpp
@@ -50,7 +50,7 @@ void BM_BuildLightmap(benchmark::State &state)
 		Lightmap lightmap = Lightmap::build(/*perPixelLighting=*/true,
 		    tilePosition, targetBufferPosition,
 		    viewportWidth, viewportHeight, rows, columns,
-		    outBuffer, outPitch, lightTables,
+		    outBuffer, outPitch, lightTables, lightTables[0].data(), lightTables.back().data(),
 		    dLight, /*microTileLen=*/10);
 
 		uint8_t lightLevel = *lightmap.getLightingAt(outBuffer + outPitch * 120 + 120);


### PR DESCRIPTION
Does not make `dun_render_benchmark` standalone yet as that will require more untangling.

Benchmark is neutral (small diffs are I think due to noise, e.g. lack of core pinning and background processes on my machine):

```
Benchmark                                                                     Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------------------------------
Render<LeftTriangle, Solid, FullyLit>_pvalue                                0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<LeftTriangle, Solid, FullyLit>_mean                                 +0.0119         +0.0120          8377          8477          8375          8475
Render<LeftTriangle, Solid, FullyLit>_median                               +0.0119         +0.0119          8376          8477          8375          8475
Render<LeftTriangle, Solid, FullyLit>_stddev                               -0.0884         -0.2462             2             1             1             1
Render<LeftTriangle, Solid, FullyLit>_cv                                   -0.0992         -0.2551             0             0             0             0
Render<LeftTriangle, Solid, FullyDark>_pvalue                               0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<LeftTriangle, Solid, FullyDark>_mean                                +0.0910         +0.0910         21174         23100         21170         23097
Render<LeftTriangle, Solid, FullyDark>_median                              +0.0869         +0.0869         21183         23023         21179         23019
Render<LeftTriangle, Solid, FullyDark>_stddev                              -0.1528         -0.1593           267           226           268           225
Render<LeftTriangle, Solid, FullyDark>_cv                                  -0.2234         -0.2294             0             0             0             0
Render<LeftTriangle, Solid, PartiallyLit>_pvalue                            0.0013          0.0013      U Test, Repetitions: 10 vs 10
Render<LeftTriangle, Solid, PartiallyLit>_mean                             +0.0065         +0.0065         81168         81698         81151         81680
Render<LeftTriangle, Solid, PartiallyLit>_median                           +0.0075         +0.0073         81143         81748         81136         81730
Render<LeftTriangle, Solid, PartiallyLit>_stddev                           +0.8663         +0.8787           167           311           164           307
Render<LeftTriangle, Solid, PartiallyLit>_cv                               +0.8542         +0.8665             0             0             0             0
Render<LeftTriangle, Transparent, FullyLit>_pvalue                          0.0028          0.0017      U Test, Repetitions: 10 vs 10
Render<LeftTriangle, Transparent, FullyLit>_mean                           -0.0239         -0.0239         94989         92719         94973         92703
Render<LeftTriangle, Transparent, FullyLit>_median                         -0.0122         -0.0123         93867         92717         93856         92704
Render<LeftTriangle, Transparent, FullyLit>_stddev                         -0.9920         -0.9955          2370            19          2368            11
Render<LeftTriangle, Transparent, FullyLit>_cv                             -0.9918         -0.9954             0             0             0             0
Render<LeftTriangle, Transparent, FullyDark>_pvalue                         0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<LeftTriangle, Transparent, FullyDark>_mean                          -0.0841         -0.0841         76234         69821         76220         69809
Render<LeftTriangle, Transparent, FullyDark>_median                        -0.0831         -0.0832         76209         69877         76202         69864
Render<LeftTriangle, Transparent, FullyDark>_stddev                        -0.4486         -0.4538           441           243           440           241
Render<LeftTriangle, Transparent, FullyDark>_cv                            -0.3979         -0.4037             0             0             0             0
Render<LeftTriangle, Transparent, PartiallyLit>_pvalue                      0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<LeftTriangle, Transparent, PartiallyLit>_mean                       +0.0022         +0.0021        128812        129091        128792        129067
Render<LeftTriangle, Transparent, PartiallyLit>_median                     +0.0023         +0.0023        128820        129115        128805        129096
Render<LeftTriangle, Transparent, PartiallyLit>_stddev                     +0.8757         +0.6866            50            93            53            90
Render<LeftTriangle, Transparent, PartiallyLit>_cv                         +0.8716         +0.6830             0             0             0             0
Render<RightTriangle, Solid, FullyLit>_pvalue                               0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<RightTriangle, Solid, FullyLit>_mean                                +0.0057         +0.0057          8521          8570          8520          8569
Render<RightTriangle, Solid, FullyLit>_median                              +0.0057         +0.0057          8522          8570          8520          8568
Render<RightTriangle, Solid, FullyLit>_stddev                              -0.1826         -0.0420             1             1             1             1
Render<RightTriangle, Solid, FullyLit>_cv                                  -0.1872         -0.0475             0             0             0             0
Render<RightTriangle, Solid, FullyDark>_pvalue                              0.0006          0.0006      U Test, Repetitions: 10 vs 10
Render<RightTriangle, Solid, FullyDark>_mean                               -0.0303         -0.0303         22678         21991         22675         21987
Render<RightTriangle, Solid, FullyDark>_median                             -0.0360         -0.0359         22704         21888         22699         21883
Render<RightTriangle, Solid, FullyDark>_stddev                             +0.4759         +0.4648           195           288           196           287
Render<RightTriangle, Solid, FullyDark>_cv                                 +0.5220         +0.5106             0             0             0             0
Render<RightTriangle, Solid, PartiallyLit>_pvalue                           0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<RightTriangle, Solid, PartiallyLit>_mean                            +0.0338         +0.0338         83355         86170         83341         86157
Render<RightTriangle, Solid, PartiallyLit>_median                          +0.0347         +0.0348         83248         86140         83230         86126
Render<RightTriangle, Solid, PartiallyLit>_stddev                          +0.3670         +0.3423           238           326           240           322
Render<RightTriangle, Solid, PartiallyLit>_cv                              +0.3224         +0.2985             0             0             0             0
Render<RightTriangle, Transparent, FullyLit>_pvalue                         0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<RightTriangle, Transparent, FullyLit>_mean                          -0.0617         -0.0616        102726         96392        102706         96375
Render<RightTriangle, Transparent, FullyLit>_median                        -0.0598         -0.0597        102521         96394        102498         96375
Render<RightTriangle, Transparent, FullyLit>_stddev                        -0.9516         -0.9548           456            22           461            21
Render<RightTriangle, Transparent, FullyLit>_cv                            -0.9485         -0.9518             0             0             0             0
Render<RightTriangle, Transparent, FullyDark>_pvalue                        0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<RightTriangle, Transparent, FullyDark>_mean                         -0.1377         -0.1377         84505         72865         84492         72853
Render<RightTriangle, Transparent, FullyDark>_median                       -0.1374         -0.1374         84339         72748         84323         72740
Render<RightTriangle, Transparent, FullyDark>_stddev                       -0.2760         -0.2867           526           381           528           377
Render<RightTriangle, Transparent, FullyDark>_cv                           -0.1604         -0.1727             0             0             0             0
Render<RightTriangle, Transparent, PartiallyLit>_pvalue                     0.0036          0.0017      U Test, Repetitions: 10 vs 10
Render<RightTriangle, Transparent, PartiallyLit>_mean                      +0.0010         +0.0010        131672        131808        131649        131784
Render<RightTriangle, Transparent, PartiallyLit>_median                    +0.0010         +0.0008        131665        131797        131654        131757
Render<RightTriangle, Transparent, PartiallyLit>_stddev                    -0.0688         -0.0128            81            75            72            71
Render<RightTriangle, Transparent, PartiallyLit>_cv                        -0.0697         -0.0138             0             0             0             0
Render<TransparentSquare, Solid, FullyLit>_pvalue                           0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<TransparentSquare, Solid, FullyLit>_mean                            -0.0300         -0.0300        143323        139021        143300        139000
Render<TransparentSquare, Solid, FullyLit>_median                          -0.0300         -0.0301        143321        139014        143310        138990
Render<TransparentSquare, Solid, FullyLit>_stddev                          +0.0008         -0.0820            43            43            43            39
Render<TransparentSquare, Solid, FullyLit>_cv                              +0.0318         -0.0536             0             0             0             0
Render<TransparentSquare, Solid, FullyDark>_pvalue                          0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<TransparentSquare, Solid, FullyDark>_mean                           -0.0100         -0.0100        134939        133588        134914        133565
Render<TransparentSquare, Solid, FullyDark>_median                         -0.0106         -0.0108        134964        133526        134948        133497
Render<TransparentSquare, Solid, FullyDark>_stddev                         +1.7508         +1.8682            99           273            96           276
Render<TransparentSquare, Solid, FullyDark>_cv                             +1.7786         +1.8972             0             0             0             0
Render<TransparentSquare, Solid, PartiallyLit>_pvalue                       0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<TransparentSquare, Solid, PartiallyLit>_mean                        -0.0460         -0.0460        152043        145043        152016        145020
Render<TransparentSquare, Solid, PartiallyLit>_median                      -0.0463         -0.0461        152012        144978        151964        144962
Render<TransparentSquare, Solid, PartiallyLit>_stddev                      -0.4453         -0.4334           267           148           266           151
Render<TransparentSquare, Solid, PartiallyLit>_cv                          -0.4185         -0.4060             0             0             0             0
Render<TransparentSquare, Transparent, FullyLit>_pvalue                     0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<TransparentSquare, Transparent, FullyLit>_mean                      -0.0846         -0.0846        181333        165997        181304        165969
Render<TransparentSquare, Transparent, FullyLit>_median                    -0.0840         -0.0839        181184        165972        181147        165945
Render<TransparentSquare, Transparent, FullyLit>_stddev                    -0.5808         -0.5755           319           134           320           136
Render<TransparentSquare, Transparent, FullyLit>_cv                        -0.5421         -0.5362             0             0             0             0
Render<TransparentSquare, Transparent, FullyDark>_pvalue                    0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<TransparentSquare, Transparent, FullyDark>_mean                     -0.0250         -0.0250        142232        138672        142208        138648
Render<TransparentSquare, Transparent, FullyDark>_median                   -0.0245         -0.0245        142144        138663        142128        138639
Render<TransparentSquare, Transparent, FullyDark>_stddev                   +0.1011         +0.0806           288           317           290           313
Render<TransparentSquare, Transparent, FullyDark>_cv                       +0.1294         +0.1084             0             0             0             0
Render<TransparentSquare, Transparent, PartiallyLit>_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<TransparentSquare, Transparent, PartiallyLit>_mean                  +0.0105         +0.0105        205439        207589        205397        207556
Render<TransparentSquare, Transparent, PartiallyLit>_median                +0.0106         +0.0107        205402        207575        205355        207558
Render<TransparentSquare, Transparent, PartiallyLit>_stddev                -0.4410         -0.3876           182           102           167           102
Render<TransparentSquare, Transparent, PartiallyLit>_cv                    -0.4468         -0.3940             0             0             0             0
Render<Square, Solid, FullyLit>_pvalue                                      0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<Square, Solid, FullyLit>_mean                                       -0.0010         -0.0010         11109         11098         11107         11096
Render<Square, Solid, FullyLit>_median                                     -0.0010         -0.0010         11109         11097         11107         11095
Render<Square, Solid, FullyLit>_stddev                                     -0.2265         +0.2791             3             2             2             2
Render<Square, Solid, FullyLit>_cv                                         -0.2257         +0.2804             0             0             0             0
Render<Square, Solid, FullyDark>_pvalue                                     0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<Square, Solid, FullyDark>_mean                                      +0.0904         +0.0904          8513          9283          8512          9282
Render<Square, Solid, FullyDark>_median                                    +0.0902         +0.0902          8521          9290          8519          9288
Render<Square, Solid, FullyDark>_stddev                                    -0.1884         -0.1616            21            17            21            18
Render<Square, Solid, FullyDark>_cv                                        -0.2557         -0.2311             0             0             0             0
Render<Square, Solid, PartiallyLit>_pvalue                                  0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<Square, Solid, PartiallyLit>_mean                                   +0.0038         +0.0038        163661        164289        163632        164259
Render<Square, Solid, PartiallyLit>_median                                 +0.0038         +0.0040        163665        164290        163621        164269
Render<Square, Solid, PartiallyLit>_stddev                                 +0.1746         +0.4412            34            40            28            40
Render<Square, Solid, PartiallyLit>_cv                                     +0.1701         +0.4356             0             0             0             0
Render<Square, Transparent, FullyLit>_pvalue                                0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<Square, Transparent, FullyLit>_mean                                 -0.0029         -0.0029        197906        197340        197876        197304
Render<Square, Transparent, FullyLit>_median                               -0.0030         -0.0029        197929        197339        197872        197307
Render<Square, Transparent, FullyLit>_stddev                               -0.5965         -0.7554            61            25            62            15
Render<Square, Transparent, FullyLit>_cv                                   -0.5953         -0.7547             0             0             0             0
Render<Square, Transparent, FullyDark>_pvalue                               0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<Square, Transparent, FullyDark>_mean                                -0.0163         -0.0163        125659        123607        125641        123588
Render<Square, Transparent, FullyDark>_median                              -0.0163         -0.0163        125651        123609        125629        123579
Render<Square, Transparent, FullyDark>_stddev                              -0.7943         -0.8033           180            37           181            36
Render<Square, Transparent, FullyDark>_cv                                  -0.7909         -0.8000             0             0             0             0
Render<Square, Transparent, PartiallyLit>_pvalue                            0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<Square, Transparent, PartiallyLit>_mean                             +0.0182         +0.0182        278103        283157        278043        283107
Render<Square, Transparent, PartiallyLit>_median                           +0.0184         +0.0184        278086        283190        278017        283120
Render<Square, Transparent, PartiallyLit>_stddev                           +1.6051         +1.5303            81           210            82           209
Render<Square, Transparent, PartiallyLit>_cv                               +1.5586         +1.4850             0             0             0             0
Render<LeftTrapezoid, Solid, FullyLit>_pvalue                               0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<LeftTrapezoid, Solid, FullyLit>_mean                                -0.0068         -0.0068          3299          3276          3298          3276
Render<LeftTrapezoid, Solid, FullyLit>_median                              -0.0068         -0.0068          3299          3276          3298          3276
Render<LeftTrapezoid, Solid, FullyLit>_stddev                              -0.4844         -0.6856             1             0             1             0
Render<LeftTrapezoid, Solid, FullyLit>_cv                                  -0.4809         -0.6834             0             0             0             0
Render<LeftTrapezoid, Solid, FullyDark>_pvalue                              0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<LeftTrapezoid, Solid, FullyDark>_mean                               +0.3996         +0.3997          5163          7227          5162          7226
Render<LeftTrapezoid, Solid, FullyDark>_median                             +0.3973         +0.3974          5174          7230          5173          7229
Render<LeftTrapezoid, Solid, FullyDark>_stddev                             -0.7835         -0.7789            89            19            89            20
Render<LeftTrapezoid, Solid, FullyDark>_cv                                 -0.8453         -0.8420             0             0             0             0
Render<LeftTrapezoid, Solid, PartiallyLit>_pvalue                           0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<LeftTrapezoid, Solid, PartiallyLit>_mean                            -0.1228         -0.1228         50053         43907         50044         43900
Render<LeftTrapezoid, Solid, PartiallyLit>_median                          -0.1228         -0.1228         50062         43916         50054         43906
Render<LeftTrapezoid, Solid, PartiallyLit>_stddev                          +1.3916         +1.3800            63           150            64           151
Render<LeftTrapezoid, Solid, PartiallyLit>_cv                              +1.7263         +1.7131             0             0             0             0
Render<LeftTrapezoid, Transparent, FullyLit>_pvalue                         0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<LeftTrapezoid, Transparent, FullyLit>_mean                          -0.1584         -0.1583         62677         52751         62665         52743
Render<LeftTrapezoid, Transparent, FullyLit>_median                        -0.1585         -0.1585         62670         52736         62656         52728
Render<LeftTrapezoid, Transparent, FullyLit>_stddev                        +1.1429         +1.4086            26            55            23            55
Render<LeftTrapezoid, Transparent, FullyLit>_cv                            +1.5461         +1.8617             0             0             0             0
Render<LeftTrapezoid, Transparent, FullyDark>_pvalue                        0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<LeftTrapezoid, Transparent, FullyDark>_mean                         -0.1929         -0.1929         57688         46558         57679         46551
Render<LeftTrapezoid, Transparent, FullyDark>_median                       -0.1943         -0.1944         57681         46473         57672         46459
Render<LeftTrapezoid, Transparent, FullyDark>_stddev                       +2.8190         +2.7914            62           237            63           238
Render<LeftTrapezoid, Transparent, FullyDark>_cv                           +3.7319         +3.6978             0             0             0             0
Render<LeftTrapezoid, Transparent, PartiallyLit>_pvalue                     0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<LeftTrapezoid, Transparent, PartiallyLit>_mean                      -0.0054         -0.0054         70694         70313         70682         70301
Render<LeftTrapezoid, Transparent, PartiallyLit>_median                    -0.0050         -0.0048         70671         70319         70650         70311
Render<LeftTrapezoid, Transparent, PartiallyLit>_stddev                    -0.7448         -0.7617           163            42           168            40
Render<LeftTrapezoid, Transparent, PartiallyLit>_cv                        -0.7434         -0.7604             0             0             0             0
Render<RightTrapezoid, Solid, FullyLit>_pvalue                              0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<RightTrapezoid, Solid, FullyLit>_mean                               +0.0123         +0.0123          2985          3022          2984          3021
Render<RightTrapezoid, Solid, FullyLit>_median                             +0.0123         +0.0123          2985          3021          2984          3021
Render<RightTrapezoid, Solid, FullyLit>_stddev                             -0.4207         -0.4667             1             0             1             0
Render<RightTrapezoid, Solid, FullyLit>_cv                                 -0.4277         -0.4731             0             0             0             0
Render<RightTrapezoid, Solid, FullyDark>_pvalue                             0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<RightTrapezoid, Solid, FullyDark>_mean                              +0.1105         +0.1105          4894          5435          4893          5434
Render<RightTrapezoid, Solid, FullyDark>_median                            +0.1083         +0.1082          4902          5433          4901          5432
Render<RightTrapezoid, Solid, FullyDark>_stddev                            -0.1973         -0.1947            45            37            45            37
Render<RightTrapezoid, Solid, FullyDark>_cv                                -0.2772         -0.2748             0             0             0             0
Render<RightTrapezoid, Solid, PartiallyLit>_pvalue                          0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<RightTrapezoid, Solid, PartiallyLit>_mean                           -0.0169         -0.0169         48201         47386         48192         47379
Render<RightTrapezoid, Solid, PartiallyLit>_median                         -0.0172         -0.0170         48184         47355         48170         47351
Render<RightTrapezoid, Solid, PartiallyLit>_stddev                         +0.6070         +0.5204            48            78            50            76
Render<RightTrapezoid, Solid, PartiallyLit>_cv                             +0.6346         +0.5465             0             0             0             0
Render<RightTrapezoid, Transparent, FullyLit>_pvalue                        0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<RightTrapezoid, Transparent, FullyLit>_mean                         -0.0023         -0.0023         48751         48639         48742         48632
Render<RightTrapezoid, Transparent, FullyLit>_median                       -0.0020         -0.0018         48751         48654         48738         48651
Render<RightTrapezoid, Transparent, FullyLit>_stddev                       +2.4354         +2.4427            10            35            11            36
Render<RightTrapezoid, Transparent, FullyLit>_cv                           +2.4433         +2.4505             0             0             0             0
Render<RightTrapezoid, Transparent, FullyDark>_pvalue                       0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<RightTrapezoid, Transparent, FullyDark>_mean                        -0.2247         -0.2247         40942         31742         40936         31736
Render<RightTrapezoid, Transparent, FullyDark>_median                      -0.2241         -0.2240         40904         31739         40895         31734
Render<RightTrapezoid, Transparent, FullyDark>_stddev                      -0.3455         -0.3546           165           108           167           108
Render<RightTrapezoid, Transparent, FullyDark>_cv                          -0.1558         -0.1676             0             0             0             0
Render<RightTrapezoid, Transparent, PartiallyLit>_pvalue                    0.0002          0.0002      U Test, Repetitions: 10 vs 10
Render<RightTrapezoid, Transparent, PartiallyLit>_mean                     -0.0908         -0.0908         74269         67523         74256         67512
Render<RightTrapezoid, Transparent, PartiallyLit>_median                   -0.0898         -0.0897         74196         67536         74176         67523
Render<RightTrapezoid, Transparent, PartiallyLit>_stddev                   -0.6590         -0.6568           147            50           146            50
Render<RightTrapezoid, Transparent, PartiallyLit>_cv                       -0.6250         -0.6225             0             0             0             0
BM_RenderBlackTile_pvalue                                                   0.0539          0.0539      U Test, Repetitions: 10 vs 10
BM_RenderBlackTile_mean                                                    -0.0188         -0.0188           125           123           125           123
BM_RenderBlackTile_median                                                  -0.0263         -0.0264           126           122           125           122
BM_RenderBlackTile_stddev                                                  +1.0907         +1.0966             1             3             1             3
BM_RenderBlackTile_cv                                                      +1.1307         +1.1368             0             0             0             0
OVERALL_GEOMEAN                                                            -0.0207         -0.0207             0             0             0             0
```