### PR TITLE
Added missing directory separator for unpacked mod initialization

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -75,7 +75,7 @@ void DiscoverMods()
 		// Find unpacked mods
 		for (const std::string &modFolder : ListDirectories(modsPath.c_str())) {
 			// Only consider this folder if the init.lua file exists.
-			std::string modScriptPath = modsPath + modFolder + DIRECTORY_SEPARATOR_STR + "init.lua";
+			std::string modScriptPath = modsPath + DIRECTORY_SEPARATOR_STR + modFolder + DIRECTORY_SEPARATOR_STR + "init.lua";
 			if (!FileExists(modScriptPath.c_str()))
 				continue;
 


### PR DESCRIPTION
When trying to initialize unpacked mods, the path separator was missing between the "mods" folder and the folder for the specific mod. This led to the strings being concatenated incorrectly, and the mod not being found. With this fix, unpacked mod initialization now works properly.