### PR TITLE
Fix compiler warnings

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -523,9 +523,6 @@ void PrintFloatingInfo(const Surface &out)
 
 	int spriteH = GetHoverSpriteHeight();
 	int anchorY = floatingInfoBox.position.y;
-	int boxH = floatingInfoBox.size.height;
-	int yAbove = anchorY - spriteH - boxH - vPadding;
-	int yBelow = anchorY + verticalSpacing / 2 + vPadding;
 
 	// Prevent the floating info box from going off-screen vertically
 	floatingInfoBox.position.y = ClampAboveOrBelow(anchorY, spriteH, floatingInfoBox.size.height, vPadding, verticalSpacing);

--- a/Source/panels/partypanel.cpp
+++ b/Source/panels/partypanel.cpp
@@ -232,7 +232,7 @@ void DrawPartyMemberInfoPanel(const Surface &out)
 		    playerPortraitSprite,
 		    portraitPos);
 
-		if ((player.getId() + 1) < (*PlayerTags).numSprites()) {
+		if ((player.getId() + 1U) < (*PlayerTags).numSprites()) {
 			// Draw the player tag
 			int tagWidth = (*PlayerTags)[player.getId() + 1].width();
 			RenderClxSprite(
@@ -294,9 +294,9 @@ void DrawPartyMemberInfoPanel(const Surface &out)
 
 bool DidRightClickPartyPortrait()
 {
-	for (int i = 0; i < sizeof(PortraitFrameRects) / sizeof(PortraitFrameRects[0]); i++) {
+	for (size_t i = 0; i < sizeof(PortraitFrameRects) / sizeof(PortraitFrameRects[0]); i++) {
 		if (PortraitFrameRects[i].contains(MousePosition)) {
-			RightClickedPortraitIndex = i;
+			RightClickedPortraitIndex = static_cast<int>(i);
 			InspectingFromPartyPanel = true;
 			return true;
 		}

--- a/Source/panels/partypanel.cpp
+++ b/Source/panels/partypanel.cpp
@@ -120,6 +120,8 @@ PartySpriteOffset GetClassSpriteOffset(HeroClass hClass)
 	case HeroClass::Barbarian:
 		hClass = HeroClass::Warrior;
 		break;
+	default:
+		break;
 	}
 
 	return ClassSpriteOffsets[static_cast<size_t>(hClass)];

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2057,7 +2057,6 @@ ClxSprite GetPlayerPortraitSprite(Player &player)
 		szCel = "as";
 
 	player_graphic graphic = player_graphic::Stand;
-	int spriteIndex = 0;
 	if (player._pHitPoints <= 0) {
 		if (animWeaponId == PlayerWeaponGraphic::Unarmed) {
 			szCel = "dt";


### PR DESCRIPTION
These popped up on my system after the recent merges.

```
.../DevilutionX/Source/player.cpp: In function ‘devilution::ClxSprite devilution::GetPlayerPortraitSprite(Player&)’:
.../DevilutionX/Source/player.cpp:2060:13: warning: unused variable ‘spriteIndex’ [-Wunused-variable]
 2060 |         int spriteIndex = 0;
      |             ^~~~~~~~~~~
```

```
.../DevilutionX/Source/control.cpp: In function ‘void devilution::{anonymous}::PrintFloatingInfo(const devilution::Surface&)’:
.../DevilutionX/Source/control.cpp:527:13: warning: unused variable ‘yAbove’ [-Wunused-variable]
  527 |         int yAbove = anchorY - spriteH - boxH - vPadding;
      |             ^~~~~~
.../DevilutionX/Source/control.cpp:528:13: warning: unused variable ‘yBelow’ [-Wunused-variable]
  528 |         int yBelow = anchorY + verticalSpacing / 2 + vPadding;
      |             ^~~~~~
```

```
.../DevilutionX/Source/panels/partypanel.cpp: In function ‘devilution::{anonymous}::PartySpriteOffset devilution::{anonymous}::GetClassSpriteOffset(devilution::HeroClass)’:
.../DevilutionX/Source/panels/partypanel.cpp:116:16: warning: enumeration value ‘Warrior’ not handled in switch [-Wswitch]
  116 |         switch (hClass) {
      |                ^
.../DevilutionX/Source/panels/partypanel.cpp:116:16: warning: enumeration value ‘Rogue’ not handled in switch [-Wswitch]
.../DevilutionX/Source/panels/partypanel.cpp:116:16: warning: enumeration value ‘Sorcerer’ not handled in switch [-Wswitch]
.../DevilutionX/Source/panels/partypanel.cpp:116:16: warning: enumeration value ‘Monk’ not handled in switch [-Wswitch]
.../DevilutionX/Source/panels/partypanel.cpp: In function ‘void devilution::DrawPartyMemberInfoPanel(const Surface&)’:
.../DevilutionX/Source/panels/partypanel.cpp:233:42: warning: comparison of integer expressions of different signedness: ‘int’ and ‘uint32_t’ {aka ‘unsigned int’} [-Wsign-compare]
  233 |                 if ((player.getId() + 1) < (*PlayerTags).numSprites()) {
      |                     ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../DevilutionX/Source/panels/partypanel.cpp: In function ‘bool devilution::DidRightClickPartyPortrait()’:
.../DevilutionX/Source/panels/partypanel.cpp:295:27: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  295 |         for (int i = 0; i < sizeof(PortraitFrameRects) / sizeof(PortraitFrameRects[0]); i++) {
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```