### PR TITLE
Fix to the GetMissileType() switch-case for MonsterAIID::GoatRanged

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1827,7 +1827,7 @@ void AiAvoidance(Monster &monster)
 MissileID GetMissileType(MonsterAIID ai)
 {
 	switch (ai) {
-	case MonsterAIID::GoatMelee:
+	case MonsterAIID::GoatRanged:
 		return MissileID::Arrow;
 	case MonsterAIID::Succubus:
 	case MonsterAIID::LazarusSuccubus:


### PR DESCRIPTION
This pull request fixes GetMissileType() for MonsterAIID::GoatRanged. Currently MonsterAIID::GoatMelee is in that function's switch-case, with the arrow missile type being returned for it.

Note that thankfully, even though MonsterAIID::GoatRanged is missing from the switch-case, thankfully this doesn't result in a bug in the game, since the arrow missile type is also returned for the default case. So even though this seems to be a bug programming-wise, it did not actually affect gameplay.