### PR TITLE
Do not assert SFX count as it's not fixed size

### DIFF
--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -147,8 +147,6 @@ void LoadEffectsData()
 		reader.readString("path", item.pszName);
 	}
 	sgSFX.shrink_to_fit();
-	// We're not actually parsing the IDs yet, thus this sanity check here.
-	assert(static_cast<size_t>(SfxID::LAST) + 1 == sgSFX.size());
 }
 
 void PrivSoundInit(uint8_t bLoadMask)


### PR DESCRIPTION
The number of loaded SFXs id different for Diablo and Hellfire, not to mention mods.