### PR TITLE
Resolved Controller Inventory Issue

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -712,7 +712,7 @@ int FindFirstSlotOnItem(int8_t itemInvId)
 {
 	if (itemInvId == 0)
 		return -1;
-	for (int s = SLOTXY_INV_FIRST; s < SLOTXY_INV_LAST; s++) {
+	for (int s = SLOTXY_INV_FIRST; s <= SLOTXY_INV_LAST; s++) {
 		if (GetItemIdOnSlot(s) == itemInvId)
 			return s;
 	}


### PR DESCRIPTION
Fixed an issue with the inventory when using a controller that was making 1x1 items clip to an invalid -1 location when picking them up if they are in the last inventory slot.