### PR TITLE
Automatically trim retired assets from the build folder

### DIFF
--- a/CMake/functions/trim_retired_files.cmake
+++ b/CMake/functions/trim_retired_files.cmake
@@ -1,0 +1,73 @@
+set(SCRIPT_CONTENT [=[
+include(functions/trim_retired_files)
+trim_retired_files("${ROOT_FOLDER}" "${CURRENT_FILES}" "${OUTPUT_FILE}")
+]=])
+
+function(trim_retired_files root_folder current_files output_file)
+  file(
+    GLOB_RECURSE retired_files
+    RELATIVE "${root_folder}"
+    "${root_folder}/*")
+
+  list(REMOVE_ITEM retired_files ${current_files})
+  list(LENGTH retired_files retired_file_count)
+  foreach(retired_file ${retired_files})
+    file(REMOVE "${root_folder}/${retired_file}")
+  endforeach()
+
+  if(${retired_file_count} GREATER 0 OR NOT EXISTS ${output_file})
+    file(TOUCH ${output_file})
+  endif()
+endfunction(trim_retired_files)
+
+function(add_trim_command)
+  set(oneValueArgs
+    ROOT_FOLDER
+    OUTPUT
+    BYPRODUCT
+    SCRIPT_PATH)
+
+  set(multiValueArgs CURRENT_FILES)
+  cmake_parse_arguments(PARSE_ARGV 0 arg "" "${oneValueArgs}" "${multiValueArgs}")
+
+  if(NOT arg_ROOT_FOLDER)
+    message(FATAL_ERROR "add_trim_command: missing required parameter ROOT_FOLDER")
+  endif()
+  if(NOT arg_OUTPUT OR NOT arg_BYPRODUCT OR NOT arg_SCRIPT_PATH)
+    cmake_path(GET arg_ROOT_FOLDER FILENAME root_filename)
+    if(NOT arg_OUTPUT)
+      set(arg_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${root_filename}.dne")
+    endif()
+    if(NOT arg_BYPRODUCT)
+      set(arg_BYPRODUCT "${CMAKE_CURRENT_BINARY_DIR}/${root_filename}.rm")
+    endif()
+    if(NOT arg_SCRIPT_PATH)
+      get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+      if(is_multi_config)
+        set(arg_SCRIPT_PATH "${CMAKE_CURRENT_BINARY_DIR}/${root_filename}_$<CONFIG>.cmake")
+      else()
+        set(arg_SCRIPT_PATH "${CMAKE_CURRENT_BINARY_DIR}/${root_filename}.cmake")
+      endif()
+    endif()
+  endif()
+
+  # Mark the output file as SYMBOLIC to indicate that it will not be created by the command.
+  # Since its output file is never created, this command should execute on every build.
+  set_source_files_properties("${arg_OUTPUT}" PROPERTIES SYMBOLIC true)
+
+  file(GENERATE OUTPUT "${arg_SCRIPT_PATH}" CONTENT "${SCRIPT_CONTENT}")
+  add_custom_command(
+    COMMENT "Trimming ${arg_ROOT_FOLDER}"
+    OUTPUT "${arg_OUTPUT}"
+    BYPRODUCTS "${arg_BYPRODUCT}"
+    COMMAND ${CMAKE_COMMAND}
+      -D "CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}"
+      -D "ROOT_FOLDER=${arg_ROOT_FOLDER}"
+      -D "CURRENT_FILES=${arg_CURRENT_FILES}"
+      -D "OUTPUT_FILE=${arg_BYPRODUCT}"
+      -P "${arg_SCRIPT_PATH}"
+    VERBATIM)
+
+  set(TRIM_COMMAND_OUTPUT "${arg_OUTPUT}" PARENT_SCOPE)
+  set(TRIM_COMMAND_BYPRODUCT "${arg_BYPRODUCT}" PARENT_SCOPE)
+endfunction(add_trim_command)


### PR DESCRIPTION
This PR introduces two functions in `trim_retired_files.cmake`.
* `trim_retired_files()` uses CMake's `file()` commands to scan a folder recursively. Any files in the folder which do not match the list of "current files" that are supposed to be in the folder are removed.
* `add_trim_command()` generates a CMake script in the build folder that invokes `trim_retired_files()`, then adds a custom command to invoke that script at build time instead of configure time.

By invoking `add_trim_command()` in `Assets.cmake`, we are able to remove files from the build folder that are no longer supposed to be there because they were moved to another location or removed altogether. This should help prevent errors due to recent changes where assets were moved from `devilutionx.mpq` to `mods/Hellfire.mpq`.

Note the dependency on `TRIM_COMMAND_BYPRODUCT` in the `DEVILUTIONX_MPQ` command. The `trim_retired_files()` function touches that `TRIM_COMMAND_BYPRODUCT` file to indicate that files were removed. Touching the file updates the timestamp, so this dependency causes a rebuild of the MPQ to ensure it doesn't also have lingering files in it.