### PR TITLE
Adjust build documentation to target current Windows SDK version

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -539,8 +539,7 @@ emrun index.html
 * Git
 * Visual Studio 2022 with the following packages installed:
     * C++ (v143) Universal Windows Platform tools
-    * Windows 11 SDK (10.0.22000.0)
-    * Windows 10 SDK (10.0.18362.0)
+    * Windows 11 SDK (10.0.26100.0)
     * MSVC v143 - VS 2022 C++ x64/x86 build tools
 
 _Note: Visual Studio Community Edition can be used._


### PR DESCRIPTION
Turns out, the version of the Windows SDK isn't that important so long as it's high enough to support the features we're using. We don't need to install both Win 10 and Win 11 SDKs in order to build our source code, nor should we need any particular version for the build to support both operating systems. Therefore, I simply modified the documentation to match the version we're targeting in our build scripts.

For the record, here are the versions currently available from Visual Studio Installer (on my system, at least).
* Windows 10 SDK (10.0.19041.0)
* Windows 11 SDK (10.0.22621.0)
* Windows 11 SDK (10.0.26100.4188)