### PR TITLE
Apply simple const rules using clang-tidy

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -10,3 +10,4 @@ UseTab: ForIndentation
 SortIncludes: true
 NamespaceIndentation: None
 FixNamespaceComments: true
+QualifierAlignment: Left

--- a/Source/DiabloUI/credits.cpp
+++ b/Source/DiabloUI/credits.cpp
@@ -34,10 +34,10 @@ const int LINE_H = 22;
 class CreditsRenderer {
 
 public:
-	CreditsRenderer(char const *const *text, std::size_t textLines)
+	CreditsRenderer(const char *const *text, std::size_t textLines)
 	{
 		for (size_t i = 0; i < textLines; i++) {
-			std::string_view orgText = _(text[i]);
+			const std::string_view orgText = _(text[i]);
 
 			uint16_t offset = 0;
 			size_t indexFirstNotTab = 0;
@@ -50,7 +50,7 @@ public:
 
 			size_t previous = 0;
 			while (true) {
-				size_t next = paragraphs.find('\n', previous);
+				const size_t next = paragraphs.find('\n', previous);
 				linesToRender.emplace_back(LineContent { offset, paragraphs.substr(previous, next - previous) });
 				if (next == std::string::npos)
 					break;
@@ -118,7 +118,7 @@ void CreditsRenderer::Render()
 	// We use unscaled coordinates for calculation throughout.
 	Sint16 destY = static_cast<Sint16>(uiPosition.y + VIEWPORT.y - (offsetY - linesBegin * LINE_H));
 	for (std::size_t i = linesBegin; i < linesEnd; ++i, destY += LINE_H) {
-		Sint16 destX = uiPosition.x + VIEWPORT.x + 31;
+		const Sint16 destX = uiPosition.x + VIEWPORT.x + 31;
 
 		auto &lineContent = linesToRender[i];
 
@@ -133,7 +133,7 @@ void CreditsRenderer::Render()
 	}
 }
 
-bool TextDialog(char const *const *text, std::size_t textLines)
+bool TextDialog(const char *const *text, std::size_t textLines)
 {
 	CreditsRenderer creditsRenderer(text, textLines);
 	bool endMenu = false;
@@ -152,7 +152,7 @@ bool TextDialog(char const *const *text, std::size_t textLines)
 				endMenu = true;
 				break;
 			default:
-				for (MenuAction menuAction : GetMenuActions(event)) {
+				for (const MenuAction menuAction : GetMenuActions(event)) {
 					if (IsNoneOf(menuAction, MenuAction_BACK, MenuAction_SELECT))
 						continue;
 					endMenu = true;

--- a/Source/DiabloUI/diabloui.cpp
+++ b/Source/DiabloUI/diabloui.cpp
@@ -424,7 +424,7 @@ void UiFocusNavigation(SDL_Event *event)
 	}
 
 	bool menuActionHandled = false;
-	for (MenuAction menuAction : GetMenuActions(*event))
+	for (const MenuAction menuAction : GetMenuActions(*event))
 		menuActionHandled |= HandleMenuAction(menuAction);
 	if (menuActionHandled)
 		return;
@@ -659,7 +659,7 @@ bool UiValidPlayerName(std::string_view name)
 	if (!c_all_of(name, IsBasicLatin))
 		return false;
 
-	std::string_view bannedNames[] = {
+	const std::string_view bannedNames[] = {
 		"gvdl",
 		"dvou",
 		"tiju",
@@ -674,8 +674,8 @@ bool UiValidPlayerName(std::string_view name)
 	for (char &character : buffer)
 		character++;
 
-	std::string_view tempName { buffer };
-	for (std::string_view bannedName : bannedNames) {
+	const std::string_view tempName { buffer };
+	for (const std::string_view bannedName : bannedNames) {
 		if (tempName.find(bannedName) != tempName.npos)
 			return false;
 	}
@@ -824,7 +824,7 @@ void Render(const UiArtText &uiArtText)
 
 void Render(const UiImageClx &uiImage)
 {
-	ClxSprite sprite = uiImage.sprite();
+	const ClxSprite sprite = uiImage.sprite();
 	int x = uiImage.m_rect.x;
 	if (uiImage.isCentered()) {
 		x += GetCenterOffset(sprite.width(), uiImage.m_rect.w);
@@ -834,7 +834,7 @@ void Render(const UiImageClx &uiImage)
 
 void Render(const UiImageAnimatedClx &uiImage)
 {
-	ClxSprite sprite = uiImage.sprite(GetAnimationFrame(uiImage.numFrames()));
+	const ClxSprite sprite = uiImage.sprite(GetAnimationFrame(uiImage.numFrames()));
 	int x = uiImage.m_rect.x;
 	if (uiImage.isCentered()) {
 		x += GetCenterOffset(sprite.width(), uiImage.m_rect.w);
@@ -916,7 +916,7 @@ void Render(const UiEdit &uiEdit)
 	DrawSelector(uiEdit.m_rect);
 
 	// To simulate padding we inset the region used to draw text in an edit control
-	Rectangle rect = MakeRectangle(uiEdit.m_rect).inset({ 43, 1 });
+	const Rectangle rect = MakeRectangle(uiEdit.m_rect).inset({ 43, 1 });
 
 	const Surface &out = Surface(DiabloUiSurface());
 	DrawString(out, uiEdit.m_value, rect,

--- a/Source/DiabloUI/dialogs.cpp
+++ b/Source/DiabloUI/dialogs.cpp
@@ -81,24 +81,24 @@ bool Init(std::string_view caption, std::string_view text, bool error, bool rend
 
 	const Point uiPosition = GetUIRectangle().position;
 	if (caption.empty()) {
-		SDL_Rect rect1 = MakeSdlRect(uiPosition.x + 180, uiPosition.y + 168, dialogSprite->width(), dialogSprite->height());
+		const SDL_Rect rect1 = MakeSdlRect(uiPosition.x + 180, uiPosition.y + 168, dialogSprite->width(), dialogSprite->height());
 		vecOkDialog.push_back(std::make_unique<UiImageClx>(*dialogSprite, rect1));
-		SDL_Rect rect2 = MakeSdlRect(uiPosition.x + 200, uiPosition.y + 211, textWidth, 80);
+		const SDL_Rect rect2 = MakeSdlRect(uiPosition.x + 200, uiPosition.y + 211, textWidth, 80);
 		vecOkDialog.push_back(std::make_unique<UiText>(wrappedText, rect2, UiFlags::AlignCenter | UiFlags::ColorDialogWhite));
 
-		SDL_Rect rect3 = MakeSdlRect(uiPosition.x + 265, uiPosition.y + 265, DialogButtonWidth, DialogButtonHeight);
+		const SDL_Rect rect3 = MakeSdlRect(uiPosition.x + 265, uiPosition.y + 265, DialogButtonWidth, DialogButtonHeight);
 		vecOkDialog.push_back(std::make_unique<UiButton>(_("OK"), &DialogActionOK, rect3));
 	} else {
-		SDL_Rect rect1 = MakeSdlRect(uiPosition.x + 127, uiPosition.y + 100, dialogSprite->width(), dialogSprite->height());
+		const SDL_Rect rect1 = MakeSdlRect(uiPosition.x + 127, uiPosition.y + 100, dialogSprite->width(), dialogSprite->height());
 		vecOkDialog.push_back(std::make_unique<UiImageClx>(*dialogSprite, rect1));
 
-		SDL_Rect rect2 = MakeSdlRect(uiPosition.x + 147, uiPosition.y + 110, textWidth, 20);
+		const SDL_Rect rect2 = MakeSdlRect(uiPosition.x + 147, uiPosition.y + 110, textWidth, 20);
 		vecOkDialog.push_back(std::make_unique<UiText>(caption, rect2, UiFlags::AlignCenter | UiFlags::ColorYellow));
 
-		SDL_Rect rect3 = MakeSdlRect(uiPosition.x + 147, uiPosition.y + 141, textWidth, 190);
+		const SDL_Rect rect3 = MakeSdlRect(uiPosition.x + 147, uiPosition.y + 141, textWidth, 190);
 		vecOkDialog.push_back(std::make_unique<UiText>(wrappedText, rect3, UiFlags::AlignCenter | UiFlags::ColorDialogWhite));
 
-		SDL_Rect rect4 = MakeSdlRect(uiPosition.x + 264, uiPosition.y + 335, DialogButtonWidth, DialogButtonHeight);
+		const SDL_Rect rect4 = MakeSdlRect(uiPosition.x + 264, uiPosition.y + 335, DialogButtonWidth, DialogButtonHeight);
 		vecOkDialog.push_back(std::make_unique<UiButton>(_("OK"), &DialogActionOK, rect4));
 	}
 	return true;
@@ -123,7 +123,7 @@ void DialogLoop(const std::vector<std::unique_ptr<UiItemBase>> &items, const std
 				UiItemMouseEvents(&event, items);
 				break;
 			default:
-				for (MenuAction menuAction : GetMenuActions(event)) {
+				for (const MenuAction menuAction : GetMenuActions(event)) {
 					if (IsNoneOf(menuAction, MenuAction_BACK, MenuAction_SELECT))
 						continue;
 					dialogEnd = true;
@@ -157,8 +157,8 @@ void UiOkDialog(std::string_view caption, std::string_view text, bool error, con
 		if (!HeadlessMode) {
 			if (SDL_ShowCursor(SDL_ENABLE) <= -1)
 				LogError("{}", SDL_GetError());
-			std::string captionStr = std::string(caption);
-			std::string textStr = std::string(text);
+			const std::string captionStr = std::string(caption);
+			const std::string textStr = std::string(text);
 			if (SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, captionStr.c_str(), textStr.c_str(), nullptr) <= -1) {
 				LogError("{}", SDL_GetError());
 			}
@@ -173,8 +173,8 @@ void UiOkDialog(std::string_view caption, std::string_view text, bool error, con
 
 	if (!Init(caption, text, error, !renderBehind.empty())) {
 		LogError("{}\n{}", caption, text);
-		std::string captionStr = std::string(caption);
-		std::string textStr = std::string(text);
+		const std::string captionStr = std::string(caption);
+		const std::string textStr = std::string(text);
 		if (SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, captionStr.c_str(), textStr.c_str(), nullptr) <= -1) {
 			LogError("{}", SDL_GetError());
 		}

--- a/Source/DiabloUI/hero/selhero.cpp
+++ b/Source/DiabloUI/hero/selhero.cpp
@@ -123,7 +123,7 @@ bool SelHeroGetHeroInfo(_uiheroinfo *pInfo)
 
 void SelheroListFocus(size_t value)
 {
-	UiFlags baseFlags = UiFlags::AlignCenter | UiFlags::FontSize30;
+	const UiFlags baseFlags = UiFlags::AlignCenter | UiFlags::FontSize30;
 	if (selhero_SaveCount != 0 && value < selhero_SaveCount) {
 		memcpy(&selhero_heroInfo, &selhero_heros[value], sizeof(selhero_heroInfo));
 		SelheroSetStats();
@@ -153,7 +153,7 @@ void SelheroListSelect(size_t value)
 	if (static_cast<std::size_t>(value) == selhero_SaveCount) {
 		vecSelDlgItems.clear();
 
-		SDL_Rect rect1 = { (Sint16)(uiPosition.x + 242), (Sint16)(uiPosition.y + 211), 365, 33 };
+		const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 242), (Sint16)(uiPosition.y + 211), 365, 33 };
 		vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Choose Class").data(), rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
 		vecSelHeroDlgItems.clear();
@@ -172,13 +172,13 @@ void SelheroListSelect(size_t value)
 		}
 		if (vecSelHeroDlgItems.size() > 4)
 			itemH = 26;
-		int itemY = static_cast<int>(246 + (176 - vecSelHeroDlgItems.size() * itemH) / 2);
+		const int itemY = static_cast<int>(246 + (176 - vecSelHeroDlgItems.size() * itemH) / 2);
 		vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, vecSelHeroDlgItems.size(), uiPosition.x + 264, (uiPosition.y + itemY), 320, itemH, UiFlags::AlignCenter | UiFlags::FontSize24 | UiFlags::ColorUiGold));
 
-		SDL_Rect rect2 = { (Sint16)(uiPosition.x + 279), (Sint16)(uiPosition.y + 429), 140, 35 };
+		const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 279), (Sint16)(uiPosition.y + 429), 140, 35 };
 		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect2, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
-		SDL_Rect rect3 = { (Sint16)(uiPosition.x + 429), (Sint16)(uiPosition.y + 429), 144, 35 };
+		const SDL_Rect rect3 = { (Sint16)(uiPosition.x + 429), (Sint16)(uiPosition.y + 429), 144, 35 };
 		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect3, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 		UiInitList(SelheroClassSelectorFocus, SelheroClassSelectorSelect, SelheroClassSelectorEsc, vecSelDlgItems, true);
@@ -193,7 +193,7 @@ void SelheroListSelect(size_t value)
 	if (selhero_heroInfo.hassaved) {
 		vecSelDlgItems.clear();
 
-		SDL_Rect rect1 = { (Sint16)(uiPosition.x + 242), (Sint16)(uiPosition.y + 211), 365, 33 };
+		const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 242), (Sint16)(uiPosition.y + 211), 365, 33 };
 		vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Save File Exists").data(), rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
 		vecSelHeroDlgItems.clear();
@@ -201,10 +201,10 @@ void SelheroListSelect(size_t value)
 		vecSelHeroDlgItems.push_back(std::make_unique<UiListItem>(_("New Game"), 1));
 		vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, vecSelHeroDlgItems.size(), uiPosition.x + 265, (uiPosition.y + 285), 320, 33, UiFlags::AlignCenter | UiFlags::FontSize24 | UiFlags::ColorUiGold));
 
-		SDL_Rect rect2 = { (Sint16)(uiPosition.x + 279), (Sint16)(uiPosition.y + 427), 140, 35 };
+		const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 279), (Sint16)(uiPosition.y + 427), 140, 35 };
 		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect2, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
-		SDL_Rect rect3 = { (Sint16)(uiPosition.x + 429), (Sint16)(uiPosition.y + 427), 144, 35 };
+		const SDL_Rect rect3 = { (Sint16)(uiPosition.x + 429), (Sint16)(uiPosition.y + 427), 144, 35 };
 		vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect3, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 		UiInitList(SelheroLoadFocus, SelheroLoadSelect, selhero_List_Init, vecSelDlgItems, true);
@@ -280,16 +280,16 @@ void SelheroClassSelectorSelect(size_t value)
 	if (ShouldPrefillHeroName())
 		strcpy(selhero_heroInfo.name, SelheroGenerateName(selhero_heroInfo.heroclass));
 	vecSelDlgItems.clear();
-	SDL_Rect rect1 = { (Sint16)(uiPosition.x + 242), (Sint16)(uiPosition.y + 211), 365, 33 };
+	const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 242), (Sint16)(uiPosition.y + 211), 365, 33 };
 	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Enter Name").data(), rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-	SDL_Rect rect2 = { (Sint16)(uiPosition.x + 265), (Sint16)(uiPosition.y + 317), 320, 33 };
+	const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 265), (Sint16)(uiPosition.y + 317), 320, 33 };
 	vecSelDlgItems.push_back(std::make_unique<UiEdit>(_("Enter Name"), selhero_heroInfo.name, 15, false, rect2, UiFlags::FontSize24 | UiFlags::ColorUiGold));
 
-	SDL_Rect rect3 = { (Sint16)(uiPosition.x + 279), (Sint16)(uiPosition.y + 429), 140, 35 };
+	const SDL_Rect rect3 = { (Sint16)(uiPosition.x + 279), (Sint16)(uiPosition.y + 429), 140, 35 };
 	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
-	SDL_Rect rect4 = { (Sint16)(uiPosition.x + 429), (Sint16)(uiPosition.y + 429), 144, 35 };
+	const SDL_Rect rect4 = { (Sint16)(uiPosition.x + 429), (Sint16)(uiPosition.y + 429), 144, 35 };
 	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect4, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 	UiInitList(nullptr, SelheroNameSelect, SelheroNameEsc, vecSelDlgItems);
@@ -450,7 +450,7 @@ const char *SelheroGenerateName(HeroClass heroClass)
 		},
 	};
 
-	int iRand = rand() % 10;
+	const int iRand = rand() % 10;
 
 	return Names[static_cast<std::size_t>(heroClass) % 6][iRand];
 }
@@ -510,7 +510,7 @@ void selhero_List_Init()
 	size_t selectedItem = 0;
 	vecSelDlgItems.clear();
 
-	SDL_Rect rect1 = { (Sint16)(uiPosition.x + 242), (Sint16)(uiPosition.y + 211), 365, 33 };
+	const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 242), (Sint16)(uiPosition.y + 211), 365, 33 };
 	vecSelDlgItems.push_back(std::make_unique<UiArtText>(_("Select Hero").data(), rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
 	vecSelHeroDlgItems.clear();
@@ -523,18 +523,18 @@ void selhero_List_Init()
 
 	vecSelDlgItems.push_back(std::make_unique<UiList>(vecSelHeroDlgItems, 6, uiPosition.x + 265, (uiPosition.y + 256), 320, 26, UiFlags::AlignCenter | UiFlags::FontSize24 | UiFlags::ColorUiGold));
 
-	SDL_Rect rect2 = { (Sint16)(uiPosition.x + 585), (Sint16)(uiPosition.y + 244), 25, 178 };
+	const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 585), (Sint16)(uiPosition.y + 244), 25, 178 };
 	vecSelDlgItems.push_back(std::make_unique<UiScrollbar>((*ArtScrollBarBackground)[0], (*ArtScrollBarThumb)[0], *ArtScrollBarArrow, rect2));
 
-	SDL_Rect rect3 = { (Sint16)(uiPosition.x + 239), (Sint16)(uiPosition.y + 429), 120, 35 };
+	const SDL_Rect rect3 = { (Sint16)(uiPosition.x + 239), (Sint16)(uiPosition.y + 429), 120, 35 };
 	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect3, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
-	SDL_Rect rect4 = { (Sint16)(uiPosition.x + 364), (Sint16)(uiPosition.y + 429), 120, 35 };
+	const SDL_Rect rect4 = { (Sint16)(uiPosition.x + 364), (Sint16)(uiPosition.y + 429), 120, 35 };
 	auto setlistDialogDeleteButton = std::make_unique<UiArtTextButton>(_("Delete"), &SelheroUiFocusNavigationYesNo, rect4, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver | UiFlags::ElementDisabled);
 	SELLIST_DIALOG_DELETE_BUTTON = setlistDialogDeleteButton.get();
 	vecSelDlgItems.push_back(std::move(setlistDialogDeleteButton));
 
-	SDL_Rect rect5 = { (Sint16)(uiPosition.x + 489), (Sint16)(uiPosition.y + 429), 144, 35 };
+	const SDL_Rect rect5 = { (Sint16)(uiPosition.x + 489), (Sint16)(uiPosition.y + 429), 144, 35 };
 	vecSelDlgItems.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect5, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 	UiInitList(SelheroListFocus, SelheroListSelect, SelheroListEsc, vecSelDlgItems, false, nullptr, SelheroListDeleteYesNo, selectedItem);

--- a/Source/DiabloUI/mainmenu.cpp
+++ b/Source/DiabloUI/mainmenu.cpp
@@ -26,7 +26,7 @@ void UiMainMenuSelect(size_t value)
 #ifndef NOEXIT
 void MainmenuEsc()
 {
-	std::size_t last = vecMenuItems.size() - 1;
+	const std::size_t last = vecMenuItems.size() - 1;
 	if (SelectedItem == last) {
 		UiMainMenuSelect(last);
 	} else {
@@ -59,13 +59,13 @@ void MainmenuLoad(const char *name)
 	const Point uiPosition = GetUIRectangle().position;
 
 	if (gbIsSpawn && gbIsHellfire) {
-		SDL_Rect rect1 = { (Sint16)(uiPosition.x), (Sint16)(uiPosition.y + 145), 640, 30 };
+		const SDL_Rect rect1 = { (Sint16)(uiPosition.x), (Sint16)(uiPosition.y + 145), 640, 30 };
 		vecMainMenuDialog.push_back(std::make_unique<UiArtText>(_("Shareware").data(), rect1, UiFlags::FontSize30 | UiFlags::ColorUiSilver | UiFlags::AlignCenter, 8));
 	}
 
 	vecMainMenuDialog.push_back(std::make_unique<UiList>(vecMenuItems, vecMenuItems.size(), uiPosition.x + 64, (uiPosition.y + 192), 510, 43, UiFlags::FontSize42 | UiFlags::ColorUiGold | UiFlags::AlignCenter, 5));
 
-	SDL_Rect rect2 = { 17, (Sint16)(gnScreenHeight - 36), 605, 21 };
+	const SDL_Rect rect2 = { 17, (Sint16)(gnScreenHeight - 36), 605, 21 };
 	vecMainMenuDialog.push_back(std::make_unique<UiArtText>(name, rect2, UiFlags::FontSize12 | UiFlags::ColorUiSilverDark));
 
 #ifndef NOEXIT

--- a/Source/DiabloUI/multi/selconn.cpp
+++ b/Source/DiabloUI/multi/selconn.cpp
@@ -54,36 +54,36 @@ void SelconnLoad()
 
 	const Point uiPosition = GetUIRectangle().position;
 
-	SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(Sint16)(uiPosition.y + 161), 590, 35 };
+	const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(Sint16)(uiPosition.y + 161), 590, 35 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Multi Player Game").data(), rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-	SDL_Rect rect2 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 218), DESCRIPTION_WIDTH, 21 };
+	const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 218), DESCRIPTION_WIDTH, 21 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_MaxPlayers, rect2, UiFlags::FontSize12 | UiFlags::ColorUiSilverDark));
 
-	SDL_Rect rect3 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 256), DESCRIPTION_WIDTH, 21 };
+	const SDL_Rect rect3 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 256), DESCRIPTION_WIDTH, 21 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Requirements:").data(), rect3, UiFlags::FontSize12 | UiFlags::ColorUiSilverDark));
 
-	SDL_Rect rect4 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 275), DESCRIPTION_WIDTH, 66 };
+	const SDL_Rect rect4 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 275), DESCRIPTION_WIDTH, 66 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_Description, rect4, UiFlags::FontSize12 | UiFlags::ColorUiSilverDark, 1, 16));
 
-	SDL_Rect rect5 = { (Sint16)(uiPosition.x + 30), (Sint16)(uiPosition.y + 356), 220, 31 };
+	const SDL_Rect rect5 = { (Sint16)(uiPosition.x + 30), (Sint16)(uiPosition.y + 356), 220, 31 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("no gateway needed").data(), rect5, UiFlags::AlignCenter | UiFlags::FontSize24 | UiFlags::ColorUiSilver, 0));
 
-	SDL_Rect rect6 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 393), DESCRIPTION_WIDTH, 21 };
+	const SDL_Rect rect6 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 393), DESCRIPTION_WIDTH, 21 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(selconn_Gateway, rect6, UiFlags::AlignCenter | UiFlags::FontSize12 | UiFlags::ColorUiSilverDark));
 
-	SDL_Rect rect7 = { (Sint16)(uiPosition.x + 300), (Sint16)(uiPosition.y + 211), 295, 33 };
+	const SDL_Rect rect7 = { (Sint16)(uiPosition.x + 300), (Sint16)(uiPosition.y + 211), 295, 33 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtText>(_("Select Connection").data(), rect7, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-	SDL_Rect rect8 = { (Sint16)(uiPosition.x + 16), (Sint16)(uiPosition.y + 427), 250, 35 };
+	const SDL_Rect rect8 = { (Sint16)(uiPosition.x + 16), (Sint16)(uiPosition.y + 427), 250, 35 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("Change Gateway"), nullptr, rect8, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold | UiFlags::ElementHidden));
 
 	vecSelConnDlg.push_back(std::make_unique<UiList>(vecConnItems, vecConnItems.size(), uiPosition.x + 305, (uiPosition.y + 256), 285, 26, UiFlags::AlignCenter | UiFlags::FontSize12 | UiFlags::VerticalCenter | UiFlags::ColorUiGoldDark));
 
-	SDL_Rect rect9 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
+	const SDL_Rect rect9 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect9, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
-	SDL_Rect rect10 = { (Sint16)(uiPosition.x + 454), (Sint16)(uiPosition.y + 427), 144, 35 };
+	const SDL_Rect rect10 = { (Sint16)(uiPosition.x + 454), (Sint16)(uiPosition.y + 427), 144, 35 };
 	vecSelConnDlg.push_back(std::make_unique<UiArtTextButton>(_("Cancel"), &UiFocusNavigationEsc, rect10, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 	UiInitList(SelconnFocus, SelconnSelect, SelconnEsc, vecSelConnDlg, true);

--- a/Source/DiabloUI/multi/selgame.cpp
+++ b/Source/DiabloUI/multi/selgame.cpp
@@ -129,19 +129,19 @@ void UiInitGameSelectionList(std::string_view search)
 
 	const Point uiPosition = GetUIRectangle().position;
 
-	SDL_Rect rectScrollbar = { (Sint16)(uiPosition.x + 590), (Sint16)(uiPosition.y + 244), 25, 178 };
+	const SDL_Rect rectScrollbar = { (Sint16)(uiPosition.x + 590), (Sint16)(uiPosition.y + 244), 25, 178 };
 	vecSelGameDialog.push_back(std::make_unique<UiScrollbar>((*ArtScrollBarBackground)[0], (*ArtScrollBarThumb)[0], *ArtScrollBarArrow, rectScrollbar));
 
-	SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
+	const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_(ConnectionNames[provider]).data(), rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-	SDL_Rect rect2 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 211), 205, 192 };
+	const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 211), 205, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Description:").data(), rect2, UiFlags::FontSize24 | UiFlags::ColorUiSilver));
 
-	SDL_Rect rect3 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 256), DESCRIPTION_WIDTH, 192 };
+	const SDL_Rect rect3 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3, UiFlags::FontSize12 | UiFlags::ColorUiSilverDark, 1, 16));
 
-	SDL_Rect rect4 = { (Sint16)(uiPosition.x + 300), (Sint16)(uiPosition.y + 211), 295, 33 };
+	const SDL_Rect rect4 = { (Sint16)(uiPosition.x + 300), (Sint16)(uiPosition.y + 211), 295, 33 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Action").data(), rect4, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
 #ifdef PACKET_ENCRYPTION
@@ -169,22 +169,22 @@ void UiInitGameSelectionList(std::string_view search)
 
 	vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, 6, uiPosition.x + 305, (uiPosition.y + 255), 285, 26, UiFlags::AlignCenter | UiFlags::FontSize24));
 
-	SDL_Rect rect5 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
+	const SDL_Rect rect5 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
-	SDL_Rect rect6 = { (Sint16)(uiPosition.x + 449), (Sint16)(uiPosition.y + 427), 140, 35 };
+	const SDL_Rect rect6 = { (Sint16)(uiPosition.x + 449), (Sint16)(uiPosition.y + 427), 140, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 	auto selectFn = [](size_t index) {
 		// UiListItem::m_value could be different from
 		// the index if packet encryption is disabled
-		int itemValue = vecSelGameDlgItems[index]->m_value;
+		const int itemValue = vecSelGameDlgItems[index]->m_value;
 		selgame_GameSelection_Select(itemValue);
 	};
 
 	if (!search.empty()) {
 		for (size_t i = 0; i < vecSelGameDlgItems.size(); i++) {
-			int gameIndex = vecSelGameDlgItems[i]->m_value - 3;
+			const int gameIndex = vecSelGameDlgItems[i]->m_value - 3;
 			if (gameIndex < 0)
 				continue;
 			if (search == Gamelist[gameIndex].name)
@@ -263,7 +263,7 @@ void selgame_GameSelection_Focus(size_t value)
 			}
 			infoString += '\n';
 			infoString.append(_("Players: "));
-			for (auto &playerName : gameInfo.players) {
+			for (const auto &playerName : gameInfo.players) {
 				infoString.append(playerName);
 				infoString += ' ';
 			}
@@ -309,13 +309,13 @@ void selgame_GameSelection_Select(size_t value)
 
 	const Point uiPosition = GetUIRectangle().position;
 
-	SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
+	const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(&title, rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-	SDL_Rect rect2 = { (Sint16)(uiPosition.x + 34), (Sint16)(uiPosition.y + 211), 205, 33 };
+	const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 34), (Sint16)(uiPosition.y + 211), 205, 33 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-	SDL_Rect rect3 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 256), DESCRIPTION_WIDTH, 192 };
+	const SDL_Rect rect3 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3, UiFlags::FontSize12 | UiFlags::ColorUiSilverDark, 1, 16));
 
 	switch (value) {
@@ -323,7 +323,7 @@ void selgame_GameSelection_Select(size_t value)
 	case 1: {
 		title = _("Create Game").data();
 
-		SDL_Rect rect4 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 211), 295, 35 };
+		const SDL_Rect rect4 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 211), 295, 35 };
 		vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Difficulty").data(), rect4, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
 		vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Normal"), DIFF_NORMAL));
@@ -332,10 +332,10 @@ void selgame_GameSelection_Select(size_t value)
 
 		vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, vecSelGameDlgItems.size(), uiPosition.x + 300, (uiPosition.y + 282), 295, 26, UiFlags::AlignCenter | UiFlags::FontSize24 | UiFlags::ColorUiGold));
 
-		SDL_Rect rect5 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
+		const SDL_Rect rect5 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
 		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
-		SDL_Rect rect6 = { (Sint16)(uiPosition.x + 449), (Sint16)(uiPosition.y + 427), 140, 35 };
+		const SDL_Rect rect6 = { (Sint16)(uiPosition.x + 449), (Sint16)(uiPosition.y + 427), 140, 35 };
 		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 		UiInitList(selgame_Diff_Focus, selgame_Diff_Select, selgame_Diff_Esc, vecSelGameDialog, true);
@@ -352,16 +352,16 @@ void selgame_GameSelection_Select(size_t value)
 			inputHint = _("Enter address").data();
 		}
 
-		SDL_Rect rect4 = { (Sint16)(uiPosition.x + 305), (Sint16)(uiPosition.y + 211), 285, 33 };
+		const SDL_Rect rect4 = { (Sint16)(uiPosition.x + 305), (Sint16)(uiPosition.y + 211), 285, 33 };
 		vecSelGameDialog.push_back(std::make_unique<UiArtText>(inputHint, rect4, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-		SDL_Rect rect5 = { (Sint16)(uiPosition.x + 305), (Sint16)(uiPosition.y + 314), 285, 33 };
+		const SDL_Rect rect5 = { (Sint16)(uiPosition.x + 305), (Sint16)(uiPosition.y + 314), 285, 33 };
 		vecSelGameDialog.push_back(std::make_unique<UiEdit>(inputHint, selgame_Ip, 128, false, rect5, UiFlags::FontSize24 | UiFlags::ColorUiGold));
 
-		SDL_Rect rect6 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
+		const SDL_Rect rect6 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
 		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect6, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
-		SDL_Rect rect7 = { (Sint16)(uiPosition.x + 449), (Sint16)(uiPosition.y + 427), 140, 35 };
+		const SDL_Rect rect7 = { (Sint16)(uiPosition.x + 449), (Sint16)(uiPosition.y + 427), 140, 35 };
 		vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect7, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 		HighlightedItem = 0;
@@ -481,16 +481,16 @@ void selgame_GameSpeedSelection()
 
 	const Point uiPosition = GetUIRectangle().position;
 
-	SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
+	const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Create Game").data(), rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-	SDL_Rect rect2 = { (Sint16)(uiPosition.x + 34), (Sint16)(uiPosition.y + 211), 205, 33 };
+	const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 34), (Sint16)(uiPosition.y + 211), 205, 33 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Label, rect2, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-	SDL_Rect rect3 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 256), DESCRIPTION_WIDTH, 192 };
+	const SDL_Rect rect3 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3, UiFlags::FontSize12 | UiFlags::ColorUiSilverDark, 1, 16));
 
-	SDL_Rect rect4 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 211), 295, 35 };
+	const SDL_Rect rect4 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 211), 295, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Select Game Speed").data(), rect4, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
 	vecSelGameDlgItems.push_back(std::make_unique<UiListItem>(_("Normal"), 20));
@@ -500,10 +500,10 @@ void selgame_GameSpeedSelection()
 
 	vecSelGameDialog.push_back(std::make_unique<UiList>(vecSelGameDlgItems, vecSelGameDlgItems.size(), uiPosition.x + 300, (uiPosition.y + 279), 295, 26, UiFlags::AlignCenter | UiFlags::FontSize24 | UiFlags::ColorUiGold));
 
-	SDL_Rect rect5 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
+	const SDL_Rect rect5 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect5, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
-	SDL_Rect rect6 = { (Sint16)(uiPosition.x + 449), (Sint16)(uiPosition.y + 427), 140, 35 };
+	const SDL_Rect rect6 = { (Sint16)(uiPosition.x + 449), (Sint16)(uiPosition.y + 427), 140, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect6, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 	UiInitList(selgame_Speed_Focus, selgame_Speed_Select, selgame_Speed_Esc, vecSelGameDialog, true);
@@ -560,27 +560,27 @@ void selgame_Password_Init(size_t /*value*/)
 
 	const Point uiPosition = GetUIRectangle().position;
 
-	SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
+	const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_(ConnectionNames[provider]).data(), rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-	SDL_Rect rect2 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 211), 205, 192 };
+	const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 211), 205, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Description:").data(), rect2, UiFlags::FontSize24 | UiFlags::ColorUiSilver));
 
-	SDL_Rect rect3 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 256), DESCRIPTION_WIDTH, 192 };
+	const SDL_Rect rect3 = { (Sint16)(uiPosition.x + 35), (Sint16)(uiPosition.y + 256), DESCRIPTION_WIDTH, 192 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(selgame_Description, rect3, UiFlags::FontSize12 | UiFlags::ColorUiSilverDark, 1, 16));
 
-	SDL_Rect rect4 = { (Sint16)(uiPosition.x + 305), (Sint16)(uiPosition.y + 211), 285, 33 };
+	const SDL_Rect rect4 = { (Sint16)(uiPosition.x + 305), (Sint16)(uiPosition.y + 211), 285, 33 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtText>(_("Enter Password").data(), rect4, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
 	// Allow password to be empty only when joining games
-	bool allowEmpty = selgame_selectedGame == 2;
-	SDL_Rect rect5 = { (Sint16)(uiPosition.x + 305), (Sint16)(uiPosition.y + 314), 285, 33 };
+	const bool allowEmpty = selgame_selectedGame == 2;
+	const SDL_Rect rect5 = { (Sint16)(uiPosition.x + 305), (Sint16)(uiPosition.y + 314), 285, 33 };
 	vecSelGameDialog.push_back(std::make_unique<UiEdit>(_("Enter Password"), selgame_Password, 15, allowEmpty, rect5, UiFlags::FontSize24 | UiFlags::ColorUiGold));
 
-	SDL_Rect rect6 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
+	const SDL_Rect rect6 = { (Sint16)(uiPosition.x + 299), (Sint16)(uiPosition.y + 427), 140, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("OK"), &UiFocusNavigationSelect, rect6, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
-	SDL_Rect rect7 = { (Sint16)(uiPosition.x + 449), (Sint16)(uiPosition.y + 427), 140, 35 };
+	const SDL_Rect rect7 = { (Sint16)(uiPosition.x + 449), (Sint16)(uiPosition.y + 427), 140, 35 };
 	vecSelGameDialog.push_back(std::make_unique<UiArtTextButton>(_("CANCEL"), &UiFocusNavigationEsc, rect7, UiFlags::AlignCenter | UiFlags::VerticalCenter | UiFlags::FontSize30 | UiFlags::ColorUiGold));
 
 	UiInitList(nullptr, selgame_Password_Select, selgame_Password_Esc, vecSelGameDialog);
@@ -593,7 +593,7 @@ static bool IsGameCompatibleWithErrorMessage(const GameData &data)
 
 	selgame_Free();
 
-	std::string errorMessage = GetErrorMessageIncompatibility(data);
+	const std::string errorMessage = GetErrorMessageIncompatibility(data);
 	UiSelOkDialog(title, errorMessage.c_str(), false);
 
 	selgame_Init();
@@ -693,7 +693,7 @@ void RefreshGameList()
 	if (selgame_enteringGame)
 		return;
 
-	uint32_t currentTime = SDL_GetTicks();
+	const uint32_t currentTime = SDL_GetTicks();
 
 	if ((lastRequest == 0 || currentTime - lastRequest > 30000) && DvlNet_SendInfoRequest()) {
 		lastRequest = currentTime;
@@ -703,8 +703,8 @@ void RefreshGameList()
 	}
 
 	if (lastUpdate == 0 || currentTime - lastUpdate > 5000) {
-		int gameIndex = vecSelGameDlgItems[HighlightedItem]->m_value - 3;
-		std::string gameSearch = gameIndex >= 0 ? Gamelist[gameIndex].name : "";
+		const int gameIndex = vecSelGameDlgItems[HighlightedItem]->m_value - 3;
+		const std::string gameSearch = gameIndex >= 0 ? Gamelist[gameIndex].name : "";
 		std::vector<GameInfo> gamelist = DvlNet_GetGamelist();
 		Gamelist.clear();
 		for (unsigned i = 0; i < gamelist.size(); i++) {

--- a/Source/DiabloUI/progress.cpp
+++ b/Source/DiabloUI/progress.cpp
@@ -41,7 +41,7 @@ void ProgressLoadForeground()
 	ProgFil = LoadPcx("ui_art\\prog_fil");
 
 	const Point uiPosition = GetUIRectangle().position;
-	SDL_Rect rect3 = { (Sint16)(uiPosition.x + 265), (Sint16)(uiPosition.y + 267), DialogButtonWidth, DialogButtonHeight };
+	const SDL_Rect rect3 = { (Sint16)(uiPosition.x + 265), (Sint16)(uiPosition.y + 267), DialogButtonWidth, DialogButtonHeight };
 	vecProgress.push_back(std::make_unique<UiButton>(_("Cancel"), &DialogActionCancel, rect3));
 }
 
@@ -138,7 +138,7 @@ bool UiProgressDialog(int (*fnfunc)())
 				endMenu = true;
 				break;
 			default:
-				for (MenuAction menuAction : GetMenuActions(event)) {
+				for (const MenuAction menuAction : GetMenuActions(event)) {
 					if (IsNoneOf(menuAction, MenuAction_BACK, MenuAction_SELECT))
 						continue;
 					endMenu = true;

--- a/Source/DiabloUI/selok.cpp
+++ b/Source/DiabloUI/selok.cpp
@@ -59,13 +59,13 @@ void UiSelOkDialog(const char *title, const char *body, bool background)
 	const Point uiPosition = GetUIRectangle().position;
 
 	if (title != nullptr) {
-		SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
+		const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
 		vecSelOkDialog.push_back(std::make_unique<UiArtText>(title, rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-		SDL_Rect rect2 = { (Sint16)(uiPosition.x + 140), (Sint16)(uiPosition.y + 210), 560, 168 };
+		const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 140), (Sint16)(uiPosition.y + 210), 560, 168 };
 		vecSelOkDialog.push_back(std::make_unique<UiArtText>(dialogText, rect2, UiFlags::FontSize24 | UiFlags::ColorUiSilver));
 	} else {
-		SDL_Rect rect1 = { (Sint16)(uiPosition.x + 140), (Sint16)(uiPosition.y + 197), 560, 168 };
+		const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 140), (Sint16)(uiPosition.y + 197), 560, 168 };
 		vecSelOkDialog.push_back(std::make_unique<UiArtText>(dialogText, rect1, UiFlags::FontSize24 | UiFlags::ColorUiSilver));
 	}
 

--- a/Source/DiabloUI/selyesno.cpp
+++ b/Source/DiabloUI/selyesno.cpp
@@ -48,10 +48,10 @@ bool UiSelHeroYesNoDialog(const char *title, const char *body)
 
 	const Point uiPosition = GetUIRectangle().position;
 
-	SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
+	const SDL_Rect rect1 = { (Sint16)(uiPosition.x + 24), (Sint16)(uiPosition.y + 161), 590, 35 };
 	vecSelYesNoDialog.push_back(std::make_unique<UiArtText>(title, rect1, UiFlags::AlignCenter | UiFlags::FontSize30 | UiFlags::ColorUiSilver, 3));
 
-	SDL_Rect rect2 = { (Sint16)(uiPosition.x + 120), (Sint16)(uiPosition.y + 236), MESSAGE_WIDTH, 168 };
+	const SDL_Rect rect2 = { (Sint16)(uiPosition.x + 120), (Sint16)(uiPosition.y + 236), MESSAGE_WIDTH, 168 };
 	vecSelYesNoDialog.push_back(std::make_unique<UiArtText>(selyesno_confirmationMessage, rect2, UiFlags::FontSize24 | UiFlags::ColorUiSilver));
 
 	vecSelYesNoDialogItems.push_back(std::make_unique<UiListItem>(_("Yes"), 0));

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -140,7 +140,7 @@ void UpdatePadEntryTimerText()
 {
 	if (shownMenu != ShownMenuType::PadInput)
 		return;
-	Uint32 elapsed = SDL_GetTicks() - padEntryStartTime;
+	const Uint32 elapsed = SDL_GetTicks() - padEntryStartTime;
 	if (padEntryStartTime == 0 || elapsed > 10000) {
 		StopPadEntryTimer();
 		return;
@@ -224,7 +224,7 @@ bool ChangeOptionValue(OptionEntryBase *pOption, size_t listIndex)
 void ItemSelected(size_t value)
 {
 	auto &vecItem = vecDialogItems[value];
-	int vecItemValue = vecItem->m_value;
+	const int vecItemValue = vecItem->m_value;
 	if (vecItemValue < 0) {
 		auto specialMenuEntry = static_cast<SpecialMenuEntry>(vecItemValue);
 		switch (specialMenuEntry) {
@@ -286,7 +286,7 @@ void ItemSelected(size_t value)
 		}
 		if (updateValueDescription) {
 			auto args = CreateDrawStringFormatArgForEntry(pOption);
-			bool optionUsesTwoLines = ((value + 1) < vecDialogItems.size() && vecDialogItems[value]->m_value == vecDialogItems[value + 1]->m_value);
+			const bool optionUsesTwoLines = ((value + 1) < vecDialogItems.size() && vecDialogItems[value]->m_value == vecDialogItems[value + 1]->m_value);
 			if (NeedsTwoLinesToDisplayOption(args) != optionUsesTwoLines) {
 				selectedOption = pOption;
 				endMenu = true;
@@ -320,7 +320,7 @@ void FullscreenChanged()
 	auto *fullscreenOption = &GetOptions().Graphics.fullscreen;
 
 	for (auto &vecItem : vecDialogItems) {
-		int vecItemValue = vecItem->m_value;
+		const int vecItemValue = vecItem->m_value;
 		if (vecItemValue < 0 || static_cast<size_t>(vecItemValue) >= vecOptions.size())
 			continue;
 
@@ -403,7 +403,7 @@ void UiSettingsMenu()
 				if (selectedOption == pEntry)
 					itemToSelect = vecDialogItems.size();
 				auto formatArgs = CreateDrawStringFormatArgForEntry(pEntry);
-				int optionId = static_cast<int>(vecOptions.size());
+				const int optionId = static_cast<int>(vecOptions.size());
 				if (NeedsTwoLinesToDisplayOption(formatArgs)) {
 					vecDialogItems.push_back(std::make_unique<UiListItem>(std::string_view("{}:"), formatArgs, optionId, UiFlags::ColorUiGold | UiFlags::NeedsNextElement));
 					vecDialogItems.push_back(std::make_unique<UiListItem>(std::string(pEntry->GetValueDescription()), optionId, UiFlags::ColorUiSilver | UiFlags::ElementDisabled));
@@ -493,9 +493,9 @@ void UiSettingsMenu()
 				if (padEntryStartTime == 0)
 					return false;
 
-				StaticVector<ControllerButtonEvent, 4> ctrlEvents = ToControllerButtonEvents(event);
-				for (ControllerButtonEvent ctrlEvent : ctrlEvents) {
-					bool isGamepadMotion = IsControllerMotion(event);
+				const StaticVector<ControllerButtonEvent, 4> ctrlEvents = ToControllerButtonEvents(event);
+				for (const ControllerButtonEvent ctrlEvent : ctrlEvents) {
+					const bool isGamepadMotion = IsControllerMotion(event);
 					DetectInputMethod(event, ctrlEvent);
 					if (event.type == SDL_KEYUP && event.key.keysym.sym == SDLK_ESCAPE) {
 						StopPadEntryTimer();
@@ -505,8 +505,8 @@ void UiSettingsMenu()
 						continue;
 					}
 
-					bool modifierPressed = padEntryCombo.modifier != ControllerButton_NONE && IsControllerButtonPressed(padEntryCombo.modifier);
-					bool buttonPressed = padEntryCombo.button != ControllerButton_NONE && IsControllerButtonPressed(padEntryCombo.button);
+					const bool modifierPressed = padEntryCombo.modifier != ControllerButton_NONE && IsControllerButtonPressed(padEntryCombo.modifier);
+					const bool buttonPressed = padEntryCombo.button != ControllerButton_NONE && IsControllerButtonPressed(padEntryCombo.button);
 					if (ctrlEvent.up) {
 						// When the player has released all relevant inputs, assume the binding is finished and stop the timer
 						if (padEntryCombo.button != ControllerButton_NONE && !modifierPressed && !buttonPressed) {

--- a/Source/DiabloUI/text_input.cpp
+++ b/Source/DiabloUI/text_input.cpp
@@ -60,7 +60,7 @@ bool HandleInputEvent(const SDL_Event &event, TextInputState &state,
 		case SDLK_v:
 			if (isCtrl) {
 				if (SDL_HasClipboardText() == SDL_TRUE) {
-					std::unique_ptr<char, SDLFreeDeleter<char>> clipboard { SDL_GetClipboardText() };
+					const std::unique_ptr<char, SDLFreeDeleter<char>> clipboard { SDL_GetClipboardText() };
 					if (clipboard == nullptr || *clipboard == '\0') {
 						Log("{}", SDL_GetError());
 					} else {

--- a/Source/DiabloUI/title.cpp
+++ b/Source/DiabloUI/title.cpp
@@ -45,7 +45,7 @@ void UiTitleDialog()
 	TitleLoad();
 	const Point uiPosition = GetUIRectangle().position;
 	if (ArtBackgroundWidescreen.has_value()) {
-		SDL_Rect rect = MakeSdlRect(0, uiPosition.y, 0, 0);
+		const SDL_Rect rect = MakeSdlRect(0, uiPosition.y, 0, 0);
 		if (ArtBackgroundWidescreen)
 			vecTitleScreen.push_back(std::make_unique<UiImageClx>((*ArtBackgroundWidescreen)[0], rect, UiFlags::AlignCenter));
 		vecTitleScreen.push_back(std::make_unique<UiImageAnimatedClx>(*ArtBackground, rect, UiFlags::AlignCenter));
@@ -55,12 +55,12 @@ void UiTitleDialog()
 		vecTitleScreen.push_back(std::make_unique<UiImageAnimatedClx>(
 		    *DiabloTitleLogo, MakeSdlRect(0, uiPosition.y + 182, 0, 0), UiFlags::AlignCenter));
 
-		SDL_Rect rect = MakeSdlRect(uiPosition.x, uiPosition.y + 410, 640, 26);
+		const SDL_Rect rect = MakeSdlRect(uiPosition.x, uiPosition.y + 410, 640, 26);
 		vecTitleScreen.push_back(std::make_unique<UiArtText>(_("Copyright © 1996-2001 Blizzard Entertainment").data(), rect, UiFlags::AlignCenter | UiFlags::FontSize24 | UiFlags::ColorUiSilver));
 	}
 
 	bool endMenu = false;
-	Uint32 timeOut = SDL_GetTicks() + 7000;
+	const Uint32 timeOut = SDL_GetTicks() + 7000;
 
 	SDL_Event event;
 	while (!endMenu && SDL_GetTicks() < timeOut) {

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -630,9 +630,9 @@ void DrawWallConnections(const Surface &out, Point center, AutomapTile tile, Aut
  */
 void DrawMapVerticalGrate(const Surface &out, Point center, uint8_t colorDim)
 {
-	Point pos1 = center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None) + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp);
-	Point pos2 = center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None);
-	Point pos3 = center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None) + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown);
+	const Point pos1 = center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None) + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileUp);
+	const Point pos2 = center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None);
+	const Point pos3 = center + AmOffset(AmWidthOffset::HalfTileLeft, AmHeightOffset::None) + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileDown);
 
 	SetMapPixel(out, pos1 + Displacement { 0, 1 }, 0);
 	SetMapPixel(out, pos2 + Displacement { 0, 1 }, 0);
@@ -647,9 +647,9 @@ void DrawMapVerticalGrate(const Surface &out, Point center, uint8_t colorDim)
  */
 void DrawMapHorizontalGrate(const Surface &out, Point center, uint8_t colorDim)
 {
-	Point pos1 = center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None) + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileUp);
-	Point pos2 = center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None);
-	Point pos3 = center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None) + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown);
+	const Point pos1 = center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None) + AmOffset(AmWidthOffset::EighthTileLeft, AmHeightOffset::EighthTileUp);
+	const Point pos2 = center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None);
+	const Point pos3 = center + AmOffset(AmWidthOffset::HalfTileRight, AmHeightOffset::None) + AmOffset(AmWidthOffset::EighthTileRight, AmHeightOffset::EighthTileDown);
 
 	SetMapPixel(out, pos1 + Displacement { 0, 1 }, 0);
 	SetMapPixel(out, pos2 + Displacement { 0, 1 }, 0);
@@ -978,7 +978,7 @@ void DrawAutomapTile(const Surface &out, Point center, Point map)
 {
 	uint8_t colorBright = MapColorsBright;
 	uint8_t colorDim = MapColorsDim;
-	MapExplorationType explorationType = static_cast<MapExplorationType>(AutomapView[std::clamp(map.x, 0, DMAXX - 1)][std::clamp(map.y, 0, DMAXY - 1)]);
+	const MapExplorationType explorationType = static_cast<MapExplorationType>(AutomapView[std::clamp(map.x, 0, DMAXX - 1)][std::clamp(map.y, 0, DMAXY - 1)]);
 
 	switch (explorationType) {
 	case MAP_EXP_SHRINE:
@@ -1324,16 +1324,16 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, cons
 {
 	const uint8_t playerColor = MapColorsPlayer + (8 * player.getId()) % 128;
 
-	Point tile = player.position.tile;
+	const Point tile = player.position.tile;
 
-	int px = tile.x - 2 * AutomapOffset.deltaX - ViewPosition.x;
-	int py = tile.y - 2 * AutomapOffset.deltaY - ViewPosition.y;
+	const int px = tile.x - 2 * AutomapOffset.deltaX - ViewPosition.x;
+	const int py = tile.y - 2 * AutomapOffset.deltaY - ViewPosition.y;
 
 	Displacement playerOffset = {};
 	if (player.isWalking())
 		playerOffset = GetOffsetForWalking(player.AnimInfo, player._pdir);
 
-	int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+	const int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
 
 	Point base = {
 		((playerOffset.deltaX + myPlayerOffset.deltaX) * scale / 100 / 2) + (px - py) * AmLine(AmLineLength::DoubleTile),
@@ -1468,7 +1468,7 @@ void DrawAutomapText(const Surface &out)
 		break;
 	}
 
-	std::string difficultyString = fmt::format(fmt::runtime(_(/* TRANSLATORS: {:s} means: Game Difficulty. */ "Difficulty: {:s}")), difficulty);
+	const std::string difficultyString = fmt::format(fmt::runtime(_(/* TRANSLATORS: {:s} means: Game Difficulty. */ "Difficulty: {:s}")), difficulty);
 	DrawString(out, difficultyString, linePosition);
 
 #ifdef _DEBUG
@@ -1545,15 +1545,15 @@ void InitAutomapOnce()
 	AutoMapScale = 50;
 
 	// Set the dimensions and screen position of the minimap relative to the screen dimensions
-	int minimapWidth = gnScreenWidth / 4;
-	Size minimapSize { minimapWidth, minimapWidth / 2 };
-	int minimapPadding = gnScreenWidth / 128;
+	const int minimapWidth = gnScreenWidth / 4;
+	const Size minimapSize { minimapWidth, minimapWidth / 2 };
+	const int minimapPadding = gnScreenWidth / 128;
 	MinimapRect = Rectangle { { gnScreenWidth - minimapPadding - minimapSize.width, minimapPadding }, minimapSize };
 
 	// Set minimap scale
-	int height = 480;
-	int scale = 25;
-	int factor = gnScreenHeight / height;
+	const int height = 480;
+	const int scale = 25;
+	const int factor = gnScreenHeight / height;
 
 	if (factor >= 8) {
 		MinimapScale = scale * 8;
@@ -1565,7 +1565,7 @@ void InitAutomapOnce()
 void InitAutomap()
 {
 	size_t tileCount = 0;
-	std::unique_ptr<AutomapTile[]> tileTypes = LoadAutomapData(tileCount);
+	const std::unique_ptr<AutomapTile[]> tileTypes = LoadAutomapData(tileCount);
 
 	switch (leveltype) {
 	case DTYPE_CATACOMBS:
@@ -1758,8 +1758,8 @@ void DrawAutomap(const Surface &out)
 	if (myPlayer.isWalking())
 		myPlayerOffset = GetOffsetForWalking(myPlayer.AnimInfo, myPlayer._pdir, true);
 
-	int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
-	int d = (scale * 64) / 100;
+	const int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+	const int d = (scale * 64) / 100;
 	int cells = 2 * (gnScreenWidth / 2 / d) + 1;
 	if (((gnScreenWidth / 2) % d) != 0)
 		cells++;
@@ -1772,7 +1772,7 @@ void DrawAutomap(const Surface &out)
 		// Background fill
 		DrawHalfTransparentRectTo(out, MinimapRect.position.x, MinimapRect.position.y, MinimapRect.size.width, MinimapRect.size.height);
 
-		uint8_t frameShadowColor = PAL16_YELLOW + 12;
+		const uint8_t frameShadowColor = PAL16_YELLOW + 12;
 
 		// Shadow
 		DrawHorizontalLine(out, MinimapRect.position + Displacement { -1, -1 }, MinimapRect.size.width + 1, frameShadowColor);
@@ -1876,8 +1876,8 @@ void SetAutomapView(Point position, MapExplorationType explorer)
 
 	UpdateAutomapExplorer(map, explorer);
 
-	AutomapTile tile = GetAutomapTileType(map);
-	bool solid = tile.hasFlag(AutomapTile::Flags::Dirt);
+	const AutomapTile tile = GetAutomapTileType(map);
+	const bool solid = tile.hasFlag(AutomapTile::Flags::Dirt);
 
 	switch (tile.type) {
 	case AutomapTile::Types::Vertical:

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -87,7 +87,7 @@ void CaptureScreen()
 	}
 	DrawAndBlit();
 
-	std::array<SDL_Color, 256> origSystemPalette = system_palette;
+	const std::array<SDL_Color, 256> origSystemPalette = system_palette;
 	RedPalette();
 
 	system_palette = origSystemPalette;

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -347,25 +347,25 @@ void PrintInfo(const Surface &out)
 Rectangle GetFloatingInfoRect(const int lineHeight, const int textSpacing)
 {
 	// Calculate the width and height of the floating info box
-	std::string txt = std::string(FloatingInfoString);
+	const std::string txt = std::string(FloatingInfoString);
 
 	auto lines = SplitByChar(txt, '\n');
 	const GameFontTables font = GameFont12;
 	int maxW = 0;
 
 	for (const auto &line : lines) {
-		int w = GetLineWidth(line, font, textSpacing, nullptr);
+		const int w = GetLineWidth(line, font, textSpacing, nullptr);
 		maxW = std::max(maxW, w);
 	}
 
 	const auto lineCount = 1 + static_cast<int>(c_count(FloatingInfoString.str(), '\n'));
-	int totalH = lineCount * lineHeight;
+	const int totalH = lineCount * lineHeight;
 
-	Player &player = *InspectPlayer;
+	const Player &player = *InspectPlayer;
 
 	// 1) Equipment (Rect position)
 	if (pcursinvitem >= INVITEM_HEAD && pcursinvitem < INVITEM_INV_FIRST) {
-		int slot = pcursinvitem - INVITEM_HEAD;
+		const int slot = pcursinvitem - INVITEM_HEAD;
 		static constexpr Point equipLocal[] = {
 			{ 133, 59 },
 			{ 48, 205 },
@@ -378,7 +378,7 @@ Rectangle GetFloatingInfoRect(const int lineHeight, const int textSpacing)
 
 		Point itemPosition = equipLocal[slot];
 		auto &item = player.InvBody[slot];
-		Size frame = GetInvItemSize(item._iCurs + CURSOR_FIRSTITEM);
+		const Size frame = GetInvItemSize(item._iCurs + CURSOR_FIRSTITEM);
 
 		if (slot == INVLOC_HAND_LEFT) {
 			itemPosition.x += frame.width == InventorySlotSizeInPixels.width
@@ -400,24 +400,24 @@ Rectangle GetFloatingInfoRect(const int lineHeight, const int textSpacing)
 		itemPosition.x += frame.width / 2; // Align position to center of the item graphic
 		itemPosition.x -= maxW / 2;        // Align position to the center of the floating item info box
 
-		Point screen = GetPanelPosition(UiPanels::Inventory, itemPosition);
+		const Point screen = GetPanelPosition(UiPanels::Inventory, itemPosition);
 
 		return { { screen.x, screen.y }, { maxW, totalH } };
 	}
 
 	// 2) Inventory grid (Rect position)
 	if (pcursinvitem >= INVITEM_INV_FIRST && pcursinvitem < INVITEM_INV_FIRST + InventoryGridCells) {
-		int itemIdx = pcursinvitem - INVITEM_INV_FIRST;
+		const int itemIdx = pcursinvitem - INVITEM_INV_FIRST;
 
 		for (int j = 0; j < InventoryGridCells; ++j) {
 			if (player.InvGrid[j] > 0 && player.InvGrid[j] - 1 == itemIdx) {
-				Item &it = player.InvList[itemIdx];
+				const Item &it = player.InvList[itemIdx];
 				Point itemPosition = InvRect[j + SLOTXY_INV_FIRST].position;
 
 				itemPosition.x += GetInventorySize(it).width * InventorySlotSizeInPixels.width / 2; // Align position to center of the item graphic
 				itemPosition.x -= maxW / 2;                                                         // Align position to the center of the floating item info box
 
-				Point screen = GetPanelPosition(UiPanels::Inventory, itemPosition);
+				const Point screen = GetPanelPosition(UiPanels::Inventory, itemPosition);
 
 				return { { screen.x, screen.y }, { maxW, totalH } };
 			}
@@ -426,20 +426,20 @@ Rectangle GetFloatingInfoRect(const int lineHeight, const int textSpacing)
 
 	// 3) Belt (Rect position)
 	if (pcursinvitem >= INVITEM_BELT_FIRST && pcursinvitem < INVITEM_BELT_FIRST + MaxBeltItems) {
-		int itemIdx = pcursinvitem - INVITEM_BELT_FIRST;
+		const int itemIdx = pcursinvitem - INVITEM_BELT_FIRST;
 		for (int i = 0; i < MaxBeltItems; ++i) {
 			if (player.SpdList[i].isEmpty())
 				continue;
 			if (i != itemIdx)
 				continue;
 
-			Item &item = player.SpdList[i];
+			const Item &item = player.SpdList[i];
 			Point itemPosition = InvRect[i + SLOTXY_BELT_FIRST].position;
 
 			itemPosition.x += GetInventorySize(item).width * InventorySlotSizeInPixels.width / 2; // Align position to center of the item graphic
 			itemPosition.x -= maxW / 2;                                                           // Align position to the center of the floating item info box
 
-			Point screen = GetMainPanel().position + Displacement { itemPosition.x, itemPosition.y };
+			const Point screen = GetMainPanel().position + Displacement { itemPosition.x, itemPosition.y };
 
 			return { { screen.x, screen.y }, { maxW, totalH } };
 		}
@@ -454,9 +454,9 @@ Rectangle GetFloatingInfoRect(const int lineHeight, const int textSpacing)
 			if (itemId != pcursstashitem)
 				continue;
 
-			Item &item = Stash.stashList[itemId];
+			const Item &item = Stash.stashList[itemId];
 			Point itemPosition = GetStashSlotCoord(slot);
-			Size itemGridSize = GetInventorySize(item);
+			const Size itemGridSize = GetInventorySize(item);
 
 			itemPosition.y += itemGridSize.height * (InventorySlotSizeInPixels.height + 1) - 1; // Align position to bottom left of the item graphic
 			itemPosition.x += itemGridSize.width * InventorySlotSizeInPixels.width / 2;         // Align position to center of the item graphic
@@ -477,14 +477,14 @@ int GetHoverSpriteHeight()
 	}
 	if (pcursinvitem >= INVITEM_INV_FIRST
 	    && pcursinvitem < INVITEM_INV_FIRST + InventoryGridCells) {
-		int idx = pcursinvitem - INVITEM_INV_FIRST;
+		const int idx = pcursinvitem - INVITEM_INV_FIRST;
 		auto &it = (*InspectPlayer).InvList[idx];
 		return GetInventorySize(it).height * (InventorySlotSizeInPixels.height + 1)
 		    - InventorySlotSizeInPixels.height;
 	}
 	if (pcursinvitem >= INVITEM_BELT_FIRST
 	    && pcursinvitem < INVITEM_BELT_FIRST + MaxBeltItems) {
-		int idx = pcursinvitem - INVITEM_BELT_FIRST;
+		const int idx = pcursinvitem - INVITEM_BELT_FIRST;
 		auto &it = (*InspectPlayer).SpdList[idx];
 		return GetInventorySize(it).height * (InventorySlotSizeInPixels.height + 1)
 		    - InventorySlotSizeInPixels.height - 1;
@@ -498,8 +498,8 @@ int GetHoverSpriteHeight()
 
 int ClampAboveOrBelow(int anchorY, int spriteH, int boxH, int pad, int linePad)
 {
-	int yAbove = anchorY - spriteH - boxH - pad;
-	int yBelow = anchorY + linePad / 2 + pad;
+	const int yAbove = anchorY - spriteH - boxH - pad;
+	const int yBelow = anchorY + linePad / 2 + pad;
 	return (yAbove >= 0) ? yAbove : yBelow;
 }
 
@@ -521,8 +521,8 @@ void PrintFloatingInfo(const Surface &out)
 	// Prevent the floating info box from going off-screen horizontally
 	floatingInfoBox.position.x = std::clamp(floatingInfoBox.position.x, hPadding, GetScreenWidth() - (floatingInfoBox.size.width + hPadding));
 
-	int spriteH = GetHoverSpriteHeight();
-	int anchorY = floatingInfoBox.position.y;
+	const int spriteH = GetHoverSpriteHeight();
+	const int anchorY = floatingInfoBox.position.y;
 
 	// Prevent the floating info box from going off-screen vertically
 	floatingInfoBox.position.y = ClampAboveOrBelow(anchorY, spriteH, floatingInfoBox.size.height, vPadding, verticalSpacing);
@@ -546,7 +546,7 @@ void PrintFloatingInfo(const Surface &out)
 
 int CapStatPointsToAdd(int remainingStatPoints, const Player &player, CharacterAttribute attribute)
 {
-	int pointsToReachCap = player.GetMaximumAttributeValue(attribute) - player.GetBaseAttributeValue(attribute);
+	const int pointsToReachCap = player.GetMaximumAttributeValue(attribute) - player.GetBaseAttributeValue(attribute);
 
 	return std::min(remainingStatPoints, pointsToReachCap);
 }
@@ -585,15 +585,15 @@ int DrawDurIcon4Item(const Surface &out, Item &pItem, int x, int c)
 	}
 
 	// Calculate how much of the icon should be gold and red
-	int height = (*pDurIcons)[c].height(); // Height of durability icon CEL
+	const int height = (*pDurIcons)[c].height(); // Height of durability icon CEL
 	int partition = 0;
 	if (pItem._iDurability > durabilityThresholdRed) {
-		int current = pItem._iDurability - durabilityThresholdRed;
+		const int current = pItem._iDurability - durabilityThresholdRed;
 		partition = (height * current) / (durabilityThresholdGold - durabilityThresholdRed);
 	}
 
 	// Draw icon
-	int y = -17 + GetMainPanel().position.y;
+	const int y = -17 + GetMainPanel().position.y;
 	if (partition > 0) {
 		const Surface stenciledBuffer = out.subregionY(y - partition, partition);
 		ClxDraw(stenciledBuffer, { x, partition }, (*pDurIcons)[c + 8]); // Gold icon
@@ -680,7 +680,7 @@ std::string TextCmdArenaPot(const std::string_view parameter)
 		StrAppend(ret, _("Arenas are only supported in multiplayer."));
 		return ret;
 	}
-	int numPots = ParseInt<int>(parameter, /*min=*/1).value_or(1);
+	const int numPots = ParseInt<int>(parameter, /*min=*/1).value_or(1);
 
 	Player &myPlayer = *MyPlayer;
 
@@ -761,7 +761,7 @@ bool IsQuestEnabled(const Quest &quest)
 
 std::string TextCmdLevelSeed(const std::string_view parameter)
 {
-	std::string_view levelType = setlevel ? "set level" : "dungeon level";
+	const std::string_view levelType = setlevel ? "set level" : "dungeon level";
 
 	char gameId[] = {
 		static_cast<char>((sgGameInitInfo.programid >> 24) & 0xFF),
@@ -771,8 +771,8 @@ std::string TextCmdLevelSeed(const std::string_view parameter)
 		'\0'
 	};
 
-	std::string_view mode = gbIsMultiplayer ? "MP" : "SP";
-	std::string_view questPool = UseMultiplayerQuests() ? "MP" : "Full";
+	const std::string_view mode = gbIsMultiplayer ? "MP" : "SP";
+	const std::string_view questPool = UseMultiplayerQuests() ? "MP" : "Full";
 
 	uint32_t questFlags = 0;
 	for (const Quest &quest : Quests) {
@@ -815,7 +815,7 @@ bool CheckChatCommand(const std::string_view text)
 		return true;
 	}
 
-	TextCmdItem &textCmd = *textCmdIterator;
+	const TextCmdItem &textCmd = *textCmdIterator;
 	std::string_view parameter = "";
 	if (text.length() > (textCmd.text.length() + 1))
 		parameter = text.substr(textCmd.text.length() + 1);
@@ -962,7 +962,7 @@ bool IsChatAvailable()
 
 void FocusOnCharInfo()
 {
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	if (invflag || myPlayer._pStatPts <= 0)
 		return;
@@ -1032,7 +1032,7 @@ void AddInfoBoxString(std::string &&str, bool floatingBox /*= false*/)
 
 Point GetPanelPosition(UiPanels panel, Point offset)
 {
-	Displacement displacement { offset.x, offset.y };
+	const Displacement displacement { offset.x, offset.y };
 
 	switch (panel) {
 	case UiPanels::Main:
@@ -1080,7 +1080,7 @@ void DrawManaFlaskLower(const Surface &out, bool drawFilledPortion)
 
 void DrawFlaskValues(const Surface &out, Point pos, int currValue, int maxValue)
 {
-	UiFlags color = (currValue > 0 ? (currValue == maxValue ? UiFlags::ColorGold : UiFlags::ColorWhite) : UiFlags::ColorRed);
+	const UiFlags color = (currValue > 0 ? (currValue == maxValue ? UiFlags::ColorGold : UiFlags::ColorWhite) : UiFlags::ColorRed);
 
 	auto drawStringWithShadow = [out, color](std::string_view text, Point pos) {
 		DrawString(out, text, pos + Displacement { -1, -1 },
@@ -1089,7 +1089,7 @@ void DrawFlaskValues(const Surface &out, Point pos, int currValue, int maxValue)
 		    { .flags = color | UiFlags::KerningFitSpacing, .spacing = 0 });
 	};
 
-	std::string currText = StrCat(currValue);
+	const std::string currText = StrCat(currValue);
 	drawStringWithShadow(currText, pos - Displacement { GetLineWidth(currText, GameFont12) + 1, 0 });
 	drawStringWithShadow("/", pos);
 	drawStringWithShadow(StrCat(maxValue), pos + Displacement { GetLineWidth("/", GameFont12) + 1, 0 });
@@ -1192,7 +1192,7 @@ void DrawMainPanelButtons(const Surface &out)
 		if (!MainPanelButtons[i]) {
 			DrawPanelBox(out, MakeSdlRect(MainPanelButtonRect[i].position.x, MainPanelButtonRect[i].position.y + PanelPaddingHeight, MainPanelButtonRect[i].size.width, MainPanelButtonRect[i].size.height + 1), mainPanelPosition + Displacement { MainPanelButtonRect[i].position.x, MainPanelButtonRect[i].position.y });
 		} else {
-			Point position = mainPanelPosition + Displacement { MainPanelButtonRect[i].position.x, MainPanelButtonRect[i].position.y };
+			const Point position = mainPanelPosition + Displacement { MainPanelButtonRect[i].position.x, MainPanelButtonRect[i].position.y };
 			RenderClxSprite(out, (*pMainPanelButtons)[i], position);
 			RenderClxSprite(out, (*PanelButtonDown)[i], position + Displacement { 4, 0 });
 		}
@@ -1201,7 +1201,7 @@ void DrawMainPanelButtons(const Surface &out)
 	if (IsChatAvailable()) {
 		RenderClxSprite(out, (*multiButtons)[MainPanelButtons[PanelButtonSendmsg] ? 1 : 0], mainPanelPosition + Displacement { MainPanelButtonRect[PanelButtonSendmsg].position.x, MainPanelButtonRect[PanelButtonSendmsg].position.y });
 
-		Point friendlyButtonPosition = mainPanelPosition + Displacement { MainPanelButtonRect[PanelButtonFriendly].position.x, MainPanelButtonRect[PanelButtonFriendly].position.y };
+		const Point friendlyButtonPosition = mainPanelPosition + Displacement { MainPanelButtonRect[PanelButtonFriendly].position.x, MainPanelButtonRect[PanelButtonFriendly].position.y };
 
 		if (MyPlayer->friendlyMode)
 			RenderClxSprite(out, (*multiButtons)[MainPanelButtons[PanelButtonFriendly] ? 3 : 2], friendlyButtonPosition);
@@ -1219,7 +1219,7 @@ void ResetMainPanelButtons()
 
 void CheckMainPanelButton()
 {
-	int totalButtons = IsChatAvailable() ? TotalMpMainPanelButtons : TotalSpMainPanelButtons;
+	const int totalButtons = IsChatAvailable() ? TotalMpMainPanelButtons : TotalSpMainPanelButtons;
 
 	for (int i = 0; i < totalButtons; i++) {
 		Rectangle button = MainPanelButtonRect[i];
@@ -1296,7 +1296,7 @@ void CheckPanelInfo()
 	InfoString = StringOrView {};
 	FloatingInfoString = StringOrView {};
 
-	int totalButtons = IsChatAvailable() ? TotalMpMainPanelButtons : TotalSpMainPanelButtons;
+	const int totalButtons = IsChatAvailable() ? TotalMpMainPanelButtons : TotalSpMainPanelButtons;
 
 	for (int i = 0; i < totalButtons; i++) {
 		Rectangle button = MainPanelButtonRect[i];
@@ -1478,12 +1478,12 @@ void DrawInfoBox(const Surface &out)
 		InfoString = StringOrView {};
 		InfoColor = UiFlags::ColorWhite;
 	}
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 	if (SpellSelectFlag || trigflag || pcurs == CURSOR_HOURGLASS) {
 		InfoColor = UiFlags::ColorWhite;
 	} else if (!myPlayer.HoldItem.isEmpty()) {
 		if (myPlayer.HoldItem._itype == ItemType::Gold) {
-			int nGold = myPlayer.HoldItem._ivalue;
+			const int nGold = myPlayer.HoldItem._ivalue;
 			InfoString = fmt::format(fmt::runtime(ngettext("{:s} gold piece", "{:s} gold pieces", nGold)), FormatInteger(nGold));
 		} else if (!myPlayer.CanUseItem(myPlayer.HoldItem)) {
 			InfoString = _("Requirements not met");
@@ -1513,7 +1513,7 @@ void DrawInfoBox(const Surface &out)
 		}
 		if (PlayerUnderCursor != nullptr) {
 			InfoColor = UiFlags::ColorWhitegold;
-			auto &target = *PlayerUnderCursor;
+			const auto &target = *PlayerUnderCursor;
 			InfoString = std::string_view(target._pName);
 			AddInfoBoxString(fmt::format(fmt::runtime(_("{:s}, Level: {:d}")), target.getClassName(), target.getCharacterLevel()));
 			AddInfoBoxString(fmt::format(fmt::runtime(_("Hit Points {:d} of {:d}")), target._pHitPoints >> 6, target._pMaxHP >> 6));
@@ -1569,7 +1569,7 @@ void CheckLevelButtonUp()
 void DrawLevelButton(const Surface &out)
 {
 	if (IsLevelUpButtonVisible()) {
-		int nCel = LevelButtonDown ? 2 : 1;
+		const int nCel = LevelButtonDown ? 2 : 1;
 		DrawString(out, _("Level Up"), { GetMainPanel().position + Displacement { 0, LevelButtonRect.position.y - 23 }, { 120, 0 } },
 		    { .flags = UiFlags::ColorWhite | UiFlags::AlignCenter | UiFlags::KerningFitSpacing });
 		RenderClxSprite(out, (*pChrButtons)[nCel], GetMainPanel().position + Displacement { LevelButtonRect.position.x, LevelButtonRect.position.y });
@@ -1578,7 +1578,7 @@ void DrawLevelButton(const Surface &out)
 
 void CheckChrBtns()
 {
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	if (CharPanelButtonActive || myPlayer._pStatPts == 0)
 		return;
@@ -1636,8 +1636,8 @@ void ReleaseChrBtns(bool addAllStatPoints)
 
 void DrawDurIcon(const Surface &out)
 {
-	bool hasRoomBetweenPanels = RightPanel.position.x - (LeftPanel.position.x + LeftPanel.size.width) >= 16 + (32 + 8 + 32 + 8 + 32 + 8 + 32) + 16;
-	bool hasRoomUnderPanels = MainPanel.position.y - (RightPanel.position.y + RightPanel.size.height) >= 16 + 32 + 16;
+	const bool hasRoomBetweenPanels = RightPanel.position.x - (LeftPanel.position.x + LeftPanel.size.width) >= 16 + (32 + 8 + 32 + 8 + 32 + 8 + 32) + 16;
+	const bool hasRoomUnderPanels = MainPanel.position.y - (RightPanel.position.y + RightPanel.size.height) >= 16 + 32 + 16;
 
 	if (!hasRoomBetweenPanels && !hasRoomUnderPanels) {
 		if (IsLeftPanelOpen() && IsRightPanelOpen())
@@ -1681,7 +1681,7 @@ void DrawDeathText(const Surface &out)
 		.spacing = 2
 	};
 	std::string text;
-	int verticalPadding = 42;
+	const int verticalPadding = 42;
 	Point linePosition { 0, gnScreenHeight / 2 - (verticalPadding * 2) };
 
 	text = _("You have died");
@@ -1798,7 +1798,7 @@ void DrawChatBox(const Surface &out)
 	DrawPanelBox(out, MakeSdlRect(170, sgbPlrTalkTbl + 80, 310, 55), mainPanelPosition + Displacement { 170, 64 });
 
 	int x = mainPanelPosition.x + 200;
-	int y = mainPanelPosition.y + 10;
+	const int y = mainPanelPosition.y + 10;
 
 	const uint32_t len = DrawString(out, TalkMessage, { { x, y }, { 250, 39 } },
 	    {
@@ -1816,12 +1816,12 @@ void DrawChatBox(const Surface &out)
 		if (&player == MyPlayer)
 			continue;
 
-		UiFlags color = player.friendlyMode ? UiFlags::ColorWhitegold : UiFlags::ColorRed;
+		const UiFlags color = player.friendlyMode ? UiFlags::ColorWhitegold : UiFlags::ColorRed;
 		const Point talkPanPosition = mainPanelPosition + Displacement { 172, 84 + 18 * talkBtn };
 		if (WhisperList[i]) {
 			// the normal (unpressed) voice button is pre-rendered on the panel, only need to draw over it when the button is held
 			if (TalkButtonsDown[talkBtn]) {
-				unsigned spriteIndex = talkBtn == 0 ? 2 : 3; // the first button sprite includes a tip from the devils wing so is different to the rest.
+				const unsigned spriteIndex = talkBtn == 0 ? 2 : 3; // the first button sprite includes a tip from the devils wing so is different to the rest.
 				ClxDraw(out, talkPanPosition, (*talkButtons)[spriteIndex]);
 
 				// Draw the translated string over the top of the default (english) button. This graphic is inset to avoid overlapping the wingtip, letting

--- a/Source/controls/controller_motion.cpp
+++ b/Source/controls/controller_motion.cpp
@@ -42,19 +42,19 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 	const float maximum = 32767.0;
 	float analogX = *x;
 	float analogY = *y;
-	float deadZone = deadzone * maximum;
+	const float deadZone = deadzone * maximum;
 
-	float magnitude = std::sqrt(analogX * analogX + analogY * analogY);
+	const float magnitude = std::sqrt(analogX * analogX + analogY * analogY);
 	if (magnitude >= deadZone) {
 		// find scaled axis values with magnitudes between zero and maximum
-		float scalingFactor = 1.F / magnitude * (magnitude - deadZone) / (maximum - deadZone);
+		const float scalingFactor = 1.F / magnitude * (magnitude - deadZone) / (maximum - deadZone);
 		analogX = (analogX * scalingFactor);
 		analogY = (analogY * scalingFactor);
 
 		// std::clamp to ensure results will never exceed the max_axis value
 		float clampingFactor = 1.F;
-		float absAnalogX = std::fabs(analogX);
-		float absAnalogY = std::fabs(analogY);
+		const float absAnalogX = std::fabs(analogX);
+		const float absAnalogY = std::fabs(analogY);
 		if (absAnalogX > 1.0 || absAnalogY > 1.0) {
 			if (absAnalogX > absAnalogY) {
 				clampingFactor = 1.F / absAnalogX;
@@ -72,21 +72,21 @@ void ScaleJoystickAxes(float *x, float *y, float deadzone)
 
 bool IsMovementOverriddenByPadmapper(ControllerButton button)
 {
-	ControllerButtonEvent releaseEvent { button, true };
-	std::string_view actionName = PadmapperActionNameTriggeredByButtonEvent(releaseEvent);
-	ControllerButtonCombo buttonCombo = GetOptions().Padmapper.ButtonComboForAction(actionName);
+	const ControllerButtonEvent releaseEvent { button, true };
+	const std::string_view actionName = PadmapperActionNameTriggeredByButtonEvent(releaseEvent);
+	const ControllerButtonCombo buttonCombo = GetOptions().Padmapper.ButtonComboForAction(actionName);
 	return buttonCombo.modifier != ControllerButton_NONE;
 }
 
 bool TriggersQuickSpellAction(ControllerButton button)
 {
-	ControllerButtonEvent releaseEvent { button, true };
-	std::string_view actionName = PadmapperActionNameTriggeredByButtonEvent(releaseEvent);
+	const ControllerButtonEvent releaseEvent { button, true };
+	const std::string_view actionName = PadmapperActionNameTriggeredByButtonEvent(releaseEvent);
 
-	std::string_view prefix { "QuickSpell" };
+	const std::string_view prefix { "QuickSpell" };
 	if (actionName.size() < prefix.size())
 		return false;
-	std::string_view truncatedActionName { actionName.data(), prefix.size() };
+	const std::string_view truncatedActionName { actionName.data(), prefix.size() };
 	return truncatedActionName == prefix;
 }
 
@@ -254,21 +254,21 @@ void SimulateRightStickWithPadmapper(ControllerButtonEvent ctrlEvent)
 	if (!ctrlEvent.up && ctrlEvent.button == SuppressedButton)
 		return;
 
-	std::string_view actionName = PadmapperActionNameTriggeredByButtonEvent(ctrlEvent);
-	bool upTriggered = actionName == "MouseUp";
-	bool downTriggered = actionName == "MouseDown";
-	bool leftTriggered = actionName == "MouseLeft";
-	bool rightTriggered = actionName == "MouseRight";
+	const std::string_view actionName = PadmapperActionNameTriggeredByButtonEvent(ctrlEvent);
+	const bool upTriggered = actionName == "MouseUp";
+	const bool downTriggered = actionName == "MouseDown";
+	const bool leftTriggered = actionName == "MouseLeft";
+	const bool rightTriggered = actionName == "MouseRight";
 	if (!upTriggered && !downTriggered && !leftTriggered && !rightTriggered) {
 		if (rightStickX == 0 && rightStickY == 0)
 			SetSimulatingMouseWithPadmapper(false);
 		return;
 	}
 
-	bool upActive = (upTriggered && !ctrlEvent.up) || (!upTriggered && PadmapperIsActionActive("MouseUp"));
-	bool downActive = (downTriggered && !ctrlEvent.up) || (!downTriggered && PadmapperIsActionActive("MouseDown"));
-	bool leftActive = (leftTriggered && !ctrlEvent.up) || (!leftTriggered && PadmapperIsActionActive("MouseLeft"));
-	bool rightActive = (rightTriggered && !ctrlEvent.up) || (!rightTriggered && PadmapperIsActionActive("MouseRight"));
+	const bool upActive = (upTriggered && !ctrlEvent.up) || (!upTriggered && PadmapperIsActionActive("MouseUp"));
+	const bool downActive = (downTriggered && !ctrlEvent.up) || (!downTriggered && PadmapperIsActionActive("MouseDown"));
+	const bool leftActive = (leftTriggered && !ctrlEvent.up) || (!leftTriggered && PadmapperIsActionActive("MouseLeft"));
+	const bool rightActive = (rightTriggered && !ctrlEvent.up) || (!rightTriggered && PadmapperIsActionActive("MouseRight"));
 
 	rightStickX = 0;
 	rightStickY = 0;

--- a/Source/controls/devices/game_controller.cpp
+++ b/Source/controls/devices/game_controller.cpp
@@ -176,7 +176,7 @@ void GameController::Add(int joystickIndex)
 	controllers_.push_back(result);
 
 	const SDL_JoystickGUID guid = SDL_JoystickGetGUID(sdlJoystick);
-	SDLUniquePtr<char> mapping { SDL_GameControllerMappingForGUID(guid) };
+	const SDLUniquePtr<char> mapping { SDL_GameControllerMappingForGUID(guid) };
 	if (mapping) {
 		Log("Opened game controller with mapping:\n{}", mapping.get());
 	}

--- a/Source/controls/devices/joystick.cpp
+++ b/Source/controls/devices/joystick.cpp
@@ -15,7 +15,7 @@ StaticVector<ControllerButtonEvent, 4> Joystick::ToControllerButtonEvents(const 
 	switch (event.type) {
 	case SDL_JOYBUTTONDOWN:
 	case SDL_JOYBUTTONUP: {
-		bool up = (event.jbutton.state == SDL_RELEASED);
+		const bool up = (event.jbutton.state == SDL_RELEASED);
 #if defined(JOY_BUTTON_A) || defined(JOY_BUTTON_B) || defined(JOY_BUTTON_X) || defined(JOY_BUTTON_Y)                                            \
     || defined(JOY_BUTTON_LEFTSTICK) || defined(JOY_BUTTON_RIGHTSTICK) || defined(JOY_BUTTON_LEFTSHOULDER) || defined(JOY_BUTTON_RIGHTSHOULDER) \
     || defined(JOY_BUTTON_TRIGGERLEFT) || defined(JOY_BUTTON_TRIGGERRIGHT) || defined(JOY_BUTTON_START) || defined(JOY_BUTTON_BACK)             \

--- a/Source/controls/game_controls.cpp
+++ b/Source/controls/game_controls.cpp
@@ -364,7 +364,7 @@ bool HandleControllerButtonEvent(const SDL_Event &event, const ControllerButtonE
 	};
 
 	const ButtonReleaser buttonReleaser { ctrlEvent };
-	bool isGamepadMotion = IsControllerMotion(event);
+	const bool isGamepadMotion = IsControllerMotion(event);
 	if (!isGamepadMotion) {
 		SimulateRightStickWithPadmapper(ctrlEvent);
 	}

--- a/Source/controls/menu_controls.cpp
+++ b/Source/controls/menu_controls.cpp
@@ -33,7 +33,7 @@ std::vector<MenuAction> GetMenuActions(const SDL_Event &event)
 			continue;
 		}
 
-		bool isGamepadMotion = IsControllerMotion(event);
+		const bool isGamepadMotion = IsControllerMotion(event);
 		DetectInputMethod(event, ctrlEvent);
 		if (isGamepadMotion) {
 			menuActions.push_back(GetMenuHeldUpDownAction());

--- a/Source/controls/modifier_hints.cpp
+++ b/Source/controls/modifier_hints.cpp
@@ -74,19 +74,19 @@ struct CircleMenuHint {
 void DrawCircleMenuHint(const Surface &out, const CircleMenuHint &hint, const Point &origin)
 {
 	const Displacement backgroundDisplacement = { (HintBoxSize - IconSize) / 2 + 1, (HintBoxSize - IconSize) / 2 - 1 };
-	Point hintBoxPositions[4] = {
+	const Point hintBoxPositions[4] = {
 		origin + Displacement { 0, LineHeight - HintBoxSize },
 		origin + Displacement { HintBoxSize + HintBoxMargin, LineHeight - HintBoxSize * 2 - HintBoxMargin },
 		origin + Displacement { HintBoxSize + HintBoxMargin, LineHeight + HintBoxMargin },
 		origin + Displacement { HintBoxSize * 2 + HintBoxMargin * 2, LineHeight - HintBoxSize }
 	};
-	Point iconPositions[4] = {
+	const Point iconPositions[4] = {
 		hintBoxPositions[0] + backgroundDisplacement,
 		hintBoxPositions[1] + backgroundDisplacement,
 		hintBoxPositions[2] + backgroundDisplacement,
 		hintBoxPositions[3] + backgroundDisplacement,
 	};
-	uint8_t iconIndices[4] { hint.left, hint.top, hint.bottom, hint.right };
+	const uint8_t iconIndices[4] { hint.left, hint.top, hint.bottom, hint.right };
 
 	for (int slot = 0; slot < 4; ++slot) {
 		if (iconIndices[slot] == HintIcon::IconNull)
@@ -107,19 +107,19 @@ void DrawSpellsCircleMenuHint(const Surface &out, const Point &origin)
 {
 	const Player &myPlayer = *MyPlayer;
 	const Displacement spellIconDisplacement = { (HintBoxSize - IconSize) / 2 + 1, HintBoxSize - (HintBoxSize - IconSize) / 2 - 1 };
-	Point hintBoxPositions[4] = {
+	const Point hintBoxPositions[4] = {
 		origin + Displacement { 0, LineHeight - HintBoxSize },
 		origin + Displacement { HintBoxSize + HintBoxMargin, LineHeight - HintBoxSize * 2 - HintBoxMargin },
 		origin + Displacement { HintBoxSize + HintBoxMargin, LineHeight + HintBoxMargin },
 		origin + Displacement { HintBoxSize * 2 + HintBoxMargin * 2, LineHeight - HintBoxSize }
 	};
-	Point spellIconPositions[4] = {
+	const Point spellIconPositions[4] = {
 		hintBoxPositions[0] + spellIconDisplacement,
 		hintBoxPositions[1] + spellIconDisplacement,
 		hintBoxPositions[2] + spellIconDisplacement,
 		hintBoxPositions[3] + spellIconDisplacement,
 	};
-	uint64_t spells = myPlayer._pAblSpells | myPlayer._pMemSpells | myPlayer._pScrlSpells | myPlayer._pISpells;
+	const uint64_t spells = myPlayer._pAblSpells | myPlayer._pMemSpells | myPlayer._pScrlSpells | myPlayer._pISpells;
 	SpellID splId;
 	SpellType splType;
 

--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -837,10 +837,10 @@ void LiftInventoryItem()
 				return 0;
 			for (int x = 0; x < cursorSizeInCells.width; x++) {
 				for (int y = 0; y < cursorSizeInCells.height; y++) {
-					int slotUnderCursor = inventorySlot + x + y * INV_ROW_SLOT_SIZE;
+					const int slotUnderCursor = inventorySlot + x + y * INV_ROW_SLOT_SIZE;
 					if (slotUnderCursor > SLOTXY_INV_LAST)
 						continue;
-					int itemId = GetItemIdOnSlot(slotUnderCursor);
+					const int itemId = GetItemIdOnSlot(slotUnderCursor);
 					if (itemId != 0)
 						return itemId;
 				}
@@ -1743,7 +1743,7 @@ void DetectInputMethod(const SDL_Event &event, const ControllerButtonEvent &game
 			ResetCursor();
 		}
 		if (ControlDevice == ControlTypes::Gamepad) {
-			GamepadLayout newGamepadLayout = GameController::getLayout(event);
+			const GamepadLayout newGamepadLayout = GameController::getLayout(event);
 			if (newGamepadLayout != GamepadType) {
 				LogGamepadChange(newGamepadLayout);
 				GamepadType = newGamepadLayout;
@@ -2084,7 +2084,7 @@ void PerformSpellAction()
 			TryIconCurs();
 			NewCursor(CURSOR_HAND);
 		} else if (pcursinvitem != -1) {
-			int itemId = GetItemIdOnSlot(Slot);
+			const int itemId = GetItemIdOnSlot(Slot);
 			CheckInvItem(true, false);
 			if (itemId != GetItemIdOnSlot(Slot))
 				ResetInvCursorPosition();
@@ -2214,10 +2214,10 @@ void PerformSecondaryAction()
 
 void QuickCast(size_t slot)
 {
-	PlayerActionType prevMouseButtonAction = LastPlayerAction;
-	Player &myPlayer = *MyPlayer;
-	SpellID spell = myPlayer._pSplHotKey[slot];
-	SpellType spellType = myPlayer._pSplTHotKey[slot];
+	const PlayerActionType prevMouseButtonAction = LastPlayerAction;
+	const Player &myPlayer = *MyPlayer;
+	const SpellID spell = myPlayer._pSplHotKey[slot];
+	const SpellType spellType = myPlayer._pSplTHotKey[slot];
 
 	if (ControlMode != ControlTypes::KeyboardAndMouse) {
 		UpdateSpellTarget(spell);

--- a/Source/controls/touch/event_handlers.cpp
+++ b/Source/controls/touch/event_handlers.cpp
@@ -38,11 +38,11 @@ Point ScaleToScreenCoordinates(float x, float y)
 
 void SimulateMouseMovement(const SDL_Event &event)
 {
-	Point position = ScaleToScreenCoordinates(event.tfinger.x, event.tfinger.y);
+	const Point position = ScaleToScreenCoordinates(event.tfinger.x, event.tfinger.y);
 
-	bool isInMainPanel = GetMainPanel().contains(position);
-	bool isInLeftPanel = GetLeftPanel().contains(position);
-	bool isInRightPanel = GetRightPanel().contains(position);
+	const bool isInMainPanel = GetMainPanel().contains(position);
+	const bool isInLeftPanel = GetLeftPanel().contains(position);
+	const bool isInRightPanel = GetRightPanel().contains(position);
 	if (IsStashOpen) {
 		if (!SpellSelectFlag && !isInMainPanel && !isInLeftPanel && !isInRightPanel)
 			return;
@@ -139,7 +139,7 @@ void HandleStashPanelInteraction(const SDL_Event &event)
 
 SdlEventType GetDeactivateEventType()
 {
-	static SdlEventType customEventType = SDL_RegisterEvents(1);
+	static const SdlEventType customEventType = SDL_RegisterEvents(1);
 	return customEventType;
 }
 
@@ -264,10 +264,10 @@ bool VirtualDirectionPadEventHandler::HandleFingerDown(const SDL_TouchFingerEven
 	if (isActive)
 		return false;
 
-	float x = event.x;
-	float y = event.y;
+	const float x = event.x;
+	const float y = event.y;
 
-	Point touchCoordinates = ScaleToScreenCoordinates(x, y);
+	const Point touchCoordinates = ScaleToScreenCoordinates(x, y);
 	if (!virtualDirectionPad->area.contains(touchCoordinates))
 		return false;
 
@@ -282,7 +282,7 @@ bool VirtualDirectionPadEventHandler::HandleFingerUp(const SDL_TouchFingerEvent 
 	if (!isActive || event.fingerId != activeFinger)
 		return false;
 
-	Point position = virtualDirectionPad->area.position;
+	const Point position = virtualDirectionPad->area.position;
 	virtualDirectionPad->UpdatePosition(position);
 	isActive = false;
 	return true;
@@ -293,10 +293,10 @@ bool VirtualDirectionPadEventHandler::HandleFingerMotion(const SDL_TouchFingerEv
 	if (!isActive || event.fingerId != activeFinger)
 		return false;
 
-	float x = event.x;
-	float y = event.y;
+	const float x = event.x;
+	const float y = event.y;
 
-	Point touchCoordinates = ScaleToScreenCoordinates(x, y);
+	const Point touchCoordinates = ScaleToScreenCoordinates(x, y);
 	virtualDirectionPad->UpdatePosition(touchCoordinates);
 	return true;
 }
@@ -336,10 +336,10 @@ bool VirtualButtonEventHandler::HandleFingerDown(const SDL_TouchFingerEvent &eve
 	if (isActive)
 		return false;
 
-	float x = event.x;
-	float y = event.y;
+	const float x = event.x;
+	const float y = event.y;
 
-	Point touchCoordinates = ScaleToScreenCoordinates(x, y);
+	const Point touchCoordinates = ScaleToScreenCoordinates(x, y);
 	if (!virtualButton->contains(touchCoordinates))
 		return false;
 
@@ -377,11 +377,11 @@ bool VirtualButtonEventHandler::HandleFingerMotion(const SDL_TouchFingerEvent &e
 	if (toggles)
 		return true;
 
-	float x = event.x;
-	float y = event.y;
-	Point touchCoordinates = ScaleToScreenCoordinates(x, y);
+	const float x = event.x;
+	const float y = event.y;
+	const Point touchCoordinates = ScaleToScreenCoordinates(x, y);
 
-	bool wasHeld = virtualButton->isHeld;
+	const bool wasHeld = virtualButton->isHeld;
 	virtualButton->isHeld = virtualButton->contains(touchCoordinates);
 	virtualButton->didStateChange = virtualButton->isHeld != wasHeld;
 

--- a/Source/controls/touch/gamepad.cpp
+++ b/Source/controls/touch/gamepad.cpp
@@ -58,7 +58,7 @@ void InitializeVirtualGamepad()
 {
 	const float sqrt2 = sqrtf(2);
 
-	int screenPixels = std::min(gnScreenWidth, gnScreenHeight);
+	const int screenPixels = std::min(gnScreenWidth, gnScreenHeight);
 	int inputMargin = screenPixels / 10;
 	int menuButtonWidth = screenPixels / 10;
 	int directionPadSize = screenPixels / 4;
@@ -67,7 +67,7 @@ void InitializeVirtualGamepad()
 
 	float hdpi;
 	float vdpi;
-	int displayIndex = SDL_GetWindowDisplayIndex(ghMainWnd);
+	const int displayIndex = SDL_GetWindowDisplayIndex(ghMainWnd);
 	if (SDL_GetDisplayDPI(displayIndex, nullptr, &hdpi, &vdpi) == 0) {
 		int clientWidth;
 		int clientHeight;
@@ -79,7 +79,7 @@ void InitializeVirtualGamepad()
 		hdpi *= static_cast<float>(gnScreenWidth) / clientWidth;
 		vdpi *= static_cast<float>(gnScreenHeight) / clientHeight;
 
-		float dpi = std::min(hdpi, vdpi);
+		const float dpi = std::min(hdpi, vdpi);
 		inputMargin = roundToInt(0.25f * dpi);
 		menuButtonWidth = roundToInt(0.2f * dpi);
 		directionPadSize = roundToInt(dpi);
@@ -87,20 +87,20 @@ void InitializeVirtualGamepad()
 		padButtonSpacing = roundToInt(0.1f * dpi);
 	}
 
-	int menuPanelTopMargin = 30;
-	int menuPanelButtonSpacing = 4;
-	Size menuPanelButtonSize = { 64, 62 };
-	int rightMarginMenuButton4 = menuPanelButtonSpacing + menuPanelButtonSize.width;
-	int rightMarginMenuButton3 = rightMarginMenuButton4 + menuPanelButtonSpacing + menuPanelButtonSize.width;
-	int rightMarginMenuButton2 = rightMarginMenuButton3 + menuPanelButtonSpacing + menuPanelButtonSize.width;
-	int rightMarginMenuButton1 = rightMarginMenuButton2 + menuPanelButtonSpacing + menuPanelButtonSize.width;
+	const int menuPanelTopMargin = 30;
+	const int menuPanelButtonSpacing = 4;
+	const Size menuPanelButtonSize = { 64, 62 };
+	const int rightMarginMenuButton4 = menuPanelButtonSpacing + menuPanelButtonSize.width;
+	const int rightMarginMenuButton3 = rightMarginMenuButton4 + menuPanelButtonSpacing + menuPanelButtonSize.width;
+	const int rightMarginMenuButton2 = rightMarginMenuButton3 + menuPanelButtonSpacing + menuPanelButtonSize.width;
+	const int rightMarginMenuButton1 = rightMarginMenuButton2 + menuPanelButtonSpacing + menuPanelButtonSize.width;
 
-	int padButtonAreaWidth = roundToInt(sqrt2 * (padButtonSize + padButtonSpacing));
+	const int padButtonAreaWidth = roundToInt(sqrt2 * (padButtonSize + padButtonSpacing));
 
-	int padButtonRight = gnScreenWidth - inputMargin - padButtonSize / 2;
-	int padButtonLeft = padButtonRight - padButtonAreaWidth;
-	int padButtonBottom = gnScreenHeight - inputMargin - padButtonSize / 2;
-	int padButtonTop = padButtonBottom - padButtonAreaWidth;
+	const int padButtonRight = gnScreenWidth - inputMargin - padButtonSize / 2;
+	const int padButtonLeft = padButtonRight - padButtonAreaWidth;
+	const int padButtonBottom = gnScreenHeight - inputMargin - padButtonSize / 2;
+	const int padButtonTop = padButtonBottom - padButtonAreaWidth;
 
 	Rectangle &charButtonArea = VirtualGamepadState.menuPanel.charButton.area;
 	charButtonArea.position.x = gnScreenWidth - rightMarginMenuButton1 * menuButtonWidth / menuPanelButtonSize.width;
@@ -139,8 +139,8 @@ void InitializeVirtualGamepad()
 	directionPadArea.radius = directionPadSize / 2;
 	directionPad.position = directionPadArea.position;
 
-	int standButtonDiagonalOffset = directionPadArea.radius + padButtonSpacing / 2 + padButtonSize / 2;
-	int standButtonOffset = roundToInt(standButtonDiagonalOffset / sqrt2);
+	const int standButtonDiagonalOffset = directionPadArea.radius + padButtonSpacing / 2 + padButtonSize / 2;
+	const int standButtonOffset = roundToInt(standButtonDiagonalOffset / sqrt2);
 	Circle &standButtonArea = VirtualGamepadState.standButton.area;
 	standButtonArea.position.x = directionPadArea.position.x - standButtonOffset;
 	standButtonArea.position.y = directionPadArea.position.y + standButtonOffset;
@@ -221,7 +221,7 @@ void VirtualDirectionPad::UpdatePosition(Point touchCoordinates)
 {
 	position = touchCoordinates;
 
-	Displacement diff = position - area.position;
+	const Displacement diff = position - area.position;
 	if (diff == Displacement { 0, 0 }) {
 		isUpPressed = false;
 		isDownPressed = false;
@@ -233,14 +233,14 @@ void VirtualDirectionPad::UpdatePosition(Point touchCoordinates)
 	if (!area.contains(position)) {
 		int x = diff.deltaX;
 		int y = diff.deltaY;
-		float dist = sqrtf(static_cast<float>(x * x + y * y));
+		const float dist = sqrtf(static_cast<float>(x * x + y * y));
 		x = roundToInt(x * area.radius / dist);
 		y = roundToInt(y * area.radius / dist);
 		position.x = area.position.x + x;
 		position.y = area.position.y + y;
 	}
 
-	float angle = atan2f(static_cast<float>(-diff.deltaY), static_cast<float>(diff.deltaX));
+	const float angle = atan2f(static_cast<float>(-diff.deltaY), static_cast<float>(diff.deltaX));
 
 	isUpPressed = PointsUp(angle);
 	isDownPressed = PointsDown(angle);

--- a/Source/controls/touch/renderers.cpp
+++ b/Source/controls/touch/renderers.cpp
@@ -105,7 +105,7 @@ void LoadButtonArt(ButtonTexture *buttonArt)
 
 void LoadPotionArt(ButtonTexture *potionArt)
 {
-	item_cursor_graphic potionGraphics[] {
+	const item_cursor_graphic potionGraphics[] {
 		ICURS_POTION_OF_HEALING,
 		ICURS_POTION_OF_MANA,
 		ICURS_POTION_OF_REJUVENATION,
@@ -116,8 +116,8 @@ void LoadPotionArt(ButtonTexture *potionArt)
 		ICURS_SCROLL_OF
 	};
 
-	int potionFrame = static_cast<int>(CURSOR_FIRSTITEM) + static_cast<int>(ICURS_POTION_OF_HEALING);
-	Size potionSize = GetInvItemSize(potionFrame);
+	const int potionFrame = static_cast<int>(CURSOR_FIRSTITEM) + static_cast<int>(ICURS_POTION_OF_HEALING);
+	const Size potionSize = GetInvItemSize(potionFrame);
 
 	auto surface = SDLWrap::CreateRGBSurfaceWithFormat(
 	    /*flags=*/0,
@@ -130,14 +130,14 @@ void LoadPotionArt(ButtonTexture *potionArt)
 	if (SDLC_SetSurfaceAndPaletteColors(surface.get(), palette.get(), logical_palette.data(), 0, 256) < 0)
 		ErrSdl();
 
-	Uint32 bgColor = SDL_MapRGB(surface->format, logical_palette[1].r, logical_palette[1].g, logical_palette[1].b);
+	const Uint32 bgColor = SDL_MapRGB(surface->format, logical_palette[1].r, logical_palette[1].g, logical_palette[1].b);
 	if (SDL_FillRect(surface.get(), nullptr, bgColor) < 0)
 		ErrSdl();
 	if (SDL_SetColorKey(surface.get(), SDL_TRUE, bgColor) < 0)
 		ErrSdl();
 
 	Point position { 0, 0 };
-	for (item_cursor_graphic graphic : potionGraphics) {
+	for (const item_cursor_graphic graphic : potionGraphics) {
 		const int cursorID = static_cast<int>(CURSOR_FIRSTITEM) + graphic;
 		position.y += potionSize.height;
 		ClxDraw(Surface(surface.get()), position, GetInvItemSprite(cursorID));
@@ -150,7 +150,7 @@ void LoadPotionArt(ButtonTexture *potionArt)
 
 bool InteractsWithCharButton(Point point)
 {
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 	if (myPlayer._pStatPts == 0)
 		return false;
 	for (auto attribute : enum_values<CharacterAttribute>()) {
@@ -187,7 +187,7 @@ void RenderVirtualGamepad(SDL_Renderer *renderer)
 	if (!gbRunGame)
 		return;
 
-	RenderFunction renderFunction = [renderer](const ButtonTexture &art, SDL_Rect *src, SDL_Rect *dst) {
+	const RenderFunction renderFunction = [renderer](const ButtonTexture &art, SDL_Rect *src, SDL_Rect *dst) {
 		if (art.texture == nullptr)
 			return;
 
@@ -203,7 +203,7 @@ void RenderVirtualGamepad(SDL_Surface *surface)
 	if (!gbRunGame)
 		return;
 
-	RenderFunction renderFunction = [surface](const ButtonTexture &art, SDL_Rect *src, SDL_Rect *dst) {
+	const RenderFunction renderFunction = [surface](const ButtonTexture &art, SDL_Rect *src, SDL_Rect *dst) {
 		if (art.surface == nullptr)
 			return;
 
@@ -257,10 +257,10 @@ void VirtualGamepadRenderer::Render(RenderFunction renderFunction)
 
 void VirtualMenuPanelRenderer::Render(RenderFunction renderFunction)
 {
-	int x = virtualMenuPanel->area.position.x;
-	int y = virtualMenuPanel->area.position.y;
-	int width = virtualMenuPanel->area.size.width;
-	int height = virtualMenuPanel->area.size.height;
+	const int x = virtualMenuPanel->area.position.x;
+	const int y = virtualMenuPanel->area.position.y;
+	const int width = virtualMenuPanel->area.size.width;
+	const int height = virtualMenuPanel->area.size.height;
 	SDL_Rect rect { x, y, width, height };
 	renderFunction(MyPlayer->_pStatPts == 0 ? menuArt : menuArtLevelUp, nullptr, &rect);
 }
@@ -275,12 +275,12 @@ void VirtualDirectionPadRenderer::RenderPad(RenderFunction renderFunction)
 {
 	auto center = virtualDirectionPad->area.position;
 	auto radius = virtualDirectionPad->area.radius;
-	int diameter = 2 * radius;
+	const int diameter = 2 * radius;
 
-	int x = center.x - radius;
-	int y = center.y - radius;
-	int width = diameter;
-	int height = diameter;
+	const int x = center.x - radius;
+	const int y = center.y - radius;
+	const int width = diameter;
+	const int height = diameter;
 	SDL_Rect rect { x, y, width, height };
 	renderFunction(padArt, nullptr, &rect);
 }
@@ -289,12 +289,12 @@ void VirtualDirectionPadRenderer::RenderKnob(RenderFunction renderFunction)
 {
 	auto center = virtualDirectionPad->position;
 	auto radius = virtualDirectionPad->area.radius / 3;
-	int diameter = 2 * radius;
+	const int diameter = 2 * radius;
 
-	int x = center.x - radius;
-	int y = center.y - radius;
-	int width = diameter;
-	int height = diameter;
+	const int x = center.x - radius;
+	const int y = center.y - radius;
+	const int width = diameter;
+	const int height = diameter;
 	SDL_Rect rect { x, y, width, height };
 	renderFunction(knobArt, nullptr, &rect);
 }
@@ -304,20 +304,20 @@ void VirtualPadButtonRenderer::Render(RenderFunction renderFunction, const Butto
 	if (!virtualPadButton->isUsable())
 		return;
 
-	VirtualGamepadButtonType buttonType = GetButtonType();
-	Size size = buttonArt.size();
+	const VirtualGamepadButtonType buttonType = GetButtonType();
+	const Size size = buttonArt.size();
 	const auto index = static_cast<unsigned>(buttonType);
 	const int xOffset = size.width * (index / buttonArt.numFrames);
 	const int yOffset = size.height * (index % buttonArt.numFrames);
 
 	auto center = virtualPadButton->area.position;
 	auto radius = virtualPadButton->area.radius;
-	int diameter = 2 * radius;
+	const int diameter = 2 * radius;
 
-	int x = center.x - radius;
-	int y = center.y - radius;
-	int width = diameter;
-	int height = diameter;
+	const int x = center.x - radius;
+	const int y = center.y - radius;
+	const int width = diameter;
+	const int height = diameter;
 
 	SDL_Rect src = MakeSdlRect(xOffset, yOffset, size.width, size.height);
 	SDL_Rect dst = MakeSdlRect(x, y, width, height);
@@ -333,18 +333,18 @@ void PotionButtonRenderer::RenderPotion(RenderFunction renderFunction, const But
 	if (potionType == std::nullopt)
 		return;
 
-	int frame = *potionType;
-	Size size = potionArt.size();
-	int offset = size.height * frame;
+	const int frame = *potionType;
+	const Size size = potionArt.size();
+	const int offset = size.height * frame;
 
 	auto center = virtualPadButton->area.position;
 	auto radius = virtualPadButton->area.radius * 8 / 10;
-	int diameter = 2 * radius;
+	const int diameter = 2 * radius;
 
-	int x = center.x - radius;
-	int y = center.y - radius;
-	int width = diameter;
-	int height = diameter;
+	const int x = center.x - radius;
+	const int y = center.y - radius;
+	const int width = diameter;
+	const int height = diameter;
 
 	SDL_Rect src = MakeSdlRect(0, offset, size.width, size.height);
 	SDL_Rect dst = MakeSdlRect(x, y, width, height);
@@ -448,7 +448,7 @@ VirtualGamepadButtonType SecondaryActionButtonRenderer::GetButtonType()
 			return GetApplyButtonType(virtualPadButton->isHeld);
 
 		if (pcursinvitem != -1) {
-			Item &item = GetInventoryItem(*MyPlayer, pcursinvitem);
+			const Item &item = GetInventoryItem(*MyPlayer, pcursinvitem);
 			if (!item.isScroll() || !TargetsMonster(item._iSpell)) {
 				if (!item.isEquipment()) {
 					return GetApplyButtonType(virtualPadButton->isHeld);

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -323,7 +323,7 @@ bool TrySelectPixelBased(Point tile)
 			if (playerId != MyPlayerId) {
 				const Player &player = Players[playerId];
 				const ClxSprite sprite = player.currentSprite();
-				Displacement renderingOffset = player.getRenderingOffset(sprite);
+				const Displacement renderingOffset = player.getRenderingOffset(sprite);
 				if (checkSprite(adjacentTile, sprite, renderingOffset)) {
 					cursPosition = adjacentTile;
 					PlayerUnderCursor = &player;
@@ -335,7 +335,7 @@ bool TrySelectPixelBased(Point tile)
 			for (const Player &player : Players) {
 				if (player.position.tile == adjacentTile && &player != MyPlayer) {
 					const ClxSprite sprite = player.currentSprite();
-					Displacement renderingOffset = player.getRenderingOffset(sprite);
+					const Displacement renderingOffset = player.getRenderingOffset(sprite);
 					if (checkSprite(adjacentTile, sprite, renderingOffset)) {
 						cursPosition = adjacentTile;
 						PlayerUnderCursor = &player;
@@ -348,7 +348,7 @@ bool TrySelectPixelBased(Point tile)
 		Object *object = FindObjectAtPosition(adjacentTile);
 		if (object != nullptr && object->canInteractWith()) {
 			const ClxSprite sprite = object->currentSprite();
-			Displacement renderingOffset = object->getRenderingOffset(sprite, adjacentTile);
+			const Displacement renderingOffset = object->getRenderingOffset(sprite, adjacentTile);
 			if (checkSprite(adjacentTile, sprite, renderingOffset)) {
 				cursPosition = adjacentTile;
 				ObjectUnderCursor = object;
@@ -361,7 +361,7 @@ bool TrySelectPixelBased(Point tile)
 			itemId = itemId - 1;
 			const Item &item = Items[itemId];
 			const ClxSprite sprite = item.AnimInfo.currentSprite();
-			Displacement renderingOffset = item.getRenderingOffset(sprite);
+			const Displacement renderingOffset = item.getRenderingOffset(sprite);
 			if (checkSprite(adjacentTile, sprite, renderingOffset)) {
 				cursPosition = adjacentTile;
 				pcursitem = static_cast<int8_t>(itemId);
@@ -380,7 +380,7 @@ std::vector<uint16_t> ReadWidths(AssetRef &&ref)
 	if (len == 0) {
 		app_fatal("Missing widths");
 	}
-	std::unique_ptr<char[]> data { new char[len] };
+	const std::unique_ptr<char[]> data { new char[len] };
 
 	AssetHandle handle = OpenAsset(std::move(ref));
 	if (!handle.ok() || !handle.read(data.get(), len)) {
@@ -500,13 +500,13 @@ void CreateHalfSizeItemSprites()
 			return;
 		}
 		const Surface itemSurface = ownedItemSurface.subregion(0, 0, itemSprite.width(), itemSprite.height());
-		SDL_Rect itemSurfaceRect = MakeSdlRect(0, 0, itemSurface.w(), itemSurface.h());
+		const SDL_Rect itemSurfaceRect = MakeSdlRect(0, 0, itemSurface.w(), itemSurface.h());
 		SDL_SetClipRect(itemSurface.surface, &itemSurfaceRect);
 		SDL_FillRect(itemSurface.surface, nullptr, 1);
 		ClxDraw(itemSurface, { 0, itemSurface.h() }, itemSprite);
 
 		const Surface halfSurface = ownedHalfSurface.subregion(0, 0, itemSurface.w() / 2, itemSurface.h() / 2);
-		SDL_Rect halfSurfaceRect = MakeSdlRect(0, 0, halfSurface.w(), halfSurface.h());
+		const SDL_Rect halfSurfaceRect = MakeSdlRect(0, 0, halfSurface.w(), halfSurface.h());
 		SDL_SetClipRect(halfSurface.surface, &halfSurfaceRect);
 		BilinearDownscaleByHalf8(itemSurface.surface, paletteTransparencyLookup, halfSurface.surface, 1);
 		HalfSizeItemSprites[outputIndex].emplace(SurfaceToClx(halfSurface, 1, 1));
@@ -695,13 +695,13 @@ void AlterMousePositionViaPlayer(Point &screenPosition, const Player &myPlayer)
 
 	// Adjust for player walking
 	if (myPlayer.isWalking()) {
-		Displacement offset = GetOffsetForWalking(myPlayer.AnimInfo, myPlayer._pdir, true);
+		const Displacement offset = GetOffsetForWalking(myPlayer.AnimInfo, myPlayer._pdir, true);
 		screenPosition.x -= offset.deltaX;
 		screenPosition.y -= offset.deltaY;
 
 		// Predict the next frame when walking to avoid input jitter
-		DisplacementOf<int16_t> offset2 = myPlayer.position.CalculateWalkingOffsetShifted8(myPlayer._pdir, myPlayer.AnimInfo);
-		DisplacementOf<int16_t> velocity = myPlayer.position.GetWalkingVelocityShifted8(myPlayer._pdir, myPlayer.AnimInfo);
+		const DisplacementOf<int16_t> offset2 = myPlayer.position.CalculateWalkingOffsetShifted8(myPlayer._pdir, myPlayer.AnimInfo);
+		const DisplacementOf<int16_t> velocity = myPlayer.position.GetWalkingVelocityShifted8(myPlayer._pdir, myPlayer.AnimInfo);
 		int fx = offset2.deltaX / 256;
 		int fy = offset2.deltaY / 256;
 		fx -= (offset2.deltaX + velocity.deltaX) / 256;
@@ -717,7 +717,7 @@ Point ConvertToTileGrid(Point &screenPosition)
 	int columns = 0;
 	int rows = 0;
 	TilesInView(&columns, &rows);
-	int lrow = rows - RowsCoveredByPanel();
+	const int lrow = rows - RowsCoveredByPanel();
 
 	// Center player tile on screen
 	Point currentTile = ViewPosition;
@@ -736,8 +736,8 @@ Point ConvertToTileGrid(Point &screenPosition)
 		screenPosition.y -= TILE_HEIGHT / 4;
 	}
 
-	int tx = screenPosition.x / TILE_WIDTH;
-	int ty = screenPosition.y / TILE_HEIGHT;
+	const int tx = screenPosition.x / TILE_WIDTH;
+	const int ty = screenPosition.y / TILE_HEIGHT;
 	ShiftGrid(&currentTile, tx, ty);
 
 	return currentTile;
@@ -748,14 +748,14 @@ Point ConvertToTileGrid(Point &screenPosition)
  */
 void ShiftToDiamondGridAlignment(Point screenPosition, Point &tile, bool &flipflag)
 {
-	int px = screenPosition.x % TILE_WIDTH;
-	int py = screenPosition.y % TILE_HEIGHT;
+	const int px = screenPosition.x % TILE_WIDTH;
+	const int py = screenPosition.y % TILE_HEIGHT;
 
-	bool flipy = py < (px / 2);
+	const bool flipy = py < (px / 2);
 	if (flipy) {
 		tile.y--;
 	}
-	bool flipx = py >= TILE_HEIGHT - (px / 2);
+	const bool flipx = py >= TILE_HEIGHT - (px / 2);
 	if (flipx) {
 		tile.x++;
 	}

--- a/Source/data/file.cpp
+++ b/Source/data/file.cpp
@@ -110,7 +110,7 @@ tl::expected<void, DataFile::Error> DataFile::parseHeader(ColumnDefinition *begi
 			continue;
 		}
 
-		uint8_t columnType = mapResult.value();
+		const uint8_t columnType = mapResult.value();
 		if (seenColumns.test(columnType)) {
 			// Repeated column? unusual, maybe this should be an error
 			continue;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -250,7 +250,7 @@ void LeftMouseCmd(bool bShift)
 		return;
 	}
 
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 	bNear = myPlayer.position.tile.WalkingDistance(cursPosition) < 2;
 	if (pcursitem != -1 && pcurs == CURSOR_HAND && !bShift) {
 		NetSendCmdLocParam1(true, invflag ? CMD_GOTOGETITEM : CMD_GOTOAGETITEM, cursPosition, pcursitem);
@@ -304,7 +304,7 @@ bool TryOpenDungeonWithMouse()
 	if (leveltype != DTYPE_TOWN)
 		return false;
 
-	Item &holdItem = MyPlayer->HoldItem;
+	const Item &holdItem = MyPlayer->HoldItem;
 	if (holdItem.IDidx == IDI_RUNEBOMB && OpensHive(cursPosition))
 		OpenHive();
 	else if (holdItem.IDidx == IDI_MAPOFDOOM && OpensGrave(cursPosition))
@@ -375,7 +375,7 @@ void LeftMouseDown(uint16_t modState)
 				CheckSBook();
 			} else if (!MyPlayer->HoldItem.isEmpty()) {
 				if (!TryOpenDungeonWithMouse()) {
-					Point currentPosition = MyPlayer->position.tile;
+					const Point currentPosition = MyPlayer->position.tile;
 					std::optional<Point> itemTile = FindAdjacentPositionForItem(currentPosition, GetDirection(currentPosition, cursPosition));
 					if (itemTile) {
 						NetSendCmdPItem(true, CMD_PUTITEM, *itemTile, MyPlayer->HoldItem);
@@ -714,9 +714,9 @@ void PrepareForFadeIn()
 
 void GameEventHandler(const SDL_Event &event, uint16_t modState)
 {
-	[[maybe_unused]] Options &options = GetOptions();
+	[[maybe_unused]] const Options &options = GetOptions();
 	StaticVector<ControllerButtonEvent, 4> ctrlEvents = ToControllerButtonEvents(event);
-	for (ControllerButtonEvent ctrlEvent : ctrlEvents) {
+	for (const ControllerButtonEvent ctrlEvent : ctrlEvents) {
 		GameAction action;
 		if (HandleControllerButtonEvent(event, ctrlEvent, action) && action.type == GameActionType_SEND_KEY) {
 			if ((action.send_key.vk_code & KeymapperMouseButtonMask) != 0) {
@@ -895,7 +895,7 @@ void RunGameLoop(interface_mode uMsg)
 
 		bool drawGame = true;
 		bool processInput = true;
-		bool runGameLoop = demo::IsRunning() ? demo::GetRunGameLoop(drawGame, processInput) : nthread_has_500ms_passed(&drawGame);
+		const bool runGameLoop = demo::IsRunning() ? demo::GetRunGameLoop(drawGame, processInput) : nthread_has_500ms_passed(&drawGame);
 		if (demo::IsRecording())
 			demo::RecordGameLoopResult(runGameLoop);
 
@@ -1439,7 +1439,7 @@ void UpdateMonsterLights()
 		Monster &monster = Monsters[ActiveMonsters[i]];
 
 		if ((monster.flags & MFLAG_BERSERK) != 0) {
-			int lightRadius = leveltype == DTYPE_NEST ? 9 : 3;
+			const int lightRadius = leveltype == DTYPE_NEST ? 9 : 3;
 			monster.lightId = AddLight(monster.position.tile, lightRadius);
 		}
 
@@ -1449,7 +1449,7 @@ void UpdateMonsterLights()
 				continue;
 			}
 
-			Light &light = Lights[monster.lightId];
+			const Light &light = Lights[monster.lightId];
 			if (monster.position.tile != light.position.tile) {
 				ChangeLightXY(monster.lightId, monster.position.tile);
 			}
@@ -1739,7 +1739,7 @@ void InitKeymapActions()
 		    N_("Use Belt item."),
 		    '1' + i,
 		    [i] {
-			    Player &myPlayer = *MyPlayer;
+			    const Player &myPlayer = *MyPlayer;
 			    if (!myPlayer.SpdList[i].isEmpty() && myPlayer.SpdList[i]._itype != ItemType::Gold) {
 				    UseInvItem(INVITEM_BELT_FIRST + i);
 			    }
@@ -2059,7 +2059,7 @@ void InitPadmapActions()
 		    N_("Use Belt item."),
 		    ControllerButton_NONE,
 		    [i] {
-			    Player &myPlayer = *MyPlayer;
+			    const Player &myPlayer = *MyPlayer;
 			    if (!myPlayer.SpdList[i].isEmpty() && myPlayer.SpdList[i]._itype != ItemType::Gold) {
 				    UseInvItem(INVITEM_BELT_FIRST + i);
 			    }
@@ -2318,14 +2318,14 @@ void InitPadmapActions()
 	    { ControllerButton_BUTTON_BACK, ControllerButton_BUTTON_DPAD_RIGHT },
 	    [] {});
 	auto leftMouseDown = [] {
-		ControllerButtonCombo standGroundCombo = GetOptions().Padmapper.ButtonComboForAction("StandGround");
-		bool standGround = StandToggle || IsControllerButtonComboPressed(standGroundCombo);
+		const ControllerButtonCombo standGroundCombo = GetOptions().Padmapper.ButtonComboForAction("StandGround");
+		const bool standGround = StandToggle || IsControllerButtonComboPressed(standGroundCombo);
 		sgbMouseDown = CLICK_LEFT;
 		LeftMouseDown(standGround ? KMOD_SHIFT : KMOD_NONE);
 	};
 	auto leftMouseUp = [] {
-		ControllerButtonCombo standGroundCombo = GetOptions().Padmapper.ButtonComboForAction("StandGround");
-		bool standGround = StandToggle || IsControllerButtonComboPressed(standGroundCombo);
+		const ControllerButtonCombo standGroundCombo = GetOptions().Padmapper.ButtonComboForAction("StandGround");
+		const bool standGround = StandToggle || IsControllerButtonComboPressed(standGroundCombo);
 		LastPlayerAction = PlayerActionType::None;
 		sgbMouseDown = CLICK_NONE;
 		LeftMouseUp(standGround ? KMOD_SHIFT : KMOD_NONE);
@@ -2345,8 +2345,8 @@ void InitPadmapActions()
 	    leftMouseDown,
 	    leftMouseUp);
 	auto rightMouseDown = [] {
-		ControllerButtonCombo standGroundCombo = GetOptions().Padmapper.ButtonComboForAction("StandGround");
-		bool standGround = StandToggle || IsControllerButtonComboPressed(standGroundCombo);
+		const ControllerButtonCombo standGroundCombo = GetOptions().Padmapper.ButtonComboForAction("StandGround");
+		const bool standGround = StandToggle || IsControllerButtonComboPressed(standGroundCombo);
 		LastPlayerAction = PlayerActionType::None;
 		sgbMouseDown = CLICK_RIGHT;
 		RightMouseDown(standGround);
@@ -2384,7 +2384,7 @@ void InitPadmapActions()
 	    [] { PadMenuNavigatorActive = true; },
 	    [] { PadMenuNavigatorActive = false; });
 	auto toggleGameMenu = [] {
-		bool inMenu = gmenu_is_active();
+		const bool inMenu = gmenu_is_active();
 		PressEscKey();
 		LastPlayerAction = PlayerActionType::None;
 		PadHotspellMenuActive = false;
@@ -2769,7 +2769,7 @@ bool TryIconCurs()
 		const SpellType spellType = SpellType::Scroll;
 		const int spellFrom = myPlayer.spellFrom;
 		if (IsWallSpell(spellID)) {
-			Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
+			const Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
 			NetSendCmdLocParam4(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellFrom);
 		} else if (pcursmonst != -1 && leveltype != DTYPE_TOWN) {
 			NetSendCmdParam4(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);
@@ -3002,7 +3002,7 @@ void LoadGameLevelStores()
 
 void LoadGameLevelStash()
 {
-	bool isHellfireSaveGame = gbIsHellfireSaveGame;
+	const bool isHellfireSaveGame = gbIsHellfireSaveGame;
 
 	gbIsHellfireSaveGame = gbIsHellfire;
 	LoadStash();
@@ -3013,10 +3013,10 @@ tl::expected<void, std::string> LoadGameLevelDungeon(bool firstflag, lvl_entry l
 {
 	if (firstflag || lvldir == ENTRY_LOAD || !myPlayer._pLvlVisited[currlevel] || gbIsMultiplayer) {
 		HoldThemeRooms();
-		[[maybe_unused]] uint32_t mid1Seed = GetLCGEngineState();
+		[[maybe_unused]] const uint32_t mid1Seed = GetLCGEngineState();
 		InitGolems();
 		InitObjects();
-		[[maybe_unused]] uint32_t mid2Seed = GetLCGEngineState();
+		[[maybe_unused]] const uint32_t mid2Seed = GetLCGEngineState();
 
 		IncProgress();
 
@@ -3026,7 +3026,7 @@ tl::expected<void, std::string> LoadGameLevelDungeon(bool firstflag, lvl_entry l
 
 		IncProgress();
 
-		[[maybe_unused]] uint32_t mid3Seed = GetLCGEngineState();
+		[[maybe_unused]] const uint32_t mid3Seed = GetLCGEngineState();
 		InitMissiles();
 		InitCorpses();
 #ifdef _DEBUG
@@ -3270,7 +3270,7 @@ void LoadGameLevelCalculateCursor()
 
 tl::expected<void, std::string> LoadGameLevel(bool firstflag, lvl_entry lvldir)
 {
-	_music_id neededTrack = GetLevelMusic(leveltype);
+	const _music_id neededTrack = GetLevelMusic(leveltype);
 
 	ClearFloatingNumbers();
 	LoadGameLevelStopMusic(neededTrack);
@@ -3315,7 +3315,7 @@ tl::expected<void, std::string> LoadGameLevel(bool firstflag, lvl_entry lvldir)
 
 	IncProgress();
 
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	if (setlevel) {
 		RETURN_IF_ERROR(LoadGameLevelSetLevel(firstflag, lvldir, myPlayer));
@@ -3357,7 +3357,7 @@ tl::expected<void, std::string> LoadGameLevel(bool firstflag, lvl_entry lvldir)
 
 bool game_loop(bool bStartup)
 {
-	uint16_t wait = bStartup ? sgGameInitInfo.nTickRate * 3 : 3;
+	const uint16_t wait = bStartup ? sgGameInitInfo.nTickRate * 3 : 3;
 
 	for (unsigned i = 0; i < wait; i++) {
 		if (!multi_handle_delta()) {

--- a/Source/dvlnet/base.cpp
+++ b/Source/dvlnet/base.cpp
@@ -46,7 +46,7 @@ tl::expected<void, PacketError> base::SendEchoRequest(plr_t player)
 	if (player == plr_self)
 		return {};
 
-	timestamp_t now = SDL_GetTicks();
+	const timestamp_t now = SDL_GetTicks();
 	tl::expected<std::unique_ptr<packet>, PacketError> pkt
 	    = pktfty->make_packet<PT_ECHO_REQUEST>(plr_self, player, now);
 	if (!pkt.has_value()) {
@@ -96,7 +96,7 @@ tl::expected<void, PacketError> base::HandleConnect(packet &pkt)
 
 tl::expected<void, PacketError> base::HandleTurn(packet &pkt)
 {
-	plr_t src = pkt.Source();
+	const plr_t src = pkt.Source();
 	PlayerState &playerState = playerStateTable_[src];
 	std::deque<turn_t> &turnQueue = playerState.turnQueue;
 	return pkt.Turn().transform([&](turn_t &&turn) {
@@ -165,7 +165,7 @@ void base::ClearMsg(plr_t plr)
 tl::expected<void, PacketError> base::Connect(plr_t player)
 {
 	PlayerState &playerState = playerStateTable_[player];
-	bool wasConnected = playerState.isConnected;
+	const bool wasConnected = playerState.isConnected;
 	playerState.isConnected = true;
 
 	if (!wasConnected)
@@ -228,7 +228,7 @@ bool base::SNetSendMessage(uint8_t playerId, void *data, size_t size)
 	if (playerId != SNPLAYER_OTHERS && playerId >= MAX_PLRS)
 		abort();
 	auto *rawMessage = reinterpret_cast<unsigned char *>(data);
-	buffer_t message(rawMessage, rawMessage + size);
+	const buffer_t message(rawMessage, rawMessage + size);
 	if (playerId == plr_self)
 		message_queue.emplace_back(plr_self, message);
 	plr_t dest;
@@ -255,11 +255,11 @@ bool base::SNetSendMessage(uint8_t playerId, void *data, size_t size)
 bool base::AllTurnsArrived()
 {
 	for (size_t i = 0; i < Players.size(); ++i) {
-		PlayerState &playerState = playerStateTable_[i];
+		const PlayerState &playerState = playerStateTable_[i];
 		if (!playerState.isConnected)
 			continue;
 
-		std::deque<turn_t> &turnQueue = playerState.turnQueue;
+		const std::deque<turn_t> &turnQueue = playerState.turnQueue;
 		if (turnQueue.empty()) {
 			LogDebug("Turn missing from player {}", i);
 			return false;
@@ -285,7 +285,7 @@ bool base::SNetReceiveTurns(char **data, size_t *size, uint32_t *status)
 		std::deque<turn_t> &turnQueue = playerState.turnQueue;
 		while (!turnQueue.empty()) {
 			const turn_t &turn = turnQueue.front();
-			seq_t diff = turn.SequenceNumber - current_turn;
+			const seq_t diff = turn.SequenceNumber - current_turn;
 			if (diff <= 0x7F)
 				break;
 			turnQueue.pop_front();
@@ -321,11 +321,11 @@ bool base::SNetReceiveTurns(char **data, size_t *size, uint32_t *status)
 	}
 
 	for (size_t i = 0; i < Players.size(); ++i) {
-		PlayerState &playerState = playerStateTable_[i];
+		const PlayerState &playerState = playerStateTable_[i];
 		if (!playerState.isConnected)
 			continue;
 
-		std::deque<turn_t> &turnQueue = playerState.turnQueue;
+		const std::deque<turn_t> &turnQueue = playerState.turnQueue;
 		if (turnQueue.empty())
 			continue;
 
@@ -373,12 +373,12 @@ tl::expected<void, PacketError> base::SendFirstTurnIfReady(plr_t player)
 	if (awaitingSequenceNumber_)
 		return {};
 
-	PlayerState &playerState = playerStateTable_[plr_self];
-	std::deque<turn_t> &turnQueue = playerState.turnQueue;
+	const PlayerState &playerState = playerStateTable_[plr_self];
+	const std::deque<turn_t> &turnQueue = playerState.turnQueue;
 	if (turnQueue.empty())
 		return {};
 
-	for (turn_t turn : turnQueue) {
+	for (const turn_t turn : turnQueue) {
 		tl::expected<std::unique_ptr<packet>, PacketError> pkt
 		    = pktfty->make_packet<PT_TURN>(plr_self, player, turn);
 		if (!pkt.has_value()) {
@@ -468,7 +468,7 @@ bool base::SNetLeaveGame(int type)
 
 bool base::SNetDropPlayer(int playerid, uint32_t flags)
 {
-	plr_t plr = static_cast<plr_t>(playerid);
+	const plr_t plr = static_cast<plr_t>(playerid);
 	tl::expected<std::unique_ptr<packet>, PacketError> pkt
 	    = pktfty->make_packet<PT_DISCONNECT>(
 	        plr_self,
@@ -509,9 +509,9 @@ bool base::SNetGetOwnerTurnsWaiting(uint32_t *turns)
 {
 	poll();
 
-	plr_t owner = GetOwner();
-	PlayerState &playerState = playerStateTable_[owner];
-	std::deque<turn_t> &turnQueue = playerState.turnQueue;
+	const plr_t owner = GetOwner();
+	const PlayerState &playerState = playerStateTable_[owner];
+	const std::deque<turn_t> &turnQueue = playerState.turnQueue;
 	*turns = static_cast<uint32_t>(turnQueue.size());
 
 	return true;
@@ -519,8 +519,8 @@ bool base::SNetGetOwnerTurnsWaiting(uint32_t *turns)
 
 bool base::SNetGetTurnsInTransit(uint32_t *turns)
 {
-	PlayerState &playerState = playerStateTable_[plr_self];
-	std::deque<turn_t> &turnQueue = playerState.turnQueue;
+	const PlayerState &playerState = playerStateTable_[plr_self];
+	const std::deque<turn_t> &turnQueue = playerState.turnQueue;
 	*turns = static_cast<uint32_t>(turnQueue.size());
 	return true;
 }

--- a/Source/dvlnet/frame_queue.cpp
+++ b/Source/dvlnet/frame_queue.cpp
@@ -31,7 +31,7 @@ tl::expected<buffer_t, PacketError> frame_queue::Read(framesize_t s)
 		return tl::make_unexpected(FrameQueueError());
 	buffer_t ret;
 	while (s > 0 && s >= buffer_deque.front().size()) {
-		framesize_t bufferSize = static_cast<framesize_t>(buffer_deque.front().size());
+		const framesize_t bufferSize = static_cast<framesize_t>(buffer_deque.front().size());
 		s -= bufferSize;
 		current_size -= bufferSize;
 		ret.insert(ret.end(),
@@ -83,7 +83,7 @@ tl::expected<buffer_t, PacketError> frame_queue::ReadPacket()
 tl::expected<buffer_t, PacketError> frame_queue::MakeFrame(buffer_t packetbuf)
 {
 	buffer_t ret;
-	framesize_t size = static_cast<framesize_t>(packetbuf.size());
+	const framesize_t size = static_cast<framesize_t>(packetbuf.size());
 	if (size > max_frame_size)
 		return tl::make_unexpected("Buffer exceeds maximum frame size");
 	static_assert(sizeof(size) == 4, "framesize_t is not 4 bytes");

--- a/Source/dvlnet/loopback.cpp
+++ b/Source/dvlnet/loopback.cpp
@@ -36,7 +36,7 @@ bool loopback::SNetSendMessage(uint8_t dest, void *data, size_t size)
 {
 	if (dest == plr_single) {
 		auto *rawMessage = reinterpret_cast<unsigned char *>(data);
-		buffer_t message(rawMessage, rawMessage + size);
+		const buffer_t message(rawMessage, rawMessage + size);
 		message_queue.push(message);
 	}
 	return true;

--- a/Source/dvlnet/packet.cpp
+++ b/Source/dvlnet/packet.cpp
@@ -231,7 +231,7 @@ tl::expected<void, PacketError> packet_in::Decrypt(buffer_t buf)
 	    - crypto_secretbox_NONCEBYTES
 	    - crypto_secretbox_MACBYTES);
 	decrypted_buffer.resize(pktlen);
-	int status = crypto_secretbox_open_easy(
+	const int status = crypto_secretbox_open_easy(
 	    decrypted_buffer.data(),
 	    encrypted_buffer.data() + crypto_secretbox_NONCEBYTES,
 	    encrypted_buffer.size() - crypto_secretbox_NONCEBYTES,
@@ -259,7 +259,7 @@ void packet_out::Encrypt()
 	encrypted_buffer.insert(encrypted_buffer.end(),
 	    crypto_secretbox_MACBYTES + lenCleartext, 0);
 	randombytes_buf(encrypted_buffer.data(), crypto_secretbox_NONCEBYTES);
-	int status = crypto_secretbox_easy(
+	const int status = crypto_secretbox_easy(
 	    encrypted_buffer.data() + crypto_secretbox_NONCEBYTES,
 	    decrypted_buffer.data(),
 	    lenCleartext,
@@ -288,7 +288,7 @@ packet_factory::packet_factory(std::string pw)
 	pw.resize(std::max<std::size_t>(pw.size(), crypto_pwhash_argon2id_PASSWD_MIN), 0);
 	std::string salt("W9bE9dQgVaeybwr2");
 	salt.resize(crypto_pwhash_argon2id_SALTBYTES, 0);
-	int status = crypto_pwhash(
+	const int status = crypto_pwhash(
 	    key.data(),
 	    crypto_secretbox_KEYBYTES,
 	    pw.data(),

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -49,7 +49,7 @@ int tcp_client::join(std::string_view addrstr)
 		}
 	} else {
 		// Assume "hostname:port"
-		SplitByChar splithost(addrstr, ':');
+		const SplitByChar splithost(addrstr, ':');
 		auto it = splithost.begin();
 		if (it != splithost.end()) host = *it++;
 		if (it != splithost.end()) port = *it++;
@@ -62,7 +62,7 @@ int tcp_client::join(std::string_view addrstr)
 	}
 
 	asio::error_code errorCode;
-	asio::ip::basic_resolver_results<asio::ip::tcp> range = resolver.resolve(host, port, errorCode);
+	const asio::ip::basic_resolver_results<asio::ip::tcp> range = resolver.resolve(host, port, errorCode);
 	if (errorCode) {
 		SDL_SetError("%s", errorCode.message().c_str());
 		return -1;
@@ -74,7 +74,7 @@ int tcp_client::join(std::string_view addrstr)
 		return -1;
 	}
 
-	asio::ip::tcp::no_delay option(true);
+	const asio::ip::tcp::no_delay option(true);
 	sock.set_option(option, errorCode);
 	if (errorCode)
 		LogError("Client error setting socket option: {}", errorCode.message());
@@ -142,12 +142,12 @@ tl::expected<void, PacketError> tcp_client::poll()
 void tcp_client::HandleReceive(const asio::error_code &error, size_t bytesRead)
 {
 	if (error) {
-		PacketError packetError = IoHandlerError(error.message());
+		const PacketError packetError = IoHandlerError(error.message());
 		RaiseIoHandlerError(packetError);
 		return;
 	}
 	if (bytesRead == 0) {
-		PacketError packetError(_("error: read 0 bytes from server"));
+		const PacketError packetError(_("error: read 0 bytes from server"));
 		RaiseIoHandlerError(packetError);
 		return;
 	}
@@ -193,7 +193,7 @@ tl::expected<void, PacketError> tcp_client::send(packet &pkt)
 	if (!frame.has_value())
 		return tl::make_unexpected(frame.error());
 	std::unique_ptr<buffer_t> framePtr = std::make_unique<buffer_t>(*frame);
-	asio::mutable_buffer buf = asio::buffer(*framePtr);
+	const asio::mutable_buffer buf = asio::buffer(*framePtr);
 	asio::async_write(sock, buf, [this, frame = std::move(framePtr)](const asio::error_code &error, size_t bytesSent) {
 		HandleSend(error, bytesSent);
 	});

--- a/Source/dvlnet/tcp_server.cpp
+++ b/Source/dvlnet/tcp_server.cpp
@@ -185,7 +185,7 @@ tl::expected<void, PacketError> tcp_server::StartSend(const scc &con, packet &pk
 	if (!frame.has_value())
 		return tl::make_unexpected(frame.error());
 	std::unique_ptr<buffer_t> framePtr = std::make_unique<buffer_t>(*frame);
-	asio::mutable_buffer buf = asio::buffer(*framePtr);
+	const asio::mutable_buffer buf = asio::buffer(*framePtr);
 	asio::async_write(con->socket, buf,
 	    [this, con, frame = std::move(framePtr)](const asio::error_code &ec, size_t bytesSent) {
 		    HandleSend(con, ec, bytesSent);
@@ -213,7 +213,7 @@ void tcp_server::StartAccept()
 void tcp_server::HandleAccept(const scc &con, const asio::error_code &ec)
 {
 	if (ec) {
-		PacketError packetError = IoHandlerError(ec.message());
+		const PacketError packetError = IoHandlerError(ec.message());
 		RaiseIoHandlerError(packetError);
 		return;
 	}
@@ -221,7 +221,7 @@ void tcp_server::HandleAccept(const scc &con, const asio::error_code &ec)
 		DropConnection(con);
 	} else {
 		asio::error_code errorCode;
-		asio::ip::tcp::no_delay option(true);
+		const asio::ip::tcp::no_delay option(true);
 		con->socket.set_option(option, errorCode);
 		if (errorCode)
 			LogError("Server error setting socket option: {}", errorCode.message());
@@ -257,7 +257,7 @@ void tcp_server::HandleTimeout(const scc &con, const asio::error_code &ec)
 
 void tcp_server::DropConnection(const scc &con)
 {
-	plr_t plr = con->plr;
+	const plr_t plr = con->plr;
 	con->timer.cancel();
 	con->socket.close();
 	if (plr == PLR_BROADCAST) {

--- a/Source/encrypt.cpp
+++ b/Source/encrypt.cpp
@@ -62,13 +62,13 @@ void PkwareBufferWrite(char *buf, unsigned int *size, void *param) // NOLINT(rea
 
 uint32_t PkwareCompress(std::byte *srcData, uint32_t size)
 {
-	std::unique_ptr<char[]> ptr = std::make_unique<char[]>(CMP_BUFFER_SIZE);
+	const std::unique_ptr<char[]> ptr = std::make_unique<char[]>(CMP_BUFFER_SIZE);
 
 	unsigned destSize = 2 * size;
 	if (destSize < 2 * 4096)
 		destSize = 2 * 4096;
 
-	std::unique_ptr<std::byte[]> destData { new std::byte[destSize] };
+	const std::unique_ptr<std::byte[]> destData { new std::byte[destSize] };
 
 	TDataInfo param;
 	param.srcData = srcData;
@@ -93,8 +93,8 @@ uint32_t PkwareCompress(std::byte *srcData, uint32_t size)
 
 uint32_t PkwareDecompress(std::byte *inBuff, uint32_t recvSize, size_t maxBytes)
 {
-	std::unique_ptr<char[]> ptr = std::make_unique<char[]>(CMP_BUFFER_SIZE);
-	std::unique_ptr<std::byte[]> outBuff { new std::byte[maxBytes] };
+	const std::unique_ptr<char[]> ptr = std::make_unique<char[]>(CMP_BUFFER_SIZE);
+	const std::unique_ptr<std::byte[]> outBuff { new std::byte[maxBytes] };
 
 	TDataInfo info;
 	info.srcData = inBuff;

--- a/Source/engine/actor_position.cpp
+++ b/Source/engine/actor_position.cpp
@@ -106,15 +106,15 @@ constexpr std::array<const WalkParameter, 8> WalkParameters { {
 
 DisplacementOf<int8_t> ActorPosition::CalculateWalkingOffset(Direction dir, const AnimationInfo &animInfo) const
 {
-	DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animInfo);
+	const DisplacementOf<int16_t> offset = CalculateWalkingOffsetShifted4(dir, animInfo);
 	return { static_cast<int8_t>(offset.deltaX >> 4), static_cast<int8_t>(offset.deltaY >> 4) };
 }
 
 DisplacementOf<int16_t> ActorPosition::CalculateWalkingOffsetShifted4(Direction dir, const AnimationInfo &animInfo) const
 {
-	int16_t velocityProgress = static_cast<int16_t>(animInfo.getAnimationProgress()) * animInfo.numberOfFrames / AnimationInfo::baseValueFraction;
+	const int16_t velocityProgress = static_cast<int16_t>(animInfo.getAnimationProgress()) * animInfo.numberOfFrames / AnimationInfo::baseValueFraction;
 	const WalkParameter &walkParameter = WalkParameters[static_cast<size_t>(dir)];
-	DisplacementOf<int16_t> velocity = walkParameter.getVelocity(animInfo.numberOfFrames);
+	const DisplacementOf<int16_t> velocity = walkParameter.getVelocity(animInfo.numberOfFrames);
 	DisplacementOf<int16_t> offset = (velocity * velocityProgress);
 	return offset;
 }

--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -34,7 +34,7 @@ int8_t AnimationInfo::getFrameToUseForRendering() const
 	}
 
 	// we don't use the processed game ticks alone but also the fraction of the next game tick (if a rendering happens between game ticks). This helps to smooth the animations.
-	int32_t totalTicksForCurrentAnimationSequence = getProgressToNextGameTick() + ticksSinceSequenceStarted;
+	const int32_t totalTicksForCurrentAnimationSequence = getProgressToNextGameTick() + ticksSinceSequenceStarted;
 
 	int8_t absoluteAnimationFrame = static_cast<int8_t>(totalTicksForCurrentAnimationSequence * tickModifier_ / baseValueFraction / baseValueFraction);
 	if (skippedFramesFromPreviousAnimation_ > 0) {
@@ -75,9 +75,9 @@ uint8_t AnimationInfo::getAnimationProgress() const
 		tickModifier = baseValueFraction / ticksPerFrame;
 	}
 
-	int32_t totalTicksForCurrentAnimationSequence = getProgressToNextGameTick() + ticksSinceSequenceStarted;
-	int32_t progressInAnimationFrames = totalTicksForCurrentAnimationSequence * tickModifier;
-	int32_t animationFraction = progressInAnimationFrames / numberOfFrames / baseValueFraction;
+	const int32_t totalTicksForCurrentAnimationSequence = getProgressToNextGameTick() + ticksSinceSequenceStarted;
+	const int32_t progressInAnimationFrames = totalTicksForCurrentAnimationSequence * tickModifier;
+	const int32_t animationFraction = progressInAnimationFrames / numberOfFrames / baseValueFraction;
 	assert(animationFraction <= baseValueFraction);
 	return static_cast<uint8_t>(animationFraction);
 }

--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -478,7 +478,7 @@ void UnloadModArchives()
 void LoadModArchives(std::span<const std::string_view> modnames)
 {
 	std::string targetPath;
-	for (std::string_view modname : modnames) {
+	for (const std::string_view modname : modnames) {
 		targetPath = StrCat(paths::PrefPath(), "mods" DIRECTORY_SEPARATOR_STR, modname, DIRECTORY_SEPARATOR_STR);
 		if (FileExists(targetPath)) {
 			OverridePaths.emplace_back(targetPath);
@@ -492,7 +492,7 @@ void LoadModArchives(std::span<const std::string_view> modnames)
 
 	int priority = 10000;
 	auto paths = GetMPQSearchPaths();
-	for (std::string_view modname : modnames) {
+	for (const std::string_view modname : modnames) {
 		LoadMPQ(paths, StrCat("mods" DIRECTORY_SEPARATOR_STR, modname), priority);
 		priority++;
 	}

--- a/Source/engine/demomode.cpp
+++ b/Source/engine/demomode.cpp
@@ -654,9 +654,9 @@ bool GetRunGameLoop(bool &drawGame, bool &processInput)
 		// disable additional rendering to speedup replay
 		drawGame = dmsg.type == DemoMsg::GameTick && !HeadlessMode;
 	} else {
-		int currentTickCount = SDL_GetTicks();
-		int ticksElapsed = currentTickCount - DemoModeLastTick;
-		bool tickDue = ticksElapsed >= gnTickDelay;
+		const int currentTickCount = SDL_GetTicks();
+		const int ticksElapsed = currentTickCount - DemoModeLastTick;
+		const bool tickDue = ticksElapsed >= gnTickDelay;
 		drawGame = false;
 		if (tickDue) {
 			if (dmsg.type == DemoMsg::GameTick) {
@@ -665,7 +665,7 @@ bool GetRunGameLoop(bool &drawGame, bool &processInput)
 		} else {
 			int32_t fraction = ticksElapsed * AnimationInfo::baseValueFraction / gnTickDelay;
 			fraction = std::clamp<int32_t>(fraction, 0, AnimationInfo::baseValueFraction);
-			uint8_t progressToNextGameTick = static_cast<uint8_t>(fraction);
+			const uint8_t progressToNextGameTick = static_cast<uint8_t>(fraction);
 			if (dmsg.type == DemoMsg::GameTick || dmsg.progressToNextGameTick > progressToNextGameTick) {
 				// we are ahead of the replay => add a additional rendering for smoothness
 				if (gbRunGame && PauseMode == 0 && (gbIsMultiplayer || !gmenu_is_active()) && gbProcessPlayers) // if game is not running or paused there is no next gametick in the near future

--- a/Source/engine/dx.cpp
+++ b/Source/engine/dx.cpp
@@ -75,7 +75,7 @@ void LimitFrameRate()
 	if (*GetOptions().Graphics.frameRateControl != FrameRateControl::CPUSleep)
 		return;
 	static uint32_t frameDeadline;
-	uint32_t tc = SDL_GetTicks() * 1000;
+	const uint32_t tc = SDL_GetTicks() * 1000;
 	uint32_t v = 0;
 	if (frameDeadline > tc) {
 		v = tc % refreshDelay;

--- a/Source/engine/palette.cpp
+++ b/Source/engine/palette.cpp
@@ -223,9 +223,9 @@ void LoadRndLvlPal(dungeon_type l)
 
 void IncreaseBrightness()
 {
-	int brightnessValue = *GetOptions().Graphics.brightness;
+	const int brightnessValue = *GetOptions().Graphics.brightness;
 	if (brightnessValue < 100) {
-		int newBrightness = std::min(brightnessValue + 5, 100);
+		const int newBrightness = std::min(brightnessValue + 5, 100);
 		GetOptions().Graphics.brightness.SetValue(newBrightness);
 		UpdateSystemPalette(logical_palette);
 	}
@@ -233,9 +233,9 @@ void IncreaseBrightness()
 
 void DecreaseBrightness()
 {
-	int brightnessValue = *GetOptions().Graphics.brightness;
+	const int brightnessValue = *GetOptions().Graphics.brightness;
 	if (brightnessValue > 0) {
-		int newBrightness = std::max(brightnessValue - 5, 0);
+		const int newBrightness = std::max(brightnessValue - 5, 0);
 		GetOptions().Graphics.brightness.SetValue(newBrightness);
 		UpdateSystemPalette(logical_palette);
 	}

--- a/Source/engine/path.cpp
+++ b/Source/engine/path.cpp
@@ -72,14 +72,14 @@ public:
 	[[nodiscard]] const_iterator find(const PointT &point) const
 	{
 		const Bucket &b = bucket(point);
-		const auto it = c_find_if(b, [r = repr(point)](const Entry &e) { return e.first == r; });
+		const auto *const it = c_find_if(b, [r = repr(point)](const Entry &e) { return e.first == r; });
 		if (it == b.end()) return nullptr;
 		return it;
 	}
 	[[nodiscard]] iterator find(const PointT &point)
 	{
 		Bucket &b = bucket(point);
-		auto it = c_find_if(b, [r = repr(point)](const Entry &e) { return e.first == r; });
+		auto *it = c_find_if(b, [r = repr(point)](const Entry &e) { return e.first == r; });
 		if (it == b.end()) return nullptr;
 		return it;
 	}
@@ -157,7 +157,7 @@ int ReconstructPath(const ExploredNodes &explored, PointT dest, int8_t *path, si
 	size_t len = 0;
 	PointT cur = dest;
 	while (true) {
-		const auto it = explored.find(cur);
+		const auto *const it = explored.find(cur);
 		if (it == explored.end()) app_fatal("Failed to reconstruct path");
 		if (it->second.g == 0) break; // reached start
 		if (len == maxPathLength) {
@@ -257,7 +257,7 @@ int FindPath(tl::function_ref<bool(Point, Point)> canStep, tl::function_ref<bool
 			const CostType g = curG + GetDistance(cur.position, neighborPos);
 			if (curG >= PathDiagonalStepCost * maxPathLength) continue;
 			bool improved = false;
-			if (auto it = explored.find(neighborPos); it == explored.end()) {
+			if (auto *it = explored.find(neighborPos); it == explored.end()) {
 				if (explored.canInsert(neighborPos)) {
 					explored.emplace(neighborPos, ExploredNode { .prev = cur.position, .g = g });
 					improved = true;

--- a/Source/engine/render/clx_render.cpp
+++ b/Source/engine/render/clx_render.cpp
@@ -223,7 +223,7 @@ void DoRenderBackwards(
 	const ClipX clipX = CalculateClipX(position.x, srcWidth, out);
 	if (clipX.width <= 0)
 		return;
-	RenderSrc srcForBackwards { src, src + srcSize, static_cast<uint_fast16_t>(srcWidth) };
+	const RenderSrc srcForBackwards { src, src + srcSize, static_cast<uint_fast16_t>(srcWidth) };
 	if (static_cast<std::size_t>(clipX.width) == srcWidth) {
 		DoRenderBackwardsClipY(
 		    out, position, srcForBackwards, std::forward<BlitFn>(blitFn));
@@ -448,14 +448,14 @@ void ClxApplyTrans(ClxSprite sprite, const uint8_t *trn)
 
 void ClxApplyTrans(ClxSpriteList list, const uint8_t *trn)
 {
-	for (ClxSprite sprite : list) {
+	for (const ClxSprite sprite : list) {
 		ClxApplyTrans(sprite, trn);
 	}
 }
 
 void ClxApplyTrans(ClxSpriteSheet sheet, const uint8_t *trn)
 {
-	for (ClxSpriteList list : sheet) {
+	for (const ClxSpriteList list : sheet) {
 		ClxApplyTrans(list, trn);
 	}
 }
@@ -492,14 +492,14 @@ bool IsPointWithinClx(Point position, ClxSprite clx)
 
 			if (IsClxOpaqueFill(val)) {
 				val = GetClxOpaqueFillWidth(val);
-				uint8_t color = *src++;
+				const uint8_t color = *src++;
 				if (xCur <= position.x && position.x < xCur + val)
 					return color != 0; // ignore shadows
 				xCur += val;
 			} else {
 				val = GetClxOpaquePixelsWidth(val);
 				for (uint8_t pixel = 0; pixel < val; pixel++) {
-					uint8_t color = *src++;
+					const uint8_t color = *src++;
 					if (xCur == position.x)
 						return color != 0; // ignore shadows
 					xCur++;

--- a/Source/engine/render/light_render.cpp
+++ b/Source/engine/render/light_render.cpp
@@ -25,7 +25,7 @@ void RenderFullTile(Point position, uint8_t lightLevel, uint8_t *lightmap, uint1
 	uint8_t *top = lightmap + (position.y + 1) * pitch + position.x - TILE_WIDTH / 2;
 	uint8_t *bottom = top + (TILE_HEIGHT - 2) * pitch;
 	for (int y = 0, w = 4; y < TILE_HEIGHT / 2 - 1; y++, w += 4) {
-		int x = (TILE_WIDTH - w) / 2;
+		const int x = (TILE_WIDTH - w) / 2;
 		memset(top + x, lightLevel, w);
 		memset(bottom + x, lightLevel, w);
 		top += pitch;
@@ -133,32 +133,32 @@ void RenderTriangle(Point p1, Point p2, Point p3, uint8_t lightLevel, uint8_t *l
 
 uint8_t GetLightLevel(const uint8_t tileLights[MAXDUNX][MAXDUNY], Point tile)
 {
-	int x = std::clamp(tile.x, 0, MAXDUNX - 1);
-	int y = std::clamp(tile.y, 0, MAXDUNY - 1);
+	const int x = std::clamp(tile.x, 0, MAXDUNX - 1);
+	const int y = std::clamp(tile.y, 0, MAXDUNY - 1);
 	return tileLights[x][y];
 }
 
 uint8_t Interpolate(int q1, int q2, int lightLevel)
 {
 	// Result will be 28.4 fixed-point
-	int numerator = (lightLevel - q1) << 4;
-	int result = (numerator + 0x8) / (q2 - q1);
+	const int numerator = (lightLevel - q1) << 4;
+	const int result = (numerator + 0x8) / (q2 - q1);
 	assert(result >= 0);
 	return static_cast<uint8_t>(result);
 }
 
 void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *lightmap, uint16_t pitch, uint16_t scanLines)
 {
-	Point center0 = position;
-	Point center1 = position + Displacement { TILE_WIDTH / 2, TILE_HEIGHT / 2 };
-	Point center2 = position + Displacement { 0, TILE_HEIGHT };
-	Point center3 = position + Displacement { -TILE_WIDTH / 2, TILE_HEIGHT / 2 };
+	const Point center0 = position;
+	const Point center1 = position + Displacement { TILE_WIDTH / 2, TILE_HEIGHT / 2 };
+	const Point center2 = position + Displacement { 0, TILE_HEIGHT };
+	const Point center3 = position + Displacement { -TILE_WIDTH / 2, TILE_HEIGHT / 2 };
 
 	// 28.4 fixed-point coordinates
-	Point fpCenter0 = center0 * (1 << 4);
-	Point fpCenter1 = center1 * (1 << 4);
-	Point fpCenter2 = center2 * (1 << 4);
-	Point fpCenter3 = center3 * (1 << 4);
+	const Point fpCenter0 = center0 * (1 << 4);
+	const Point fpCenter1 = center1 * (1 << 4);
+	const Point fpCenter2 = center2 * (1 << 4);
+	const Point fpCenter3 = center3 * (1 << 4);
 
 	// Marching squares
 	// https://en.wikipedia.org/wiki/Marching_squares
@@ -175,34 +175,34 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Fill in the bottom-left corner of the cell
 	// In isometric view, only the west tile of the quad is lit
 	case 1: {
-		uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
-		uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
-		Point p1 = fpCenter3 + (center2 - center3) * bottomFactor;
-		Point p2 = fpCenter3;
-		Point p3 = fpCenter3 + (center0 - center3) * leftFactor;
+		const uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
+		const uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
+		const Point p1 = fpCenter3 + (center2 - center3) * bottomFactor;
+		const Point p2 = fpCenter3;
+		const Point p3 = fpCenter3 + (center0 - center3) * leftFactor;
 		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch, scanLines);
 	} break;
 
 	// Fill in the bottom-right corner of the cell
 	// In isometric view, only the south tile of the quad is lit
 	case 2: {
-		uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
-		uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
-		Point p1 = fpCenter2 + (center1 - center2) * rightFactor;
-		Point p2 = fpCenter2;
-		Point p3 = fpCenter2 + (center3 - center2) * bottomFactor;
+		const uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
+		const uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
+		const Point p1 = fpCenter2 + (center1 - center2) * rightFactor;
+		const Point p2 = fpCenter2;
+		const Point p3 = fpCenter2 + (center3 - center2) * bottomFactor;
 		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch, scanLines);
 	} break;
 
 	// Fill in the bottom half of the cell
 	// In isometric view, the south and west tiles of the quad are lit
 	case 3: {
-		uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
-		uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
-		Point p1 = fpCenter2 + (center1 - center2) * rightFactor;
-		Point p2 = fpCenter2;
-		Point p3 = fpCenter3;
-		Point p4 = fpCenter3 + (center1 - center2) * leftFactor;
+		const uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
+		const uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
+		const Point p1 = fpCenter2 + (center1 - center2) * rightFactor;
+		const Point p2 = fpCenter2;
+		const Point p3 = fpCenter3;
+		const Point p4 = fpCenter3 + (center1 - center2) * leftFactor;
 		RenderTriangle(p1, p4, p2, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p2, p4, p3, lightLevel, lightmap, pitch, scanLines);
 	} break;
@@ -210,11 +210,11 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Fill in the top-right corner of the cell
 	// In isometric view, only the east tile of the quad is lit
 	case 4: {
-		uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
-		uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
-		Point p1 = fpCenter1 + (center0 - center1) * topFactor;
-		Point p2 = fpCenter1;
-		Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
+		const uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
+		const uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
+		const Point p1 = fpCenter1 + (center0 - center1) * topFactor;
+		const Point p2 = fpCenter1;
+		const Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
 		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch, scanLines);
 	} break;
 
@@ -222,23 +222,23 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Use the average of all values in the quad to determine whether to fill in the center
 	// In isometric view, the east and west tiles of the quad are lit
 	case 5: {
-		uint8_t cell = (quad[0] + quad[1] + quad[2] + quad[3] + 2) / 4;
-		uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
-		uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
-		uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
-		uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
-		Point p1 = fpCenter1 + (center0 - center1) * topFactor;
-		Point p2 = fpCenter1;
-		Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
-		Point p4 = fpCenter3 + (center2 - center3) * bottomFactor;
-		Point p5 = fpCenter3;
-		Point p6 = fpCenter3 + (center0 - center3) * leftFactor;
+		const uint8_t cell = (quad[0] + quad[1] + quad[2] + quad[3] + 2) / 4;
+		const uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
+		const uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
+		const uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
+		const uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
+		const Point p1 = fpCenter1 + (center0 - center1) * topFactor;
+		const Point p2 = fpCenter1;
+		const Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
+		const Point p4 = fpCenter3 + (center2 - center3) * bottomFactor;
+		const Point p5 = fpCenter3;
+		const Point p6 = fpCenter3 + (center0 - center3) * leftFactor;
 
 		if (cell <= lightLevel) {
-			uint8_t midFactor0 = Interpolate(quad[0], cell, lightLevel);
-			uint8_t midFactor2 = Interpolate(quad[2], cell, lightLevel);
-			Point p7 = fpCenter0 + (center2 - center0) / 2 * midFactor0;
-			Point p8 = fpCenter2 + (center0 - center2) / 2 * midFactor2;
+			const uint8_t midFactor0 = Interpolate(quad[0], cell, lightLevel);
+			const uint8_t midFactor2 = Interpolate(quad[2], cell, lightLevel);
+			const Point p7 = fpCenter0 + (center2 - center0) / 2 * midFactor0;
+			const Point p8 = fpCenter2 + (center0 - center2) / 2 * midFactor2;
 			RenderTriangle(p1, p7, p2, lightLevel, lightmap, pitch, scanLines);
 			RenderTriangle(p2, p7, p8, lightLevel, lightmap, pitch, scanLines);
 			RenderTriangle(p2, p8, p3, lightLevel, lightmap, pitch, scanLines);
@@ -246,10 +246,10 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 			RenderTriangle(p5, p8, p7, lightLevel, lightmap, pitch, scanLines);
 			RenderTriangle(p5, p7, p6, lightLevel, lightmap, pitch, scanLines);
 		} else {
-			uint8_t midFactor1 = Interpolate(quad[1], cell, lightLevel);
-			uint8_t midFactor3 = Interpolate(quad[3], cell, lightLevel);
-			Point p7 = fpCenter1 + (center3 - center1) / 2 * midFactor1;
-			Point p8 = fpCenter3 + (center1 - center3) / 2 * midFactor3;
+			const uint8_t midFactor1 = Interpolate(quad[1], cell, lightLevel);
+			const uint8_t midFactor3 = Interpolate(quad[3], cell, lightLevel);
+			const Point p7 = fpCenter1 + (center3 - center1) / 2 * midFactor1;
+			const Point p8 = fpCenter3 + (center1 - center3) / 2 * midFactor3;
 			RenderTriangle(p1, p7, p2, lightLevel, lightmap, pitch, scanLines);
 			RenderTriangle(p2, p7, p3, lightLevel, lightmap, pitch, scanLines);
 			RenderTriangle(p4, p8, p5, lightLevel, lightmap, pitch, scanLines);
@@ -260,12 +260,12 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Fill in the right half of the cell
 	// In isometric view, the south and east tiles of the quad are lit
 	case 6: {
-		uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
-		uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
-		Point p1 = fpCenter1 + (center0 - center1) * topFactor;
-		Point p2 = fpCenter1;
-		Point p3 = fpCenter2;
-		Point p4 = fpCenter2 + (center3 - center2) * bottomFactor;
+		const uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
+		const uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
+		const Point p1 = fpCenter1 + (center0 - center1) * topFactor;
+		const Point p2 = fpCenter1;
+		const Point p3 = fpCenter2;
+		const Point p4 = fpCenter2 + (center3 - center2) * bottomFactor;
 		RenderTriangle(p1, p4, p2, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p2, p4, p3, lightLevel, lightmap, pitch, scanLines);
 	} break;
@@ -273,13 +273,13 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Fill in everything except the top-left corner of the cell
 	// In isometric view, the south, east, and west tiles of the quad are lit
 	case 7: {
-		uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
-		uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
-		Point p1 = fpCenter1 + (center0 - center1) * topFactor;
-		Point p2 = fpCenter1;
-		Point p3 = fpCenter2;
-		Point p4 = fpCenter3;
-		Point p5 = fpCenter3 + (center0 - center3) * leftFactor;
+		const uint8_t topFactor = Interpolate(quad[1], quad[0], lightLevel);
+		const uint8_t leftFactor = Interpolate(quad[3], quad[0], lightLevel);
+		const Point p1 = fpCenter1 + (center0 - center1) * topFactor;
+		const Point p2 = fpCenter1;
+		const Point p3 = fpCenter2;
+		const Point p4 = fpCenter3;
+		const Point p5 = fpCenter3 + (center0 - center3) * leftFactor;
 		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p1, p5, p3, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p3, p5, p4, lightLevel, lightmap, pitch, scanLines);
@@ -288,23 +288,23 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Fill in the top-left corner of the cell
 	// In isometric view, only the north tile of the quad is lit
 	case 8: {
-		uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
-		uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
-		Point p1 = fpCenter0;
-		Point p2 = fpCenter0 + (center1 - center0) * topFactor;
-		Point p3 = fpCenter0 + (center3 - center0) * leftFactor;
+		const uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
+		const uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
+		const Point p1 = fpCenter0;
+		const Point p2 = fpCenter0 + (center1 - center0) * topFactor;
+		const Point p3 = fpCenter0 + (center3 - center0) * leftFactor;
 		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch, scanLines);
 	} break;
 
 	// Fill in the left half of the cell
 	// In isometric view, the north and west tiles of the quad are lit
 	case 9: {
-		uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
-		uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
-		Point p1 = fpCenter0;
-		Point p2 = fpCenter0 + (center1 - center0) * topFactor;
-		Point p3 = fpCenter3 + (center2 - center3) * bottomFactor;
-		Point p4 = fpCenter3;
+		const uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
+		const uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
+		const Point p1 = fpCenter0;
+		const Point p2 = fpCenter0 + (center1 - center0) * topFactor;
+		const Point p3 = fpCenter3 + (center2 - center3) * bottomFactor;
+		const Point p4 = fpCenter3;
 		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p1, p4, p3, lightLevel, lightmap, pitch, scanLines);
 	} break;
@@ -313,23 +313,23 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Use the average of all values in the quad to determine whether to fill in the center
 	// In isometric view, the north and south tiles of the quad are lit
 	case 10: {
-		uint8_t cell = (quad[0] + quad[1] + quad[2] + quad[3] + 2) / 4;
-		uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
-		uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
-		uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
-		uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
-		Point p1 = fpCenter0;
-		Point p2 = fpCenter0 + (center1 - center0) * topFactor;
-		Point p3 = fpCenter2 + (center1 - center2) * rightFactor;
-		Point p4 = fpCenter2;
-		Point p5 = fpCenter2 + (center3 - center2) * bottomFactor;
-		Point p6 = fpCenter0 + (center3 - center0) * leftFactor;
+		const uint8_t cell = (quad[0] + quad[1] + quad[2] + quad[3] + 2) / 4;
+		const uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
+		const uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
+		const uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
+		const uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
+		const Point p1 = fpCenter0;
+		const Point p2 = fpCenter0 + (center1 - center0) * topFactor;
+		const Point p3 = fpCenter2 + (center1 - center2) * rightFactor;
+		const Point p4 = fpCenter2;
+		const Point p5 = fpCenter2 + (center3 - center2) * bottomFactor;
+		const Point p6 = fpCenter0 + (center3 - center0) * leftFactor;
 
 		if (cell <= lightLevel) {
-			uint8_t midFactor1 = Interpolate(quad[1], cell, lightLevel);
-			uint8_t midFactor3 = Interpolate(quad[3], cell, lightLevel);
-			Point p7 = fpCenter1 + (center3 - center1) / 2 * midFactor1;
-			Point p8 = fpCenter3 + (center1 - center3) / 2 * midFactor3;
+			const uint8_t midFactor1 = Interpolate(quad[1], cell, lightLevel);
+			const uint8_t midFactor3 = Interpolate(quad[3], cell, lightLevel);
+			const Point p7 = fpCenter1 + (center3 - center1) / 2 * midFactor1;
+			const Point p8 = fpCenter3 + (center1 - center3) / 2 * midFactor3;
 			RenderTriangle(p1, p7, p2, lightLevel, lightmap, pitch, scanLines);
 			RenderTriangle(p1, p6, p8, lightLevel, lightmap, pitch, scanLines);
 			RenderTriangle(p1, p8, p7, lightLevel, lightmap, pitch, scanLines);
@@ -337,10 +337,10 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 			RenderTriangle(p4, p8, p5, lightLevel, lightmap, pitch, scanLines);
 			RenderTriangle(p4, p7, p8, lightLevel, lightmap, pitch, scanLines);
 		} else {
-			uint8_t midFactor0 = Interpolate(quad[0], cell, lightLevel);
-			uint8_t midFactor2 = Interpolate(quad[2], cell, lightLevel);
-			Point p7 = fpCenter0 + (center2 - center0) / 2 * midFactor0;
-			Point p8 = fpCenter2 + (center0 - center2) / 2 * midFactor2;
+			const uint8_t midFactor0 = Interpolate(quad[0], cell, lightLevel);
+			const uint8_t midFactor2 = Interpolate(quad[2], cell, lightLevel);
+			const Point p7 = fpCenter0 + (center2 - center0) / 2 * midFactor0;
+			const Point p8 = fpCenter2 + (center0 - center2) / 2 * midFactor2;
 			RenderTriangle(p1, p7, p2, lightLevel, lightmap, pitch, scanLines);
 			RenderTriangle(p1, p6, p7, lightLevel, lightmap, pitch, scanLines);
 			RenderTriangle(p3, p8, p4, lightLevel, lightmap, pitch, scanLines);
@@ -351,13 +351,13 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Fill in everything except the top-right corner of the cell
 	// In isometric view, the north, south, and west tiles of the quad are lit
 	case 11: {
-		uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
-		uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
-		Point p1 = fpCenter0;
-		Point p2 = fpCenter0 + (center1 - center0) * topFactor;
-		Point p3 = fpCenter2 + (center1 - center2) * rightFactor;
-		Point p4 = fpCenter2;
-		Point p5 = fpCenter3;
+		const uint8_t topFactor = Interpolate(quad[0], quad[1], lightLevel);
+		const uint8_t rightFactor = Interpolate(quad[2], quad[1], lightLevel);
+		const Point p1 = fpCenter0;
+		const Point p2 = fpCenter0 + (center1 - center0) * topFactor;
+		const Point p3 = fpCenter2 + (center1 - center2) * rightFactor;
+		const Point p4 = fpCenter2;
+		const Point p5 = fpCenter3;
 		RenderTriangle(p1, p5, p2, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p2, p5, p3, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p3, p5, p4, lightLevel, lightmap, pitch, scanLines);
@@ -366,12 +366,12 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Fill in the top half of the cell
 	// In isometric view, the north and east tiles of the quad are lit
 	case 12: {
-		uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
-		uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
-		Point p1 = fpCenter0;
-		Point p2 = fpCenter1;
-		Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
-		Point p4 = fpCenter0 + (center3 - center0) * leftFactor;
+		const uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
+		const uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
+		const Point p1 = fpCenter0;
+		const Point p2 = fpCenter1;
+		const Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
+		const Point p4 = fpCenter0 + (center3 - center0) * leftFactor;
 		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p1, p4, p3, lightLevel, lightmap, pitch, scanLines);
 	} break;
@@ -379,13 +379,13 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Fill in everything except the bottom-right corner of the cell
 	// In isometric view, the north, east, and west tiles of the quad are lit
 	case 13: {
-		uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
-		uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
-		Point p1 = fpCenter0;
-		Point p2 = fpCenter1;
-		Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
-		Point p4 = fpCenter3 + (center2 - center3) * bottomFactor;
-		Point p5 = fpCenter3;
+		const uint8_t rightFactor = Interpolate(quad[1], quad[2], lightLevel);
+		const uint8_t bottomFactor = Interpolate(quad[3], quad[2], lightLevel);
+		const Point p1 = fpCenter0;
+		const Point p2 = fpCenter1;
+		const Point p3 = fpCenter1 + (center2 - center1) * rightFactor;
+		const Point p4 = fpCenter3 + (center2 - center3) * bottomFactor;
+		const Point p5 = fpCenter3;
 		RenderTriangle(p1, p3, p2, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p1, p4, p3, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p1, p5, p4, lightLevel, lightmap, pitch, scanLines);
@@ -394,13 +394,13 @@ void RenderCell(uint8_t quad[4], Point position, uint8_t lightLevel, uint8_t *li
 	// Fill in everything except the bottom-left corner of the cell
 	// In isometric view, the north, south, and east tiles of the quad are lit
 	case 14: {
-		uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
-		uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
-		Point p1 = fpCenter0;
-		Point p2 = fpCenter1;
-		Point p3 = fpCenter2;
-		Point p4 = fpCenter2 + (center3 - center2) * bottomFactor;
-		Point p5 = fpCenter0 + (center3 - center0) * leftFactor;
+		const uint8_t bottomFactor = Interpolate(quad[2], quad[3], lightLevel);
+		const uint8_t leftFactor = Interpolate(quad[0], quad[3], lightLevel);
+		const Point p1 = fpCenter0;
+		const Point p2 = fpCenter1;
+		const Point p3 = fpCenter2;
+		const Point p4 = fpCenter2 + (center3 - center2) * bottomFactor;
+		const Point p5 = fpCenter0 + (center3 - center0) * leftFactor;
 		RenderTriangle(p1, p5, p2, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p2, p5, p4, lightLevel, lightmap, pitch, scanLines);
 		RenderTriangle(p2, p4, p3, lightLevel, lightmap, pitch, scanLines);
@@ -442,12 +442,12 @@ void BuildLightmap(Point tilePosition, Point targetBufferPosition, uint16_t view
 	memset(lightmap, LightsMax, totalPixels);
 	for (int i = 0; i < rows; i++) {
 		for (int j = 0; j < columns; j++, tilePosition += Direction::East, targetBufferPosition.x += TILE_WIDTH) {
-			Point center0 = targetBufferPosition + Displacement { TILE_WIDTH / 2, -TILE_HEIGHT / 2 };
+			const Point center0 = targetBufferPosition + Displacement { TILE_WIDTH / 2, -TILE_HEIGHT / 2 };
 
-			Point tile0 = tilePosition;
-			Point tile1 = tilePosition + Displacement { 1, 0 };
-			Point tile2 = tilePosition + Displacement { 1, 1 };
-			Point tile3 = tilePosition + Displacement { 0, 1 };
+			const Point tile0 = tilePosition;
+			const Point tile1 = tilePosition + Displacement { 1, 0 };
+			const Point tile2 = tilePosition + Displacement { 1, 1 };
+			const Point tile3 = tilePosition + Displacement { 0, 1 };
 
 			uint8_t quad[] = {
 				GetLightLevel(tileLights, tile0),
@@ -456,11 +456,11 @@ void BuildLightmap(Point tilePosition, Point targetBufferPosition, uint16_t view
 				GetLightLevel(tileLights, tile3)
 			};
 
-			uint8_t maxLight = std::max({ quad[0], quad[1], quad[2], quad[3] });
-			uint8_t minLight = std::min({ quad[0], quad[1], quad[2], quad[3] });
+			const uint8_t maxLight = std::max({ quad[0], quad[1], quad[2], quad[3] });
+			const uint8_t minLight = std::min({ quad[0], quad[1], quad[2], quad[3] });
 
 			for (uint8_t i = 0; i < LightsMax; i++) {
-				uint8_t lightLevel = LightsMax - i - 1;
+				const uint8_t lightLevel = LightsMax - i - 1;
 				if (lightLevel > maxLight)
 					continue;
 				if (lightLevel < minLight)

--- a/Source/engine/render/primitive_render.cpp
+++ b/Source/engine/render/primitive_render.cpp
@@ -133,8 +133,8 @@ void DrawHalfTransparentHorizontalLine(const Surface &out, Point from, int width
 	if (from.y < 0 || from.y >= out.h() || width <= 0 || from.x >= out.w() || from.x + width <= 0)
 		return;
 
-	int x0 = std::max(0, from.x);
-	int x1 = std::min(out.w(), from.x + width);
+	const int x0 = std::max(0, from.x);
+	const int x1 = std::min(out.w(), from.x + width);
 
 	for (int x = x0; x < x1; ++x) {
 		SetHalfTransparentPixel(out, { x, from.y }, colorIndex);
@@ -148,8 +148,8 @@ void DrawHalfTransparentVerticalLine(const Surface &out, Point from, int height,
 	if (from.x < 0 || from.x >= out.w() || height <= 0 || from.y >= out.h() || from.y + height <= 0)
 		return;
 
-	int y0 = std::max(0, from.y);
-	int y1 = std::min(out.h(), from.y + height);
+	const int y0 = std::max(0, from.y);
+	const int y1 = std::min(out.h(), from.y + height);
 
 	for (int y = y0; y < y1; ++y) {
 		SetHalfTransparentPixel(out, { from.x, y }, colorIndex);

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -126,8 +126,8 @@ void UpdateMissilePositionForRendering(Missile &m, int progress)
 	DisplacementOf<int64_t> velocity = m.position.velocity;
 	velocity *= progress;
 	velocity /= AnimationInfo::baseValueFraction;
-	Displacement pixelsTravelled = (m.position.traveled + Displacement { static_cast<int>(velocity.deltaX), static_cast<int>(velocity.deltaY) }) >> 16;
-	Displacement tileOffset = pixelsTravelled.screenToMissile();
+	const Displacement pixelsTravelled = (m.position.traveled + Displacement { static_cast<int>(velocity.deltaX), static_cast<int>(velocity.deltaY) }) >> 16;
+	const Displacement tileOffset = pixelsTravelled.screenToMissile();
 
 	// calculate the future missile position
 	m.position.tileForRendering = m.position.start + tileOffset;
@@ -268,7 +268,7 @@ void DrawCursor(const Surface &out)
 		return;
 	}
 
-	Size cursSize = GetInvItemSize(pcurs);
+	const Size cursSize = GetInvItemSize(pcurs);
 	if (cursSize.width == 0 || cursSize.height == 0) {
 		cursor.rect.size = { 0, 0 };
 		return;
@@ -288,8 +288,8 @@ void DrawCursor(const Surface &out)
 
 	// Copy the buffer before the item cursor and its 1px outline are drawn to a temporary buffer.
 	const int outlineWidth = !MyPlayer->HoldItem.isEmpty() ? 1 : 0;
-	Displacement offset = !MyPlayer->HoldItem.isEmpty() ? Displacement { cursSize / 2 } : Displacement { 0 };
-	Point cursPosition = MousePosition - offset;
+	const Displacement offset = !MyPlayer->HoldItem.isEmpty() ? Displacement { cursSize / 2 } : Displacement { 0 };
+	const Point cursPosition = MousePosition - offset;
 
 	Rectangle &rect = cursor.rect;
 	rect.position.x = cursPosition.x - outlineWidth;
@@ -435,7 +435,7 @@ void DrawPlayer(const Surface &out, const Player &player, Point tilePosition, Po
 	}
 
 	const ClxSprite sprite = player.currentSprite();
-	Point spriteBufferPosition = targetBufferPosition + player.getRenderingOffset(sprite);
+	const Point spriteBufferPosition = targetBufferPosition + player.getRenderingOffset(sprite);
 
 	if (&player == PlayerUnderCursor)
 		ClxDrawOutlineSkipColorZero(out, 165, spriteBufferPosition, sprite);
@@ -467,7 +467,7 @@ void DrawDeadPlayer(const Surface &out, Point tilePosition, Point targetBufferPo
 {
 	dFlags[tilePosition.x][tilePosition.y] &= ~DungeonFlag::DeadPlayer;
 
-	for (Player &player : Players) {
+	for (const Player &player : Players) {
 		if (player.plractive && player._pHitPoints == 0 && player.isOnActiveLevel() && player.position.tile == tilePosition) {
 			dFlags[tilePosition.x][tilePosition.y] |= DungeonFlag::DeadPlayer;
 			const Point playerRenderPosition { targetBufferPosition };
@@ -570,7 +570,7 @@ void DrawCell(const Surface &out, const Lightmap lightmap, Point tilePosition, P
 
 	// Create a special lightmap buffer to bleed light up walls
 	uint8_t lightmapBuffer[TILE_WIDTH * TILE_HEIGHT];
-	Lightmap bleedLightmap = Lightmap::bleedUp(*GetOptions().Graphics.perPixelLighting, lightmap, targetBufferPosition, lightmapBuffer);
+	const Lightmap bleedLightmap = Lightmap::bleedUp(*GetOptions().Graphics.perPixelLighting, lightmap, targetBufferPosition, lightmapBuffer);
 
 	// If the first micro tile is a floor tile, it may be followed
 	// by foliage which should be rendered now.
@@ -724,7 +724,7 @@ void DrawMonsterHelper(const Surface &out, Point tilePosition, Point targetBuffe
 	}
 
 	const ClxSprite sprite = monster.animInfo.currentSprite();
-	Displacement offset = monster.getRenderingOffset(sprite);
+	const Displacement offset = monster.getRenderingOffset(sprite);
 
 	const Point monsterRenderPosition = targetBufferPosition + offset;
 	if (mi == pcursmonst) {
@@ -788,7 +788,7 @@ void DrawDungeon(const Surface &out, const Lightmap &lightmap, Point tilePositio
 	}
 	Player *player = PlayerAtPosition(tilePosition);
 	if (player != nullptr) {
-		uint8_t pid = player->getId();
+		const uint8_t pid = player->getId();
 		assert(pid < MAX_PLRS);
 		int playerId = static_cast<int>(pid) + 1;
 		// If sprite is moving southwards or east, we want to draw it offset from the tile it's moving to, so we need negative ID
@@ -870,8 +870,8 @@ void DrawDungeon(const Surface &out, const Lightmap &lightmap, Point tilePositio
 	}
 
 	if (leveltype != DTYPE_TOWN) {
-		bool perPixelLighting = *GetOptions().Graphics.perPixelLighting;
-		int8_t bArch = dSpecial[tilePosition.x][tilePosition.y] - 1;
+		const bool perPixelLighting = *GetOptions().Graphics.perPixelLighting;
+		const int8_t bArch = dSpecial[tilePosition.x][tilePosition.y] - 1;
 		if (bArch >= 0) {
 			bool transparency = TransList[bMap];
 #ifdef _DEBUG
@@ -881,7 +881,7 @@ void DrawDungeon(const Surface &out, const Lightmap &lightmap, Point tilePositio
 			if (perPixelLighting) {
 				// Create a special lightmap buffer to bleed light up walls
 				uint8_t lightmapBuffer[TILE_WIDTH * TILE_HEIGHT];
-				Lightmap bleedLightmap = Lightmap::bleedUp(*GetOptions().Graphics.perPixelLighting, lightmap, targetBufferPosition, lightmapBuffer);
+				const Lightmap bleedLightmap = Lightmap::bleedUp(*GetOptions().Graphics.perPixelLighting, lightmap, targetBufferPosition, lightmapBuffer);
 
 				if (transparency)
 					ClxDrawBlendedWithLightmap(out, targetBufferPosition, (*pSpecialCels)[bArch], bleedLightmap);
@@ -898,7 +898,7 @@ void DrawDungeon(const Surface &out, const Lightmap &lightmap, Point tilePositio
 		// So delay the rendering until after the next row is being drawn.
 		// This could probably have been better solved by sprites in screen space.
 		if (tilePosition.x > 0 && tilePosition.y > 0 && targetBufferPosition.y > TILE_HEIGHT) {
-			int8_t bArch = dSpecial[tilePosition.x - 1][tilePosition.y - 1] - 1;
+			const int8_t bArch = dSpecial[tilePosition.x - 1][tilePosition.y - 1] - 1;
 			if (bArch >= 0)
 				ClxDraw(out, targetBufferPosition + Displacement { 0, -TILE_HEIGHT }, (*pSpecialCels)[bArch]);
 		}
@@ -1071,7 +1071,7 @@ int tileRows;
 void CalcFirstTilePosition(Point &position, Displacement &offset)
 {
 	// Adjust by player offset and tile grid alignment
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 	offset = tileOffset;
 	if (myPlayer.isWalking())
 		offset += GetOffsetForWalking(myPlayer.AnimInfo, myPlayer._pdir, true);
@@ -1080,7 +1080,7 @@ void CalcFirstTilePosition(Point &position, Displacement &offset)
 
 	// Skip rendering parts covered by the panels
 	if (CanPanelsCoverView() && (IsLeftPanelOpen() || IsRightPanelOpen())) {
-		int multiplier = (*GetOptions().Graphics.zoom) ? 1 : 2;
+		const int multiplier = (*GetOptions().Graphics.zoom) ? 1 : 2;
 		position += Displacement(Direction::East) * multiplier;
 		offset.deltaX += -TILE_WIDTH * multiplier / 2 / 2;
 
@@ -1355,8 +1355,8 @@ void DrawFPS(const Surface &out)
 	}
 
 	framesSinceLastUpdate++;
-	uint32_t runtimeInMs = SDL_GetTicks();
-	uint32_t msSinceLastUpdate = runtimeInMs - lastFpsUpdateInMs;
+	const uint32_t runtimeInMs = SDL_GetTicks();
+	const uint32_t msSinceLastUpdate = runtimeInMs - lastFpsUpdateInMs;
 	if (msSinceLastUpdate >= 1000) {
 		lastFpsUpdateInMs = runtimeInMs;
 		constexpr int FpsPow10 = 10;
@@ -1442,7 +1442,7 @@ void DrawMain(int dwHgt, bool drawDesc, bool drawHp, bool drawMana, bool drawSba
 		if (PrevCursorRect.size.width != 0 && PrevCursorRect.size.height != 0) {
 			DoBlitScreen(PrevCursorRect);
 		}
-		Rectangle &cursorRect = GetDrawnCursor().rect;
+		const Rectangle &cursorRect = GetDrawnCursor().rect;
 		if (cursorRect.size.width != 0 && cursorRect.size.height != 0) {
 			DoBlitScreen(cursorRect);
 		}
@@ -1467,7 +1467,7 @@ Displacement GetOffsetForWalking(const AnimationInfo &animationInfo, const Direc
 	constexpr Displacement MovingOffset[8]   = { {   0,  32 }, { -32,  16 }, { -64,   0 }, { -32, -16 }, {   0, -32 }, {  32, -16 },  {  64,   0 }, {  32,  16 } };
 	// clang-format on
 
-	uint8_t animationProgress = animationInfo.getAnimationProgress();
+	const uint8_t animationProgress = animationInfo.getAnimationProgress();
 	Displacement offset = MovingOffset[static_cast<size_t>(dir)];
 	offset *= animationProgress;
 	offset /= AnimationInfo::baseValueFraction;
@@ -1492,7 +1492,7 @@ void ShiftGrid(Point *offset, int horizontal, int vertical)
 
 int RowsCoveredByPanel()
 {
-	auto &mainPanelSize = GetMainPanel().size;
+	const auto &mainPanelSize = GetMainPanel().size;
 	if (GetScreenWidth() <= mainPanelSize.width) {
 		return 0;
 	}
@@ -1507,8 +1507,8 @@ int RowsCoveredByPanel()
 
 void CalcTileOffset(int *offsetX, int *offsetY)
 {
-	uint16_t screenWidth = GetScreenWidth();
-	uint16_t viewportHeight = GetViewportHeight();
+	const uint16_t screenWidth = GetScreenWidth();
+	const uint16_t viewportHeight = GetViewportHeight();
 
 	int x;
 	int y;
@@ -1532,8 +1532,8 @@ void CalcTileOffset(int *offsetX, int *offsetY)
 
 void TilesInView(int *rcolumns, int *rrows)
 {
-	uint16_t screenWidth = GetScreenWidth();
-	uint16_t viewportHeight = GetViewportHeight();
+	const uint16_t screenWidth = GetScreenWidth();
+	const uint16_t viewportHeight = GetViewportHeight();
 
 	int columns = screenWidth / TILE_WIDTH;
 	if ((screenWidth % TILE_WIDTH) != 0) {
@@ -1613,7 +1613,7 @@ Point GetScreenPosition(Point tile)
 	Displacement offset = {};
 	CalcFirstTilePosition(firstTile, offset);
 
-	Displacement delta = firstTile - tile;
+	const Displacement delta = firstTile - tile;
 
 	Point position {};
 	position += delta.worldToScreen();
@@ -1730,7 +1730,7 @@ void DrawAndBlit()
 	bool drawMana = IsRedrawComponent(PanelDrawComponent::Mana);
 	bool drawControlButtons = IsRedrawComponent(PanelDrawComponent::ControlButtons);
 	bool drawBelt = IsRedrawComponent(PanelDrawComponent::Belt);
-	bool drawChatInput = ChatFlag;
+	const bool drawChatInput = ChatFlag;
 	bool drawInfoBox = false;
 	bool drawCtrlPan = false;
 
@@ -1802,7 +1802,7 @@ void DrawAndBlit()
 #endif
 
 	RedrawComplete();
-	for (PanelDrawComponent component : enum_values<PanelDrawComponent>()) {
+	for (const PanelDrawComponent component : enum_values<PanelDrawComponent>()) {
 		if (IsRedrawComponent(component)) {
 			RedrawComponentComplete(component);
 		}

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -280,7 +280,7 @@ public:
 		if (rest[0] != '{')
 			return result;
 
-		std::size_t closingBracePos = rest.find('}', 1);
+		const std::size_t closingBracePos = rest.find('}', 1);
 		if (closingBracePos == std::string_view::npos) {
 			LogError("Unclosed format argument: {}", fmt_);
 			return result;

--- a/Source/engine/sound.cpp
+++ b/Source/engine/sound.cpp
@@ -185,7 +185,7 @@ void snd_play_snd(TSnd *pSnd, int lVolume, int lPan)
 		return;
 	}
 
-	uint32_t tc = SDL_GetTicks();
+	const uint32_t tc = SDL_GetTicks();
 	if (tc - pSnd->start_tc < 80) {
 		return;
 	}

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -89,7 +89,7 @@ void GamemenuUpdateSingle()
 {
 	sgSingleMenu[2].setEnabled(gbValidSaveFile);
 
-	bool enable = MyPlayer->_pmode != PM_DEATH && !MyPlayerIsDead;
+	const bool enable = MyPlayer->_pmode != PM_DEATH && !MyPlayerIsDead;
 
 	sgSingleMenu[0].setEnabled(enable);
 }
@@ -200,7 +200,7 @@ void GamemenuMusicVolume(bool bActivate)
 			music_start(GetLevelMusic(leveltype));
 		}
 	} else {
-		int volume = GamemenuSliderMusicSound(&sgOptionsMenu[0]);
+		const int volume = GamemenuSliderMusicSound(&sgOptionsMenu[0]);
 		sound_get_or_set_music_volume(volume);
 		if (volume == VOLUME_MIN) {
 			if (gbMusicOn) {
@@ -228,7 +228,7 @@ void GamemenuSoundVolume(bool bActivate)
 			sound_get_or_set_sound_volume(VOLUME_MAX);
 		}
 	} else {
-		int volume = GamemenuSliderMusicSound(&sgOptionsMenu[1]);
+		const int volume = GamemenuSliderMusicSound(&sgOptionsMenu[1]);
 		sound_get_or_set_sound_volume(volume);
 		if (volume == VOLUME_MIN) {
 			if (gbSoundOn) {
@@ -300,7 +300,7 @@ void gamemenu_load_game(bool /*bActivate*/)
 	RedrawEverything();
 	DrawAndBlit();
 
-	std::array<SDL_Color, 256> prevPalette = logical_palette;
+	const std::array<SDL_Color, 256> prevPalette = logical_palette;
 #ifndef USE_SDL1
 	DeactivateVirtualGamepad();
 	FreeVirtualGamepadTextures();
@@ -345,7 +345,7 @@ void gamemenu_save_game(bool /*bActivate*/)
 	InitDiabloMsg(EMSG_SAVING);
 	RedrawEverything();
 	DrawAndBlit();
-	uint32_t currentTime = SDL_GetTicks();
+	const uint32_t currentTime = SDL_GetTicks();
 	SaveGame();
 	ClrDiabloMsg();
 	InitDiabloMsg(EMSG_GAME_SAVED, currentTime + 1000 - SDL_GetTicks());

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -117,9 +117,9 @@ int GmenuGetLineWidth(TMenuItem *pItem)
 
 void GmenuDrawMenuItem(const Surface &out, TMenuItem *pItem, int y)
 {
-	int w = GmenuGetLineWidth(pItem);
+	const int w = GmenuGetLineWidth(pItem);
 	if (pItem->isSlider()) {
-		int uiPositionX = GetUIRectangle().position.x;
+		const int uiPositionX = GetUIRectangle().position.x;
 		ClxDraw(out, { SliderValueBoxLeft + uiPositionX, y + 40 }, (*optbar_cel)[0]);
 		const uint16_t step = pItem->dwFlags & 0xFFF;
 		const uint16_t steps = std::max<uint16_t>(pItem->sliderSteps(), 2);
@@ -129,8 +129,8 @@ void GmenuDrawMenuItem(const Surface &out, TMenuItem *pItem, int y)
 		ClxDraw(out, { SliderValueLeft + pos - SliderMarkerWidth / 2 + uiPositionX, y + SliderValuePaddingTop + SliderValueHeight - 1 }, (*option_cel)[0]);
 	}
 
-	int x = (gnScreenWidth - w) / 2;
-	UiFlags style = pItem->enabled() ? UiFlags::ColorGold : UiFlags::ColorBlack;
+	const int x = (gnScreenWidth - w) / 2;
+	const UiFlags style = pItem->enabled() ? UiFlags::ColorGold : UiFlags::ColorBlack;
 	DrawString(out, _(pItem->pszStr), Point { x, y },
 	    { .flags = style | UiFlags::FontSize46, .spacing = 2 });
 	if (pItem == sgpCurrItem) {
@@ -152,7 +152,7 @@ void GameMenuMove()
 
 bool GmenuMouseIsOverSlider()
 {
-	int uiPositionX = GetUIRectangle().position.x;
+	const int uiPositionX = GetUIRectangle().position.x;
 	if (MousePosition.x < SliderValueLeft + uiPositionX) {
 		return false;
 	}
@@ -251,7 +251,7 @@ void gmenu_draw(const Surface &out)
 				LogoAnim_tick = ticks;
 			}
 		}
-		int uiPositionY = GetUIRectangle().position.y;
+		const int uiPositionY = GetUIRectangle().position.y;
 		const ClxSprite sprite = (*sgpLogo)[LogoAnim_frame];
 		ClxDraw(out, { (gnScreenWidth - sprite.width()) / 2, 102 + uiPositionY }, sprite);
 		int y = 110 + uiPositionY;
@@ -334,7 +334,7 @@ bool gmenu_left_mouse(bool isDown)
 	if (MousePosition.y - (GMenuTop + uiPosition.y) < 0) {
 		return true;
 	}
-	int i = (MousePosition.y - (GMenuTop + uiPosition.y)) / GMenuItemHeight;
+	const int i = (MousePosition.y - (GMenuTop + uiPosition.y)) / GMenuItemHeight;
 	if (i >= sgCurrentMenuIdx) {
 		return true;
 	}
@@ -342,8 +342,8 @@ bool gmenu_left_mouse(bool isDown)
 	if (!pItem->enabled()) {
 		return true;
 	}
-	int w = GmenuGetLineWidth(pItem);
-	uint16_t screenWidth = GetScreenWidth();
+	const int w = GmenuGetLineWidth(pItem);
+	const uint16_t screenWidth = GetScreenWidth();
 	if (MousePosition.x < screenWidth / 2 - w / 2) {
 		return true;
 	}
@@ -364,14 +364,14 @@ bool gmenu_left_mouse(bool isDown)
 void gmenu_slider_set(TMenuItem *pItem, int min, int max, int value)
 {
 	assert(pItem);
-	uint16_t nSteps = std::max<uint16_t>(pItem->sliderSteps(), 2);
+	const uint16_t nSteps = std::max<uint16_t>(pItem->sliderSteps(), 2);
 	pItem->setSliderStep(((max - min - 1) / 2 + (value - min) * nSteps) / (max - min));
 }
 
 int gmenu_slider_get(TMenuItem *pItem, int min, int max)
 {
-	uint16_t step = pItem->sliderStep();
-	uint16_t steps = std::max<uint16_t>(pItem->sliderSteps(), 2);
+	const uint16_t step = pItem->sliderStep();
+	const uint16_t steps = std::max<uint16_t>(pItem->sliderSteps(), 2);
 	return min + (step * (max - min) + (steps - 1) / 2) / steps;
 }
 

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -144,7 +144,7 @@ void DrawHelpSlider(const Surface &out)
 	const Point uiPosition = GetUIRectangle().position;
 	const int sliderXPos = ContentTextWidth + uiPosition.x + 36;
 	int sliderStart = uiPosition.y + HeaderHeight() + LineHeight() + 3;
-	int sliderEnd = uiPosition.y + PaddingTop + PanelHeight - 12;
+	const int sliderEnd = uiPosition.y + PaddingTop + PanelHeight - 12;
 	ClxDraw(out, { sliderXPos, sliderStart }, (*pSTextSlidCels)[11]);
 	sliderStart += 12;
 	int sliderCurrent = sliderStart;
@@ -176,7 +176,7 @@ void InitHelp()
 
 		size_t previous = 0;
 		while (true) {
-			size_t next = paragraph.find('\n', previous);
+			const size_t next = paragraph.find('\n', previous);
 			HelpTextLines.emplace_back(paragraph.substr(previous, next - previous));
 			if (next == std::string::npos)
 				break;

--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -83,9 +83,9 @@ bool SetHardwareCursorFromSurface(SDL_Surface *surface, HotpointPosition hotpoin
 		newCursor = SDLCursorUniquePtr { SDL_CreateColorCursor(surface, hotpoint.x, hotpoint.y) };
 	} else {
 		// SDL does not support BlitScaled from 8-bit to RGBA.
-		SDLSurfaceUniquePtr converted { SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ARGB8888, 0) };
+		const SDLSurfaceUniquePtr converted { SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ARGB8888, 0) };
 
-		SDLSurfaceUniquePtr scaledSurface = SDLWrap::CreateRGBSurfaceWithFormat(0, scaledSize.width, scaledSize.height, 32, SDL_PIXELFORMAT_ARGB8888);
+		const SDLSurfaceUniquePtr scaledSurface = SDLWrap::CreateRGBSurfaceWithFormat(0, scaledSize.width, scaledSize.height, 32, SDL_PIXELFORMAT_ARGB8888);
 		if (ShouldUseBilinearScaling()) {
 #if LOG_HWCURSOR
 			Log("hwcursor: SetHardwareCursorFromSurface {}x{} scaled to {}x{} using bilinear scaling",
@@ -114,7 +114,7 @@ bool SetHardwareCursorFromSurface(SDL_Surface *surface, HotpointPosition hotpoin
 
 bool SetHardwareCursorFromClxSprite(ClxSprite sprite, HotpointPosition hotpointPosition)
 {
-	OwnedSurface surface { sprite.width(), sprite.height() };
+	const OwnedSurface surface { sprite.width(), sprite.height() };
 	SDL_SetSurfacePalette(surface.surface, Palette.get());
 	SDL_SetColorKey(surface.surface, SDL_TRUE, 0);
 	RenderClxSprite(surface, sprite, { 0, 0 });
@@ -136,7 +136,7 @@ bool SetHardwareCursorFromSprite(int pcurs)
 	if (!IsCursorSizeAllowed(size))
 		return false;
 
-	OwnedSurface out { size };
+	const OwnedSurface out { size };
 	SDL_SetSurfacePalette(out.surface, Palette.get());
 
 	// Transparent color must not be used in the sprite itself.

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -54,7 +54,7 @@ bool AssetContentsEq(AssetRef &&ref, std::string_view expected)
 	const size_t size = ref.size();
 	AssetHandle handle = OpenAsset(std::move(ref), false);
 	if (!handle.ok()) return false;
-	std::unique_ptr<char[]> contents { new char[size] };
+	const std::unique_ptr<char[]> contents { new char[size] };
 	if (!handle.read(contents.get(), size)) return false;
 	return std::string_view { contents.get(), size } == expected;
 }

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -92,7 +92,7 @@ Cutscenes PickCutscene(interface_mode uMsg)
 	case WM_DIABPREVLVL:
 	case WM_DIABTOWNWARP:
 	case WM_DIABTWARPUP: {
-		int lvl = MyPlayer->plrlevel;
+		const int lvl = MyPlayer->plrlevel;
 		if (lvl == 1 && uMsg == WM_DIABNEXTLVL)
 			return CutTown;
 		if (lvl == 16 && uMsg == WM_DIABNEXTLVL)
@@ -504,7 +504,7 @@ void ProgressEventHandler(const SDL_Event &event, uint16_t modState)
 		ProgressEventHandlerState.prevHandler = nullptr;
 		IsProgress = false;
 
-		Player &myPlayer = *MyPlayer;
+		const Player &myPlayer = *MyPlayer;
 		NetSendCmdLocParam2(true, CMD_PLAYER_JOINLEVEL, myPlayer.position.tile, myPlayer.plrlevel, myPlayer.plrIsOnSetLevel ? 1 : 0);
 		DelayPlrMessages(SDL_GetTicks() - ProgressEventHandlerState.loadStartedAt);
 

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -143,7 +143,7 @@ void AddItemToInvGrid(Player &player, int invGridIndex, int invListIndex, Size i
 {
 	const int pitch = 10;
 	for (int y = 0; y < itemSize.height; y++) {
-		int rowGridIndex = invGridIndex + pitch * y;
+		const int rowGridIndex = invGridIndex + pitch * y;
 		for (int x = 0; x < itemSize.width; x++) {
 			if (x == 0 && y == itemSize.height - 1)
 				player.InvGrid[rowGridIndex + x] = invListIndex;
@@ -192,8 +192,8 @@ bool CanWield(Player &player, const Item &item)
 	if (!CanEquip(item) || IsNoneOf(player.GetItemLocation(item), ILOC_ONEHAND, ILOC_TWOHAND))
 		return false;
 
-	Item &leftHandItem = player.InvBody[INVLOC_HAND_LEFT];
-	Item &rightHandItem = player.InvBody[INVLOC_HAND_RIGHT];
+	const Item &leftHandItem = player.InvBody[INVLOC_HAND_LEFT];
+	const Item &rightHandItem = player.InvBody[INVLOC_HAND_RIGHT];
 
 	if (leftHandItem.isEmpty() && rightHandItem.isEmpty()) {
 		return true;
@@ -203,15 +203,15 @@ bool CanWield(Player &player, const Item &item)
 		return false;
 	}
 
-	Item &occupiedHand = !leftHandItem.isEmpty() ? leftHandItem : rightHandItem;
+	const Item &occupiedHand = !leftHandItem.isEmpty() ? leftHandItem : rightHandItem;
 
 	// Bard can dual wield swords and maces, so we allow equiping one-handed weapons in her free slot as long as her occupied
 	// slot is another one-handed weapon.
 	if (player._pClass == HeroClass::Bard) {
-		bool occupiedHandIsOneHandedSwordOrMace = player.GetItemLocation(occupiedHand) == ILOC_ONEHAND
+		const bool occupiedHandIsOneHandedSwordOrMace = player.GetItemLocation(occupiedHand) == ILOC_ONEHAND
 		    && IsAnyOf(occupiedHand._itype, ItemType::Sword, ItemType::Mace);
 
-		bool weaponToEquipIsOneHandedSwordOrMace = player.GetItemLocation(item) == ILOC_ONEHAND
+		const bool weaponToEquipIsOneHandedSwordOrMace = player.GetItemLocation(item) == ILOC_ONEHAND
 		    && IsAnyOf(item._itype, ItemType::Sword, ItemType::Mace);
 
 		if (occupiedHandIsOneHandedSwordOrMace && weaponToEquipIsOneHandedSwordOrMace) {
@@ -315,9 +315,9 @@ int FindTargetSlotUnderItemCursor(Point cursorPosition, Size itemSize)
 				hotPixelCellOffset.deltaY++;
 			}
 			// Then work out the top left cell of the nearest area that could fit this item (as pasting on the edge of the inventory would otherwise put it out of bounds)
-			int hotPixelCell = r - SLOTXY_INV_FIRST;
-			int targetRow = std::clamp((hotPixelCell / InventorySizeInSlots.width) - hotPixelCellOffset.deltaY, 0, InventorySizeInSlots.height - itemSize.height);
-			int targetColumn = std::clamp((hotPixelCell % InventorySizeInSlots.width) - hotPixelCellOffset.deltaX, 0, InventorySizeInSlots.width - itemSize.width);
+			const int hotPixelCell = r - SLOTXY_INV_FIRST;
+			const int targetRow = std::clamp((hotPixelCell / InventorySizeInSlots.width) - hotPixelCellOffset.deltaY, 0, InventorySizeInSlots.height - itemSize.height);
+			const int targetColumn = std::clamp((hotPixelCell % InventorySizeInSlots.width) - hotPixelCellOffset.deltaX, 0, InventorySizeInSlots.width - itemSize.width);
 			return SLOTXY_INV_FIRST + targetRow * InventorySizeInSlots.width + targetColumn;
 		}
 	}
@@ -393,13 +393,13 @@ void ChangeTwoHandItem(Player &player)
 	}
 
 	if (player.InvBody[INVLOC_HAND_RIGHT].isEmpty()) {
-		Item previouslyEquippedItem = player.InvBody[INVLOC_HAND_LEFT];
+		const Item previouslyEquippedItem = player.InvBody[INVLOC_HAND_LEFT];
 		ChangeEquipment(player, INVLOC_HAND_LEFT, player.HoldItem.pop(), &player == MyPlayer);
 		if (!previouslyEquippedItem.isEmpty()) {
 			player.HoldItem = previouslyEquippedItem;
 		}
 	} else {
-		Item previouslyEquippedItem = player.InvBody[INVLOC_HAND_RIGHT];
+		const Item previouslyEquippedItem = player.InvBody[INVLOC_HAND_RIGHT];
 		RemoveEquipment(player, INVLOC_HAND_RIGHT, false);
 		ChangeEquipment(player, INVLOC_HAND_LEFT, player.HoldItem, &player == MyPlayer);
 		player.HoldItem = previouslyEquippedItem;
@@ -415,11 +415,11 @@ int8_t CheckOverlappingItems(int slot, const Player &player, Size itemSize)
 	for (unsigned rowOffset = 0; rowOffset < static_cast<unsigned>(itemSize.height * InventorySizeInSlots.width); rowOffset += InventorySizeInSlots.width) {
 
 		for (unsigned columnOffset = 0; columnOffset < static_cast<unsigned>(itemSize.width); columnOffset++) {
-			unsigned testCell = originCell + rowOffset + columnOffset;
+			const unsigned testCell = originCell + rowOffset + columnOffset;
 			// FindTargetSlotUnderItemCursor returns the top left slot of the inventory region that fits the item, we can be confident this calculation is not going to read out of range.
 			assert(testCell < sizeof(player.InvGrid));
 			if (player.InvGrid[testCell] != 0) {
-				int8_t iv = std::abs(player.InvGrid[testCell]);
+				const int8_t iv = std::abs(player.InvGrid[testCell]);
 				if (overlappingId != 0) {
 					if (overlappingId != iv) {
 						// Found two different items that would be displaced by the held item, can't paste the item here.
@@ -439,7 +439,7 @@ int8_t GetPrevItemId(int slot, const Player &player, const Size &itemSize)
 {
 	if (player.HoldItem._itype != ItemType::Gold)
 		return CheckOverlappingItems(slot, player, itemSize);
-	int8_t item_cell_begin = player.InvGrid[slot - SLOTXY_INV_FIRST];
+	const int8_t item_cell_begin = player.InvGrid[slot - SLOTXY_INV_FIRST];
 	if (item_cell_begin == 0)
 		return 0;
 	if (item_cell_begin <= 0)
@@ -750,7 +750,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 		return;
 	}
 
-	inv_xy_slot r = *maybeSlot;
+	const inv_xy_slot r = *maybeSlot;
 
 	Item &holdItem = player.HoldItem;
 	holdItem.clear();
@@ -761,7 +761,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 	HeroSpeech failedSpeech = HeroSpeech::ICantDoThat; // Default message if the player attempts to automove an item that can't go anywhere else
 
 	if (r >= SLOTXY_HEAD && r <= SLOTXY_CHEST) {
-		inv_body_loc invloc = MapSlotToInvBodyLoc(r);
+		const inv_body_loc invloc = MapSlotToInvBodyLoc(r);
 		if (!player.InvBody[invloc].isEmpty()) {
 			if (automaticMove) {
 				attemptedMove = true;
@@ -780,8 +780,8 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 	}
 
 	if (r >= SLOTXY_INV_FIRST && r <= SLOTXY_INV_LAST) {
-		unsigned ig = r - SLOTXY_INV_FIRST;
-		int iv = std::abs(player.InvGrid[ig]) - 1;
+		const unsigned ig = r - SLOTXY_INV_FIRST;
+		const int iv = std::abs(player.InvGrid[ig]) - 1;
 		if (iv >= 0) {
 			if (automaticMove) {
 				attemptedMove = true;
@@ -897,7 +897,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 	}
 
 	if (r >= SLOTXY_BELT_FIRST) {
-		Item &beltItem = player.SpdList[r - SLOTXY_BELT_FIRST];
+		const Item &beltItem = player.SpdList[r - SLOTXY_BELT_FIRST];
 		if (!beltItem.isEmpty()) {
 			if (automaticMove) {
 				attemptedMove = true;
@@ -946,14 +946,14 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 
 void TryCombineNaKrulNotes(Player &player, Item &noteItem)
 {
-	int idx = noteItem.IDidx;
-	_item_indexes notes[] = { IDI_NOTE1, IDI_NOTE2, IDI_NOTE3 };
+	const int idx = noteItem.IDidx;
+	const _item_indexes notes[] = { IDI_NOTE1, IDI_NOTE2, IDI_NOTE3 };
 
 	if (IsNoneOf(idx, IDI_NOTE1, IDI_NOTE2, IDI_NOTE3)) {
 		return;
 	}
 
-	for (_item_indexes note : notes) {
+	for (const _item_indexes note : notes) {
 		if (idx != note && !HasInventoryItemWithId(player, note)) {
 			return; // the player doesn't have all notes
 		}
@@ -961,13 +961,13 @@ void TryCombineNaKrulNotes(Player &player, Item &noteItem)
 
 	MyPlayer->Say(HeroSpeech::JustWhatIWasLookingFor, 10);
 
-	for (_item_indexes note : notes) {
+	for (const _item_indexes note : notes) {
 		if (idx != note) {
 			RemoveInventoryItemById(player, note);
 		}
 	}
 
-	Point position = noteItem.position; // copy the position to restore it after re-initialising the item
+	const Point position = noteItem.position; // copy the position to restore it after re-initialising the item
 	noteItem = {};
 	GetItemAttrs(noteItem, IDI_FULLNOTE, 16);
 	SetupItem(noteItem);
@@ -976,7 +976,7 @@ void TryCombineNaKrulNotes(Player &player, Item &noteItem)
 
 void CheckQuestItem(Player &player, Item &questItem)
 {
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	if (Quests[Q_BLIND]._qactive == QUEST_ACTIVE
 	    && (questItem.IDidx == IDI_OPTAMULET
@@ -1036,7 +1036,7 @@ void CheckQuestItem(Player &player, Item &questItem)
 
 void CleanupItems(int ii)
 {
-	Item &item = Items[ii];
+	const Item &item = Items[ii];
 	dItem[item.position.x][item.position.y] = 0;
 
 	if (CornerStone.isAvailable() && item.position == CornerStone.position) {
@@ -1083,7 +1083,7 @@ void StartGoldDrop()
 	if (ChatFlag)
 		ResetChat();
 
-	Point start = GetPanelPosition(UiPanels::Inventory, { 67, 128 });
+	const Point start = GetPanelPosition(UiPanels::Inventory, { 67, 128 });
 	SDL_Rect rect = MakeSdlRect(start.x, start.y, 180, 20);
 	SDL_SetTextInputRect(&rect);
 
@@ -1180,7 +1180,7 @@ void DrawInv(const Surface &out)
 {
 	ClxDraw(out, GetPanelPosition(UiPanels::Inventory, { 0, 351 }), (*pInvCels)[0]);
 
-	Size slotSize[] = {
+	const Size slotSize[] = {
 		{ 2, 2 }, // head
 		{ 1, 1 }, // left ring
 		{ 1, 1 }, // right ring
@@ -1190,7 +1190,7 @@ void DrawInv(const Surface &out)
 		{ 2, 3 }, // chest
 	};
 
-	Point slotPos[] = {
+	const Point slotPos[] = {
 		{ 133, 59 },  // head
 		{ 48, 205 },  // left ring
 		{ 249, 205 }, // right ring
@@ -1200,7 +1200,7 @@ void DrawInv(const Surface &out)
 		{ 133, 160 }, // chest
 	};
 
-	Player &myPlayer = *InspectPlayer;
+	const Player &myPlayer = *InspectPlayer;
 
 	for (int slot = INVLOC_HEAD; slot < NUM_INVLOC; slot++) {
 		if (!myPlayer.InvBody[slot].isEmpty()) {
@@ -1210,7 +1210,7 @@ void DrawInv(const Surface &out)
 
 			const int cursId = myPlayer.InvBody[slot]._iCurs + CURSOR_FIRSTITEM;
 
-			Size frameSize = GetInvItemSize(cursId);
+			const Size frameSize = GetInvItemSize(cursId);
 
 			// calc item offsets for weapons/armor smaller than 2x3 slots
 			if (IsAnyOf(slot, INVLOC_HAND_LEFT, INVLOC_HAND_RIGHT, INVLOC_CHEST)) {
@@ -1250,8 +1250,8 @@ void DrawInv(const Surface &out)
 
 	for (int j = 0; j < InventoryGridCells; j++) {
 		if (myPlayer.InvGrid[j] > 0) { // first slot of an item
-			int ii = myPlayer.InvGrid[j] - 1;
-			int cursId = myPlayer.InvList[ii]._iCurs + CURSOR_FIRSTITEM;
+			const int ii = myPlayer.InvGrid[j] - 1;
+			const int cursId = myPlayer.InvList[ii]._iCurs + CURSOR_FIRSTITEM;
 
 			const ClxSprite sprite = GetInvItemSprite(cursId);
 			const Point position = GetPanelPosition(UiPanels::Inventory, InvRect[j + SLOTXY_INV_FIRST].position) + Displacement { 0, InventorySlotSizeInPixels.height };
@@ -1274,7 +1274,7 @@ void DrawInvBelt(const Surface &out)
 
 	DrawPanelBox(out, { 205, 21, 232, 28 }, mainPanelPosition + Displacement { 205, 5 });
 
-	Player &myPlayer = *InspectPlayer;
+	const Player &myPlayer = *InspectPlayer;
 
 	for (int i = 0; i < MaxBeltItems; i++) {
 		if (myPlayer.SpdList[i].isEmpty()) {
@@ -1394,7 +1394,7 @@ bool CanFitItemInInventory(const Player &player, const Item &item)
 
 bool AutoPlaceItemInInventory(Player &player, const Item &item, bool sendNetworkMessage)
 {
-	Size itemSize = GetInventorySize(item);
+	const Size itemSize = GetInventorySize(item);
 	std::optional<int> targetSlot = FindSlotForItem(player, itemSize);
 
 	if (targetSlot) {
@@ -1416,7 +1416,7 @@ std::vector<int> SortItemsBySize(Player &player)
 	itemSizes.reserve(player._pNumInv);          // Reserves space for the number of items in the player's inventory
 
 	for (int i = 0; i < player._pNumInv; i++) {
-		Size size = GetInventorySize(player.InvList[i]);
+		const Size size = GetInventorySize(player.InvList[i]);
 		itemSizes.emplace_back(size, i);
 	}
 
@@ -1440,7 +1440,7 @@ std::vector<int> SortItemsBySize(Player &player)
 void ReorganizeInventory(Player &player)
 {
 	// Sort items by size
-	std::vector<int> sortedIndices = SortItemsBySize(player);
+	const std::vector<int> sortedIndices = SortItemsBySize(player);
 
 	// Temporary storage for items and a copy of InvGrid
 	std::vector<Item> tempStorage(player._pNumInv);
@@ -1457,8 +1457,8 @@ void ReorganizeInventory(Player &player)
 
 	// Attempt to place items back, now from the temp storage
 	bool reorganizationFailed = false;
-	for (int index : sortedIndices) {
-		Item &item = tempStorage[index];
+	for (const int index : sortedIndices) {
+		const Item &item = tempStorage[index];
 		if (!AutoPlaceItemInInventory(player, item, false)) {
 			reorganizationFailed = true;
 			break;
@@ -1467,7 +1467,7 @@ void ReorganizeInventory(Player &player)
 
 	// If reorganization failed, restore items and InvGrid from tempStorage and originalInvGrid
 	if (reorganizationFailed) {
-		for (Item &item : tempStorage) {
+		for (const Item &item : tempStorage) {
 			if (!item.isEmpty()) {
 				player.InvList[player._pNumInv++] = item;
 			}
@@ -1479,7 +1479,7 @@ void ReorganizeInventory(Player &player)
 int RoomForGold()
 {
 	int amount = 0;
-	for (int8_t &itemIndex : MyPlayer->InvGrid) {
+	for (const int8_t &itemIndex : MyPlayer->InvGrid) {
 		if (itemIndex < 0) {
 			continue;
 		}
@@ -1488,7 +1488,7 @@ int RoomForGold()
 			continue;
 		}
 
-		Item &goldItem = MyPlayer->InvList[itemIndex - 1];
+		const Item &goldItem = MyPlayer->InvList[itemIndex - 1];
 		if (goldItem._itype != ItemType::Gold || goldItem._ivalue == MaxGold) {
 			continue;
 		}
@@ -1547,7 +1547,7 @@ bool GoldAutoPlace(Player &player, Item &goldStack)
 
 void CheckInvSwap(Player &player, inv_body_loc bLoc)
 {
-	Item &item = player.InvBody[bLoc];
+	const Item &item = player.InvBody[bLoc];
 
 	if (bLoc == INVLOC_HAND_LEFT && player.GetItemLocation(item) == ILOC_TWOHAND) {
 		player.InvBody[INVLOC_HAND_RIGHT].clear();
@@ -1570,11 +1570,11 @@ void CheckInvSwap(Player &player, const Item &item, int invGridIndex)
 	Size itemSize = GetInventorySize(item);
 
 	const int pitch = 10;
-	int invListIndex = [&]() -> int {
+	const int invListIndex = [&]() -> int {
 		for (int y = 0; y < itemSize.height; y++) {
-			int rowGridIndex = invGridIndex + pitch * y;
+			const int rowGridIndex = invGridIndex + pitch * y;
 			for (int x = 0; x < itemSize.width; x++) {
-				int gridIndex = rowGridIndex + x;
+				const int gridIndex = rowGridIndex + x;
 				if (player.InvGrid[gridIndex] != 0)
 					return std::abs(player.InvGrid[gridIndex]);
 			}
@@ -1595,7 +1595,7 @@ void CheckInvSwap(Player &player, const Item &item, int invGridIndex)
 	player.InvList[invListIndex - 1] = item;
 
 	for (int y = 0; y < itemSize.height; y++) {
-		int rowGridIndex = invGridIndex + pitch * y;
+		const int rowGridIndex = invGridIndex + pitch * y;
 		for (int x = 0; x < itemSize.width; x++) {
 			if (x == 0 && y == itemSize.height - 1)
 				player.InvGrid[rowGridIndex + x] = invListIndex;
@@ -1609,7 +1609,7 @@ void CheckInvSwap(Player &player, const Item &item, int invGridIndex)
 
 void CheckInvRemove(Player &player, int invGridIndex)
 {
-	int invListIndex = std::abs(player.InvGrid[invGridIndex]) - 1;
+	const int invListIndex = std::abs(player.InvGrid[invGridIndex]) - 1;
 
 	if (invListIndex >= 0) {
 		player.RemoveInvItem(invListIndex);
@@ -1622,7 +1622,7 @@ void TransferItemToStash(Player &player, int location)
 		return;
 	}
 
-	Item &item = GetInventoryItem(player, location);
+	const Item &item = GetInventoryItem(player, location);
 	if (!AutoPlaceItemInStash(player, item, true)) {
 		player.SaySpecific(HeroSpeech::WhereWouldIPutThis);
 		return;
@@ -1785,7 +1785,7 @@ void AutoGetItem(Player &player, Item *itemPointer, int ii)
 int FindGetItem(uint32_t iseed, _item_indexes idx, uint16_t createInfo)
 {
 	for (uint8_t i = 0; i < ActiveItemCount; i++) {
-		Item &item = Items[ActiveItems[i]];
+		const Item &item = Items[ActiveItems[i]];
 		if (item.keyAttributesMatch(iseed, idx, createInfo)) {
 			return i;
 		}
@@ -1963,10 +1963,10 @@ int8_t CheckInvHLight()
 		rv = INVLOC_CHEST;
 		pi = &myPlayer.InvBody[rv];
 	} else if (r >= SLOTXY_INV_FIRST && r <= SLOTXY_INV_LAST) {
-		int8_t itemId = std::abs(myPlayer.InvGrid[r - SLOTXY_INV_FIRST]);
+		const int8_t itemId = std::abs(myPlayer.InvGrid[r - SLOTXY_INV_FIRST]);
 		if (itemId == 0)
 			return -1;
-		int ii = itemId - 1;
+		const int ii = itemId - 1;
 		rv = ii + INVITEM_INV_FIRST;
 		pi = &myPlayer.InvList[ii];
 	} else if (r >= SLOTXY_BELT_FIRST) {
@@ -1982,7 +1982,7 @@ int8_t CheckInvHLight()
 		return -1;
 
 	if (pi->_itype == ItemType::Gold) {
-		int nGold = pi->_ivalue;
+		const int nGold = pi->_ivalue;
 		InfoString = fmt::format(fmt::runtime(ngettext("{:s} gold piece", "{:s} gold pieces", nGold)), FormatInteger(nGold));
 		FloatingInfoString = fmt::format(fmt::runtime(ngettext("{:s} gold piece", "{:s} gold pieces", nGold)), FormatInteger(nGold));
 	} else {
@@ -2178,7 +2178,7 @@ bool UseInvItem(int cii)
 		return true;
 	}
 
-	int idata = ItemCAnimTbl[item->_iCurs];
+	const int idata = ItemCAnimTbl[item->_iCurs];
 	if (item->_iMiscId == IMISC_BOOK)
 		PlaySFX(SfxID::ReadBook);
 	else if (&player == MyPlayer)
@@ -2250,7 +2250,7 @@ void DoTelekinesis()
 	if (pcursitem != -1)
 		NetSendCmdGItem(true, CMD_REQUESTAGITEM, *MyPlayer, pcursitem);
 	if (pcursmonst != -1) {
-		Monster &monter = Monsters[pcursmonst];
+		const Monster &monter = Monsters[pcursmonst];
 		if (!M_Talker(monter) && monter.talkMsg == TEXT_NONE)
 			NetSendCmdParam1(true, CMD_KNOCKBACK, pcursmonst);
 	}
@@ -2271,7 +2271,7 @@ int CalculateGold(Player &player)
 
 Size GetInventorySize(const Item &item)
 {
-	Size size = GetInvItemSize(item._iCurs + CURSOR_FIRSTITEM);
+	const Size size = GetInvItemSize(item._iCurs + CURSOR_FIRSTITEM);
 
 	return { size.width / InventorySlotSizeInPixels.width, size.height / InventorySlotSizeInPixels.height };
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -801,7 +801,7 @@ int SaveItemPower(const Player &player, Item &item, ItemPower &power)
 		RedrawComponent(PanelDrawComponent::Mana);
 		break;
 	case IPL_DUR: {
-		int bonus = r * item._iMaxDur / 100;
+		const int bonus = r * item._iMaxDur / 100;
 		item._iMaxDur += bonus;
 		item._iDurability += bonus;
 	} break;
@@ -978,12 +978,12 @@ int SaveItemPower(const Player &player, Item &item, ItemPower &power)
 		item._iDamAcFlags |= ItemSpecialEffectHf::ACAgainstUndead;
 		break;
 	case IPL_MANATOLIFE: {
-		int portion = ((player._pMaxManaBase >> 6) * 50 / 100) << 6;
+		const int portion = ((player._pMaxManaBase >> 6) * 50 / 100) << 6;
 		item._iPLMana -= portion;
 		item._iPLHP += portion;
 	} break;
 	case IPL_LIFETOMANA: {
-		int portion = ((player._pMaxHPBase >> 6) * 40 / 100) << 6;
+		const int portion = ((player._pMaxHPBase >> 6) * 40 / 100) << 6;
 		item._iPLHP -= portion;
 		item._iPLMana += portion;
 	} break;
@@ -1069,7 +1069,7 @@ std::string GenerateStaffName(const ItemData &baseItemData, SpellID spellId, boo
 {
 	std::string_view baseName = translate ? _(baseItemData.iName) : baseItemData.iName;
 	std::string_view spellName = translate ? pgettext("spell", GetSpellData(spellId).sNameText) : GetSpellData(spellId).sNameText;
-	std::string_view normalFmt = translate ? pgettext("spell", /* TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall */ "{0} of {1}") : "{0} of {1}";
+	const std::string_view normalFmt = translate ? pgettext("spell", /* TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall */ "{0} of {1}") : "{0} of {1}";
 	std::string name = fmt::format(fmt::runtime(normalFmt), baseName, spellName);
 	if (!StringInPanel(name.c_str())) {
 		std::string_view shortName = translate ? _(baseItemData.iSName) : baseItemData.iSName;
@@ -1081,7 +1081,7 @@ std::string GenerateStaffName(const ItemData &baseItemData, SpellID spellId, boo
 std::string GenerateStaffNameMagical(const ItemData &baseItemData, SpellID spellId, const PLStruct &power, bool translate, std::optional<bool> forceNameLengthCheck)
 {
 	std::string_view baseName = translate ? _(baseItemData.iName) : baseItemData.iName;
-	std::string_view magicFmt = translate ? pgettext("spell", /* TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall */ "{0} {1} of {2}") : "{0} {1} of {2}";
+	const std::string_view magicFmt = translate ? pgettext("spell", /* TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall */ "{0} {1} of {2}") : "{0} {1} of {2}";
 	std::string_view spellName = translate ? pgettext("spell", GetSpellData(spellId).sNameText) : GetSpellData(spellId).sNameText;
 	std::string_view prefixName = translate ? _(power.PLName) : power.PLName;
 
@@ -1103,11 +1103,11 @@ void GetStaffPower(const Player &player, Item &item, int maxlvl, bool onlygood)
 	}
 
 	const ItemData &baseItemData = AllItemsList[item.IDidx];
-	std::string staffName = GenerateStaffName(baseItemData, item._iSpell, false);
+	const std::string staffName = GenerateStaffName(baseItemData, item._iSpell, false);
 
 	CopyUtf8(item._iName, staffName, ItemNameLength);
 	if (prefix.has_value()) {
-		std::string staffNameMagical = GenerateStaffNameMagical(baseItemData, item._iSpell, **prefix, false, std::nullopt);
+		const std::string staffNameMagical = GenerateStaffNameMagical(baseItemData, item._iSpell, **prefix, false, std::nullopt);
 		CopyUtf8(item._iIName, staffNameMagical, ItemNameLength);
 	} else {
 		CopyUtf8(item._iIName, item._iName, ItemNameLength);
@@ -1119,13 +1119,13 @@ void GetStaffPower(const Player &player, Item &item, int maxlvl, bool onlygood)
 std::string GenerateMagicItemName(const std::string_view &baseNamel, const PLStruct *pPrefix, const PLStruct *pSufix, bool translate)
 {
 	if (pPrefix != nullptr && pSufix != nullptr) {
-		std::string_view fmt = translate ? _(/* TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale */ "{0} {1} of {2}") : "{0} {1} of {2}";
+		const std::string_view fmt = translate ? _(/* TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale */ "{0} {1} of {2}") : "{0} {1} of {2}";
 		return fmt::format(fmt::runtime(fmt), translate ? _(pPrefix->PLName) : pPrefix->PLName, baseNamel, translate ? _(pSufix->PLName) : pSufix->PLName);
 	} else if (pPrefix != nullptr) {
-		std::string_view fmt = translate ? _(/* TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword */ "{0} {1}") : "{0} {1}";
+		const std::string_view fmt = translate ? _(/* TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword */ "{0} {1}") : "{0} {1}";
 		return fmt::format(fmt::runtime(fmt), translate ? _(pPrefix->PLName) : pPrefix->PLName, baseNamel);
 	} else if (pSufix != nullptr) {
-		std::string_view fmt = translate ? _(/* TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale */ "{0} of {1}") : "{0} of {1}";
+		const std::string_view fmt = translate ? _(/* TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale */ "{0} of {1}") : "{0} of {1}";
 		return fmt::format(fmt::runtime(fmt), baseNamel, translate ? _(pSufix->PLName) : pSufix->PLName);
 	}
 
@@ -1213,7 +1213,7 @@ void GetStaffSpell(const Player &player, Item &item, int lvl, bool onlygood)
 	int s = static_cast<int8_t>(SpellID::Firebolt);
 	SpellID bs = SpellID::Null;
 	while (rv > 0) {
-		int sLevel = GetSpellStaffLevel(static_cast<SpellID>(s));
+		const int sLevel = GetSpellStaffLevel(static_cast<SpellID>(s));
 		if (sLevel != -1 && l >= sLevel) {
 			rv--;
 			bs = static_cast<SpellID>(s);
@@ -1227,14 +1227,14 @@ void GetStaffSpell(const Player &player, Item &item, int lvl, bool onlygood)
 			s = static_cast<int8_t>(SpellID::Firebolt);
 	}
 
-	int minc = GetSpellData(bs).sStaffMin;
-	int maxc = GetSpellData(bs).sStaffMax - minc + 1;
+	const int minc = GetSpellData(bs).sStaffMin;
+	const int maxc = GetSpellData(bs).sStaffMax - minc + 1;
 	item._iSpell = bs;
 	item._iCharges = minc + GenerateRnd(maxc);
 	item._iMaxCharges = item._iCharges;
 
 	item._iMinMag = GetSpellData(bs).minInt;
-	int v = item._iCharges * GetSpellData(bs).staffCost() / 5;
+	const int v = item._iCharges * GetSpellData(bs).staffCost() / 5;
 	item._ivalue += v;
 	item._iIvalue += v;
 	GetStaffPower(player, item, lvl, onlygood);
@@ -1258,7 +1258,7 @@ void GetOilType(Item &item, int maxLvl)
 		}
 	}
 
-	int8_t t = rnd[GenerateRnd(cnt)];
+	const int8_t t = rnd[GenerateRnd(cnt)];
 
 	CopyUtf8(item._iName, OilNames[t], ItemNameLength);
 	CopyUtf8(item._iIName, OilNames[t], ItemNameLength);
@@ -1331,7 +1331,7 @@ _item_indexes GetItemIndexForDroppableItem(bool considerDropRate, tl::function_r
 		cumulativeWeight += considerDropRate ? item.dropRate : 1;
 		ril.push_back({ static_cast<_item_indexes>(i), cumulativeWeight });
 	}
-	unsigned targetWeight = static_cast<unsigned>(RandomIntLessThan(static_cast<int>(cumulativeWeight)));
+	const unsigned targetWeight = static_cast<unsigned>(RandomIntLessThan(static_cast<int>(cumulativeWeight)));
 	return std::upper_bound(ril.begin(), ril.end(), targetWeight, [](unsigned target, const WeightedItemIndex &value) { return target < value.cumulativeWeight; })->index;
 }
 
@@ -1382,7 +1382,7 @@ std::vector<uint8_t> GetValidUniques(int lvl, unique_base_item baseItemId)
 {
 	std::vector<uint8_t> validUniques;
 	int index = 0;
-	for (UniqueItem &itemData : UniqueItems) {
+	for (const UniqueItem &itemData : UniqueItems) {
 		if (itemData.UIItemId == baseItemId && lvl >= itemData.UIMinLvl) {
 			validUniques.push_back(index);
 		}
@@ -1461,10 +1461,10 @@ void SetupBaseItem(Point position, _item_indexes idx, bool onlygood, bool sendms
 	if (ActiveItemCount >= MAXITEMS)
 		return;
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	auto &item = Items[ii];
 	GetSuperItemSpace(position, ii);
-	int curlv = ItemsGetCurrlevel();
+	const int curlv = ItemsGetCurrlevel();
 
 	SetupAllItems(*MyPlayer, item, idx, AdvanceRndSeed(), 2 * curlv, 1, onlygood, delta);
 	TryRandomUniqueItem(item, idx, 2 * curlv, 1, onlygood, delta);
@@ -1554,12 +1554,12 @@ void SpawnRock()
 	if (stand == nullptr)
 		return;
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	Item &item = Items[ii];
 
 	item.position = stand->position;
 	dItem[item.position.x][item.position.y] = ii + 1;
-	int curlv = ItemsGetCurrlevel();
+	const int curlv = ItemsGetCurrlevel();
 	GetItemAttrs(item, IDI_ROCK, curlv);
 	SetupItem(item);
 	item.selectionRegion = SelectionRegion::Middle;
@@ -1713,7 +1713,7 @@ Point DrawUniqueInfoWindow(const Surface &out)
 	const Point leftInfoPos = GetLeftPanel().position + Displacement { SidePanelSize.width, 0 };
 
 	const bool isInfoOverlapping = IsLeftPanelOpen() && IsRightPanelOpen() && GetLeftPanel().contains(rightInfoPos);
-	int fadeLevel = isInfoOverlapping ? 3 : 1;
+	const int fadeLevel = isInfoOverlapping ? 3 : 1;
 
 	for (int i = 0; i < fadeLevel; ++i) {
 		DrawHalfTransparentRectTo(out, panelX, panelY, 265, 297);
@@ -1909,13 +1909,13 @@ void SpawnOnePremium(Item &premiumItem, int plvl, const Player &player)
 
 	plvl = std::clamp(plvl, 1, 30);
 
-	int maxCount = 150;
+	const int maxCount = 150;
 	const bool unlimited = !gbIsHellfire; // TODO: This could lead to an infinite loop if a suitable item can never be generated
 	for (int count = 0; unlimited || count < maxCount; count++) {
 		premiumItem = {};
 		premiumItem._iSeed = AdvanceRndSeed();
 		SetRndSeed(premiumItem._iSeed);
-		_item_indexes itemType = RndPremiumItem(player, plvl / 4, plvl);
+		const _item_indexes itemType = RndPremiumItem(player, plvl / 4, plvl);
 		GetItemAttrs(premiumItem, itemType, plvl);
 		GetItemBonus(player, premiumItem, plvl / 2, plvl, true, !gbIsHellfire);
 
@@ -2042,7 +2042,7 @@ _item_indexes RndHealerItem(const Player &player, int lvl)
 void RecreateSmithItem(const Player &player, Item &item, int lvl, int iseed)
 {
 	SetRndSeed(iseed);
-	_item_indexes itype = RndSmithItem(player, lvl);
+	const _item_indexes itype = RndSmithItem(player, lvl);
 	GetItemAttrs(item, itype, lvl);
 
 	item._iSeed = iseed;
@@ -2053,7 +2053,7 @@ void RecreateSmithItem(const Player &player, Item &item, int lvl, int iseed)
 void RecreatePremiumItem(const Player &player, Item &item, int plvl, int iseed)
 {
 	SetRndSeed(iseed);
-	_item_indexes itype = RndPremiumItem(player, plvl / 4, plvl);
+	const _item_indexes itype = RndPremiumItem(player, plvl / 4, plvl);
 	GetItemAttrs(item, itype, plvl);
 	GetItemBonus(player, item, plvl / 2, plvl, true, !gbIsHellfire);
 
@@ -2065,7 +2065,7 @@ void RecreatePremiumItem(const Player &player, Item &item, int plvl, int iseed)
 void RecreateBoyItem(const Player &player, Item &item, int lvl, int iseed)
 {
 	SetRndSeed(iseed);
-	_item_indexes itype = RndBoyItem(player, lvl);
+	const _item_indexes itype = RndBoyItem(player, lvl);
 	GetItemAttrs(item, itype, lvl);
 	GetItemBonus(player, item, lvl, 2 * lvl, true, true);
 
@@ -2084,7 +2084,7 @@ void RecreateWitchItem(const Player &player, Item &item, _item_indexes idx, int 
 		GetItemAttrs(item, idx, lvl);
 	} else {
 		SetRndSeed(iseed);
-		_item_indexes itype = RndWitchItem(player, lvl);
+		const _item_indexes itype = RndWitchItem(player, lvl);
 		GetItemAttrs(item, itype, lvl);
 		int iblvl = -1;
 		if (GenerateRnd(100) <= 5)
@@ -2106,7 +2106,7 @@ void RecreateHealerItem(const Player &player, Item &item, _item_indexes idx, int
 		GetItemAttrs(item, idx, lvl);
 	} else {
 		SetRndSeed(iseed);
-		_item_indexes itype = RndHealerItem(player, lvl);
+		const _item_indexes itype = RndHealerItem(player, lvl);
 		GetItemAttrs(item, itype, lvl);
 	}
 
@@ -2134,7 +2134,7 @@ void CreateMagicItem(Point position, int lvl, ItemType itemType, int imid, int i
 	if (ActiveItemCount >= MAXITEMS)
 		return;
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	auto &item = Items[ii];
 	_item_indexes idx = RndTypeItems(itemType, imid, lvl);
 
@@ -2202,10 +2202,10 @@ std::string GetTranslatedItemNameMagical(const Item &item, bool hellfireItem, bo
 	std::string identifiedName;
 	const auto &baseItemData = AllItemsList[static_cast<size_t>(item.IDidx)];
 
-	int lvl = item._iCreateInfo & CF_LEVEL;
-	bool onlygood = (item._iCreateInfo & (CF_ONLYGOOD | CF_SMITHPREMIUM | CF_BOY | CF_WITCH)) != 0;
+	const int lvl = item._iCreateInfo & CF_LEVEL;
+	const bool onlygood = (item._iCreateInfo & (CF_ONLYGOOD | CF_SMITHPREMIUM | CF_BOY | CF_WITCH)) != 0;
 
-	uint32_t currentSeed = GetLCGEngineState();
+	const uint32_t currentSeed = GetLCGEngineState();
 	SetRndSeed(item._iSeed);
 
 	int minlvl;
@@ -2229,7 +2229,7 @@ std::string GetTranslatedItemNameMagical(const Item &item, bool hellfireItem, bo
 		maxlvl = iblvl;
 	} else {
 		DiscardRandomValues(1); // GetItemAttrs
-		int iblvl = GetItemBLevel(lvl, item._iMiscId, onlygood, item._iCreateInfo & CF_UPER15);
+		const int iblvl = GetItemBLevel(lvl, item._iMiscId, onlygood, item._iCreateInfo & CF_UPER15);
 		minlvl = iblvl / 2;
 		maxlvl = iblvl;
 		DiscardRandomValues(1); // CheckUnique
@@ -2259,7 +2259,7 @@ std::string GetTranslatedItemNameMagical(const Item &item, bool hellfireItem, bo
 		affixItemType = AffixItemType::Armor;
 		break;
 	case ItemType::Staff: {
-		bool allowspells = !hellfireItem || ((item._iCreateInfo & CF_SMITHPREMIUM) == 0);
+		const bool allowspells = !hellfireItem || ((item._iCreateInfo & CF_SMITHPREMIUM) == 0);
 
 		if (!allowspells)
 			affixItemType = AffixItemType::Staff;
@@ -2385,7 +2385,7 @@ void InitItemGFX()
 {
 	char arglist[64];
 
-	int itemTypes = gbIsHellfire ? ITEMTYPES : 35;
+	const int itemTypes = gbIsHellfire ? ITEMTYPES : 35;
 	for (int i = 0; i < itemTypes; i++) {
 		*BufCopy(arglist, "items\\", ItemDropNames[i]) = '\0';
 		itemanims[i] = LoadCel(arglist, ItemAnimWidth);
@@ -2630,9 +2630,9 @@ PlayerWeaponGraphic GetPlrAnimWeaponId(const Player &player)
 {
 	const Item &leftHandItem = player.InvBody[INVLOC_HAND_LEFT];
 	const Item &rightHandItem = player.InvBody[INVLOC_HAND_RIGHT];
-	bool holdsShield = player.isHoldingItem(ItemType::Shield);
-	bool leftHandUsable = player.CanUseItem(leftHandItem);
-	bool rightHandUsable = player.CanUseItem(rightHandItem);
+	const bool holdsShield = player.isHoldingItem(ItemType::Shield);
+	const bool leftHandUsable = player.CanUseItem(leftHandItem);
+	const bool rightHandUsable = player.CanUseItem(rightHandItem);
 	ItemType weaponItemType = ItemType::None;
 
 	if (!leftHandItem.isEmpty() && leftHandItem._iClass == ICLASS_WEAPON && leftHandUsable) {
@@ -2662,7 +2662,7 @@ PlayerWeaponGraphic GetPlrAnimWeaponId(const Player &player)
 PlayerArmorGraphic GetPlrAnimArmorId(Player &player)
 {
 	const Item &chestItem = player.InvBody[INVLOC_CHEST];
-	bool chestUsable = player.CanUseItem(chestItem);
+	const bool chestUsable = player.CanUseItem(chestItem);
 	const uint8_t playerLevel = player.getCharacterLevel();
 
 	if (chestUsable) {
@@ -2699,7 +2699,7 @@ void CalcPlrGraphics(Player &player, PlayerWeaponGraphic animWeaponId, PlayerArm
 		ResetPlayerGFX(player);
 		SetPlrAnims(player);
 		player.previewCelSprite = std::nullopt;
-		player_graphic graphic = player.getGraphic();
+		const player_graphic graphic = player.getGraphic();
 		int8_t numberOfFrames;
 		int8_t ticksPerFrame;
 		player.getAnimationFramesAndTicksPerFrame(graphic, numberOfFrames, ticksPerFrame);
@@ -2718,7 +2718,7 @@ void CalcPlrAuricBonus(Player &player)
 {
 	if (&player == MyPlayer) {
 		if (player.InvBody[INVLOC_AMULET].isEmpty() || player.InvBody[INVLOC_AMULET].IDidx != IDI_AURIC) {
-			int half = MaxGold;
+			const int half = MaxGold;
 			MaxGold = GOLD_MAX_LIMIT;
 
 			if (half != MaxGold)
@@ -2977,8 +2977,8 @@ void CreatePlrItems(Player &player)
 	}
 
 	InitCursor();
-	for (auto &itemChoice : loadout.items) {
-		_item_indexes itemData = gbIsHellfire && itemChoice.hellfire != _item_indexes::IDI_NONE ? itemChoice.hellfire : itemChoice.diablo;
+	for (const auto &itemChoice : loadout.items) {
+		const _item_indexes itemData = gbIsHellfire && itemChoice.hellfire != _item_indexes::IDI_NONE ? itemChoice.hellfire : itemChoice.diablo;
 		if (itemData != _item_indexes::IDI_NONE)
 			CreateStartingItem(player, itemData);
 	}
@@ -3030,7 +3030,7 @@ int AllocateItem()
 {
 	assert(ActiveItemCount < MAXITEMS);
 
-	int inum = ActiveItems[ActiveItemCount];
+	const int inum = ActiveItems[ActiveItemCount];
 	ActiveItemCount++;
 
 	Items[inum] = {};
@@ -3042,7 +3042,7 @@ uint8_t PlaceItemInWorld(Item &&item, WorldTilePosition position)
 {
 	assert(ActiveItemCount < MAXITEMS);
 
-	uint8_t ii = ActiveItems[ActiveItemCount];
+	const uint8_t ii = ActiveItems[ActiveItemCount];
 	ActiveItemCount++;
 
 	dItem[position.x][position.y] = static_cast<int8_t>(ii + 1);
@@ -3062,7 +3062,7 @@ uint8_t PlaceItemInWorld(Item &&item, WorldTilePosition position)
 
 Point GetSuperItemLoc(Point position)
 {
-	std::optional<Point> itemPosition = FindClosestValidPosition(ItemSpaceOk, position, 1, 50);
+	const std::optional<Point> itemPosition = FindClosestValidPosition(ItemSpaceOk, position, 1, 50);
 
 	return itemPosition.value_or(Point { 0, 0 }); // TODO handle no space for dropping items
 }
@@ -3106,7 +3106,7 @@ void GetItemAttrs(Item &item, _item_indexes itemData, int lvl)
 		return;
 
 	int rndv;
-	int itemlevel = ItemsGetCurrlevel();
+	const int itemlevel = ItemsGetCurrlevel();
 	switch (sgGameInitInfo.nDifficulty) {
 	case DIFF_NORMAL:
 		rndv = 5 * itemlevel + GenerateRnd(10 * itemlevel);
@@ -3136,7 +3136,7 @@ Item *SpawnUnique(_unique_items uid, Point position, std::optional<int> level /*
 	if (ActiveItemCount >= MAXITEMS)
 		return nullptr;
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	auto &item = Items[ii];
 	if (exactPosition && CanPut(position)) {
 		item.position = position;
@@ -3158,7 +3158,7 @@ Item *SpawnUnique(_unique_items uid, Point position, std::optional<int> level /*
 		if (level)
 			curlv = *level;
 		const ItemData &uniqueItemData = AllItemsList[idx];
-		_item_indexes dropIdx = GetItemIndexForDroppableItem(false, [&uniqueItemData](const ItemData &item) {
+		const _item_indexes dropIdx = GetItemIndexForDroppableItem(false, [&uniqueItemData](const ItemData &item) {
 			return item.itype == uniqueItemData.itype;
 		});
 		SetupAllItems(*MyPlayer, item, dropIdx, AdvanceRndSeed(), curlv * 2, 15, true, false);
@@ -3180,7 +3180,7 @@ void GetSuperItemSpace(Point position, int8_t inum)
 	for (int k = 2; k < 50; k++) {
 		for (int j = -k; j <= k; j++) {
 			for (int i = -k; i <= k; i++) {
-				Displacement offset = { i, j };
+				const Displacement offset = { i, j };
 				positionToCheck = position + offset;
 				if (!ItemSpaceOk(positionToCheck))
 					continue;
@@ -3223,7 +3223,7 @@ void SetupAllItems(const Player &player, Item &item, _item_indexes idx, uint32_t
 		item._iCreateInfo |= CF_UPER1;
 
 	if (item._iMiscId != IMISC_UNIQUE) {
-		int iblvl = GetItemBLevel(lvl, item._iMiscId, onlygood, uper == 15);
+		const int iblvl = GetItemBLevel(lvl, item._iMiscId, onlygood, uper == 15);
 		if (iblvl != -1) {
 			_unique_items uid = UITEM_INVALID;
 			if (!forceNotUnique) {
@@ -3261,7 +3261,7 @@ void TryRandomUniqueItem(Item &item, _item_indexes idx, int8_t mLevel, int uper,
 
 	// Get item base level, which is used in CheckUnique to get the correct valid uniques for the base item.
 	DiscardRandomValues(1); // GetItemAttrs
-	int blvl = GetItemBLevel(mLevel, item._iMiscId, onlygood, uper == 15);
+	const int blvl = GetItemBLevel(mLevel, item._iMiscId, onlygood, uper == 15);
 
 	// Gather all potential unique items. uid is the index into UniqueItems.
 	auto validUniques = GetValidUniques(blvl, AllItemsList[static_cast<size_t>(idx)].iItemId);
@@ -3281,7 +3281,7 @@ void TryRandomUniqueItem(Item &item, _item_indexes idx, int8_t mLevel, int uper,
 			mLevel += 4;
 		uper = 1;
 
-		Point itemPos = item.position;
+		const Point itemPos = item.position;
 
 		// Force generate a non-unique item.
 		DiabloGenerator itemGenerator(item._iSeed);
@@ -3294,8 +3294,8 @@ void TryRandomUniqueItem(Item &item, _item_indexes idx, int8_t mLevel, int uper,
 		return;
 	}
 
-	int32_t uidsIdx = std::max<int32_t>(0, GenerateRnd(static_cast<int32_t>(uids.size()))); // Index into uids, used to get a random uid from the uids vector.
-	int uid = uids[uidsIdx];                                                                // Actual unique id.
+	const int32_t uidsIdx = std::max<int32_t>(0, GenerateRnd(static_cast<int32_t>(uids.size()))); // Index into uids, used to get a random uid from the uids vector.
+	const int uid = uids[uidsIdx];                                                                // Actual unique id.
 	const UniqueItem &uniqueItem = UniqueItems[uid];
 
 	// If the selected unique was already generated, there is no need to fiddle with its parameters.
@@ -3363,8 +3363,8 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg, bool spawn /*= fa
 	_item_indexes idx;
 	bool onlygood = true;
 
-	bool dropsSpecialTreasure = (monster.data().treasure & T_UNIQ) != 0;
-	bool dropBrain = Quests[Q_MUSHROOM]._qactive == QUEST_ACTIVE && Quests[Q_MUSHROOM]._qvar1 == QS_MUSHGIVEN;
+	const bool dropsSpecialTreasure = (monster.data().treasure & T_UNIQ) != 0;
+	const bool dropBrain = Quests[Q_MUSHROOM]._qactive == QUEST_ACTIVE && Quests[Q_MUSHROOM]._qvar1 == QS_MUSHGIVEN;
 
 	if (dropsSpecialTreasure && !UseMultiplayerQuests()) {
 		Item *uniqueItem = SpawnUnique(static_cast<_unique_items>(monster.data().treasure & T_MASK), position, std::nullopt, false);
@@ -3386,7 +3386,7 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg, bool spawn /*= fa
 			NetSendCmdQuest(true, Quests[Q_MUSHROOM]);
 			// Drop the brain as extra item to ensure that all clients see the brain drop
 			// When executing SpawnItem is not reliable, because another client can already have the quest state updated before SpawnItem is executed
-			Point posBrain = GetSuperItemLoc(position);
+			const Point posBrain = GetSuperItemLoc(position);
 			SpawnQuestItem(IDI_BRAIN, posBrain, 0, SelectionRegion::None, true);
 		}
 		// Normal monster
@@ -3402,12 +3402,12 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg, bool spawn /*= fa
 	if (ActiveItemCount >= MAXITEMS)
 		return;
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	auto &item = Items[ii];
 	GetSuperItemSpace(position, ii);
-	int uper = monster.isUnique() ? 15 : 1;
+	const int uper = monster.isUnique() ? 15 : 1;
 
-	int8_t mLevel = monster.data().level;
+	const int8_t mLevel = monster.data().level;
 	SetupAllItems(*MyPlayer, item, idx, AdvanceRndSeed(), mLevel, uper, onlygood, false, false);
 	TryRandomUniqueItem(item, idx, mLevel, uper, onlygood, false);
 	SetupItem(item);
@@ -3420,7 +3420,7 @@ void SpawnItem(Monster &monster, Point position, bool sendmsg, bool spawn /*= fa
 
 void CreateRndItem(Point position, bool onlygood, bool sendmsg, bool delta)
 {
-	_item_indexes idx = onlygood ? RndUItem(nullptr) : RndAllItems();
+	const _item_indexes idx = onlygood ? RndUItem(nullptr) : RndAllItems();
 
 	SetupBaseItem(position, idx, onlygood, sendmsg, delta);
 }
@@ -3430,10 +3430,10 @@ void CreateRndUseful(Point position, bool sendmsg)
 	if (ActiveItemCount >= MAXITEMS)
 		return;
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	auto &item = Items[ii];
 	GetSuperItemSpace(position, ii);
-	int curlv = ItemsGetCurrlevel();
+	const int curlv = ItemsGetCurrlevel();
 
 	SetupAllUseful(item, AdvanceRndSeed(), curlv);
 	if (sendmsg)
@@ -3444,7 +3444,7 @@ void CreateTypeItem(Point position, bool onlygood, ItemType itemType, int imisc,
 {
 	_item_indexes idx;
 
-	int curlv = ItemsGetCurrlevel();
+	const int curlv = ItemsGetCurrlevel();
 	if (itemType != ItemType::Gold)
 		idx = RndTypeItems(itemType, imisc, curlv);
 	else
@@ -3455,7 +3455,7 @@ void CreateTypeItem(Point position, bool onlygood, ItemType itemType, int imisc,
 
 void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t icreateinfo, uint32_t iseed, int ivalue, uint32_t dwBuff)
 {
-	bool tmpIsHellfire = gbIsHellfire;
+	const bool tmpIsHellfire = gbIsHellfire;
 	item.dwBuff = dwBuff;
 	gbIsHellfire = (item.dwBuff & CF_HELLFIRE) != 0;
 
@@ -3490,7 +3490,7 @@ void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t 
 		}
 	}
 
-	int level = icreateinfo & CF_LEVEL;
+	const int level = icreateinfo & CF_LEVEL;
 
 	int uper = 0;
 	if ((icreateinfo & CF_UPER1) != 0)
@@ -3498,9 +3498,9 @@ void RecreateItem(const Player &player, Item &item, _item_indexes idx, uint16_t 
 	if ((icreateinfo & CF_UPER15) != 0)
 		uper = 15;
 
-	bool onlygood = (icreateinfo & CF_ONLYGOOD) != 0;
-	bool forceNotUnique = (icreateinfo & CF_UNIQUE) == 0;
-	bool pregen = (icreateinfo & CF_PREGEN) != 0;
+	const bool onlygood = (icreateinfo & CF_ONLYGOOD) != 0;
+	const bool forceNotUnique = (icreateinfo & CF_UNIQUE) == 0;
+	const bool pregen = (icreateinfo & CF_PREGEN) != 0;
 	auto uidOffset = static_cast<int>((item.dwBuff & CF_UIDOFFSET) >> 1);
 
 	SetupAllItems(player, item, idx, iseed, level, uper, onlygood, pregen, uidOffset, forceNotUnique);
@@ -3512,7 +3512,7 @@ void RecreateEar(Item &item, uint16_t ic, uint32_t iseed, uint8_t bCursval, std:
 {
 	InitializeItem(item, IDI_EAR);
 
-	std::string itemName = fmt::format(fmt::runtime("Ear of {:s}"), heroName);
+	const std::string itemName = fmt::format(fmt::runtime("Ear of {:s}"), heroName);
 
 	CopyUtf8(item._iName, itemName, ItemNameLength);
 	CopyUtf8(item._iIName, heroName, ItemNameLength);
@@ -3551,7 +3551,7 @@ void CornerstoneLoad(Point position)
 	CornerStone.item.clear();
 	CornerStone.activated = true;
 	if (dItem[position.x][position.y] != 0) {
-		int ii = dItem[position.x][position.y] - 1;
+		const int ii = dItem[position.x][position.y] - 1;
 		for (int i = 0; i < ActiveItemCount; i++) {
 			if (ActiveItems[i] == ii) {
 				DeleteItem(i);
@@ -3566,7 +3566,7 @@ void CornerstoneLoad(Point position)
 
 	Hex2bin(GetOptions().Hellfire.szItem, sizeof(ItemPack), reinterpret_cast<uint8_t *>(&pkSItem));
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	auto &item = Items[ii];
 
 	dItem[position.x][position.y] = static_cast<int8_t>(ii + 1);
@@ -3603,14 +3603,14 @@ void SpawnQuestItem(_item_indexes itemid, Point position, int randarea, Selectio
 	if (ActiveItemCount >= MAXITEMS)
 		return;
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	auto &item = Items[ii];
 
 	item.position = position;
 
 	dItem[position.x][position.y] = ii + 1;
 
-	int curlv = ItemsGetCurrlevel();
+	const int curlv = ItemsGetCurrlevel();
 	GetItemAttrs(item, itemid, curlv);
 
 	SetupItem(item);
@@ -3636,12 +3636,12 @@ void SpawnRewardItem(_item_indexes itemid, Point position, bool sendmsg)
 	if (ActiveItemCount >= MAXITEMS)
 		return;
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	auto &item = Items[ii];
 
 	item.position = position;
 	dItem[position.x][position.y] = ii + 1;
-	int curlv = ItemsGetCurrlevel();
+	const int curlv = ItemsGetCurrlevel();
 	GetItemAttrs(item, itemid, curlv);
 	item.setNewAnimation(true);
 	item.selectionRegion = SelectionRegion::Middle;
@@ -3671,7 +3671,7 @@ void SpawnTheodore(Point position, bool sendmsg)
 
 void RespawnItem(Item &item, bool flipFlag)
 {
-	int it = ItemCAnimTbl[item._iCurs];
+	const int it = ItemCAnimTbl[item._iCurs];
 	item.setNewAnimation(flipFlag);
 	item._iRequest = false; // Item isn't being picked up by a player
 
@@ -3719,7 +3719,7 @@ void DeleteItem(int i)
 void ProcessItems()
 {
 	for (int i = 0; i < ActiveItemCount; i++) {
-		int ii = ActiveItems[i];
+		const int ii = ActiveItems[i];
 		auto &item = Items[ii];
 		if (!item._iAnimFlag)
 			continue;
@@ -3752,7 +3752,7 @@ void FreeItemGFX()
 
 void GetItemFrm(Item &item)
 {
-	int it = ItemCAnimTbl[item._iCurs];
+	const int it = ItemCAnimTbl[item._iCurs];
 	if (itemanims[it])
 		item.AnimInfo.sprites.emplace(*itemanims[it]);
 }
@@ -3763,7 +3763,7 @@ void GetItemStr(Item &item)
 		InfoString = item.getName();
 		InfoColor = item.getTextColor();
 	} else {
-		int nGold = item._ivalue;
+		const int nGold = item._ivalue;
 		InfoString = fmt::format(fmt::runtime(ngettext("{:s} gold piece", "{:s} gold pieces", nGold)), FormatInteger(nGold));
 	}
 }
@@ -4227,7 +4227,7 @@ void UseItem(Player &player, item_misc_id mid, SpellID spellID, int spellFrom)
 		}
 		break;
 	case IMISC_BOOK: {
-		uint8_t newSpellLevel = player._pSplLvl[static_cast<int8_t>(spellID)] + 1;
+		const uint8_t newSpellLevel = player._pSplLvl[static_cast<int8_t>(spellID)] + 1;
 		if (newSpellLevel <= MaxSpellLevel) {
 			player._pSplLvl[static_cast<int8_t>(spellID)] = newSpellLevel;
 			NetSendCmdParam2(true, CMD_CHANGE_SPELL_LEVEL, static_cast<uint16_t>(spellID), newSpellLevel);
@@ -4312,7 +4312,7 @@ bool UseItemOpensHive(const Item &item, Point position)
 	if (item.IDidx != IDI_RUNEBOMB)
 		return false;
 	for (auto dir : PathDirs) {
-		Point adjacentPosition = position + dir;
+		const Point adjacentPosition = position + dir;
 		if (OpensHive(adjacentPosition))
 			return true;
 	}
@@ -4324,7 +4324,7 @@ bool UseItemOpensGrave(const Item &item, Point position)
 	if (item.IDidx != IDI_MAPOFDOOM)
 		return false;
 	for (auto dir : PathDirs) {
-		Point adjacentPosition = position + dir;
+		const Point adjacentPosition = position + dir;
 		if (OpensGrave(adjacentPosition))
 			return true;
 	}
@@ -4342,7 +4342,7 @@ void SpawnSmith(int lvl)
 		maxItems = NumSmithBasicItemsHf;
 	}
 
-	int iCnt = RandomIntBetween(10, maxItems);
+	const int iCnt = RandomIntBetween(10, maxItems);
 	for (int i = 0; i < iCnt; i++) {
 		Item &newItem = SmithItems[i];
 
@@ -4350,7 +4350,7 @@ void SpawnSmith(int lvl)
 			newItem = {};
 			newItem._iSeed = AdvanceRndSeed();
 			SetRndSeed(newItem._iSeed);
-			_item_indexes itemData = RndSmithItem(*MyPlayer, lvl);
+			const _item_indexes itemData = RndSmithItem(*MyPlayer, lvl);
 			GetItemAttrs(newItem, itemData, lvl);
 		} while (newItem._iIvalue > maxValue);
 
@@ -4365,12 +4365,12 @@ void SpawnSmith(int lvl)
 
 void SpawnPremium(const Player &player)
 {
-	int lvl = player.getCharacterLevel();
-	int maxItems = gbIsHellfire ? NumSmithItemsHf : NumSmithItems;
+	const int lvl = player.getCharacterLevel();
+	const int maxItems = gbIsHellfire ? NumSmithItemsHf : NumSmithItems;
 	if (PremiumItemCount < maxItems) {
 		for (int i = 0; i < maxItems; i++) {
 			if (PremiumItems[i].isEmpty()) {
-				int plvl = PremiumItemLevel + (gbIsHellfire ? itemLevelAddHf[i] : itemLevelAdd[i]);
+				const int plvl = PremiumItemLevel + (gbIsHellfire ? itemLevelAddHf[i] : itemLevelAdd[i]);
 				SpawnOnePremium(PremiumItems[i], plvl, player);
 			}
 		}
@@ -4422,7 +4422,7 @@ void SpawnWitch(int lvl)
 
 		if (gbIsHellfire) {
 			if (i < PinnedItemCount + MaxPinnedBookCount && bookCount < pinnedBookCount) {
-				_item_indexes bookType = PinnedBookTypes[i - PinnedItemCount];
+				const _item_indexes bookType = PinnedBookTypes[i - PinnedItemCount];
 				if (lvl >= AllItemsList[bookType].iMinMLvl) {
 					item._iSeed = AdvanceRndSeed();
 					SetRndSeed(item._iSeed);
@@ -4445,7 +4445,7 @@ void SpawnWitch(int lvl)
 			item = {};
 			item._iSeed = AdvanceRndSeed();
 			SetRndSeed(item._iSeed);
-			_item_indexes itemData = RndWitchItem(*MyPlayer, lvl);
+			const _item_indexes itemData = RndWitchItem(*MyPlayer, lvl);
 			GetItemAttrs(item, itemData, lvl);
 			int maxlvl = -1;
 			if (GenerateRnd(100) <= 5)
@@ -4469,9 +4469,9 @@ void SpawnBoy(int lvl)
 	bool keepgoing = false;
 	int count = 0;
 
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
-	HeroClass pc = myPlayer._pClass;
+	const HeroClass pc = myPlayer._pClass;
 	int strength = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Strength), myPlayer._pStrength);
 	int dexterity = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Dexterity), myPlayer._pDexterity);
 	int magic = std::max(myPlayer.GetMaximumAttributeValue(CharacterAttribute::Magic), myPlayer._pMagic);
@@ -4486,7 +4486,7 @@ void SpawnBoy(int lvl)
 		BoyItem = {};
 		BoyItem._iSeed = AdvanceRndSeed();
 		SetRndSeed(BoyItem._iSeed);
-		_item_indexes itype = RndBoyItem(*MyPlayer, lvl);
+		const _item_indexes itype = RndBoyItem(*MyPlayer, lvl);
 		GetItemAttrs(BoyItem, itype, lvl);
 		GetItemBonus(*MyPlayer, BoyItem, lvl, 2 * lvl, true, true);
 
@@ -4500,7 +4500,7 @@ void SpawnBoy(int lvl)
 
 		ivalue = 0;
 
-		ItemType itemType = BoyItem._itype;
+		const ItemType itemType = BoyItem._itype;
 
 		switch (itemType) {
 		case ItemType::LightArmor:
@@ -4602,7 +4602,7 @@ void SpawnHealer(int lvl)
 
 		item._iSeed = AdvanceRndSeed();
 		SetRndSeed(item._iSeed);
-		_item_indexes itype = RndHealerItem(*MyPlayer, lvl);
+		const _item_indexes itype = RndHealerItem(*MyPlayer, lvl);
 		GetItemAttrs(item, itype, lvl);
 		item._iCreateInfo = lvl | CF_HEALER;
 		item._iIdentified = true;
@@ -4622,7 +4622,7 @@ void MakeGoldStack(Item &goldItem, int value)
 
 int ItemNoFlippy()
 {
-	int r = ActiveItems[ActiveItemCount - 1];
+	const int r = ActiveItems[ActiveItemCount - 1];
 	Items[r].AnimInfo.currentFrame = Items[r].AnimInfo.numberOfFrames - 1;
 	Items[r]._iAnimFlag = false;
 	Items[r].selectionRegion = SelectionRegion::Bottom;
@@ -4641,11 +4641,11 @@ void CreateSpellBook(Point position, SpellID ispell, bool sendmsg, bool delta)
 		}
 	}
 
-	_item_indexes idx = RndTypeItems(ItemType::Misc, IMISC_BOOK, lvl);
+	const _item_indexes idx = RndTypeItems(ItemType::Misc, IMISC_BOOK, lvl);
 	if (ActiveItemCount >= MAXITEMS)
 		return;
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	auto &item = Items[ii];
 
 	while (true) {
@@ -4665,7 +4665,7 @@ void CreateSpellBook(Point position, SpellID ispell, bool sendmsg, bool delta)
 
 void CreateMagicArmor(Point position, ItemType itemType, int icurs, bool sendmsg, bool delta)
 {
-	int lvl = ItemsGetCurrlevel();
+	const int lvl = ItemsGetCurrlevel();
 	CreateMagicItem(position, lvl, itemType, IMISC_NONE, icurs, sendmsg, delta);
 }
 
@@ -4680,14 +4680,14 @@ void CreateMagicWeapon(Point position, ItemType itemType, int icurs, bool sendms
 	if (itemType == ItemType::Staff)
 		imid = IMISC_STAFF;
 
-	int curlv = ItemsGetCurrlevel();
+	const int curlv = ItemsGetCurrlevel();
 
 	CreateMagicItem(position, curlv, itemType, imid, icurs, sendmsg, delta);
 }
 
 bool GetItemRecord(uint32_t nSeed, uint16_t wCI, int nIndex)
 {
-	uint32_t ticks = SDL_GetTicks();
+	const uint32_t ticks = SDL_GetTicks();
 
 	for (int i = 0; i < gnNumGetRecords; i++) {
 		if (ticks - itemrecord[i].dwTimestamp > 6000) {
@@ -4704,7 +4704,7 @@ bool GetItemRecord(uint32_t nSeed, uint16_t wCI, int nIndex)
 
 void SetItemRecord(uint32_t nSeed, uint16_t wCI, int nIndex)
 {
-	uint32_t ticks = SDL_GetTicks();
+	const uint32_t ticks = SDL_GetTicks();
 
 	if (gnNumGetRecords == MAXITEMS) {
 		return;
@@ -4719,7 +4719,7 @@ void SetItemRecord(uint32_t nSeed, uint16_t wCI, int nIndex)
 
 void PutItemRecord(uint32_t nSeed, uint16_t wCI, int nIndex)
 {
-	uint32_t ticks = SDL_GetTicks();
+	const uint32_t ticks = SDL_GetTicks();
 
 	for (int i = 0; i < gnNumGetRecords; i++) {
 		if (ticks - itemrecord[i].dwTimestamp > 6000) {
@@ -4741,9 +4741,9 @@ bool Item::isUsable() const
 
 void Item::setNewAnimation(bool showAnimation)
 {
-	int8_t it = ItemCAnimTbl[_iCurs];
-	int8_t numberOfFrames = ItemAnimLs[it];
-	OptionalClxSpriteList sprite = itemanims[it] ? OptionalClxSpriteList { *itemanims[static_cast<size_t>(it)] } : std::nullopt;
+	const int8_t it = ItemCAnimTbl[_iCurs];
+	const int8_t numberOfFrames = ItemAnimLs[it];
+	const OptionalClxSpriteList sprite = itemanims[it] ? OptionalClxSpriteList { *itemanims[static_cast<size_t>(it)] } : std::nullopt;
 	if (_iCurs != ICURS_MAGIC_ROCK)
 		AnimInfo.setNewAnimation(sprite, numberOfFrames, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
 	else
@@ -4833,7 +4833,7 @@ void RechargeItem(Item &item, Player &player)
 	if (item._iCharges == item._iMaxCharges)
 		return;
 
-	int rechargeStrength = RandomIntBetween(1, player.getCharacterLevel() / GetSpellStaffLevel(item._iSpell));
+	const int rechargeStrength = RandomIntBetween(1, player.getCharacterLevel() / GetSpellStaffLevel(item._iSpell));
 
 	do {
 		item._iMaxCharges--;
@@ -4985,14 +4985,14 @@ void UpdateHellfireFlag(Item &item, const char *identifiedItemName)
 	if (gbIsMultiplayer)
 		return; // Vanilla hellfire multiplayer is not supported in devilutionX, so there can't be items with missing dwBuff from there
 	// We need to test both short and long name, because StringInPanel can return a different result (other font and some bugfixes)
-	std::string diabloItemNameShort = GetTranslatedItemNameMagical(item, false, false, false);
+	const std::string diabloItemNameShort = GetTranslatedItemNameMagical(item, false, false, false);
 	if (diabloItemNameShort == identifiedItemName)
 		return; // Diablo item name is identical => not a hellfire specific item
-	std::string diabloItemNameLong = GetTranslatedItemNameMagical(item, false, false, true);
+	const std::string diabloItemNameLong = GetTranslatedItemNameMagical(item, false, false, true);
 	if (diabloItemNameLong == identifiedItemName)
 		return; // Diablo item name is identical => not a hellfire specific item
-	std::string hellfireItemNameShort = GetTranslatedItemNameMagical(item, true, false, false);
-	std::string hellfireItemNameLong = GetTranslatedItemNameMagical(item, true, false, true);
+	const std::string hellfireItemNameShort = GetTranslatedItemNameMagical(item, true, false, false);
+	const std::string hellfireItemNameLong = GetTranslatedItemNameMagical(item, true, false, true);
 	if (hellfireItemNameShort == identifiedItemName || hellfireItemNameLong == identifiedItemName) {
 		// This item should be a vanilla hellfire item that has CF_HELLFIRE missing, cause only then the item name matches
 		item.dwBuff |= CF_HELLFIRE;

--- a/Source/items/validation.cpp
+++ b/Source/items/validation.cpp
@@ -184,7 +184,7 @@ bool IsItemDeltaValid(const TCmdPItem &itemDelta)
 		return false;
 	if (!InDungeonBounds({ itemDelta.x, itemDelta.y }))
 		return false;
-	_item_indexes idx = static_cast<_item_indexes>(SDL_SwapLE16(itemDelta.def.wIndx));
+	const _item_indexes idx = static_cast<_item_indexes>(SDL_SwapLE16(itemDelta.def.wIndx));
 	if (idx == IDI_EAR)
 		return true;
 	if (!IsItemAvailable(idx))

--- a/Source/levels/crypt.cpp
+++ b/Source/levels/crypt.cpp
@@ -616,28 +616,28 @@ void PlaceMiniSetRandom1x1(uint8_t search, uint8_t replace, int rndper)
 
 void CryptCracked(int rndper)
 {
-	for (ReplaceTile pair : CrackedTiles) {
+	for (const ReplaceTile pair : CrackedTiles) {
 		PlaceMiniSetRandom1x1(pair.search, pair.replace, rndper);
 	}
 }
 
 void CryptBroken(int rndper)
 {
-	for (ReplaceTile pair : BrokenTiles) {
+	for (const ReplaceTile pair : BrokenTiles) {
 		PlaceMiniSetRandom1x1(pair.search, pair.replace, rndper);
 	}
 }
 
 void CryptLeaking(int rndper)
 {
-	for (ReplaceTile pair : LeakingTiles) {
+	for (const ReplaceTile pair : LeakingTiles) {
 		PlaceMiniSetRandom1x1(pair.search, pair.replace, rndper);
 	}
 }
 
 void CryptSubstitions1(int rndper)
 {
-	for (ReplaceTile pair : Substitions1Tiles) {
+	for (const ReplaceTile pair : Substitions1Tiles) {
 		PlaceMiniSetRandom1x1(pair.search, pair.replace, rndper);
 	}
 }
@@ -651,14 +651,14 @@ void CryptSubstitions2(int rndper)
 	PlaceMiniSetRandom(CryptPillar5, rndper);
 	PlaceMiniSetRandom(CryptStar, rndper);
 
-	for (ReplaceTile pair : Substition1Floor) {
+	for (const ReplaceTile pair : Substition1Floor) {
 		PlaceMiniSetRandom1x1(pair.search, pair.replace, rndper);
 	}
 }
 
 void CryptFloor(int rndper)
 {
-	for (ReplaceTile pair : Substition2Floor) {
+	for (const ReplaceTile pair : Substition2Floor) {
 		PlaceMiniSetRandom1x1(pair.search, pair.replace, rndper);
 	}
 }
@@ -680,7 +680,7 @@ void InitCryptPieces()
 
 void SetCryptRoom()
 {
-	Point position = SelectChamber();
+	const Point position = SelectChamber();
 
 	UberRow = 2 * position.x + 6;
 	UberCol = 2 * position.y + 8;
@@ -696,7 +696,7 @@ void SetCryptRoom()
 
 void SetCornerRoom()
 {
-	Point position = SelectChamber();
+	const Point position = SelectChamber();
 
 	auto dunData = LoadFileInMem<uint16_t>("nlevels\\l5data\\cornerstone.dun");
 
@@ -750,7 +750,7 @@ bool PlaceCryptStairs(lvl_entry entry)
 
 void CryptSubstitution()
 {
-	for (ReplaceTile pair : Statues) {
+	for (const ReplaceTile pair : Statues) {
 		PlaceMiniSetRandom1x1(pair.search, pair.replace, 10);
 	}
 	PlaceMiniSetRandom1x1(VArch, VArch5, 95);

--- a/Source/levels/drlg_l1.cpp
+++ b/Source/levels/drlg_l1.cpp
@@ -373,7 +373,7 @@ void FillFloor()
 			if (dungeon[i][j] != Floor || Protected.test(i, j))
 				continue;
 
-			int rv = RandomIntLessThan(3);
+			const int rv = RandomIntLessThan(3);
 			if (rv == 1)
 				dungeon[i][j] = Floor22;
 			else if (rv == 2)
@@ -395,7 +395,7 @@ void InitSetPiece()
 		return; // no setpiece needed for this level
 	}
 
-	WorldTilePosition setPiecePosition = SelectChamber();
+	const WorldTilePosition setPiecePosition = SelectChamber();
 	PlaceDunTiles(setPieceData.get(), setPiecePosition, Floor);
 	SetPiece = { setPiecePosition, GetDunSize(setPieceData.get()) };
 }
@@ -459,7 +459,7 @@ bool CheckRoom(Rectangle room)
 
 void GenerateRoom(Rectangle area, bool verticalLayout)
 {
-	bool rotate = FlipCoin(4);
+	const bool rotate = FlipCoin(4);
 	verticalLayout = (!verticalLayout && rotate) || (verticalLayout && !rotate);
 
 	bool placeRoom1;
@@ -518,7 +518,7 @@ void FirstRoom()
 		HasChamber2 = true;
 
 	Rectangle chamber1 { { 1, 15 }, { 10, 10 } };
-	Rectangle chamber2 { { 15, 15 }, { 10, 10 } };
+	const Rectangle chamber2 { { 15, 15 }, { 10, 10 } };
 	Rectangle chamber3 { { 29, 15 }, { 10, 10 } };
 	Rectangle hallway { { 1, 17 }, { 38, 6 } };
 	if (!HasChamber1) {
@@ -653,7 +653,7 @@ void HorizontalWall(Point position, Tile start, int maxX)
 		dungeon[position.x + x][position.y] = wallTile;
 	}
 
-	int x = GenerateRnd(maxX - 1) + 1;
+	const int x = GenerateRnd(maxX - 1) + 1;
 
 	dungeon[position.x + x][position.y] = doorTile;
 	if (doorTile == HDoor) {
@@ -695,7 +695,7 @@ void VerticalWall(Point position, Tile start, int maxY)
 		dungeon[position.x][position.y + y] = wallTile;
 	}
 
-	int y = GenerateRnd(maxY - 1) + 1;
+	const int y = GenerateRnd(maxY - 1) + 1;
 
 	dungeon[position.x][position.y + y] = doorTile;
 	if (doorTile == VDoor) {
@@ -712,42 +712,42 @@ void AddWall()
 
 			if (dungeon[i][j] == Corner) {
 				DiscardRandomValues(1);
-				int maxX = HorizontalWallOk({ i, j });
+				const int maxX = HorizontalWallOk({ i, j });
 				if (maxX != -1) {
 					HorizontalWall({ i, j }, HWall, maxX);
 				}
 			}
 			if (dungeon[i][j] == Corner) {
 				DiscardRandomValues(1);
-				int maxY = VerticalWallOk({ i, j });
+				const int maxY = VerticalWallOk({ i, j });
 				if (maxY != -1) {
 					VerticalWall({ i, j }, VWall, maxY);
 				}
 			}
 			if (dungeon[i][j] == VWallEnd) {
 				DiscardRandomValues(1);
-				int maxX = HorizontalWallOk({ i, j });
+				const int maxX = HorizontalWallOk({ i, j });
 				if (maxX != -1) {
 					HorizontalWall({ i, j }, DWall, maxX);
 				}
 			}
 			if (dungeon[i][j] == HWallEnd) {
 				DiscardRandomValues(1);
-				int maxY = VerticalWallOk({ i, j });
+				const int maxY = VerticalWallOk({ i, j });
 				if (maxY != -1) {
 					VerticalWall({ i, j }, DWall, maxY);
 				}
 			}
 			if (dungeon[i][j] == HWall) {
 				DiscardRandomValues(1);
-				int maxX = HorizontalWallOk({ i, j });
+				const int maxX = HorizontalWallOk({ i, j });
 				if (maxX != -1) {
 					HorizontalWall({ i, j }, HWall, maxX);
 				}
 			}
 			if (dungeon[i][j] == VWall) {
 				DiscardRandomValues(1);
-				int maxY = VerticalWallOk({ i, j });
+				const int maxY = VerticalWallOk({ i, j });
 				if (maxY != -1) {
 					VerticalWall({ i, j }, VWall, maxY);
 				}
@@ -953,7 +953,7 @@ void Substitution()
 	for (int y = 0; y < DMAXY; y++) {
 		for (int x = 0; x < DMAXX; x++) {
 			if (FlipCoin(4)) {
-				uint8_t c = TileDecorations[dungeon[x][y]];
+				const uint8_t c = TileDecorations[dungeon[x][y]];
 				if (c != 0 && !Protected.test(x, y)) {
 					int rv = GenerateRnd(16);
 					int i = -1;
@@ -1118,9 +1118,9 @@ bool PlaceCathedralStairs(lvl_entry entry)
 		if (!position) {
 			success = false;
 		} else {
-			int8_t t = TransVal;
+			const int8_t t = TransVal;
 			TransVal = 0;
-			Point miniPosition = *position;
+			const Point miniPosition = *position;
 			DRLG_MRectTrans({ miniPosition + Displacement { 0, 2 }, { 5, 2 } });
 			TransVal = t;
 			Quests[Q_PWATER].position = miniPosition.megaToWorld() + Displacement { 5, 6 };
@@ -1202,8 +1202,8 @@ void GenerateLevel(lvl_entry entry)
 	for (int j = 0; j < DMAXY; j++) {
 		for (int i = 0; i < DMAXX; i++) {
 			if (dungeon[i][j] == EntranceStairs) {
-				int xx = 2 * i + 16; /* todo: fix loop */
-				int yy = 2 * j + 16;
+				const int xx = 2 * i + 16; /* todo: fix loop */
+				const int yy = 2 * j + 16;
 				DRLG_CopyTrans(xx, yy + 1, xx, yy);
 				DRLG_CopyTrans(xx + 1, yy + 1, xx + 1, yy);
 			}
@@ -1224,7 +1224,7 @@ void GenerateLevel(lvl_entry entry)
 		Substitution();
 		ApplyShadowsPatterns();
 
-		int numt = GenerateRnd(5) + 5;
+		const int numt = GenerateRnd(5) + 5;
 		for (int i = 0; i < numt; i++) {
 			PlaceMiniSet(LAMPS, DMAXX * DMAXY, true);
 		}

--- a/Source/levels/drlg_l2.cpp
+++ b/Source/levels/drlg_l2.cpp
@@ -1644,7 +1644,7 @@ void InitSetPiece()
 		return; // no setpiece needed for this level
 	}
 
-	WorldTilePosition setPiecePosition = SetPieceRoom.position;
+	const WorldTilePosition setPiecePosition = SetPieceRoom.position;
 	PlaceDunTiles(setPieceData.get(), setPiecePosition, 3);
 	SetPiece = { setPiecePosition, GetDunSize(setPieceData.get()) };
 }
@@ -1769,8 +1769,8 @@ void CreateRoom(WorldTilePosition topLeft, WorldTilePosition bottomRight, int nR
 	if (nRoomCnt >= 80 || topLeft.x + AreaMin > bottomRight.x || topLeft.y + AreaMin > bottomRight.y)
 		return;
 
-	WorldTileDisplacement areaDisplacement = bottomRight - topLeft;
-	WorldTileSize area(areaDisplacement.deltaX, areaDisplacement.deltaY);
+	const WorldTileDisplacement areaDisplacement = bottomRight - topLeft;
+	const WorldTileSize area(areaDisplacement.deltaX, areaDisplacement.deltaY);
 
 	constexpr WorldTileCoord RoomMax = 10;
 	constexpr WorldTileCoord RoomMin = 4;
@@ -1808,7 +1808,7 @@ void CreateRoom(WorldTilePosition topLeft, WorldTilePosition bottomRight, int nR
 	if (size)
 		SetPieceRoom = { roomTopLeft + standoff, roomSize - 1 };
 
-	int nRid = nRoomCnt;
+	const int nRid = nRoomCnt;
 
 	if (nRDest != 0) {
 		WorldTileCoord nHx1 = 0;
@@ -1818,14 +1818,14 @@ void CreateRoom(WorldTilePosition topLeft, WorldTilePosition bottomRight, int nR
 		if (nHDir == HallDirection::Up) {
 			nHx1 = GenerateRnd(roomSize.width - 2) + roomTopLeft.x + 1;
 			nHy1 = roomTopLeft.y;
-			int nHw = RoomList[nRDest].bottomRight.x - RoomList[nRDest].topLeft.x - 2;
+			const int nHw = RoomList[nRDest].bottomRight.x - RoomList[nRDest].topLeft.x - 2;
 			nHx2 = GenerateRnd(nHw) + RoomList[nRDest].topLeft.x + 1;
 			nHy2 = RoomList[nRDest].bottomRight.y;
 		}
 		if (nHDir == HallDirection::Down) {
 			nHx1 = GenerateRnd(roomSize.width - 2) + roomTopLeft.x + 1;
 			nHy1 = roomBottomRight.y;
-			int nHw = RoomList[nRDest].bottomRight.x - RoomList[nRDest].topLeft.x - 2;
+			const int nHw = RoomList[nRDest].bottomRight.x - RoomList[nRDest].topLeft.x - 2;
 			nHx2 = GenerateRnd(nHw) + RoomList[nRDest].topLeft.x + 1;
 			nHy2 = RoomList[nRDest].topLeft.y;
 		}
@@ -1833,21 +1833,21 @@ void CreateRoom(WorldTilePosition topLeft, WorldTilePosition bottomRight, int nR
 			nHx1 = roomBottomRight.x;
 			nHy1 = GenerateRnd(roomSize.height - 2) + roomTopLeft.y + 1;
 			nHx2 = RoomList[nRDest].topLeft.x;
-			int nHh = RoomList[nRDest].bottomRight.y - RoomList[nRDest].topLeft.y - 2;
+			const int nHh = RoomList[nRDest].bottomRight.y - RoomList[nRDest].topLeft.y - 2;
 			nHy2 = GenerateRnd(nHh) + RoomList[nRDest].topLeft.y + 1;
 		}
 		if (nHDir == HallDirection::Left) {
 			nHx1 = roomTopLeft.x;
 			nHy1 = GenerateRnd(roomSize.height - 2) + roomTopLeft.y + 1;
 			nHx2 = RoomList[nRDest].bottomRight.x;
-			int nHh = RoomList[nRDest].bottomRight.y - RoomList[nRDest].topLeft.y - 2;
+			const int nHh = RoomList[nRDest].bottomRight.y - RoomList[nRDest].topLeft.y - 2;
 			nHy2 = GenerateRnd(nHh) + RoomList[nRDest].topLeft.y + 1;
 		}
 		HallList.push_back({ { nHx1, nHy1 }, { nHx2, nHy2 }, nHDir });
 	}
 
-	WorldTilePosition roomBottomLeft { roomTopLeft.x, roomBottomRight.y };
-	WorldTilePosition roomTopRight { roomBottomRight.x, roomTopLeft.y };
+	const WorldTilePosition roomBottomLeft { roomTopLeft.x, roomBottomRight.y };
+	const WorldTilePosition roomTopRight { roomBottomRight.x, roomTopLeft.y };
 	if (roomSize.height > roomSize.width) {
 		CreateRoom(topLeft + standoff, roomBottomLeft - standoff, nRid, HallDirection::Right, {});
 		CreateRoom(roomTopRight + standoff, bottomRight - standoff, nRid, HallDirection::Left, {});
@@ -1866,8 +1866,8 @@ void ConnectHall(const HallNode &node)
 	Point beginning = node.beginning;
 	Point end = node.end;
 
-	bool fMinusFlag = GenerateRnd(100) < 50;
-	bool fPlusFlag = GenerateRnd(100) < 50;
+	const bool fMinusFlag = GenerateRnd(100) < 50;
+	const bool fPlusFlag = GenerateRnd(100) < 50;
 	CreateDoorType(beginning);
 	CreateDoorType(end);
 	HallDirection nCurrd = node.direction;
@@ -1918,10 +1918,10 @@ void ConnectHall(const HallNode &node)
 			if (predungeon[beginning.x][beginning.y] != ',')
 				fInroom = true;
 		}
-		int nDx = std::abs(end.x - beginning.x);
-		int nDy = std::abs(end.y - beginning.y);
+		const int nDx = std::abs(end.x - beginning.x);
+		const int nDy = std::abs(end.y - beginning.y);
 		if (nDx > nDy) {
-			int nRp = std::min(2 * nDx, 30);
+			const int nRp = std::min(2 * nDx, 30);
 			if (GenerateRnd(100) < nRp) {
 				if (end.x <= beginning.x || beginning.x >= DMAXX)
 					nCurrd = HallDirection::Left;
@@ -1929,7 +1929,7 @@ void ConnectHall(const HallNode &node)
 					nCurrd = HallDirection::Right;
 			}
 		} else {
-			int nRp = std::min(5 * nDy, 80);
+			const int nRp = std::min(5 * nDy, 80);
 			if (GenerateRnd(100) < nRp) {
 				if (end.y <= beginning.y || beginning.y >= DMAXY)
 					nCurrd = HallDirection::Up;
@@ -2077,7 +2077,7 @@ void Substitution()
 			if (!FlipCoin(4))
 				continue;
 
-			uint8_t c = BTYPESL2[dungeon[x][y]];
+			const uint8_t c = BTYPESL2[dungeon[x][y]];
 			if (c != 0) {
 				int rv = GenerateRnd(16);
 				int i = -1;
@@ -2379,8 +2379,8 @@ bool FillVoids()
 {
 	int to = 0;
 	while (CountEmptyTiles() > 700 && to < 100) {
-		int xx = GenerateRnd(38) + 1;
-		int yy = GenerateRnd(38) + 1;
+		const int xx = GenerateRnd(38) + 1;
+		const int yy = GenerateRnd(38) + 1;
 		if (predungeon[xx][yy] != '#') {
 			continue;
 		}

--- a/Source/levels/drlg_l3.cpp
+++ b/Source/levels/drlg_l3.cpp
@@ -759,8 +759,8 @@ void CreateBlock(int x, int y, int obs, int dir)
 	int x2;
 	int y2;
 
-	int blksizex = RandomIntBetween(3, 4);
-	int blksizey = RandomIntBetween(3, 4);
+	const int blksizex = RandomIntBetween(3, 4);
+	const int blksizey = RandomIntBetween(3, 4);
 
 	if (dir == 0) {
 		y2 = y - 1;
@@ -851,7 +851,7 @@ void FillDiagonals()
 {
 	for (int j = 0; j < DMAXY - 1; j++) {
 		for (int i = 0; i < DMAXX - 1; i++) {
-			int v = dungeon[i + 1][j + 1] + 2 * dungeon[i][j + 1] + 4 * dungeon[i + 1][j] + 8 * dungeon[i][j];
+			const int v = dungeon[i + 1][j + 1] + 2 * dungeon[i][j + 1] + 4 * dungeon[i + 1][j] + 8 * dungeon[i][j];
 			if (v == 6) {
 				if (FlipCoin()) {
 					dungeon[i][j] = 1;
@@ -900,7 +900,7 @@ void FillStraights()
 			} else {
 				if (xs > 3 && !FlipCoin()) {
 					for (int k = xc; k < i; k++) {
-						int rv = GenerateRnd(2);
+						const int rv = GenerateRnd(2);
 						dungeon[k][j] = rv;
 					}
 				}
@@ -919,7 +919,7 @@ void FillStraights()
 			} else {
 				if (xs > 3 && !FlipCoin()) {
 					for (int k = xc; k < i; k++) {
-						int rv = GenerateRnd(2);
+						const int rv = GenerateRnd(2);
 						dungeon[k][j + 1] = rv;
 					}
 				}
@@ -938,7 +938,7 @@ void FillStraights()
 			} else {
 				if (ys > 3 && !FlipCoin()) {
 					for (int k = yc; k < j; k++) {
-						int rv = GenerateRnd(2);
+						const int rv = GenerateRnd(2);
 						dungeon[i][k] = rv;
 					}
 				}
@@ -957,7 +957,7 @@ void FillStraights()
 			} else {
 				if (ys > 3 && !FlipCoin()) {
 					for (int k = yc; k < j; k++) {
-						int rv = GenerateRnd(2);
+						const int rv = GenerateRnd(2);
 						dungeon[i + 1][k] = rv;
 					}
 				}
@@ -1077,8 +1077,8 @@ void River()
 			int nodir2 = 4;
 			int dircheck = 0;
 			while (dircheck < 4 && riveramt < 100) {
-				int px = rx;
-				int py = ry;
+				const int px = rx;
+				const int py = ry;
 				if (dircheck == 0) {
 					dir = GenerateRnd(4);
 				} else {
@@ -1280,7 +1280,7 @@ bool SpawnEdge(int x, int y, int *totarea)
 		return true;
 	}
 
-	uint8_t i = dungeon[x][y];
+	const uint8_t i = dungeon[x][y];
 	dungeon[x][y] |= 0x80;
 	*totarea += 1;
 
@@ -1329,7 +1329,7 @@ bool Spawn(int x, int y, int *totarea)
 		return true;
 	}
 
-	uint8_t i = dungeon[x][y];
+	const uint8_t i = dungeon[x][y];
 	dungeon[x][y] |= 0x80;
 	*totarea += 1;
 
@@ -1471,7 +1471,7 @@ bool PlaceLavaPool()
 			} else {
 				found = true;
 			}
-			bool placePool = GenerateRnd(100) < 25;
+			const bool placePool = GenerateRnd(100) < 25;
 			for (int j = std::max(duny - totarea, 0); j < std::min(duny + totarea, DMAXY); j++) {
 				for (int i = std::max(dunx - totarea, 0); i < std::min(dunx + totarea, DMAXX); i++) {
 					// BUGFIX: In the following swap the order to first do the
@@ -1479,7 +1479,7 @@ bool PlaceLavaPool()
 					if ((dungeon[i][j] & 0x80) != 0) {
 						dungeon[i][j] &= ~0x80;
 						if (totarea > 4 && placePool && !found) {
-							uint8_t k = Poolsub[dungeon[i][j]];
+							const uint8_t k = Poolsub[dungeon[i][j]];
 							if (k != 0 && k <= 37) {
 								dungeon[i][j] = k;
 							}
@@ -1508,13 +1508,13 @@ bool PlacePool()
  */
 void PoolFix()
 {
-	for (Point tile : PointsInRectangle(Rectangle { { 1, 1 }, { DMAXX - 2, DMAXY - 2 } })) {
+	for (const Point tile : PointsInRectangle(Rectangle { { 1, 1 }, { DMAXX - 2, DMAXY - 2 } })) {
 		// Check if the tile is the default dirt ceiling tile
 		if (dungeon[tile.x][tile.y] != 8)
 			continue;
 
-		for (Point adjacentTiles : PointsInRectangle(Rectangle { tile - Displacement(1, 1), { 3, 3 } })) {
-			int tileId = dungeon[adjacentTiles.x][adjacentTiles.y];
+		for (const Point adjacentTiles : PointsInRectangle(Rectangle { tile - Displacement(1, 1), { 3, 3 } })) {
+			const int tileId = dungeon[adjacentTiles.x][adjacentTiles.y];
 			// Check if the adjacent tile is a ground lava tile
 			if (tileId >= 25 && tileId <= 41) {
 				// A ground lava tile can never be directly connected to our ceiling tile.
@@ -1712,7 +1712,7 @@ void Fence()
 						skip = false;
 					}
 					if (y2 - y1 > 1 && skip) {
-						int rp = GenerateRnd(y2 - y1 - 1) + y1 + 1;
+						const int rp = GenerateRnd(y2 - y1 - 1) + y1 + 1;
 						for (int y = y1; y <= y2; y++) {
 							if (y == rp) {
 								continue;
@@ -1761,7 +1761,7 @@ void Fence()
 						skip = false;
 					}
 					if (x2 - x1 > 1 && skip) {
-						int rp = GenerateRnd(x2 - x1 - 1) + x1 + 1;
+						const int rp = GenerateRnd(x2 - x1 - 1) + x1 + 1;
 						for (int x = x1; x <= x2; x++) {
 							if (x == rp) {
 								continue;
@@ -1800,9 +1800,9 @@ void Fence()
 
 bool PlaceAnvil()
 {
-	std::unique_ptr<uint16_t[]> setPieceData = LoadFileInMem<uint16_t>("levels\\l3data\\anvil.dun");
+	const std::unique_ptr<uint16_t[]> setPieceData = LoadFileInMem<uint16_t>("levels\\l3data\\anvil.dun");
 	// growing the size by 2 to allow a 1 tile border on all sides
-	WorldTileSize areaSize = GetDunSize(setPieceData.get()) + 2;
+	const WorldTileSize areaSize = GetDunSize(setPieceData.get()) + 2;
 	WorldTileCoord sx = GenerateRnd(DMAXX - areaSize.width);
 	WorldTileCoord sy = GenerateRnd(DMAXY - areaSize.height);
 
@@ -1819,7 +1819,7 @@ bool PlaceAnvil()
 		}
 
 		bool found = true;
-		for (WorldTilePosition tile : PointsInRectangle(WorldTileRectangle { { sx, sy }, areaSize })) {
+		for (const WorldTilePosition tile : PointsInRectangle(WorldTileRectangle { { sx, sy }, areaSize })) {
 			if (Protected.test(tile.x, tile.y) || dungeon[tile.x][tile.y] != 7) {
 				found = false;
 				break;
@@ -1832,7 +1832,7 @@ bool PlaceAnvil()
 	PlaceDunTiles(setPieceData.get(), { sx + 1, sy + 1 }, 7);
 	SetPiece = { { sx, sy }, areaSize };
 
-	for (WorldTilePosition tile : PointsInRectangle(SetPiece)) {
+	for (const WorldTilePosition tile : PointsInRectangle(SetPiece)) {
 		Protected.set(tile.x, tile.y);
 	}
 

--- a/Source/levels/drlg_l4.cpp
+++ b/Source/levels/drlg_l4.cpp
@@ -172,7 +172,7 @@ void InitSetPiece()
 		return; // no setpiece needed for this level
 	}
 
-	WorldTilePosition setPiecePosition = SetPieceRoom.position;
+	const WorldTilePosition setPiecePosition = SetPieceRoom.position;
 	PlaceDunTiles(setPieceData.get(), setPiecePosition, 6);
 	SetPiece = { setPiecePosition, GetDunSize(setPieceData.get()) };
 }
@@ -215,7 +215,7 @@ bool CheckRoom(WorldTileRectangle room)
 
 void GenerateRoom(WorldTileRectangle area, bool verticalLayout)
 {
-	bool rotate = !FlipCoin(4);
+	const bool rotate = !FlipCoin(4);
 	verticalLayout = (!verticalLayout && rotate) || (verticalLayout && !rotate);
 
 	bool placeRoom1;
@@ -273,10 +273,10 @@ void FirstRoom()
 		}
 	}
 
-	int xmin = (DMAXX / 2 - room.size.width) / 2;
-	int xmax = DMAXX / 2 - 1 - room.size.width;
-	int ymin = (DMAXY / 2 - room.size.height) / 2;
-	int ymax = DMAXY / 2 - 1 - room.size.height;
+	const int xmin = (DMAXX / 2 - room.size.width) / 2;
+	const int xmax = DMAXX / 2 - 1 - room.size.width;
+	const int ymin = (DMAXY / 2 - room.size.height) / 2;
+	const int ymax = DMAXY / 2 - 1 - room.size.height;
 	const int32_t randomX = GenerateRnd(xmax - xmin + 1) + xmin;
 	const int32_t randomY = GenerateRnd(ymax - ymin + 1) + ymin;
 	room.position = WorldTilePosition(randomX, randomY);
@@ -314,7 +314,7 @@ void MakeDmt()
 {
 	for (int y = 0; y < DMAXY - 1; y++) {
 		for (int x = 0; x < DMAXX - 1; x++) {
-			int val = (DungeonMask.test(x + 1, y + 1) << 3) | (DungeonMask.test(x, y + 1) << 2) | (DungeonMask.test(x + 1, y) << 1) | (DungeonMask.test(x, y) << 0);
+			const int val = (DungeonMask.test(x + 1, y + 1) << 3) | (DungeonMask.test(x, y + 1) << 2) | (DungeonMask.test(x + 1, y) << 1) | (DungeonMask.test(x, y) << 0);
 			dungeon[x][y] = L4ConvTbl[val];
 		}
 	}
@@ -391,7 +391,7 @@ void HorizontalWall(int i, int j, int dx)
 		dungeon[i + dx][j] = 29;
 	}
 
-	int xx = GenerateRnd(dx - 3) + 1;
+	const int xx = GenerateRnd(dx - 3) + 1;
 	dungeon[i + xx][j] = 57;
 	dungeon[i + xx + 2][j] = 56;
 	dungeon[i + xx + 1][j] = 60;
@@ -436,7 +436,7 @@ void VerticalWall(int i, int j, int dy)
 		dungeon[i][j + dy] = 29;
 	}
 
-	int yy = GenerateRnd(dy - 3) + 1;
+	const int yy = GenerateRnd(dy - 3) + 1;
 	dungeon[i][j + yy] = 53;
 	dungeon[i][j + yy + 2] = 52;
 	dungeon[i][j + yy + 1] = 6;
@@ -459,7 +459,7 @@ void AddWall()
 			for (auto d : { 10, 12, 13, 15, 16, 21, 22 }) {
 				if (d == dungeon[i][j]) {
 					DiscardRandomValues(1);
-					int x = HorizontalWallOk(i, j);
+					const int x = HorizontalWallOk(i, j);
 					if (x != -1) {
 						HorizontalWall(i, j, x);
 					}
@@ -468,7 +468,7 @@ void AddWall()
 			for (auto d : { 8, 9, 11, 14, 15, 16, 21, 23 }) {
 				if (d == dungeon[i][j]) {
 					DiscardRandomValues(1);
-					int y = VerticalWallOk(i, j);
+					const int y = VerticalWallOk(i, j);
 					if (y != -1) {
 						VerticalWall(i, j, y);
 					}
@@ -832,7 +832,7 @@ void Substitution()
 	for (int y = 0; y < DMAXY; y++) {
 		for (int x = 0; x < DMAXX; x++) {
 			if (FlipCoin(3)) {
-				uint8_t c = L4BTYPES[dungeon[x][y]];
+				const uint8_t c = L4BTYPES[dungeon[x][y]];
 				if (c != 0 && !Protected.test(x, y)) {
 					int rv = GenerateRnd(16);
 					int i = -1;
@@ -854,7 +854,7 @@ void Substitution()
 	for (int y = 0; y < DMAXY; y++) {
 		for (int x = 0; x < DMAXX; x++) {
 			if (FlipCoin(10)) {
-				uint8_t c = dungeon[x][y];
+				const uint8_t c = dungeon[x][y];
 				if (L4BTYPES[c] == 6 && !Protected.test(x, y)) {
 					dungeon[x][y] = PickRandomlyAmong({ 95, 96, 97 });
 				}
@@ -873,8 +873,8 @@ void PrepareInnerBorders()
 			if (!DungeonMask.test(x, y)) {
 				hallok[y] = false;
 			} else {
-				bool hasSouthWestRoom = y + 1 < DMAXY / 2 && DungeonMask.test(x, y + 1);
-				bool hasSouthRoom = x + 1 < DMAXX / 2 && y + 1 < DMAXY / 2 && DungeonMask.test(x + 1, y + 1);
+				const bool hasSouthWestRoom = y + 1 < DMAXY / 2 && DungeonMask.test(x, y + 1);
+				const bool hasSouthRoom = x + 1 < DMAXX / 2 && y + 1 < DMAXY / 2 && DungeonMask.test(x + 1, y + 1);
 				hallok[y] = hasSouthWestRoom && !hasSouthRoom;
 				x = 0;
 			}
@@ -906,8 +906,8 @@ void PrepareInnerBorders()
 			if (!DungeonMask.test(x, y)) {
 				hallok[x] = false;
 			} else {
-				bool hasSouthEastRoom = x + 1 < DMAXX / 2 && DungeonMask.test(x + 1, y);
-				bool hasSouthRoom = x + 1 < DMAXX / 2 && y + 1 < DMAXY / 2 && DungeonMask.test(x + 1, y + 1);
+				const bool hasSouthEastRoom = x + 1 < DMAXX / 2 && DungeonMask.test(x + 1, y);
+				const bool hasSouthRoom = x + 1 < DMAXX / 2 && y + 1 < DMAXY / 2 && DungeonMask.test(x + 1, y + 1);
 				hallok[x] = hasSouthEastRoom && !hasSouthRoom;
 				y = 0;
 			}
@@ -1195,7 +1195,7 @@ void GenerateLevel(lvl_entry entry)
 	DRLG_CheckQuests(SetPieceRoom.position);
 
 	if (currlevel == 15) {
-		bool isGateOpen = UseMultiplayerQuests() || IsAnyOf(Quests[Q_DIABLO]._qactive, QUEST_ACTIVE, QUEST_DONE);
+		const bool isGateOpen = UseMultiplayerQuests() || IsAnyOf(Quests[Q_DIABLO]._qactive, QUEST_ACTIVE, QUEST_DONE);
 		if (!isGateOpen)
 			L4PENTA.place(Quests[Q_DIABLO].position);
 

--- a/Source/levels/gendung.cpp
+++ b/Source/levels/gendung.cpp
@@ -230,13 +230,13 @@ void CreateThemeRoom(int themeIndex)
 	}
 	if (leveltype == DTYPE_HELL) {
 		if (FlipCoin()) {
-			int yy = (ly + hy) / 2;
+			const int yy = (ly + hy) / 2;
 			dungeon[hx - 1][yy - 1] = 53;
 			dungeon[hx - 1][yy] = 6;
 			dungeon[hx - 1][yy + 1] = 52;
 			dungeon[hx - 2][yy - 1] = 54;
 		} else {
-			int xx = (lx + hx) / 2;
+			const int xx = (lx + hx) / 2;
 			dungeon[xx - 1][hy - 1] = 57;
 			dungeon[xx][hy - 1] = 6;
 			dungeon[xx + 1][hy - 1] = 56;
@@ -248,8 +248,8 @@ void CreateThemeRoom(int themeIndex)
 
 bool IsFloor(Point p, uint8_t floorID)
 {
-	int i = (p.x - 16) / 2;
-	int j = (p.y - 16) / 2;
+	const int i = (p.x - 16) / 2;
+	const int j = (p.y - 16) / 2;
 	if (i < 0 || i >= DMAXX)
 		return false;
 	if (j < 0 || j >= DMAXY)
@@ -259,7 +259,7 @@ bool IsFloor(Point p, uint8_t floorID)
 
 void FillTransparencyValues(Point floor, uint8_t floorID)
 {
-	Direction allDirections[] = {
+	const Direction allDirections[] = {
 		Direction::North,
 		Direction::South,
 		Direction::East,
@@ -272,8 +272,8 @@ void FillTransparencyValues(Point floor, uint8_t floorID)
 
 	// We only fill in the surrounding tiles if they are not floor tiles
 	// because they would otherwise not be visited by the span filling algorithm
-	for (Direction dir : allDirections) {
-		Point adjacent = floor + dir;
+	for (const Direction dir : allDirections) {
+		const Point adjacent = floor + dir;
 		if (!IsFloor(adjacent, floorID))
 			dTransVal[adjacent.x][adjacent.y] = TransVal;
 	}
@@ -308,13 +308,13 @@ void FindTransparencyValues(Point floor, uint8_t floorID)
 	const Displacement left = { -1, 0 };
 	const Displacement right = { 1, 0 };
 	const auto checkDiagonals = [&](Point p, Displacement direction) {
-		Point up = p + Displacement { 0, -1 };
-		Point upOver = up + direction;
+		const Point up = p + Displacement { 0, -1 };
+		const Point upOver = up + direction;
 		if (!isInside(up.x, up.y) && isInside(upOver.x, upOver.y))
 			seedStack.push({ upOver.x, upOver.x + 1, upOver.y, -1 });
 
-		Point down = p + Displacement { 0, 1 };
-		Point downOver = down + direction;
+		const Point down = p + Displacement { 0, 1 };
+		const Point downOver = down + direction;
 		if (!isInside(down.x, down.y) && isInside(downOver.x, downOver.y))
 			seedStack.push(Seed { downOver.x, downOver.x + 1, downOver.y, 1 });
 	};
@@ -518,7 +518,7 @@ void SetDungeonMicros(std::unique_ptr<std::byte[]> &dungeonCels, uint_fast8_t &m
 	}
 
 	size_t tileCount;
-	std::unique_ptr<uint16_t[]> levelPieces = LoadMinData(tileCount);
+	const std::unique_ptr<uint16_t[]> levelPieces = LoadMinData(tileCount);
 
 	ankerl::unordered_dense::map<uint16_t, DunFrameInfo> frameToTypeMap;
 	frameToTypeMap.reserve(4096);
@@ -566,8 +566,8 @@ void DRLG_InitTrans()
 
 void DRLG_RectTrans(WorldTileRectangle area)
 {
-	WorldTilePosition position = area.position;
-	WorldTileSize size = area.size;
+	const WorldTilePosition position = area.position;
+	const WorldTileSize size = area.size;
 
 	for (int j = position.y; j <= position.y + size.height; j++) {
 		for (int i = position.x; i <= position.x + size.width; i++) {
@@ -597,7 +597,7 @@ void LoadTransparency(const uint16_t *dunData)
 {
 	WorldTileSize size = GetDunSize(dunData);
 
-	int layer2Offset = 2 + size.width * size.height;
+	const int layer2Offset = 2 + size.width * size.height;
 
 	// The rest of the layers are at dPiece scale
 	size *= static_cast<WorldTileCoord>(2);
@@ -631,8 +631,8 @@ void LoadDungeonBase(const char *path, Point spawn, int floorId, int dirtId)
 
 void Make_SetPC(WorldTileRectangle area)
 {
-	WorldTilePosition position = area.position.megaToWorld();
-	WorldTileSize size = area.size * 2;
+	const WorldTilePosition position = area.position.megaToWorld();
+	const WorldTileSize size = area.size * 2;
 
 	for (unsigned j = 0; j < size.height; j++) {
 		for (unsigned i = 0; i < size.width; i++) {
@@ -643,8 +643,8 @@ void Make_SetPC(WorldTileRectangle area)
 
 std::optional<Point> PlaceMiniSet(const Miniset &miniset, int tries, bool drlg1Quirk)
 {
-	int sw = miniset.size.width;
-	int sh = miniset.size.height;
+	const int sw = miniset.size.width;
+	const int sh = miniset.size.height;
 	Point position { GenerateRnd(DMAXX - sw), GenerateRnd(DMAXY - sh) };
 
 	for (int i = 0; i < tries; i++, position.x++) {
@@ -687,7 +687,7 @@ std::optional<Point> PlaceMiniSet(const Miniset &miniset, int tries, bool drlg1Q
 
 void PlaceDunTiles(const uint16_t *dunData, Point position, int floorId)
 {
-	WorldTileSize size = GetDunSize(dunData);
+	const WorldTileSize size = GetDunSize(dunData);
 
 	const uint16_t *tileLayer = &dunData[2];
 
@@ -717,8 +717,8 @@ void DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, bool rn
 					continue;
 
 				if (rndSize) {
-					int min = minSize - 2;
-					int max = maxSize - 2;
+					const int min = minSize - 2;
+					const int max = maxSize - 2;
 					themeSize->width = min + GenerateRnd(GenerateRnd(themeSize->width - min + 1));
 					if (themeSize->width < min || themeSize->width > max)
 						themeSize->width = min;
@@ -747,8 +747,8 @@ void DRLG_HoldThemeRooms()
 	for (int i = 0; i < themeCount; i++) {
 		for (int y = themeLoc[i].room.position.y; y < themeLoc[i].room.position.y + themeLoc[i].room.size.height - 1; y++) {
 			for (int x = themeLoc[i].room.position.x; x < themeLoc[i].room.position.x + themeLoc[i].room.size.width - 1; x++) {
-				int xx = 2 * x + 16;
-				int yy = 2 * y + 16;
+				const int xx = 2 * x + 16;
+				const int yy = 2 * y + 16;
 				dFlags[xx][yy] |= DungeonFlag::Populated;
 				dFlags[xx + 1][yy] |= DungeonFlag::Populated;
 				dFlags[xx][yy + 1] |= DungeonFlag::Populated;
@@ -766,11 +766,11 @@ WorldTileSize GetDunSize(const uint16_t *dunData)
 void DRLG_LPass3(int lv)
 {
 	{
-		MegaTile mega = pMegaTiles[lv];
-		int v1 = SDL_SwapLE16(mega.micro1);
-		int v2 = SDL_SwapLE16(mega.micro2);
-		int v3 = SDL_SwapLE16(mega.micro3);
-		int v4 = SDL_SwapLE16(mega.micro4);
+		const MegaTile mega = pMegaTiles[lv];
+		const int v1 = SDL_SwapLE16(mega.micro1);
+		const int v2 = SDL_SwapLE16(mega.micro2);
+		const int v3 = SDL_SwapLE16(mega.micro3);
+		const int v4 = SDL_SwapLE16(mega.micro4);
 
 		for (int j = 0; j < MAXDUNY; j += 2) {
 			for (int i = 0; i < MAXDUNX; i += 2) {
@@ -786,8 +786,8 @@ void DRLG_LPass3(int lv)
 	for (int j = 0; j < DMAXY; j++) {
 		int xx = 16;
 		for (int i = 0; i < DMAXX; i++) { // NOLINT(modernize-loop-convert)
-			int tileId = dungeon[i][j] - 1;
-			MegaTile mega = pMegaTiles[tileId];
+			const int tileId = dungeon[i][j] - 1;
+			const MegaTile mega = pMegaTiles[tileId];
 			dPiece[xx + 0][yy + 0] = SDL_SwapLE16(mega.micro1);
 			dPiece[xx + 1][yy + 0] = SDL_SwapLE16(mega.micro2);
 			dPiece[xx + 0][yy + 1] = SDL_SwapLE16(mega.micro3);

--- a/Source/levels/reencode_dun_cels.cpp
+++ b/Source/levels/reencode_dun_cels.cpp
@@ -309,7 +309,7 @@ std::vector<std::pair<uint16_t, uint16_t>> ComputeCelBlockAdjustments(std::span<
 	uint16_t lastFrameIndex = 0;
 	uint16_t adjustment = 0;
 	for (auto &[frame, info] : frames) {
-		uint16_t diff = frame - lastFrameIndex - 1;
+		const uint16_t diff = frame - lastFrameIndex - 1;
 		if (diff > 0) celBlockAdjustments.emplace_back(frame, adjustment);
 		adjustment += diff;
 		lastFrameIndex = frame;

--- a/Source/levels/themes.cpp
+++ b/Source/levels/themes.cpp
@@ -49,7 +49,7 @@ bool TFit_Shrine(int i)
 	size_t found = 0;
 
 	while (found == 0) {
-		Point testPosition = position;
+		const Point testPosition = position;
 		if (dTransVal[position.x][position.y] == themes[i].ttval) {
 			if (TileHasAny(position + Direction::NorthEast, TileProperties::Trap)
 			    && IsTileNotSolid(testPosition + Direction::NorthWest)
@@ -113,7 +113,7 @@ bool TFit_Obj5(int t)
 	}
 
 	int candidatesFound = 0;
-	for (Point tile : PointsInRectangle(Rectangle { { 0, 0 }, { MAXDUNX, MAXDUNY } })) {
+	for (const Point tile : PointsInRectangle(Rectangle { { 0, 0 }, { MAXDUNX, MAXDUNY } })) {
 		if (dTransVal[tile.x][tile.y] == themes[t].ttval && IsTileNotSolid(tile) && CheckThemeObj5(tile, themes[t].ttval)) {
 			// Use themex/y to keep track of the last candidate area found, in case we end up with fewer candidates than the target
 			themex = tile.x;
@@ -358,7 +358,7 @@ void PlaceThemeMonsts(int t, int f)
 			numscattypes++;
 		}
 	}
-	size_t mtype = scattertypes[GenerateRnd(numscattypes)];
+	const size_t mtype = scattertypes[GenerateRnd(numscattypes)];
 	for (int yp = 0; yp < MAXDUNY; yp++) {
 		for (int xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && IsTileNotSolid({ xp, yp }) && dItem[xp][yp] == 0 && !IsObjectAtPosition({ xp, yp })) {
@@ -377,14 +377,14 @@ void PlaceThemeMonsts(int t, int f)
  */
 void Theme_Barrel(int t)
 {
-	int barrnd[4] = { 2, 6, 4, 8 };
-	int monstrnd[4] = { 5, 7, 3, 9 };
+	const int barrnd[4] = { 2, 6, 4, 8 };
+	const int monstrnd[4] = { 5, 7, 3, 9 };
 
 	for (int yp = 0; yp < MAXDUNY; yp++) {
 		for (int xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && IsTileNotSolid({ xp, yp })) {
 				if (FlipCoin(barrnd[leveltype - 1])) {
-					_object_id r = FlipCoin(barrnd[leveltype - 1]) ? OBJ_BARREL : OBJ_BARRELEX;
+					const _object_id r = FlipCoin(barrnd[leveltype - 1]) ? OBJ_BARREL : OBJ_BARRELEX;
 					AddObject(r, { xp, yp });
 				}
 			}
@@ -400,7 +400,7 @@ void Theme_Barrel(int t)
  */
 void Theme_Shrine(int t)
 {
-	int monstrnd[4] = { 6, 6, 3, 9 };
+	const int monstrnd[4] = { 6, 6, 3, 9 };
 
 	TFit_Shrine(t);
 	if (themeVar1 == 1) {
@@ -422,7 +422,7 @@ void Theme_Shrine(int t)
  */
 void Theme_MonstPit(int t)
 {
-	int monstrnd[4] = { 6, 7, 3, 9 };
+	const int monstrnd[4] = { 6, 7, 3, 9 };
 
 	int r = GenerateRnd(100) + 1;
 	int ixp = 0;
@@ -469,8 +469,8 @@ void Theme_SkelRoom(int t)
 
 	TFit_SkelRoom(t);
 
-	int xp = themex;
-	int yp = themey;
+	const int xp = themex;
+	const int yp = themey;
 
 	AddObject(OBJ_SKFIRE, { xp, yp });
 
@@ -513,15 +513,15 @@ void Theme_SkelRoom(int t)
  */
 void Theme_Treasure(int t)
 {
-	int treasrnd[4] = { 4, 9, 7, 10 };
-	int monstrnd[4] = { 6, 8, 3, 7 };
+	const int treasrnd[4] = { 4, 9, 7, 10 };
+	const int monstrnd[4] = { 6, 8, 3, 7 };
 
 	DiscardRandomValues(1);
 	for (int yp = 0; yp < MAXDUNY; yp++) {
 		for (int xp = 0; xp < MAXDUNX; xp++) {
 			if (dTransVal[xp][yp] == themes[t].ttval && IsTileNotSolid({ xp, yp })) {
-				int8_t treasureType = treasrnd[leveltype - 1];
-				int rv = GenerateRnd(treasureType);
+				const int8_t treasureType = treasrnd[leveltype - 1];
+				const int rv = GenerateRnd(treasureType);
 				// BUGFIX: this used to be `2*GenerateRnd(treasureType) == 0` however 2*0 has no effect, should probably be `FlipCoin(2*treasureType)`
 				if (FlipCoin(treasureType)) {
 					CreateTypeItem({ xp, yp }, false, ItemType::Gold, IMISC_NONE, false, true);
@@ -555,7 +555,7 @@ void Theme_Treasure(int t)
 void Theme_Library(int t)
 {
 	constexpr unsigned librnd[4] = { 1, 2, 2, 5 };
-	int monstrnd[4] = { 5, 7, 3, 9 };
+	const int monstrnd[4] = { 5, 7, 3, 9 };
 
 	TFit_Shrine(t);
 
@@ -597,7 +597,7 @@ void Theme_Library(int t)
 void Theme_Torture(int t)
 {
 	constexpr unsigned tortrnd[4] = { 6, 8, 3, 8 };
-	int monstrnd[4] = { 6, 8, 3, 9 };
+	const int monstrnd[4] = { 6, 8, 3, 9 };
 
 	for (int yp = 1; yp < MAXDUNY - 1; yp++) {
 		for (int xp = 1; xp < MAXDUNX - 1; xp++) {
@@ -619,7 +619,7 @@ void Theme_Torture(int t)
  */
 void Theme_BloodFountain(int t)
 {
-	int monstrnd[4] = { 6, 8, 3, 9 };
+	const int monstrnd[4] = { 6, 8, 3, 9 };
 
 	TFit_Obj5(t);
 	AddObject(OBJ_BLOODFTN, { themex, themey });
@@ -634,7 +634,7 @@ void Theme_BloodFountain(int t)
 void Theme_Decap(int t)
 {
 	constexpr unsigned decaprnd[4] = { 6, 8, 3, 8 };
-	int monstrnd[4] = { 6, 8, 3, 9 };
+	const int monstrnd[4] = { 6, 8, 3, 9 };
 
 	for (int yp = 1; yp < MAXDUNY - 1; yp++) {
 		for (int xp = 1; xp < MAXDUNX - 1; xp++) {
@@ -657,7 +657,7 @@ void Theme_Decap(int t)
  */
 void Theme_PurifyingFountain(int t)
 {
-	int monstrnd[4] = { 6, 7, 3, 9 };
+	const int monstrnd[4] = { 6, 7, 3, 9 };
 
 	TFit_Obj5(t);
 	AddObject(OBJ_PURIFYINGFTN, { themex, themey });
@@ -672,7 +672,7 @@ void Theme_PurifyingFountain(int t)
 void Theme_ArmorStand(int t)
 {
 	constexpr unsigned armorrnd[4] = { 6, 8, 3, 8 };
-	int monstrnd[4] = { 6, 7, 3, 9 };
+	const int monstrnd[4] = { 6, 7, 3, 9 };
 
 	if (armorFlag) {
 		TFit_Obj3(themes[t].ttval);
@@ -718,7 +718,7 @@ void Theme_GoatShrine(int t)
  */
 void Theme_Cauldron(int t)
 {
-	int monstrnd[4] = { 6, 7, 3, 9 };
+	const int monstrnd[4] = { 6, 7, 3, 9 };
 
 	TFit_Obj5(t);
 	AddObject(OBJ_CAULDRON, { themex, themey });
@@ -732,7 +732,7 @@ void Theme_Cauldron(int t)
  */
 void Theme_MurkyFountain(int t)
 {
-	int monstrnd[4] = { 6, 7, 3, 9 };
+	const int monstrnd[4] = { 6, 7, 3, 9 };
 
 	TFit_Obj5(t);
 	AddObject(OBJ_MURKYFTN, { themex, themey });
@@ -746,7 +746,7 @@ void Theme_MurkyFountain(int t)
  */
 void Theme_TearFountain(int t)
 {
-	int monstrnd[4] = { 6, 7, 3, 9 };
+	const int monstrnd[4] = { 6, 7, 3, 9 };
 
 	TFit_Obj5(t);
 	AddObject(OBJ_TEARFTN, { themex, themey });
@@ -760,8 +760,8 @@ void Theme_TearFountain(int t)
  */
 void Theme_BrnCross(int t)
 {
-	int8_t regionId = themes[t].ttval;
-	int monstrnd[4] = { 6, 8, 3, 9 };
+	const int8_t regionId = themes[t].ttval;
+	const int monstrnd[4] = { 6, 8, 3, 9 };
 	constexpr unsigned bcrossrnd[4] = { 5, 7, 3, 8 };
 
 	for (int yp = 0; yp < MAXDUNY; yp++) {
@@ -785,9 +785,9 @@ void Theme_BrnCross(int t)
  */
 void Theme_WeaponRack(int t)
 {
-	int8_t regionId = themes[t].ttval;
+	const int8_t regionId = themes[t].ttval;
 	constexpr unsigned weaponrnd[4] = { 6, 8, 5, 8 };
-	int monstrnd[4] = { 6, 7, 3, 9 };
+	const int monstrnd[4] = { 6, 7, 3, 9 };
 
 	if (weaponFlag) {
 		TFit_Obj3(regionId);
@@ -900,7 +900,7 @@ void HoldThemeRooms()
 	}
 
 	for (int i = 0; i < numthemes; i++) {
-		int8_t v = themes[i].ttval;
+		const int8_t v = themes[i].ttval;
 		for (int y = 0; y < MAXDUNY; y++) {
 			for (int x = 0; x < MAXDUNX; x++) {
 				if (dTransVal[x][y] == v) {

--- a/Source/levels/town.cpp
+++ b/Source/levels/town.cpp
@@ -26,7 +26,7 @@ void FillSector(const char *path, int xi, int yy)
 {
 	auto dunData = LoadFileInMem<uint16_t>(path);
 
-	WorldTileSize size = GetDunSize(dunData.get());
+	const WorldTileSize size = GetDunSize(dunData.get());
 	const uint16_t *tileLayer = &dunData[2];
 
 	for (WorldTileCoord j = 0; j < size.height; j++) {
@@ -37,9 +37,9 @@ void FillSector(const char *path, int xi, int yy)
 			int v3 = 218;
 			int v4 = 218;
 
-			int tileId = SDL_SwapLE16(tileLayer[j * size.width + i]) - 1;
+			const int tileId = SDL_SwapLE16(tileLayer[j * size.width + i]) - 1;
 			if (tileId >= 0) {
-				MegaTile mega = pMegaTiles[tileId];
+				const MegaTile mega = pMegaTiles[tileId];
 				v1 = SDL_SwapLE16(mega.micro1);
 				v2 = SDL_SwapLE16(mega.micro2);
 				v3 = SDL_SwapLE16(mega.micro3);
@@ -64,7 +64,7 @@ void FillSector(const char *path, int xi, int yy)
  */
 void FillTile(int xx, int yy, int t)
 {
-	MegaTile mega = pMegaTiles[t - 1];
+	const MegaTile mega = pMegaTiles[t - 1];
 
 	dPiece[xx + 0][yy + 0] = SDL_SwapLE16(mega.micro1);
 	dPiece[xx + 1][yy + 0] = SDL_SwapLE16(mega.micro2);
@@ -249,15 +249,15 @@ void DrlgTPass3()
 
 bool OpensHive(Point position)
 {
-	int yp = position.y;
-	int xp = position.x;
+	const int yp = position.y;
+	const int xp = position.x;
 	return xp >= 79 && xp <= 82 && yp >= 61 && yp <= 64;
 }
 
 bool OpensGrave(Point position)
 {
-	int yp = position.y;
-	int xp = position.x;
+	const int yp = position.y;
+	const int xp = position.x;
 	return xp >= 35 && xp <= 38 && yp >= 20 && yp <= 24;
 }
 

--- a/Source/levels/trigs.cpp
+++ b/Source/levels/trigs.cpp
@@ -82,7 +82,7 @@ bool IsWarpOpen(dungeon_type type)
 	if (gbIsMultiplayer && type != DTYPE_NEST) // Opening the nest is part of in town quest
 		return true;
 
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	if (type == DTYPE_CATACOMBS && (myPlayer.pTownWarps & 1) != 0)
 		return true;
@@ -448,8 +448,8 @@ bool ForceL2Trig()
 		if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 			for (int j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABPREVLVL) {
-					int dx = std::abs(trigs[j].position.x - cursPosition.x);
-					int dy = std::abs(trigs[j].position.y - cursPosition.y);
+					const int dx = std::abs(trigs[j].position.x - cursPosition.x);
+					const int dy = std::abs(trigs[j].position.y - cursPosition.y);
 					if (dx < 4 && dy < 4) {
 						InfoString = fmt::format(fmt::runtime(_("Up to level {:d}")), currlevel - 1);
 						cursPosition = trigs[j].position;
@@ -477,8 +477,8 @@ bool ForceL2Trig()
 			if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABTWARPUP) {
-						int dx = std::abs(trigs[j].position.x - cursPosition.x);
-						int dy = std::abs(trigs[j].position.y - cursPosition.y);
+						const int dx = std::abs(trigs[j].position.x - cursPosition.x);
+						const int dy = std::abs(trigs[j].position.y - cursPosition.y);
 						if (dx < 4 && dy < 4) {
 							InfoString = _("Up to town");
 							cursPosition = trigs[j].position;
@@ -500,8 +500,8 @@ bool ForceL3Trig()
 			InfoString = fmt::format(fmt::runtime(_("Up to level {:d}")), currlevel - 1);
 			for (int j = 0; j < numtrigs; j++) {
 				if (trigs[j]._tmsg == WM_DIABPREVLVL) {
-					int dx = std::abs(trigs[j].position.x - cursPosition.x);
-					int dy = std::abs(trigs[j].position.y - cursPosition.y);
+					const int dx = std::abs(trigs[j].position.x - cursPosition.x);
+					const int dy = std::abs(trigs[j].position.y - cursPosition.y);
 					if (dx < 4 && dy < 4) {
 						cursPosition = trigs[j].position;
 						return true;
@@ -529,8 +529,8 @@ bool ForceL3Trig()
 			if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABTWARPUP) {
-						int dx = std::abs(trigs[j].position.x - cursPosition.x);
-						int dy = std::abs(trigs[j].position.y - cursPosition.y);
+						const int dx = std::abs(trigs[j].position.x - cursPosition.x);
+						const int dy = std::abs(trigs[j].position.y - cursPosition.y);
 						if (dx < 4 && dy < 4) {
 							InfoString = _("Up to town");
 							cursPosition = trigs[j].position;
@@ -576,8 +576,8 @@ bool ForceL4Trig()
 			if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABTWARPUP) {
-						int dx = std::abs(trigs[j].position.x - cursPosition.x);
-						int dy = std::abs(trigs[j].position.y - cursPosition.y);
+						const int dx = std::abs(trigs[j].position.x - cursPosition.x);
+						const int dy = std::abs(trigs[j].position.y - cursPosition.y);
 						if (dx < 4 && dy < 4) {
 							InfoString = _("Up to town");
 							cursPosition = trigs[j].position;
@@ -638,8 +638,8 @@ bool ForceHiveTrig()
 			if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABTWARPUP) {
-						int dx = std::abs(trigs[j].position.x - cursPosition.x);
-						int dy = std::abs(trigs[j].position.y - cursPosition.y);
+						const int dx = std::abs(trigs[j].position.x - cursPosition.x);
+						const int dy = std::abs(trigs[j].position.y - cursPosition.y);
 						if (dx < 4 && dy < 4) {
 							InfoString = _("Up to town");
 							cursPosition = trigs[j].position;
@@ -687,8 +687,8 @@ bool ForceCryptTrig()
 			if (dPiece[cursPosition.x][cursPosition.y] == tileId) {
 				for (int j = 0; j < numtrigs; j++) {
 					if (trigs[j]._tmsg == WM_DIABTWARPUP) {
-						int dx = std::abs(trigs[j].position.x - cursPosition.x);
-						int dy = std::abs(trigs[j].position.y - cursPosition.y);
+						const int dx = std::abs(trigs[j].position.x - cursPosition.x);
+						const int dy = std::abs(trigs[j].position.y - cursPosition.y);
 						if (dx < 4 && dy < 4) {
 							InfoString = _("Up to town");
 							cursPosition = trigs[j].position;
@@ -706,8 +706,8 @@ bool ForceCryptTrig()
 void Freeupstairs()
 {
 	for (int i = 0; i < numtrigs; i++) {
-		int tx = trigs[i].position.x;
-		int ty = trigs[i].position.y;
+		const int tx = trigs[i].position.x;
+		const int ty = trigs[i].position.y;
 
 		for (int yy = -2; yy <= 2; yy++) {
 			for (int xx = -2; xx <= 2; xx++) {

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -118,7 +118,7 @@ void DoUnLight(Point position, uint8_t radius)
 
 	auto searchArea = PointsInRectangle(WorldTileRectangle { position, radius });
 
-	for (WorldTilePosition targetPosition : searchArea) {
+	for (const WorldTilePosition targetPosition : searchArea) {
 		if (InDungeonBounds(targetPosition))
 			dLight[targetPosition.x][targetPosition.y] = dPreLight[targetPosition.x][targetPosition.y];
 	}
@@ -169,15 +169,15 @@ void DoLighting(Point position, uint8_t radius, DisplacementOf<int8_t> offset)
 	}
 
 	for (int i = 0; i < 4; i++) {
-		int yBound = i > 0 && i < 3 ? maxY : minY;
-		int xBound = i < 2 ? maxX : minX;
+		const int yBound = i > 0 && i < 3 ? maxY : minY;
+		const int xBound = i < 2 ? maxX : minX;
 		for (int y = 0; y < yBound; y++) {
 			for (int x = 1; x < xBound; x++) {
-				int linearDistance = LightConeInterpolations[offset.deltaX][offset.deltaY][x + block.deltaX][y + block.deltaY];
+				const int linearDistance = LightConeInterpolations[offset.deltaX][offset.deltaY][x + block.deltaX][y + block.deltaY];
 				if (linearDistance >= 128)
 					continue;
-				Point temp = position + (Displacement { x, y }).Rotate(-i);
-				uint8_t v = LightFalloffs[radius][linearDistance];
+				const Point temp = position + (Displacement { x, y }).Rotate(-i);
+				const uint8_t v = LightFalloffs[radius][linearDistance];
 				if (!InDungeonBounds(temp))
 					continue;
 				if (v < GetLight(temp))
@@ -195,7 +195,7 @@ void DoUnVision(Point position, uint8_t radius)
 
 	auto searchArea = PointsInRectangle(WorldTileRectangle { position, radius });
 
-	for (WorldTilePosition targetPosition : searchArea) {
+	for (const WorldTilePosition targetPosition : searchArea) {
 		if (InDungeonBounds(targetPosition))
 			dFlags[targetPosition.x][targetPosition.y] &= ~(DungeonFlag::Visible | DungeonFlag::Lit);
 	}
@@ -207,7 +207,7 @@ void DoVision(Point position, uint8_t radius, MapExplorationType doAutomap, bool
 		DoVisionFlags(rayPoint, doAutomap, visible);
 	};
 	auto markTransparentFn = [](Point rayPoint) {
-		int8_t trans = dTransVal[rayPoint.x][rayPoint.y];
+		const int8_t trans = dTransVal[rayPoint.x][rayPoint.y];
 		if (trans != 0)
 			TransList[trans] = true;
 	};
@@ -236,7 +236,7 @@ void MakeLightTable()
 	constexpr uint8_t White = 255;
 	for (auto &lightTable : LightTables) {
 		uint8_t colorIndex = 0;
-		for (uint8_t steps : { 16, 16, 16, 16, 16, 16, 16, 16, 8, 8, 8, 8, 16, 16, 16, 16, 16, 16 }) {
+		for (const uint8_t steps : { 16, 16, 16, 16, 16, 16, 16, 16, 8, 8, 8, 8, 16, 16, 16, 16, 16, 16 }) {
 			const uint8_t shading = shade * steps / 16;
 			const uint8_t shadeStart = colorIndex;
 			const uint8_t shadeEnd = shadeStart + steps - 1;
@@ -318,8 +318,8 @@ void MakeLightTable()
 		for (int offsetX = 0; offsetX < 8; offsetX++) {
 			for (int y = 0; y < 16; y++) {
 				for (int x = 0; x < 16; x++) {
-					int a = (8 * x - offsetX);
-					int b = (8 * y - offsetY);
+					const int a = (8 * x - offsetX);
+					const int b = (8 * y - offsetY);
 					LightConeInterpolations[offsetX][offsetY][x][y] = static_cast<uint8_t>(sqrt(a * a + b * b));
 				}
 			}
@@ -369,7 +369,7 @@ int AddLight(Point position, uint8_t radius)
 	if (ActiveLightCount >= MAXLIGHTS)
 		return NO_LIGHT;
 
-	int lid = ActiveLights[ActiveLightCount++];
+	const int lid = ActiveLights[ActiveLightCount++];
 	Light &light = Lights[lid];
 	light.position.tile = position;
 	light.radius = radius;
@@ -569,7 +569,7 @@ void ProcessVisionList()
 		const size_t id = player.getId();
 		if (!VisionActive[id])
 			continue;
-		Light &vision = VisionList[id];
+		const Light &vision = VisionList[id];
 		MapExplorationType doautomap = MAP_EXP_SELF;
 		if (&player != MyPlayer)
 			doautomap = player.friendlyMode ? MAP_EXP_OTHERS : MAP_EXP_NONE;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -90,9 +90,9 @@ T SwapBE(T in)
 
 void TerminateUtf8(char *str, size_t maxLength)
 {
-	std::string_view inStr { str, maxLength };
-	std::string_view truncStr = TruncateUtf8(inStr, maxLength - 1);
-	size_t utf8Length = truncStr.size();
+	const std::string_view inStr { str, maxLength };
+	const std::string_view truncStr = TruncateUtf8(inStr, maxLength - 1);
+	const size_t utf8Length = truncStr.size();
 	str[utf8Length] = '\0';
 }
 
@@ -800,7 +800,7 @@ void SyncPackSize(Monster &leader)
 	leader.packSize = 0;
 
 	for (size_t i = 0; i < ActiveMonsterCount; i++) {
-		Monster &minion = Monsters[ActiveMonsters[i]];
+		const Monster &minion = Monsters[ActiveMonsters[i]];
 		if (minion.leaderRelation == LeaderRelation::Leashed && minion.getLeader() == &leader)
 			leader.packSize++;
 	}
@@ -1284,7 +1284,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int32_t>(static_cast<int8_t>(player._pSBkSpell));
 	file.Skip<int8_t>(); // Skip _pSBkSplType
 
-	for (uint8_t spellLevel : player._pSplLvl)
+	for (const uint8_t spellLevel : player._pSplLvl)
 		file.WriteLE<uint8_t>(spellLevel);
 
 	file.Skip(7); // Alignment
@@ -1404,7 +1404,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 
 	file.WriteLE<int32_t>(player._pNumInv);
 
-	for (int8_t cell : player.InvGrid)
+	for (const int8_t cell : player.InvGrid)
 		file.WriteLE<int8_t>(cell);
 
 	for (const Item &item : player.SpdList)
@@ -1828,7 +1828,7 @@ constexpr uint32_t VersionAdditionalMissiles = 0;
 void SaveAdditionalMissiles(SaveWriter &saveWriter)
 {
 	constexpr size_t BytesWrittenBySaveMissile = 180;
-	uint32_t missileCountAdditional = (Missiles.size() > MaxMissilesForSaveGame) ? static_cast<uint32_t>(Missiles.size() - MaxMissilesForSaveGame) : 0;
+	const uint32_t missileCountAdditional = (Missiles.size() > MaxMissilesForSaveGame) ? static_cast<uint32_t>(Missiles.size() - MaxMissilesForSaveGame) : 0;
 	SaveHelper file(saveWriter, "additionalMissiles", sizeof(uint32_t) + sizeof(uint32_t) + (missileCountAdditional * BytesWrittenBySaveMissile));
 
 	file.WriteLE<uint32_t>(VersionAdditionalMissiles);
@@ -1916,7 +1916,7 @@ void SaveLevel(SaveWriter &saveWriter, LevelConversionData *levelConversionData)
 	file.WriteBE<int32_t>(ActiveObjectCount);
 
 	if (leveltype != DTYPE_TOWN) {
-		for (unsigned monsterId : ActiveMonsters)
+		for (const unsigned monsterId : ActiveMonsters)
 			file.WriteBE<uint32_t>(monsterId);
 		for (size_t i = 0; i < ActiveMonsterCount; i++) {
 			MonsterConversionData *monsterConversionData = nullptr;
@@ -1924,9 +1924,9 @@ void SaveLevel(SaveWriter &saveWriter, LevelConversionData *levelConversionData)
 				monsterConversionData = &levelConversionData->monsterConversionData[ActiveMonsters[i]];
 			SaveMonster(&file, Monsters[ActiveMonsters[i]], monsterConversionData);
 		}
-		for (int objectId : ActiveObjects)
+		for (const int objectId : ActiveObjects)
 			file.WriteLE<int8_t>(objectId);
-		for (int objectId : AvailableObjects)
+		for (const int objectId : AvailableObjects)
 			file.WriteLE<int8_t>(objectId);
 		for (int i = 0; i < ActiveObjectCount; i++) {
 			SaveObject(file, Objects[ActiveObjects[i]]);
@@ -2064,7 +2064,7 @@ tl::expected<void, std::string> LoadLevel(LevelConversionData *levelConversionDa
 		UpdateLighting = true;
 	}
 
-	for (Player &player : Players) {
+	for (const Player &player : Players) {
 		if (player.plractive && player.isOnActiveLevel())
 			Lights[player.lightId].hasChanged = true;
 	}
@@ -2094,10 +2094,10 @@ bool IsStashSizeValid(size_t stashSize, uint32_t pages, uint32_t itemCount)
 tl::expected<void, std::string> ConvertLevels(SaveWriter &saveWriter)
 {
 	// Backup current level state
-	bool tmpSetlevel = setlevel;
-	_setlevels tmpSetlvlnum = setlvlnum;
-	int tmpCurrlevel = currlevel;
-	dungeon_type tmpLeveltype = leveltype;
+	const bool tmpSetlevel = setlevel;
+	const _setlevels tmpSetlvlnum = setlvlnum;
+	const int tmpCurrlevel = currlevel;
+	const dungeon_type tmpLeveltype = leveltype;
 
 	gbSkipSync = true;
 
@@ -2345,10 +2345,10 @@ void SaveHotkeys(SaveWriter &saveWriter, const Player &player)
 	file.WriteLE<uint8_t>(static_cast<uint8_t>(NumHotkeys));
 
 	// Write the spell hotkeys
-	for (auto &spellId : player._pSplHotKey) {
+	for (const auto &spellId : player._pSplHotKey) {
 		file.WriteLE<int32_t>(static_cast<int8_t>(spellId));
 	}
-	for (auto &spellType : player._pSplTHotKey) {
+	for (const auto &spellType : player._pSplTHotKey) {
 		file.WriteLE<uint8_t>(static_cast<uint8_t>(spellType));
 	}
 
@@ -2423,7 +2423,7 @@ void LoadStash()
 void RemoveEmptyInventory(Player &player)
 {
 	for (int i = InventoryGridCells; i > 0; i--) {
-		int8_t idx = player.InvGrid[i - 1];
+		const int8_t idx = player.InvGrid[i - 1];
 		if (idx > 0 && player.InvList[idx - 1].isEmpty()) {
 			player.RemoveInvItem(idx - 1);
 		}
@@ -2462,14 +2462,14 @@ tl::expected<void, std::string> LoadGame(bool firstflag)
 	leveltype = static_cast<dungeon_type>(file.NextBE<uint32_t>());
 	if (!setlevel)
 		leveltype = GetLevelType(currlevel);
-	int viewX = file.NextBE<int32_t>();
-	int viewY = file.NextBE<int32_t>();
+	const int viewX = file.NextBE<int32_t>();
+	const int viewY = file.NextBE<int32_t>();
 	invflag = file.NextBool8();
 	CharFlag = file.NextBool8();
-	int tmpNummonsters = file.NextBE<int32_t>();
+	const int tmpNummonsters = file.NextBE<int32_t>();
 	auto savedItemCount = file.NextBE<uint32_t>();
-	int tmpNummissiles = file.NextBE<int32_t>();
-	int tmpNobjects = file.NextBE<int32_t>();
+	const int tmpNummissiles = file.NextBE<int32_t>();
+	const int tmpNobjects = file.NextBE<int32_t>();
 
 	if (!gbIsHellfire && IsAnyOf(leveltype, DTYPE_NEST, DTYPE_CRYPT)) {
 		return tl::make_unexpected(std::string(_("Player is on a Hellfire only level")));
@@ -2546,7 +2546,7 @@ tl::expected<void, std::string> LoadGame(bool firstflag)
 			LoadLighting(&file, &Lights[ActiveLights[i]]);
 
 		file.Skip<int32_t>(); // VisionId
-		int visionCount = file.NextBE<int32_t>();
+		const int visionCount = file.NextBE<int32_t>();
 
 		for (int i = 0; i < visionCount; i++) {
 			LoadLighting(&file, &VisionList[i]);
@@ -2653,7 +2653,7 @@ tl::expected<void, std::string> LoadGame(bool firstflag)
 
 void SaveHeroItems(SaveWriter &saveWriter, Player &player)
 {
-	size_t itemCount = static_cast<size_t>(NUM_INVLOC) + InventoryGridCells + MaxBeltItems;
+	const size_t itemCount = static_cast<size_t>(NUM_INVLOC) + InventoryGridCells + MaxBeltItems;
 	SaveHelper file(saveWriter, "heroitems", itemCount * (gbIsHellfire ? HellfireItemSaveSize : DiabloItemSaveSize) + sizeof(uint8_t));
 
 	file.WriteLE<uint8_t>(gbIsHellfire ? 1 : 0);
@@ -2708,7 +2708,7 @@ void SaveStash(SaveWriter &stashWriter)
 	for (const auto &page : pagesToSave) {
 		file.WriteLE<uint32_t>(page);
 		for (const auto &row : Stash.stashGrids[page]) {
-			for (uint16_t cell : row) {
+			for (const uint16_t cell : row) {
 				file.WriteLE<uint16_t>(cell);
 			}
 		}
@@ -2769,20 +2769,20 @@ void SaveGameData(SaveWriter &saveWriter)
 		file.WriteBE<int32_t>(getHellfireLevelType(GetLevelType(i)));
 	}
 
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 	SavePlayer(file, myPlayer);
 
 	for (int i = 0; i < giNumberQuests; i++)
 		SaveQuest(&file, i);
 	for (int i = 0; i < MAXPORTAL; i++)
 		SavePortal(&file, i);
-	for (int monstkill : MonsterKillCounts)
+	for (const int monstkill : MonsterKillCounts)
 		file.WriteBE<int32_t>(monstkill);
 	// add padding for vanilla save compatibility (Related to bugfix where MonsterKillCounts[MaxMonsters] was changed to MonsterKillCounts[NUM_MTYPES]
 	file.Skip(4 * (MaxMonsters - NUM_MTYPES));
 
 	if (leveltype != DTYPE_TOWN) {
-		for (unsigned monsterId : ActiveMonsters)
+		for (const unsigned monsterId : ActiveMonsters)
 			file.WriteBE<uint32_t>(monsterId);
 		for (size_t i = 0; i < ActiveMonsterCount; i++)
 			SaveMonster(&file, Monsters[ActiveMonsters[i]]);
@@ -2802,16 +2802,16 @@ void SaveGameData(SaveWriter &saveWriter)
 				SaveMissile(&file, *it);
 			}
 		}
-		for (int objectId : ActiveObjects)
+		for (const int objectId : ActiveObjects)
 			file.WriteLE(static_cast<int8_t>(objectId));
-		for (int objectId : AvailableObjects)
+		for (const int objectId : AvailableObjects)
 			file.WriteLE(static_cast<int8_t>(objectId));
 		for (int i = 0; i < ActiveObjectCount; i++)
 			SaveObject(file, Objects[ActiveObjects[i]]);
 
 		file.WriteBE<int32_t>(ActiveLightCount);
 
-		for (uint8_t lightId : ActiveLights)
+		for (const uint8_t lightId : ActiveLights)
 			file.WriteLE<uint8_t>(lightId);
 		for (int i = 0; i < ActiveLightCount; i++)
 			SaveLighting(&file, &Lights[ActiveLights[i]]);
@@ -2826,7 +2826,7 @@ void SaveGameData(SaveWriter &saveWriter)
 
 	auto itemIndexes = SaveDroppedItems(file);
 
-	for (bool uniqueItemFlag : UniqueItemFlags)
+	for (const bool uniqueItemFlag : UniqueItemFlags)
 		file.WriteLE<uint8_t>(uniqueItemFlag ? 1 : 0);
 
 	for (int j = 0; j < MAXDUNY; j++) {

--- a/Source/lua/lua_global.cpp
+++ b/Source/lua/lua_global.cpp
@@ -86,7 +86,7 @@ sol::object LuaLoadScriptFromAssets(std::string_view packageName)
 		sol::stack::push(luaState.sol.lua_state(), assetData.error());
 		return sol::stack_object(luaState.sol.lua_state(), -1);
 	}
-	sol::load_result result = luaState.sol.load(std::string_view(*assetData), path, sol::load_mode::text);
+	const sol::load_result result = luaState.sol.load(std::string_view(*assetData), path, sol::load_mode::text);
 	if (!result.valid()) {
 		sol::stack::push(luaState.sol.lua_state(),
 		    StrCat("Lua error when loading ", path, ": ", result.get<std::string>()));
@@ -124,7 +124,7 @@ void LuaWarn(void *userData, const char *message, int continued)
 
 sol::object RunScript(std::optional<sol::environment> env, std::string_view packageName, bool optional)
 {
-	sol::object result = LuaLoadScriptFromAssets(packageName);
+	const sol::object result = LuaLoadScriptFromAssets(packageName);
 	// We return a string on error:
 	if (result.get_type() == sol::type::string) {
 		if (!optional)
@@ -220,12 +220,12 @@ void LuaReloadActiveMods()
 	std::vector<std::string_view> modnames = GetOptions().Mods.GetActiveModList();
 	LoadModArchives(modnames);
 
-	for (std::string_view modname : modnames) {
-		std::string packageName = StrCat("mods.", modname, ".init");
+	for (const std::string_view modname : modnames) {
+		const std::string packageName = StrCat("mods.", modname, ".init");
 		RunScript(CreateLuaSandbox(), packageName, /*optional=*/true);
 	}
 
-	for (tl::function_ref<void()> handler : IsModChangeHandlers) {
+	for (const tl::function_ref<void()> handler : IsModChangeHandlers) {
 		handler();
 	}
 

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -48,7 +48,7 @@ void LoadText(std::string_view text)
 
 	size_t previous = 0;
 	while (true) {
-		size_t next = paragraphs.find('\n', previous);
+		const size_t next = paragraphs.find('\n', previous);
 		TextLines.emplace_back(paragraphs.substr(previous, next - previous));
 		if (next == std::string::npos)
 			break;
@@ -98,7 +98,7 @@ int CalculateTextPosition()
  */
 void DrawQTextContent(const Surface &out)
 {
-	int y = CalculateTextPosition();
+	const int y = CalculateTextPosition();
 
 	const int sx = GetUIRectangle().position.x + 48;
 	const int sy = 0 - (y % LineHeight);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -129,7 +129,7 @@ Monster *FindClosest(Point source, int rad)
 	    source, 1, rad);
 
 	if (monsterPosition) {
-		int mid = dMonster[monsterPosition->x][monsterPosition->y];
+		const int mid = dMonster[monsterPosition->x][monsterPosition->y];
 		return &Monsters[mid - 1];
 	}
 
@@ -138,7 +138,7 @@ Monster *FindClosest(Point source, int rad)
 
 constexpr Direction16 Direction16Flip(Direction16 x, Direction16 pivot)
 {
-	std::underlying_type_t<Direction16> ret = (2 * static_cast<std::underlying_type_t<Direction16>>(pivot) + 16 - static_cast<std::underlying_type_t<Direction16>>(x)) % 16;
+	const std::underlying_type_t<Direction16> ret = (2 * static_cast<std::underlying_type_t<Direction16>>(pivot) + 16 - static_cast<std::underlying_type_t<Direction16>>(x)) % 16;
 
 	return static_cast<Direction16>(ret);
 }
@@ -151,7 +151,7 @@ void UpdateMissileVelocity(Missile &missile, WorldTilePosition destination, int 
 		return;
 
 	// Get the normalized vector in isometric projection
-	Displacement fixed16NormalVector = (Point { missile.position.tile } - Point { destination }).worldToNormalScreen();
+	const Displacement fixed16NormalVector = (Point { missile.position.tile } - Point { destination }).worldToNormalScreen();
 
 	// Multiplying by the target velocity gives us a scaled velocity vector.
 	missile.position.velocity = fixed16NormalVector * velocityInPixels;
@@ -163,7 +163,7 @@ void UpdateMissileVelocity(Missile &missile, WorldTilePosition destination, int 
  */
 void PutMissile(Missile &missile)
 {
-	Point position = missile.position.tile;
+	const Point position = missile.position.tile;
 
 	if (!InDungeonBounds(position))
 		missile._miDelFlag = true;
@@ -185,14 +185,14 @@ void PutMissile(Missile &missile)
 
 void UpdateMissilePos(Missile &missile)
 {
-	Displacement pixelsTravelled = missile.position.traveled >> 16;
+	const Displacement pixelsTravelled = missile.position.traveled >> 16;
 
-	Displacement tileOffset = pixelsTravelled.screenToMissile();
+	const Displacement tileOffset = pixelsTravelled.screenToMissile();
 	missile.position.tile = missile.position.start + tileOffset;
 
 	missile.position.offset = pixelsTravelled + tileOffset.worldToScreen();
 
-	Displacement absoluteLightOffset = pixelsTravelled.screenToLight();
+	const Displacement absoluteLightOffset = pixelsTravelled.screenToLight();
 	ChangeLightOffset(missile._mlid, absoluteLightOffset - tileOffset * 8);
 }
 
@@ -290,7 +290,7 @@ bool MonsterMHit(const Player &player, int monsterId, int mindam, int maxdam, in
 		if (monster.data().monsterClass == MonsterClass::Demon && HasAnyOf(player._pIFlags, ItemSpecialEffect::TripleDemonDamage))
 			dam *= 3;
 	}
-	bool resist = monster.isResistant(t, damageType);
+	const bool resist = monster.isResistant(t, damageType);
 	if (!shift)
 		dam <<= 6;
 	if (resist)
@@ -360,7 +360,7 @@ bool Plr2PlrMHit(const Player &player, Player &target, int mindam, int maxdam, i
 		break;
 	}
 
-	int hper = GenerateRnd(100);
+	const int hper = GenerateRnd(100);
 
 	int hit;
 	if (missileData.isArrow()) {
@@ -393,7 +393,7 @@ bool Plr2PlrMHit(const Player &player, Player &target, int mindam, int maxdam, i
 	} else {
 		dam = RandomIntBetween(mindam, maxdam);
 		if (missileData.isArrow() && damageType == DamageType::Physical) {
-			int damMod = IsAnyOf(player._pClass, HeroClass::Rogue) ? player._pDamageMod : player._pDamageMod / 2;
+			const int damMod = IsAnyOf(player._pClass, HeroClass::Rogue) ? player._pDamageMod : player._pDamageMod / 2;
 			dam += player._pIBonusDamMod + damMod + dam * player._pIBonusDam / 100;
 		}
 		if (!shift)
@@ -423,16 +423,16 @@ bool Plr2PlrMHit(const Player &player, Player &target, int mindam, int maxdam, i
 
 void RotateBlockedMissile(Missile &missile)
 {
-	int rotation = PickRandomlyAmong({ -1, 1 });
+	const int rotation = PickRandomlyAmong({ -1, 1 });
 
 	if (missile._miAnimType == MissileGraphicID::Arrow) {
-		int dir = missile._miAnimFrame + rotation;
+		const int dir = missile._miAnimFrame + rotation;
 		missile._miAnimFrame = (dir + 15) % 16 + 1;
 		return;
 	}
 
 	int dir = missile.getFrameGroupRaw() + rotation;
-	int mAnimFAmt = GetMissileSpriteData(missile._miAnimType).animFAmt;
+	const int mAnimFAmt = GetMissileSpriteData(missile._miAnimType).animFAmt;
 	if (dir < 0)
 		dir = mAnimFAmt - 1;
 	else if (dir >= mAnimFAmt)
@@ -446,8 +446,8 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 	if (!InDungeonBounds(position))
 		return;
 
-	int mx = position.x;
-	int my = position.y;
+	const int mx = position.x;
+	const int my = position.y;
 
 	bool isMonsterHit = false;
 	int mid = dMonster[mx][my];
@@ -485,7 +485,7 @@ void CheckMissileCol(Missile &missile, DamageType damageType, int minDamage, int
 				isPlayerHit = PlayerMHit(*player, &monster, missile._midist, minDamage, maxDamage, missile._mitype, damageType, isDamageShifted, DeathReason::MonsterOrTrap, &blocked);
 			}
 		} else {
-			DeathReason deathReason = missile.sourceType() == MissileSource::Player ? DeathReason::Player : DeathReason::MonsterOrTrap;
+			const DeathReason deathReason = missile.sourceType() == MissileSource::Player ? DeathReason::Player : DeathReason::MonsterOrTrap;
 			isPlayerHit = PlayerMHit(*player, nullptr, missile._midist, minDamage, maxDamage, missile._mitype, damageType, isDamageShifted, deathReason, &blocked);
 		}
 	}
@@ -553,9 +553,9 @@ bool MoveMissile(Missile &missile, tl::function_ref<bool(Point)> checkTile, bool
 				break;
 
 			// calculate in-between tile
-			Displacement pixelsTraveled = traveled >> 16;
-			Displacement tileOffset = pixelsTraveled.screenToMissile();
-			Point tile = missile.position.start + tileOffset;
+			const Displacement pixelsTraveled = traveled >> 16;
+			const Displacement tileOffset = pixelsTraveled.screenToMissile();
+			const Point tile = missile.position.start + tileOffset;
 
 			// we haven't quite reached the missile's current position,
 			// but we can break early to avoid checking collisions in this tile twice
@@ -617,9 +617,9 @@ void MoveMissileAndCheckMissileCol(Missile &missile, DamageType damageType, int 
 		return !IsMissileBlockedByTile(tile);
 	};
 
-	bool tileChanged = MoveMissile(missile, checkTile, ifCollidesDontMoveToHitTile);
+	const bool tileChanged = MoveMissile(missile, checkTile, ifCollidesDontMoveToHitTile);
 
-	int16_t tileTargetHash = dMonster[missile.position.tile.x][missile.position.tile.y] ^ dPlayer[missile.position.tile.x][missile.position.tile.y];
+	const int16_t tileTargetHash = dMonster[missile.position.tile.x][missile.position.tile.y] ^ dPlayer[missile.position.tile.x][missile.position.tile.y];
 
 	// missile didn't change the tile... check that we perform CheckMissileCol only once for any monster/player to avoid multiple hits for slow missiles
 	if (!tileChanged && missile.lastCollisionTargetHash != tileTargetHash) {
@@ -673,11 +673,11 @@ bool CheckIfTrig(Point position)
 
 bool GuardianTryFireAt(Missile &missile, Point target)
 {
-	Point position = missile.position.tile;
+	const Point position = missile.position.tile;
 
 	if (!LineClearMissile(position, target))
 		return false;
-	int mid = dMonster[target.x][target.y] - 1;
+	const int mid = dMonster[target.x][target.y] - 1;
 	if (mid < 0)
 		return false;
 	const Monster &monster = Monsters[mid];
@@ -686,11 +686,11 @@ bool GuardianTryFireAt(Missile &missile, Point target)
 	if (monster.hitPoints >> 6 <= 0)
 		return false;
 
-	Player &player = Players[missile._misource];
+	const Player &player = Players[missile._misource];
 	int dmg = GenerateRnd(10) + (player.getCharacterLevel() / 2) + 1;
 	dmg = ScaleSpellEffect(dmg, missile._mispllvl);
 
-	Direction dir = GetDirection(position, target);
+	const Direction dir = GetDirection(position, target);
 	AddMissile(position, target, dir, MissileID::Firebolt, TARGET_MONSTERS, missile._misource, missile._midam, missile.sourcePlayer()->GetSpellLevel(SpellID::Guardian), &missile);
 	missile.setFrameGroup<GuardianFrame>(GuardianFrame::Attack);
 	missile.var2 = 3;
@@ -700,7 +700,7 @@ bool GuardianTryFireAt(Missile &missile, Point target)
 
 bool GrowWall(int id, Point position, Point target, MissileID type, int spellLevel, int damage, bool skipWall = false)
 {
-	[[maybe_unused]] int dp = dPiece[position.x][position.y];
+	[[maybe_unused]] const int dp = dPiece[position.x][position.y];
 	assert(dp <= MAXTILES && dp >= 0);
 
 	if (TileHasAny(position, TileProperties::BlockMissile) || !InDungeonBounds(target)) {
@@ -729,7 +729,7 @@ void SpawnLightning(Missile &missile, int dam)
 	MoveMissile(
 	    missile, [&](Point tile) {
 		    assert(InDungeonBounds(tile));
-		    [[maybe_unused]] int pn = dPiece[tile.x][tile.y];
+		    [[maybe_unused]] const int pn = dPiece[tile.x][tile.y];
 		    assert(pn >= 0 && pn <= MAXTILES);
 
 		    if (!missile.IsTrap() || tile != missile.position.start) {
@@ -799,7 +799,7 @@ DamageRange GetDamageAmt(SpellID spell, int spellLevel)
 	assert(MyPlayer != nullptr);
 	assert(spell >= SpellID::FIRST && spell <= SpellID::LAST);
 
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	switch (spell) {
 	case SpellID::Firebolt: {
@@ -910,11 +910,11 @@ DamageRange GetDamageAmt(SpellID spell, int spellLevel)
 
 Direction16 GetDirection16(Point p1, Point p2)
 {
-	Displacement offset = p2 - p1;
+	const Displacement offset = p2 - p1;
 	Displacement absolute = abs(offset);
 
-	bool flipY = offset.deltaX != absolute.deltaX;
-	bool flipX = offset.deltaY != absolute.deltaY;
+	const bool flipY = offset.deltaX != absolute.deltaX;
+	const bool flipX = offset.deltaY != absolute.deltaY;
 
 	bool flipMedian = false;
 	if (absolute.deltaX > absolute.deltaY) {
@@ -951,7 +951,7 @@ bool MonsterTrapHit(int monsterId, int mindam, int maxdam, int dist, MissileID t
 	if (!monster.isPossibleToHit() || monster.isImmune(t, damageType))
 		return false;
 
-	int hit = GenerateRnd(100);
+	const int hit = GenerateRnd(100);
 	int hper = 90 - monster.armorClass - dist;
 	hper = std::clamp(hper, 5, 95);
 	if (monster.tryLiftGargoyle())
@@ -963,7 +963,7 @@ bool MonsterTrapHit(int monsterId, int mindam, int maxdam, int dist, MissileID t
 			return false;
 	}
 
-	bool resist = monster.isResistant(t, damageType);
+	const bool resist = monster.isResistant(t, damageType);
 	int dam = RandomIntBetween(mindam, maxdam);
 	if (!shift)
 		dam <<= 6;
@@ -1009,7 +1009,7 @@ bool PlayerMHit(Player &player, Monster *monster, int dist, int mind, int maxd, 
 #endif
 	int hper = 40;
 	if (missileData.isArrow()) {
-		int tac = player.GetArmor();
+		const int tac = player.GetArmor();
 		if (monster != nullptr) {
 			hper = monster->toHit(sgGameInitInfo.nDifficulty)
 			    + ((monster->level(sgGameInitInfo.nDifficulty) - player.getCharacterLevel()) * 2)
@@ -1160,8 +1160,8 @@ void InitMissiles()
 
 void AddOpenNest(Missile &missile, AddMissileParameter &parameter)
 {
-	for (WorldTileCoord x : { 80, 81 }) {
-		for (WorldTileCoord y : { 62, 63 }) {
+	for (const WorldTileCoord x : { 80, 81 }) {
+		for (const WorldTileCoord y : { 62, 63 }) {
 			AddMissile({ x, y }, { 80, 62 }, parameter.midir, MissileID::BigExplosion, missile._micaster, missile._misource, missile._midam, 0);
 		}
 	}
@@ -1175,8 +1175,8 @@ void AddRuneOfFire(Missile &missile, AddMissileParameter &parameter)
 
 void AddRuneOfLight(Missile &missile, AddMissileParameter &parameter)
 {
-	int lvl = (missile.sourceType() == MissileSource::Player) ? missile.sourcePlayer()->getCharacterLevel() : 0;
-	int dmg = 16 * (GenerateRndSum(10, 2) + lvl + 2);
+	const int lvl = (missile.sourceType() == MissileSource::Player) ? missile.sourcePlayer()->getCharacterLevel() : 0;
+	const int dmg = 16 * (GenerateRndSum(10, 2) + lvl + 2);
 	missile._midam = dmg;
 	AddRune(missile, parameter.dst, MissileID::LightningWall);
 }
@@ -1227,7 +1227,7 @@ void AddBerserk(Missile &missile, AddMissileParameter &parameter)
 			    return false;
 		    }
 
-		    int monsterId = std::abs(dMonster[target.x][target.y]) - 1;
+		    const int monsterId = std::abs(dMonster[target.x][target.y]) - 1;
 		    if (monsterId < 0)
 			    return false;
 
@@ -1251,14 +1251,14 @@ void AddBerserk(Missile &missile, AddMissileParameter &parameter)
 
 	if (targetMonsterPosition) {
 		Monster &monster = Monsters[std::abs(dMonster[targetMonsterPosition->x][targetMonsterPosition->y]) - 1];
-		Player &player = *missile.sourcePlayer();
+		const Player &player = *missile.sourcePlayer();
 		const int slvl = player.GetSpellLevel(SpellID::Berserk);
 		monster.flags |= MFLAG_BERSERK | MFLAG_GOLEM;
 		monster.minDamage = (GenerateRnd(10) + 120) * monster.minDamage / 100 + slvl;
 		monster.maxDamage = (GenerateRnd(10) + 120) * monster.maxDamage / 100 + slvl;
 		monster.minDamageSpecial = (GenerateRnd(10) + 120) * monster.minDamageSpecial / 100 + slvl;
 		monster.maxDamageSpecial = (GenerateRnd(10) + 120) * monster.maxDamageSpecial / 100 + slvl;
-		int lightRadius = leveltype == DTYPE_NEST ? 9 : 3;
+		const int lightRadius = leveltype == DTYPE_NEST ? 9 : 3;
 		monster.lightId = AddLight(monster.position.tile, lightRadius);
 		parameter.spellFizzled = false;
 	}
@@ -1313,7 +1313,7 @@ void AddJester(Missile &missile, AddMissileParameter &parameter)
 void AddStealPotions(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	Crawl(0, 2, [&](Displacement displacement) {
-		Point target = missile.position.start + displacement;
+		const Point target = missile.position.start + displacement;
 		if (!InDungeonBounds(target))
 			return false;
 		Player *player = PlayerAtPosition(target);
@@ -1429,7 +1429,7 @@ void AddWarp(Missile &missile, AddMissileParameter &parameter)
 {
 	int minDistanceSq = std::numeric_limits<int>::max();
 
-	int id = missile._misource;
+	const int id = missile._misource;
 	Player &player = Players[id];
 	Point tile = player.position.tile;
 
@@ -1511,7 +1511,7 @@ void AddLightningWall(Missile &missile, AddMissileParameter &parameter)
 		missile.var2 = missile.position.start.y;
 		break;
 	case MissileSource::Player: {
-		Player &player = *missile.sourcePlayer();
+		const Player &player = *missile.sourcePlayer();
 		missile.var1 = player.position.tile.x;
 		missile.var2 = player.position.tile.y;
 	} break;
@@ -1530,7 +1530,7 @@ void AddBigExplosion(Missile &missile, AddMissileParameter & /*parameter*/)
 		missile._midam = dmg;
 
 		const DamageType damageType = GetMissileData(missile._mitype).damageType();
-		for (Point position : PointsInRectangleColMajor(Rectangle { missile.position.tile, 1 }))
+		for (const Point position : PointsInRectangleColMajor(Rectangle { missile.position.tile, 1 }))
 			CheckMissileCol(missile, damageType, dmg, dmg, false, position, true);
 	}
 	missile._mlid = AddLight(missile.position.start, 8);
@@ -1628,8 +1628,8 @@ void AddSearch(Missile &missile, AddMissileParameter & /*parameter*/)
 
 	for (auto &other : Missiles) {
 		if (&other != &missile && missile.isSameSource(other) && other._mitype == MissileID::Search) {
-			int r1 = missile.duration;
-			int r2 = other.duration;
+			const int r1 = missile.duration;
+			const int r2 = other.duration;
 			if (r2 < INT_MAX - r1)
 				other.duration = r1 + r2;
 			missile._miDelFlag = true;
@@ -1732,9 +1732,9 @@ void UpdateVileMissPos(Missile &missile, Point dst)
 {
 	for (int k = 1; k < 50; k++) {
 		for (int j = -k; j <= k; j++) {
-			int yy = j + dst.y;
+			const int yy = j + dst.y;
 			for (int i = -k; i <= k; i++) {
-				int xx = i + dst.x;
+				const int xx = i + dst.x;
 				if (PosOkPlayer(*MyPlayer, { xx, yy })) {
 					missile.position.tile = WorldTilePosition(xx, yy);
 					return;
@@ -1748,7 +1748,7 @@ void AddPhasing(Missile &missile, AddMissileParameter &parameter)
 {
 	missile.duration = 2;
 
-	Player &player = Players[missile._misource];
+	const Player &player = Players[missile._misource];
 
 	if (missile._micaster == TARGET_BOTH) {
 		missile.position.tile = parameter.dst;
@@ -1765,7 +1765,7 @@ void AddPhasing(Missile &missile, AddMissileParameter &parameter)
 			if ((x >= -3 && x <= 3) || (y >= -3 && y <= 3))
 				continue; // Skip center
 
-			Point target = missile.position.start + Displacement { x, y };
+			const Point target = missile.position.start + Displacement { x, y };
 			if (!PosOkPlayer(player, target))
 				continue;
 
@@ -1882,7 +1882,7 @@ void AddFireWall(Missile &missile, AddMissileParameter &parameter)
 	missile._midam += missile._misource >= 0 ? Players[missile._misource].getCharacterLevel() : currlevel; // BUGFIX: missing parenthesis around ternary (fixed)
 	missile._midam <<= 3;
 	UpdateMissileVelocity(missile, parameter.dst, 16);
-	int i = missile._mispllvl;
+	const int i = missile._mispllvl;
 	missile.duration = 10;
 	if (i > 0)
 		missile.duration *= i + 1;
@@ -1901,9 +1901,9 @@ void AddFireball(Missile &missile, AddMissileParameter &parameter)
 	int sp = 16;
 	if (missile._micaster == TARGET_MONSTERS) {
 		sp += std::min(missile._mispllvl * 2, 34);
-		Player &player = Players[missile._misource];
+		const Player &player = Players[missile._misource];
 
-		int dmg = 2 * (player.getCharacterLevel() + GenerateRndSum(10, 2)) + 4;
+		const int dmg = 2 * (player.getCharacterLevel() + GenerateRndSum(10, 2)) + 4;
 		missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
 	}
 	UpdateMissileVelocity(missile, dst, sp);
@@ -2038,8 +2038,8 @@ void AddFlashBottom(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	switch (missile.sourceType()) {
 	case MissileSource::Player: {
-		Player &player = *missile.sourcePlayer();
-		int dmg = GenerateRndSum(20, player.getCharacterLevel() + 1) + player.getCharacterLevel() + 1;
+		const Player &player = *missile.sourcePlayer();
+		const int dmg = GenerateRndSum(20, player.getCharacterLevel() + 1) + player.getCharacterLevel() + 1;
 		missile._midam = ScaleSpellEffect(dmg, missile._mispllvl);
 		missile._midam += missile._midam / 2;
 	} break;
@@ -2099,7 +2099,7 @@ void AddFlameWave(Missile &missile, AddMissileParameter &parameter)
 
 void AddGuardian(Missile &missile, AddMissileParameter &parameter)
 {
-	Player &player = Players[missile._misource];
+	const Player &player = Players[missile._misource];
 
 	std::optional<Point> spawnPosition = FindClosestValidPosition(
 	    [start = missile.position.start](Point target) {
@@ -2160,7 +2160,7 @@ void InitMissileAnimationFromMonster(Missile &mis, Direction midir, const Monste
 	const AnimStruct &anim = mon.type().getAnimData(graphic);
 	mis.setDirection(midir);
 	mis._miAnimFlags = MissileGraphicsFlags::None;
-	ClxSpriteList sprites = *anim.spritesForDirection(midir);
+	const ClxSpriteList sprites = *anim.spritesForDirection(midir);
 	const uint16_t width = sprites[0].width();
 	mis._miAnimData.emplace(sprites);
 	mis._miAnimDelay = anim.rate;
@@ -2177,7 +2177,7 @@ void InitMissileAnimationFromMonster(Missile &mis, Direction midir, const Monste
 
 void AddRhino(Missile &missile, AddMissileParameter &parameter)
 {
-	Monster &monster = Monsters[missile._misource];
+	const Monster &monster = Monsters[missile._misource];
 
 	MonsterGraphic graphic = MonsterGraphic::Walk;
 	if (IsAnyOf(monster.type().type, MT_HORNED, MT_MUDRUN, MT_FROSTC, MT_OBLORD)) {
@@ -2207,7 +2207,7 @@ void AddGenericMagicMissile(Missile &missile, AddMissileParameter &parameter)
 	missile.var2 = missile.position.start.y;
 	missile._mlid = AddLight(missile.position.start, 8);
 	if (missile._micaster != TARGET_MONSTERS && missile._misource > 0) {
-		Monster &monster = Monsters[missile._misource];
+		const Monster &monster = Monsters[missile._misource];
 		if (monster.type().type == MT_SUCCUBUS)
 			missile.setAnimation(MissileGraphicID::BloodStar);
 		if (monster.type().type == MT_SNOWWICH)
@@ -2269,7 +2269,7 @@ void AddAcid(Missile &missile, AddMissileParameter &parameter)
 void AddAcidPuddle(Missile &missile, AddMissileParameter & /*parameter*/)
 {
 	missile._miLightFlag = true;
-	int monst = missile._misource;
+	const int monst = missile._misource;
 	missile.duration = GenerateRnd(15) + 40 * (Monsters[monst].intelligence + 1);
 	missile._miPreFlag = true;
 }
@@ -2282,12 +2282,12 @@ void AddStoneCurse(Missile &missile, AddMissileParameter &parameter)
 			    return false;
 		    }
 
-		    int monsterId = std::abs(dMonster[target.x][target.y]) - 1;
+		    const int monsterId = std::abs(dMonster[target.x][target.y]) - 1;
 		    if (monsterId < 0) {
 			    return false;
 		    }
 
-		    Monster &monster = Monsters[monsterId];
+		    const Monster &monster = Monsters[monsterId];
 
 		    if (IsAnyOf(monster.type().type, MT_GOLEM, MT_DIABLO, MT_NAKRUL)) {
 			    return false;
@@ -2307,7 +2307,7 @@ void AddStoneCurse(Missile &missile, AddMissileParameter &parameter)
 	}
 
 	// Petrify the targeted monster
-	int monsterId = std::abs(dMonster[targetMonsterPosition->x][targetMonsterPosition->y]) - 1;
+	const int monsterId = std::abs(dMonster[targetMonsterPosition->x][targetMonsterPosition->y]) - 1;
 	Monster &monster = Monsters[monsterId];
 
 	if (monster.mode == MonsterMode::Petrified) {
@@ -2334,7 +2334,7 @@ void AddGolem(Missile &missile, AddMissileParameter &parameter)
 {
 	missile._miDelFlag = true;
 
-	int playerId = missile._misource;
+	const int playerId = missile._misource;
 	Player &player = Players[playerId];
 	Monster *golem = FindGolemForPlayer(player);
 
@@ -2356,7 +2356,7 @@ void AddGolem(Missile &missile, AddMissileParameter &parameter)
 	if (&player != MyPlayer)
 		return;
 
-	uint8_t spellLevel = static_cast<uint8_t>(missile._mispllvl);
+	const uint8_t spellLevel = static_cast<uint8_t>(missile._mispllvl);
 
 	// The command is only executed for the level owner, to prevent desyncs in multiplayer.
 	if (!MyPlayer->isLevelOwnedByLocalClient()) {
@@ -2415,9 +2415,9 @@ void AddElemental(Missile &missile, AddMissileParameter &parameter)
 		dst += parameter.midir;
 	}
 
-	Player &player = Players[missile._misource];
+	const Player &player = Players[missile._misource];
 
-	int dmg = 2 * (player.getCharacterLevel() + GenerateRndSum(10, 2)) + 4;
+	const int dmg = 2 * (player.getCharacterLevel() + GenerateRndSum(10, 2)) + 4;
 	missile._midam = ScaleSpellEffect(dmg, missile._mispllvl) / 2;
 
 	UpdateMissileVelocity(missile, dst, 16);
@@ -2492,8 +2492,8 @@ void AddNova(Missile &missile, AddMissileParameter &parameter)
 	missile.var2 = parameter.dst.y;
 
 	if (!missile.IsTrap()) {
-		Player &player = Players[missile._misource];
-		int dmg = GenerateRndSum(6, 5) + player.getCharacterLevel() + 5;
+		const Player &player = Players[missile._misource];
+		const int dmg = GenerateRndSum(6, 5) + player.getCharacterLevel() + 5;
 		missile._midam = ScaleSpellEffect(dmg / 2, missile._mispllvl);
 	} else {
 		missile._midam = (currlevel / 2) + GenerateRndSum(3, 3);
@@ -2573,7 +2573,7 @@ void AddTrapDisarm(Missile &missile, AddMissileParameter & /*parameter*/)
 
 void AddApocalypse(Missile &missile, AddMissileParameter & /*parameter*/)
 {
-	Player &player = Players[missile._misource];
+	const Player &player = Players[missile._misource];
 
 	missile.var1 = 8;
 	missile.var2 = std::max(missile.position.start.y - 8, 1);
@@ -2581,7 +2581,7 @@ void AddApocalypse(Missile &missile, AddMissileParameter & /*parameter*/)
 	missile.var4 = std::max(missile.position.start.x - 8, 1);
 	missile.var5 = std::min(missile.position.start.x + 8, MAXDUNX - 1);
 	missile.var6 = missile.var4;
-	int playerLevel = player.getCharacterLevel();
+	const int playerLevel = player.getCharacterLevel();
 	missile._midam = GenerateRndSum(6, playerLevel) + playerLevel;
 	missile.duration = 255;
 }
@@ -2596,10 +2596,10 @@ void AddInferno(Missile &missile, AddMissileParameter &parameter)
 	missile.duration = missile.var2 + 20;
 	missile._mlid = AddLight(missile.position.start, 1);
 	if (missile._micaster == TARGET_MONSTERS) {
-		int i = GenerateRnd(Players[missile._misource].getCharacterLevel()) + GenerateRnd(2);
+		const int i = GenerateRnd(Players[missile._misource].getCharacterLevel()) + GenerateRnd(2);
 		missile._midam = 8 * i + 16 + ((8 * i + 16) / 2);
 	} else {
-		Monster &monster = Monsters[missile._misource];
+		const Monster &monster = Monsters[missile._misource];
 		missile._midam = RandomIntBetween(monster.minDamage, monster.maxDamage);
 	}
 }
@@ -2645,7 +2645,7 @@ void AddHolyBolt(Missile &missile, AddMissileParameter &parameter)
 		sp += std::min(missile._mispllvl * 2, 47);
 	}
 
-	Player &player = Players[missile._misource];
+	const Player &player = Players[missile._misource];
 
 	UpdateMissileVelocity(missile, dst, sp);
 	missile.setDirection(GetDirection16(missile.position.start, dst));
@@ -2747,7 +2747,7 @@ Missile *AddMissile(WorldTilePosition src, WorldTilePosition dst, Direction midi
 	missile.lastCollisionTargetHash = 0;
 
 	if (!missile.IsTrap() && micaster == TARGET_PLAYERS) {
-		Monster &monster = Monsters[id];
+		const Monster &monster = Monsters[id];
 		if (monster.isUnique()) {
 			missile._miUniqTrans = monster.uniqTrans + 1;
 		}
@@ -2783,7 +2783,7 @@ void ProcessElementalArrow(Missile &missile)
 	} else {
 		int mind;
 		int maxd;
-		int p = missile._misource;
+		const int p = missile._misource;
 		missile._midist++;
 		if (!missile.IsTrap()) {
 			if (missile._micaster == TARGET_MONSTERS) {
@@ -2793,7 +2793,7 @@ void ProcessElementalArrow(Missile &missile)
 				maxd = player._pIMaxDam;
 			} else {
 				// BUGFIX: damage of missile should be encoded in missile struct; monster can be dead before missile arrives.
-				Monster &monster = Monsters[p];
+				const Monster &monster = Monsters[p];
 				mind = monster.minDamage;
 				maxd = monster.maxDamage;
 			}
@@ -2897,8 +2897,8 @@ void ProcessGenericProjectile(Missile &missile)
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, true);
 	if (missile.duration == 0) {
 		missile._miDelFlag = true;
-		Point dst = { 0, 0 };
-		Direction dir = missile.getDirection();
+		const Point dst = { 0, 0 };
+		const Direction dir = missile.getDirection();
 		switch (missile._mitype) {
 		case MissileID::Firebolt:
 		case MissileID::MagmaBall:
@@ -2944,9 +2944,9 @@ void ProcessGenericProjectile(Missile &missile)
 
 void ProcessNovaBall(Missile &missile)
 {
-	Point targetPosition = { missile.var1, missile.var2 };
+	const Point targetPosition = { missile.var1, missile.var2 };
 	missile.duration--;
-	int j = missile.duration;
+	const int j = missile.duration;
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, false, false);
 	if (missile._miHitFlag)
 		missile.duration = j;
@@ -2965,7 +2965,7 @@ void ProcessNovaBall(Missile &missile)
 void ProcessAcidPuddle(Missile &missile)
 {
 	missile.duration--;
-	int range = missile.duration;
+	const int range = missile.duration;
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
 	missile.duration = range;
 	if (range == 0) {
@@ -3003,7 +3003,7 @@ void ProcessFireWall(Missile &missile)
 	if (missile.getFrameGroup<FireWallFrame>() == FireWallFrame::Start && missile.duration != 0 && missile.var2 <= MaxExpLightIndex * 2) {
 		if (missile.var2 == 0)
 			missile._mlid = AddLight(missile.position.tile, ExpLight[0]);
-		int expLightIndex = MaxExpLightIndex - std::abs(missile.var2 - MaxExpLightIndex);
+		const int expLightIndex = MaxExpLightIndex - std::abs(missile.var2 - MaxExpLightIndex);
 		ChangeLight(missile._mlid, missile.position.tile, ExpLight[expLightIndex]);
 		missile.var2++;
 	}
@@ -3024,7 +3024,7 @@ void ProcessFireball(Missile &missile)
 		int maxDam = missile._midam;
 
 		if (missile._micaster != TARGET_MONSTERS) {
-			Monster &monster = Monsters[missile._misource];
+			const Monster &monster = Monsters[missile._misource];
 			minDam = monster.minDamage;
 			maxDam = monster.maxDamage;
 		}
@@ -3045,7 +3045,7 @@ void ProcessFireball(Missile &missile)
 				Direction::West,
 				Direction::North
 			};
-			for (Direction offset : Offsets) {
+			for (const Direction offset : Offsets) {
 				if (!CheckBlock(missile.position.start, missilePosition + offset))
 					CheckMissileCol(missile, damageType, minDam, maxDam, false, missilePosition + offset, true);
 			}
@@ -3106,12 +3106,12 @@ void ProcessHorkSpawn(Missile &missile)
 
 void ProcessRune(Missile &missile)
 {
-	Point position = missile.position.tile;
-	int mid = dMonster[position.x][position.y];
+	const Point position = missile.position.tile;
+	const int mid = dMonster[position.x][position.y];
 	Player *player = PlayerAtPosition(position);
 	if (mid != 0 || player != nullptr) {
-		Point targetPosition = mid != 0 ? Monsters[std::abs(mid) - 1].position.tile : player->position.tile;
-		Direction dir = GetDirection(position, targetPosition);
+		const Point targetPosition = mid != 0 ? Monsters[std::abs(mid) - 1].position.tile : player->position.tile;
+		const Direction dir = GetDirection(position, targetPosition);
 
 		missile._miDelFlag = true;
 		AddUnLight(missile._mlid);
@@ -3125,7 +3125,7 @@ void ProcessRune(Missile &missile)
 void ProcessLightningWall(Missile &missile)
 {
 	missile.duration--;
-	int range = missile.duration;
+	const int range = missile.duration;
 	CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
 	if (missile._miHitFlag)
 		missile.duration = range;
@@ -3153,14 +3153,14 @@ void ProcessRingOfFire(Missile &missile)
 {
 	missile._miDelFlag = true;
 	int8_t src = missile._misource;
-	uint8_t lvl = missile._micaster == TARGET_MONSTERS ? Players[src].getCharacterLevel() : currlevel;
+	const uint8_t lvl = missile._micaster == TARGET_MONSTERS ? Players[src].getCharacterLevel() : currlevel;
 	int dmg = 16 * (GenerateRndSum(10, 2) + lvl + 2) / 2;
 
 	if (missile.limitReached)
 		return;
 
 	Crawl(3, [&](Displacement displacement) {
-		Point target = Point { missile.var1, missile.var2 } + displacement;
+		const Point target = Point { missile.var1, missile.var2 } + displacement;
 		if (!InDungeonBounds(target))
 			return false;
 		if (TileHasAny(target, TileProperties::Solid))
@@ -3195,9 +3195,9 @@ void ProcessSearch(Missile &missile)
 
 void ProcessNovaCommon(Missile &missile, MissileID projectileType)
 {
-	int id = missile._misource;
-	int dam = missile._midam;
-	Point src = missile.position.tile;
+	const int id = missile._misource;
+	const int dam = missile._midam;
+	const Point src = missile.position.tile;
 	Direction dir = Direction::South;
 	mienemy_type en = TARGET_PLAYERS;
 	if (!missile.IsTrap()) {
@@ -3206,10 +3206,10 @@ void ProcessNovaCommon(Missile &missile, MissileID projectileType)
 	}
 
 	constexpr std::array<WorldTileDisplacement, 9> quarterRadius = { { { 4, 0 }, { 4, 1 }, { 4, 2 }, { 4, 3 }, { 4, 4 }, { 3, 4 }, { 2, 4 }, { 1, 4 }, { 0, 4 } } };
-	for (WorldTileDisplacement quarterOffset : quarterRadius) {
+	for (const WorldTileDisplacement quarterOffset : quarterRadius) {
 		// This ends up with two missiles targeting offsets 4,0, 0,4, -4,0, 0,-4.
-		std::array<WorldTileDisplacement, 4> offsets { quarterOffset, quarterOffset.flipXY(), quarterOffset.flipX(), quarterOffset.flipY() };
-		for (WorldTileDisplacement offset : offsets)
+		const std::array<WorldTileDisplacement, 4> offsets { quarterOffset, quarterOffset.flipXY(), quarterOffset.flipX(), quarterOffset.flipY() };
+		for (const WorldTileDisplacement offset : offsets)
 			AddMissile(src, src + offset, dir, projectileType, en, id, dam, missile._mispllvl);
 	}
 	missile.duration--;
@@ -3229,11 +3229,11 @@ void ProcessNova(Missile &missile)
 
 void ProcessSpectralArrow(Missile &missile)
 {
-	int id = missile._misource;
-	int dam = missile._midam;
-	Point src = missile.position.tile;
-	Point dst = { missile.var1, missile.var2 };
-	int spllvl = missile.var3;
+	const int id = missile._misource;
+	const int dam = missile._midam;
+	const Point src = missile.position.tile;
+	const Point dst = { missile.var1, missile.var2 };
+	const int spllvl = missile.var3;
 	MissileID mitype = MissileID::Arrow;
 	Direction dir = Direction::South;
 	mienemy_type micaster = TARGET_PLAYERS;
@@ -3279,7 +3279,7 @@ void ProcessLightningControl(Missile &missile)
 		// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
 		dam = (GenerateRnd(2) + GenerateRnd(Players[missile._misource].getCharacterLevel()) + 2) << 6;
 	} else {
-		Monster &monster = Monsters[missile._misource];
+		const Monster &monster = Monsters[missile._misource];
 		dam = 2 * RandomIntBetween(monster.minDamage, monster.maxDamage);
 	}
 
@@ -3289,7 +3289,7 @@ void ProcessLightningControl(Missile &missile)
 void ProcessLightning(Missile &missile)
 {
 	missile.duration--;
-	int j = missile.duration;
+	const int j = missile.duration;
 	if (missile.position.tile != missile.position.start)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile, false);
 	if (missile._miHitFlag)
@@ -3303,7 +3303,7 @@ void ProcessLightning(Missile &missile)
 
 void ProcessTownPortal(Missile &missile)
 {
-	int expLight[17] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 15 };
+	const int expLight[17] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 15 };
 
 	if (missile.duration > 1)
 		missile.duration--;
@@ -3349,7 +3349,7 @@ void ProcessFlashBottom(Missile &missile)
 		Direction::SouthWest,
 		Direction::South
 	};
-	for (Direction offset : Offsets)
+	for (const Direction offset : Offsets)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile + offset, true);
 
 	if (missile.duration == 0) {
@@ -3375,7 +3375,7 @@ void ProcessFlashTop(Missile &missile)
 		Direction::NorthEast,
 		Direction::East
 	};
-	for (Direction offset : Offsets)
+	for (const Direction offset : Offsets)
 		CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, true, missile.position.tile + offset, true);
 
 	if (missile.duration == 0) {
@@ -3402,7 +3402,7 @@ void ProcessFlameWave(Missile &missile)
 		missile.setFrameGroup<FireWallFrame>(FireWallFrame::Idle);
 		missile._miAnimFrame = GenerateRnd(11) + 1;
 	}
-	int j = missile.duration;
+	const int j = missile.duration;
 	MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), missile._midam, missile._midam, false, false);
 	if (missile._miHitFlag)
 		missile.duration = j;
@@ -3433,7 +3433,7 @@ void ProcessGuardian(Missile &missile)
 		missile.setFrameGroup<GuardianFrame>(GuardianFrame::Idle);
 	}
 
-	Point position = missile.position.tile;
+	const Point position = missile.position.tile;
 
 	if ((missile.duration % 16) == 0) {
 		// Guardians pick a target by working backwards along lines originally based on VisionCrawlTable.
@@ -3462,7 +3462,7 @@ void ProcessGuardian(Missile &missile)
 			    // clang-format on
 			}
 		};
-		for (WorldTileDisplacement offset : guardianArc) {
+		for (const WorldTileDisplacement offset : guardianArc) {
 			if (GuardianTryFireAt(missile, position + offset)
 			    || GuardianTryFireAt(missile, position + offset.flipXY())
 			    || GuardianTryFireAt(missile, position + offset.flipY())
@@ -3497,12 +3497,12 @@ void ProcessChainLightning(Missile &missile)
 {
 	int id = missile._misource;
 	Point position = missile.position.tile;
-	Point dst { missile.var1, missile.var2 };
+	const Point dst { missile.var1, missile.var2 };
 	Direction dir = GetDirection(position, dst);
 	AddMissile(position, dst, dir, MissileID::LightningControl, TARGET_MONSTERS, id, 1, missile._mispllvl);
-	int rad = std::min<int>(missile._mispllvl + 3, MaxCrawlRadius);
+	const int rad = std::min<int>(missile._mispllvl + 3, MaxCrawlRadius);
 	Crawl(1, rad, [&](Displacement displacement) {
-		Point target = position + displacement;
+		const Point target = position + displacement;
 		if (InDungeonBounds(target) && dMonster[target.x][target.y] > 0) {
 			dir = GetDirection(position, target);
 			AddMissile(position, target, dir, MissileID::LightningControl, TARGET_MONSTERS, id, 1, missile._mispllvl);
@@ -3577,8 +3577,8 @@ void ProcessAcidSplate(Missile &missile)
 	missile.duration--;
 	if (missile.duration == 0) {
 		missile._miDelFlag = true;
-		int monst = missile._misource;
-		int dam = (Monsters[monst].data().level >= 2 ? 2 : 1);
+		const int monst = missile._misource;
+		const int dam = (Monsters[monst].data().level >= 2 ? 2 : 1);
 		AddMissile(missile.position.tile, { 0, 0 }, Direction::South, MissileID::AcidPuddle, TARGET_PLAYERS, monst, dam, missile._mispllvl);
 	} else {
 		PutMissile(missile);
@@ -3593,7 +3593,7 @@ void ProcessTeleport(Missile &missile)
 		return;
 	}
 
-	int id = missile._misource;
+	const int id = missile._misource;
 	Player &player = Players[id];
 
 	std::optional<Point> teleportDestination = FindClosestValidPosition(
@@ -3664,14 +3664,14 @@ void ProcessApocalypseBoom(Missile &missile)
 
 void ProcessRhino(Missile &missile)
 {
-	int monst = missile._misource;
+	const int monst = missile._misource;
 	Monster &monster = Monsters[monst];
 	if (monster.mode != MonsterMode::Charge) {
 		missile._miDelFlag = true;
 		return;
 	}
 	UpdateMissilePos(missile);
-	Point prevPos = missile.position.tile;
+	const Point prevPos = missile.position.tile;
 	Point newPosSnake;
 	dMonster[prevPos.x][prevPos.y] = 0;
 	if (monster.ai == MonsterAIID::Snake) {
@@ -3683,7 +3683,7 @@ void ProcessRhino(Missile &missile)
 		missile.position.traveled += missile.position.velocity;
 	}
 	UpdateMissilePos(missile);
-	Point newPos = missile.position.tile;
+	const Point newPos = missile.position.tile;
 	if (!IsTileAvailable(monster, newPos) || (monster.ai == MonsterAIID::Snake && (!IsTileAvailable(monster, newPosSnake) || missile._miAnimFrame >= missile._miAnimLen))) {
 		MissToMonst(missile, prevPos);
 		missile._miDelFlag = true;
@@ -3786,7 +3786,7 @@ void ProcessApocalypse(Missile &missile)
 {
 	for (int j = missile.var2; j < missile.var3; j++) {
 		for (int k = missile.var4; k < missile.var5; k++) {
-			int mid = dMonster[k][j] - 1;
+			const int mid = dMonster[k][j] - 1;
 			if (mid < 0)
 				continue;
 			if (Monsters[mid].isPlayerMinion())
@@ -3796,7 +3796,7 @@ void ProcessApocalypse(Missile &missile)
 			if (gbIsHellfire && !LineClearMissile(missile.position.tile, { k, j }))
 				continue;
 
-			int id = missile._misource;
+			const int id = missile._misource;
 			AddMissile(WorldTilePosition(k, j), WorldTilePosition(k, j), Players[id]._pdir, MissileID::ApocalypseBoom, TARGET_MONSTERS, id, missile._midam, 0);
 			missile.var2 = j;
 			missile.var4 = k + 1;
@@ -3812,16 +3812,16 @@ void ProcessFlameWaveControl(Missile &missile)
 	bool f1 = false;
 	bool f2 = false;
 
-	int id = missile._misource;
-	Point src = missile.position.tile;
-	Direction sd = GetDirection(src, { missile.var1, missile.var2 });
-	Direction dira = Left(Left(sd));
-	Direction dirb = Right(Right(sd));
+	const int id = missile._misource;
+	const Point src = missile.position.tile;
+	const Direction sd = GetDirection(src, { missile.var1, missile.var2 });
+	const Direction dira = Left(Left(sd));
+	const Direction dirb = Right(Right(sd));
 	Point na = src + sd;
 	[[maybe_unused]] int pn = dPiece[na.x][na.y];
 	assert(pn >= 0 && pn <= MAXTILES);
 	if (!TileHasAny(na, TileProperties::BlockMissile)) {
-		Direction pdir = Players[id]._pdir;
+		const Direction pdir = Players[id]._pdir;
 		AddMissile(na, na + sd, pdir, MissileID::FlameWave, TARGET_MONSTERS, id, 0, missile._mispllvl);
 		na += dira;
 		Point nb = src + sd + dirb;
@@ -3978,7 +3978,7 @@ void ProcessHolyBolt(Missile &missile)
 {
 	missile.duration--;
 	if (missile._miAnimType != MissileGraphicID::HolyBoltExplosion) {
-		int dam = missile._midam;
+		const int dam = missile._midam;
 		MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), dam, dam, true, true);
 		if (missile.duration == 0) {
 			missile.setDefaultFrameGroup();
@@ -4005,12 +4005,12 @@ void ProcessHolyBolt(Missile &missile)
 void ProcessElemental(Missile &missile)
 {
 	missile.duration--;
-	int dam = missile._midam;
+	const int dam = missile._midam;
 	const Point missilePosition = missile.position.tile;
 	if (missile._miAnimType == MissileGraphicID::BigExplosion) {
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
 
-		Point startPoint = missile.var3 == 2 ? Point { missile.var4, missile.var5 } : Point(missile.position.start);
+		const Point startPoint = missile.var3 == 2 ? Point { missile.var4, missile.var5 } : Point(missile.position.start);
 		constexpr Direction Offsets[] = {
 			Direction::NoDirection,
 			Direction::SouthWest,
@@ -4022,7 +4022,7 @@ void ProcessElemental(Missile &missile)
 			Direction::West,
 			Direction::North
 		};
-		for (Direction offset : Offsets) {
+		for (const Direction offset : Offsets) {
 			if (!CheckBlock(startPoint, missilePosition + offset))
 				CheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), dam, dam, true, missilePosition + offset, true);
 		}
@@ -4040,11 +4040,11 @@ void ProcessElemental(Missile &missile)
 			missile.duration = 255;
 			auto *nextMonster = FindClosest(missilePosition, 19);
 			if (nextMonster != nullptr) {
-				Direction sd = GetDirection(missilePosition, nextMonster->position.tile);
+				const Direction sd = GetDirection(missilePosition, nextMonster->position.tile);
 				missile.setDirection(sd);
 				UpdateMissileVelocity(missile, nextMonster->position.tile, 16);
 			} else {
-				Direction sd = Players[missile._misource]._pdir;
+				const Direction sd = Players[missile._misource]._pdir;
 				missile.setDirection(sd);
 				UpdateMissileVelocity(missile, missilePosition + sd, 16);
 			}
@@ -4067,7 +4067,7 @@ void ProcessElemental(Missile &missile)
 void ProcessBoneSpirit(Missile &missile)
 {
 	missile.duration--;
-	int dam = missile._midam;
+	const int dam = missile._midam;
 	if (missile.getDirection() == Direction::NoDirection) {
 		ChangeLight(missile._mlid, missile.position.tile, missile._miAnimFrame);
 		if (missile.duration == 0) {
@@ -4077,7 +4077,7 @@ void ProcessBoneSpirit(Missile &missile)
 		PutMissile(missile);
 	} else {
 		MoveMissileAndCheckMissileCol(missile, GetMissileData(missile._mitype).damageType(), dam, dam, false, false);
-		Point c = missile.position.tile;
+		const Point c = missile.position.tile;
 		if (missile.var3 == 0 && c == Point { missile.var4, missile.var5 })
 			missile.var3 = 1;
 		if (missile.var3 == 1) {
@@ -4089,7 +4089,7 @@ void ProcessBoneSpirit(Missile &missile)
 				missile.setDirection(GetDirection(c, monster->position.tile));
 				UpdateMissileVelocity(missile, monster->position.tile, 16);
 			} else {
-				Direction sd = Players[missile._misource]._pdir;
+				const Direction sd = Players[missile._misource]._pdir;
 				missile.setDirection(sd);
 				UpdateMissileVelocity(missile, c + sd, 16);
 			}
@@ -4118,7 +4118,7 @@ void ProcessResurrectBeam(Missile &missile)
 
 void ProcessRedPortal(Missile &missile)
 {
-	int expLight[17] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 15 };
+	const int expLight[17] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15, 15 };
 
 	if (missile.duration > 1)
 		missile.duration--;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -160,7 +160,7 @@ void InitMonster(Monster &monster, Direction rd, size_t typeIndex, Point positio
 	monster.animInfo.tickCounterOfCurrentFrame = GenerateRnd(monster.animInfo.ticksPerFrame - 1);
 	monster.animInfo.currentFrame = GenerateRnd(monster.animInfo.numberOfFrames - 1);
 
-	int maxhp = RandomIntBetween(monster.data().hitPointsMinimum, monster.data().hitPointsMaximum);
+	const int maxhp = RandomIntBetween(monster.data().hitPointsMinimum, monster.data().hitPointsMaximum);
 	monster.maxHitPoints = maxhp << 6;
 
 	if (!gbIsMultiplayer)
@@ -269,7 +269,7 @@ void PlaceGroup(size_t typeIndex, size_t num, Monster *leader = nullptr, bool le
 		int xp;
 		int yp;
 		if (leader != nullptr) {
-			int offset = GenerateRnd(8);
+			const int offset = GenerateRnd(8);
 			auto position = leader->position.tile + static_cast<Direction>(offset);
 			xp = position.x;
 			yp = position.y;
@@ -279,8 +279,8 @@ void PlaceGroup(size_t typeIndex, size_t num, Monster *leader = nullptr, bool le
 				yp = GenerateRnd(80) + 16;
 			} while (!CanPlaceMonster({ xp, yp }));
 		}
-		int x1 = xp;
-		int y1 = yp;
+		const int x1 = xp;
+		const int y1 = yp;
 
 		if (num + ActiveMonsterCount > totalmonsters) {
 			num = totalmonsters - ActiveMonsterCount;
@@ -460,7 +460,7 @@ tl::expected<void, std::string> PlaceUniqueMonsters()
 		if (minionType == LevelMonsterTypeCount)
 			continue;
 
-		UniqueMonsterType uniqueType = static_cast<UniqueMonsterType>(u);
+		const UniqueMonsterType uniqueType = static_cast<UniqueMonsterType>(u);
 		if (uniqueType == UniqueMonsterType::Garbud && Quests[Q_GARBUD]._qactive == QUEST_NOTAVAIL)
 			continue;
 		if (uniqueType == UniqueMonsterType::Zhar && Quests[Q_ZHAR]._qactive == QUEST_NOTAVAIL)
@@ -536,7 +536,7 @@ tl::expected<void, std::string> PlaceQuestMonsters()
 			const size_t typeIndex = GetMonsterTypeIndex(MT_NAKRUL);
 			if (typeIndex < LevelMonsterTypeCount) {
 				for (size_t i = 0; i < ActiveMonsterCount; i++) {
-					Monster &monster = Monsters[i];
+					const Monster &monster = Monsters[i];
 					if (monster.isUnique() || monster.levelType == typeIndex) {
 						UberDiabloMonsterIndex = static_cast<int>(i);
 						break;
@@ -771,7 +771,7 @@ void WalkInDirection(Monster &monster, Direction endDir)
 
 void StartAttack(Monster &monster)
 {
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 	NewMonsterAnim(monster, MonsterGraphic::Attack, md, AnimationDistributionFlags::ProcessAnimationPending);
 	monster.mode = MonsterMode::MeleeAttack;
 	monster.position.future = monster.position.tile;
@@ -780,7 +780,7 @@ void StartAttack(Monster &monster)
 
 void StartRangedAttack(Monster &monster, MissileID missileType, int dam)
 {
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 	NewMonsterAnim(monster, MonsterGraphic::Attack, md, AnimationDistributionFlags::ProcessAnimationPending);
 	monster.mode = MonsterMode::RangedAttack;
 	monster.var1 = static_cast<int8_t>(missileType);
@@ -791,7 +791,7 @@ void StartRangedAttack(Monster &monster, MissileID missileType, int dam)
 
 void StartRangedSpecialAttack(Monster &monster, MissileID missileType, int dam)
 {
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 	int8_t distributeFramesBeforeFrame = 0;
 	if (monster.ai == MonsterAIID::Mega)
 		distributeFramesBeforeFrame = monster.data().animFrameNumSpecial;
@@ -806,7 +806,7 @@ void StartRangedSpecialAttack(Monster &monster, MissileID missileType, int dam)
 
 void StartSpecialAttack(Monster &monster)
 {
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 	NewMonsterAnim(monster, MonsterGraphic::Special, md);
 	monster.mode = MonsterMode::SpecialMeleeAttack;
 	monster.position.future = monster.position.tile;
@@ -831,7 +831,7 @@ void DiabloDeath(Monster &diablo, bool sendmsg)
 	sgbSaveSoundOn = gbSoundOn;
 	gbProcessPlayers = false;
 	for (size_t i = 0; i < ActiveMonsterCount; i++) {
-		int monsterId = ActiveMonsters[i];
+		const int monsterId = ActiveMonsters[i];
 		Monster &monster = Monsters[monsterId];
 		if (monster.type().type == MT_DIABLO || diablo.activeForTicks == 0)
 			continue;
@@ -896,17 +896,17 @@ void SpawnLoot(Monster &monster, bool sendmsg)
 
 std::optional<Point> GetTeleportTile(const Monster &monster)
 {
-	int mx = monster.enemyPosition.x;
-	int my = monster.enemyPosition.y;
-	int rx = PickRandomlyAmong({ -1, 1 });
-	int ry = PickRandomlyAmong({ -1, 1 });
+	const int mx = monster.enemyPosition.x;
+	const int my = monster.enemyPosition.y;
+	const int rx = PickRandomlyAmong({ -1, 1 });
+	const int ry = PickRandomlyAmong({ -1, 1 });
 
 	for (int j = -1; j <= 1; j++) {
 		for (int k = -1; k < 1; k++) {
 			if (j == 0 && k == 0)
 				continue;
-			int x = mx + rx * j;
-			int y = my + ry * k;
+			const int x = mx + rx * j;
+			const int y = my + ry * k;
 			if (!InDungeonBounds({ x, y }) || x == monster.position.tile.x || y == monster.position.tile.y)
 				continue;
 			if (IsTileAvailable(monster, { x, y }))
@@ -957,7 +957,7 @@ void MonsterHitMonster(Monster &attacker, Monster &target, int dam)
 
 void StartDeathFromMonster(Monster &attacker, Monster &target)
 {
-	Direction md = GetDirection(target.position.tile, attacker.position.tile);
+	const Direction md = GetDirection(target.position.tile, attacker.position.tile);
 	MonsterDeath(target, md, true);
 
 	if (gbIsHellfire)
@@ -1070,11 +1070,11 @@ void MonsterAttackMonster(Monster &attacker, Monster &target, int hper, int mind
 	if (hit >= hper)
 		return;
 
-	int dam = RandomIntBetween(mind, maxd) << 6;
+	const int dam = RandomIntBetween(mind, maxd) << 6;
 	ApplyMonsterDamage(DamageType::Physical, target, dam);
 
 	if (attacker.isPlayerMinion()) {
-		size_t playerId = static_cast<size_t>(attacker.goalVar3);
+		const size_t playerId = static_cast<size_t>(attacker.goalVar3);
 		const Player &player = Players[playerId];
 		target.tag(player);
 	}
@@ -1097,7 +1097,7 @@ int CheckReflect(Monster &monster, Player &player, int dam)
 	if (player.wReflections <= 0)
 		NetSendCmdParam1(true, CMD_SETREFLECT, 0);
 	// reflects 20-30% damage
-	int mdam = dam * RandomIntBetween(20, 30, true) / 100;
+	const int mdam = dam * RandomIntBetween(20, 30, true) / 100;
 	ApplyMonsterDamage(DamageType::Physical, monster, mdam);
 	if (monster.hitPoints >> 6 <= 0)
 		M_StartKill(monster, player);
@@ -1141,7 +1141,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 	hit += 2 * (monster.level(sgGameInitInfo.nDifficulty) - player.getCharacterLevel())
 	    + 30
 	    - ac;
-	int minhit = GetMinHit();
+	const int minhit = GetMinHit();
 	hit = std::max(hit, minhit);
 	int blkper = 100;
 	if ((player._pmode == PM_STAND || player._pmode == PM_ATTACK) && player._pBlockFlag) {
@@ -1152,7 +1152,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 	if (hper >= hit)
 		return;
 	if (blkper < blk) {
-		Direction dir = GetDirection(player.position.tile, monster.position.tile);
+		const Direction dir = GetDirection(player.position.tile, monster.position.tile);
 		StartPlrBlock(player, dir);
 		if (&player == MyPlayer && player.wReflections > 0) {
 			int dam = GenerateRnd(((maxDam - minDam) << 6) + 1) + (minDam << 6);
@@ -1180,7 +1180,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 	dam = std::max(dam + (player._pIGetHit << 6), 64);
 	if (&player == MyPlayer) {
 		if (player.wReflections > 0) {
-			int reflectedDamage = CheckReflect(monster, player, dam);
+			const int reflectedDamage = CheckReflect(monster, player, dam);
 			dam = std::max(dam - reflectedDamage, 0);
 		}
 		ApplyPlrDamage(DamageType::Physical, player, 0, 0, dam);
@@ -1188,7 +1188,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 
 	// Reflect can also kill a monster, so make sure the monster is still alive
 	if (HasAnyOf(player._pIFlags, ItemSpecialEffect::Thorns) && monster.mode != MonsterMode::Death) {
-		int mdam = (GenerateRnd(3) + 1) << 6;
+		const int mdam = (GenerateRnd(3) + 1) << 6;
 		ApplyMonsterDamage(DamageType::Physical, monster, mdam);
 		if (monster.hitPoints >> 6 <= 0)
 			M_StartKill(monster, player);
@@ -1208,7 +1208,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 		if (player._pmode != PM_GOTHIT)
 			StartPlrHit(player, 0, true);
 
-		Point newPosition = player.position.tile + monster.direction;
+		const Point newPosition = player.position.tile + monster.direction;
 		if (PosOkPlayer(player, newPosition)) {
 			player.position.tile = newPosition;
 			FixPlayerLocation(player, player._pdir);
@@ -1509,7 +1509,7 @@ bool MonsterDelay(Monster &monster)
 	}
 
 	if (monster.var2-- == 0) {
-		int oFrame = monster.animInfo.currentFrame;
+		const int oFrame = monster.animInfo.currentFrame;
 		M_StartStand(monster, monster.direction);
 		monster.animInfo.currentFrame = oFrame;
 		return true;
@@ -1617,7 +1617,7 @@ void GroupUnity(Monster &monster)
 
 bool RandomWalk(Monster &monster, Direction md)
 {
-	Direction mdtemp = md;
+	const Direction mdtemp = md;
 
 	bool ok = DirOK(monster, md);
 	if (FlipCoin())
@@ -1721,8 +1721,8 @@ Direction Turn(Direction direction, bool turnLeft)
 
 bool RoundWalk(Monster &monster, Direction direction, int8_t *dir)
 {
-	Direction turn45deg = Turn(direction, *dir != 0);
-	Direction turn90deg = Turn(turn45deg, *dir != 0);
+	const Direction turn45deg = Turn(direction, *dir != 0);
+	const Direction turn90deg = Turn(turn45deg, *dir != 0);
 
 	// Turn 90 degrees
 	if (Walk(monster, turn90deg)) {
@@ -1757,7 +1757,7 @@ bool AiPlanPath(Monster &monster)
 			return false;
 	}
 
-	bool clear = LineClear(
+	const bool clear = LineClear(
 	    [&monster](Point position) { return (IsTileWalkable(position) && IsTileSafe(monster, position)); },
 	    monster.position.tile,
 	    monster.enemyPosition);
@@ -1783,11 +1783,11 @@ void AiAvoidance(Monster &monster)
 		return;
 	}
 
-	Direction md = GetDirection(monster.position.tile, monster.position.last);
+	const Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (monster.activeForTicks < UINT8_MAX)
 		MonstCheckDoors(monster);
-	int v = GenerateRnd(100);
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const int v = GenerateRnd(100);
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (distanceToEnemy >= 2 && monster.activeForTicks == UINT8_MAX && dTransVal[monster.position.tile.x][monster.position.tile.y] == dTransVal[monster.enemyPosition.x][monster.enemyPosition.y]) {
 		if (monster.goal == MonsterGoal::Move || (distanceToEnemy >= 4 && FlipCoin(4))) {
 			if (monster.goal != MonsterGoal::Move) {
@@ -1867,7 +1867,7 @@ void AiRanged(Monster &monster)
 	}
 
 	if (monster.activeForTicks == UINT8_MAX || (monster.flags & MFLAG_TARGETS_MONSTER) != 0) {
-		Direction md = GetMonsterDirection(monster);
+		const Direction md = GetMonsterDirection(monster);
 		if (monster.activeForTicks < UINT8_MAX)
 			MonstCheckDoors(monster);
 		monster.direction = md;
@@ -1879,7 +1879,7 @@ void AiRanged(Monster &monster)
 		}
 		if (monster.mode == MonsterMode::Stand) {
 			if (LineClearMissile(monster.position.tile, monster.enemyPosition)) {
-				MissileID missileType = GetMissileType(monster.ai);
+				const MissileID missileType = GetMissileType(monster.ai);
 				if (monster.ai == MonsterAIID::AcidUnique)
 					StartRangedSpecialAttack(monster, missileType, 0);
 				else
@@ -1892,7 +1892,7 @@ void AiRanged(Monster &monster)
 	}
 
 	if (monster.activeForTicks != 0) {
-		Direction md = GetDirection(monster.position.tile, monster.position.last);
+		const Direction md = GetDirection(monster.position.tile, monster.position.last);
 		RandomWalk(monster, md);
 	}
 }
@@ -1903,14 +1903,14 @@ void AiRangedAvoidance(Monster &monster)
 		return;
 	}
 
-	Direction md = GetDirection(monster.position.tile, monster.position.last);
+	const Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (IsAnyOf(monster.ai, MonsterAIID::Magma, MonsterAIID::Storm, MonsterAIID::BoneDemon) && monster.activeForTicks < UINT8_MAX)
 		MonstCheckDoors(monster);
-	int lessmissiles = (monster.ai == MonsterAIID::Acid) ? 1 : 0;
-	int dam = (monster.ai == MonsterAIID::Diablo) ? 40 : 0;
-	MissileID missileType = GetMissileType(monster.ai);
+	const int lessmissiles = (monster.ai == MonsterAIID::Acid) ? 1 : 0;
+	const int dam = (monster.ai == MonsterAIID::Diablo) ? 40 : 0;
+	const MissileID missileType = GetMissileType(monster.ai);
 	int v = GenerateRnd(10000);
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (distanceToEnemy >= 2 && monster.activeForTicks == UINT8_MAX && dTransVal[monster.position.tile.x][monster.position.tile.y] == dTransVal[monster.enemyPosition.x][monster.enemyPosition.y]) {
 		if (monster.goal == MonsterGoal::Move || (distanceToEnemy >= 3 && FlipCoin(4 << lessmissiles))) {
 			if (monster.goal != MonsterGoal::Move) {
@@ -1964,7 +1964,7 @@ void ZombieAi(Monster &monster)
 	}
 
 	if (GenerateRnd(100) < 2 * monster.intelligence + 10) {
-		int dist = monster.enemyPosition.WalkingDistance(monster.position.tile);
+		const int dist = monster.enemyPosition.WalkingDistance(monster.position.tile);
 		if (dist >= 2) {
 			if (dist >= 2 * monster.intelligence + 4) {
 				Direction md = monster.direction;
@@ -1989,9 +1989,9 @@ void OverlordAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 	monster.direction = md;
-	int v = GenerateRnd(100);
+	const int v = GenerateRnd(100);
 	if (monster.distanceToEnemy() >= 2) {
 		if ((monster.var2 > 20 && v < 4 * monster.intelligence + 20)
 		    || (IsMonsterModeMove(static_cast<MonsterMode>(monster.var1))
@@ -2014,7 +2014,7 @@ void SkeletonAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetDirection(monster.position.tile, monster.position.last);
+	const Direction md = GetDirection(monster.position.tile, monster.position.last);
 	monster.direction = md;
 	if (monster.distanceToEnemy() >= 2) {
 		if (static_cast<MonsterMode>(monster.var1) == MonsterMode::Delay || (GenerateRnd(100) >= 35 - 4 * monster.intelligence)) {
@@ -2039,9 +2039,9 @@ void SkeletonBowAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 	monster.direction = md;
-	int v = GenerateRnd(100);
+	const int v = GenerateRnd(100);
 
 	bool walking = false;
 
@@ -2066,10 +2066,10 @@ void SkeletonBowAi(Monster &monster)
 
 std::optional<Point> ScavengerFindCorpse(const Monster &scavenger)
 {
-	bool reverseSearch = FlipCoin();
-	int first = reverseSearch ? 4 : -4;
-	int last = reverseSearch ? -4 : 4;
-	int increment = reverseSearch ? -1 : 1;
+	const bool reverseSearch = FlipCoin();
+	const int first = reverseSearch ? 4 : -4;
+	const int last = reverseSearch ? -4 : 4;
+	const int increment = reverseSearch ? -1 : 1;
 
 	for (int y = first; y <= last; y += increment) {
 		for (int x = first; x <= last; x += increment) {
@@ -2103,7 +2103,7 @@ void ScavengerAi(Monster &monster)
 		if (dCorpse[monster.position.tile.x][monster.position.tile.y] != 0) {
 			StartEating(monster);
 			if (gbIsHellfire) {
-				int mMaxHP = monster.maxHitPoints;
+				const int mMaxHP = monster.maxHitPoints;
 				monster.hitPoints += mMaxHP / 8;
 				if (monster.hitPoints > monster.maxHitPoints)
 					monster.hitPoints = monster.maxHitPoints;
@@ -2129,8 +2129,8 @@ void ScavengerAi(Monster &monster)
 				}
 			}
 			if (monster.goalVar1 != 0) {
-				int x = monster.goalVar1 - 1;
-				int y = monster.goalVar2 - 1;
+				const int x = monster.goalVar1 - 1;
+				const int y = monster.goalVar2 - 1;
 				monster.direction = GetDirection(monster.position.tile, { x, y });
 				RandomWalk(monster, monster.direction);
 			}
@@ -2147,11 +2147,11 @@ void RhinoAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetDirection(monster.position.tile, monster.position.last);
+	const Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (monster.activeForTicks < UINT8_MAX)
 		MonstCheckDoors(monster);
 	int v = GenerateRnd(100);
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (distanceToEnemy >= 2) {
 		if (monster.goal == MonsterGoal::Move || (distanceToEnemy >= 5 && !FlipCoin(4))) {
 			if (monster.goal != MonsterGoal::Move) {
@@ -2227,13 +2227,13 @@ void FallenAi(Monster &monster)
 			monster.hitPoints += 2 * monster.intelligence + 2;
 		else
 			monster.hitPoints = monster.maxHitPoints;
-		int rad = 2 * monster.intelligence + 4;
+		const int rad = 2 * monster.intelligence + 4;
 		for (int y = -rad; y <= rad; y++) {
 			for (int x = -rad; x <= rad; x++) {
-				int xpos = monster.position.tile.x + x;
-				int ypos = monster.position.tile.y + y;
+				const int xpos = monster.position.tile.x + x;
+				const int ypos = monster.position.tile.y + y;
 				if (InDungeonBounds({ xpos, ypos })) {
-					int m = dMonster[xpos][ypos];
+					const int m = dMonster[xpos][ypos];
 					if (m <= 0)
 						continue;
 
@@ -2264,11 +2264,11 @@ void LeoricAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetDirection(monster.position.tile, monster.position.last);
+	const Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (monster.activeForTicks < UINT8_MAX)
 		MonstCheckDoors(monster);
 	int v = GenerateRnd(100);
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (distanceToEnemy >= 2 && monster.activeForTicks == UINT8_MAX && dTransVal[monster.position.tile.x][monster.position.tile.y] == dTransVal[monster.enemyPosition.x][monster.enemyPosition.y]) {
 		if (monster.goal == MonsterGoal::Move || (distanceToEnemy >= 3 && FlipCoin(4))) {
 			if (monster.goal != MonsterGoal::Move) {
@@ -2289,7 +2289,7 @@ void LeoricAi(Monster &monster)
 		if (!UseMultiplayerQuests()
 		    && ((distanceToEnemy >= 3 && v < 4 * monster.intelligence + 35) || v < 6)
 		    && LineClearMissile(monster.position.tile, monster.enemyPosition)) {
-			Point newPosition = monster.position.tile + md;
+			const Point newPosition = monster.position.tile + md;
 			if (IsTileAvailable(monster, newPosition) && ActiveMonsterCount < MaxMonsters) {
 				auto typeIndex = GetRandomSkeletonTypeIndex();
 				if (typeIndex) {
@@ -2322,9 +2322,9 @@ void BatAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetDirection(monster.position.tile, monster.position.last);
+	const Direction md = GetDirection(monster.position.tile, monster.position.last);
 	monster.direction = md;
-	int v = GenerateRnd(100);
+	const int v = GenerateRnd(100);
 	if (monster.goal == MonsterGoal::Retreat) {
 		if (monster.goalVar1 == 0) {
 			RandomWalk(monster, Opposite(md));
@@ -2336,7 +2336,7 @@ void BatAi(Monster &monster)
 		return;
 	}
 
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (monster.type().type == MT_GLOOM
 	    && distanceToEnemy >= 5
 	    && v < 4 * monster.intelligence + 33
@@ -2366,8 +2366,8 @@ void BatAi(Monster &monster)
 
 void GargoyleAi(Monster &monster)
 {
-	Direction md = GetMonsterDirection(monster);
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const Direction md = GetMonsterDirection(monster);
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (monster.activeForTicks != 0 && (monster.flags & MFLAG_ALLOW_SPECIAL) != 0) {
 		UpdateEnemy(monster);
 		if (distanceToEnemy < monster.intelligence + 2u) {
@@ -2399,7 +2399,7 @@ void ButcherAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetDirection(monster.position.tile, monster.position.last);
+	const Direction md = GetDirection(monster.position.tile, monster.position.last);
 	monster.direction = md;
 
 	if (monster.distanceToEnemy() >= 2)
@@ -2416,8 +2416,8 @@ void SneakAi(Monster &monster)
 		return;
 	}
 
-	unsigned dist = 5 - monster.intelligence;
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const unsigned dist = 5 - monster.intelligence;
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (static_cast<MonsterMode>(monster.var1) == MonsterMode::HitRecovery) {
 		monster.goal = MonsterGoal::Retreat;
 		monster.goalVar1 = 0;
@@ -2437,7 +2437,7 @@ void SneakAi(Monster &monster)
 		}
 	}
 	monster.direction = md;
-	int v = GenerateRnd(100);
+	const int v = GenerateRnd(100);
 	if (distanceToEnemy < dist && (monster.flags & MFLAG_HIDDEN) != 0) {
 		StartFadein(monster, md, false);
 	} else {
@@ -2468,7 +2468,7 @@ void GharbadAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 
 	if (monster.talkMsg >= TEXT_GARBUD1
 	    && monster.talkMsg <= TEXT_GARBUD3
@@ -2520,7 +2520,7 @@ void SnotSpilAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 
 	if (monster.talkMsg == TEXT_BANNER10 && !IsTileVisible(monster.position.tile) && monster.goal == MonsterGoal::Talking) {
 		monster.talkMsg = TEXT_BANNER11;
@@ -2555,12 +2555,12 @@ void SnotSpilAi(Monster &monster)
 
 void SnakeAi(Monster &monster)
 {
-	int8_t pattern[6] = { 1, 1, 0, -1, -1, 0 };
+	const int8_t pattern[6] = { 1, 1, 0, -1, -1, 0 };
 	if (monster.mode != MonsterMode::Stand || monster.activeForTicks == 0)
 		return;
 	Direction md = GetDirection(monster.position.tile, monster.position.last);
 	monster.direction = md;
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (distanceToEnemy >= 2) {
 		if (distanceToEnemy < 3 && LineClear([&monster](Point position) { return IsTileAvailable(monster, position); }, monster.position.tile, monster.enemyPosition) && static_cast<MonsterMode>(monster.var1) != MonsterMode::Charge) {
 			if (AddMissile(monster.position.tile, monster.enemyPosition, md, MissileID::Rhino, TARGET_PLAYERS, monster, 0, 0) != nullptr) {
@@ -2578,7 +2578,7 @@ void SnakeAi(Monster &monster)
 			if (monster.goalVar1 > 5)
 				monster.goalVar1 = 0;
 
-			Direction targetDirection = static_cast<Direction>(monster.goalVar2);
+			const Direction targetDirection = static_cast<Direction>(monster.goalVar2);
 			if (md != targetDirection) {
 				int drift = static_cast<int>(md) - monster.goalVar2;
 				if (drift < 0)
@@ -2612,11 +2612,11 @@ void CounselorAi(Monster &monster)
 	if (monster.mode != MonsterMode::Stand || monster.activeForTicks == 0) {
 		return;
 	}
-	Direction md = GetDirection(monster.position.tile, monster.position.last);
+	const Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (monster.activeForTicks < UINT8_MAX)
 		MonstCheckDoors(monster);
-	int v = GenerateRnd(100);
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const int v = GenerateRnd(100);
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (monster.goal == MonsterGoal::Retreat) {
 		if (monster.goalVar1++ <= 3)
 			RandomWalk(monster, Opposite(md));
@@ -2673,7 +2673,7 @@ void ZharAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 	if (monster.talkMsg == TEXT_ZHAR1 && !IsTileVisible(monster.position.tile) && monster.goal == MonsterGoal::Talking) {
 		monster.talkMsg = TEXT_ZHAR2;
 		monster.goal = MonsterGoal::Inquiring;
@@ -2701,7 +2701,7 @@ void ZharAi(Monster &monster)
 
 void MegaAi(Monster &monster)
 {
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (distanceToEnemy >= 5) {
 		SkeletonAi(monster);
 		return;
@@ -2711,7 +2711,7 @@ void MegaAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetDirection(monster.position.tile, monster.position.last);
+	const Direction md = GetDirection(monster.position.tile, monster.position.last);
 	if (monster.activeForTicks < UINT8_MAX)
 		MonstCheckDoors(monster);
 	int v = GenerateRnd(100);
@@ -2765,10 +2765,10 @@ void LazarusAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 	if (IsTileVisible(monster.position.tile)) {
 		if (!UseMultiplayerQuests()) {
-			Player &myPlayer = *MyPlayer;
+			const Player &myPlayer = *MyPlayer;
 			if (monster.talkMsg == TEXT_VILE13 && monster.goal == MonsterGoal::Inquiring && myPlayer.position.tile == Point { 35, 46 }) {
 				if (!gbIsMultiplayer) {
 					// Playing ingame movies is currently not supported in multiplayer
@@ -2813,7 +2813,7 @@ void LazarusMinionAi(Monster &monster)
 	if (monster.mode != MonsterMode::Stand)
 		return;
 
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 
 	if (IsTileVisible(monster.position.tile)) {
 		if (!UseMultiplayerQuests()) {
@@ -2838,7 +2838,7 @@ void LachdananAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 
 	if (monster.talkMsg == TEXT_VEIL9 && !IsTileVisible(monster.position.tile) && monster.goal == MonsterGoal::Talking) {
 		monster.talkMsg = TEXT_VEIL10;
@@ -2869,7 +2869,7 @@ void WarlordAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetMonsterDirection(monster);
+	const Direction md = GetMonsterDirection(monster);
 	if (IsTileVisible(monster.position.tile)) {
 		if (monster.talkMsg == TEXT_WARLRD9 && monster.goal == MonsterGoal::Inquiring)
 			monster.mode = MonsterMode::Talk;
@@ -2894,7 +2894,7 @@ void HorkDemonAi(Monster &monster)
 		return;
 	}
 
-	Direction md = GetDirection(monster.position.tile, monster.position.last);
+	const Direction md = GetDirection(monster.position.tile, monster.position.last);
 
 	if (monster.activeForTicks < 255) {
 		MonstCheckDoors(monster);
@@ -2902,7 +2902,7 @@ void HorkDemonAi(Monster &monster)
 
 	int v = GenerateRnd(100);
 
-	unsigned distanceToEnemy = monster.distanceToEnemy();
+	const unsigned distanceToEnemy = monster.distanceToEnemy();
 	if (distanceToEnemy < 2) {
 		monster.goal = MonsterGoal::Normal;
 	} else if (monster.goal == MonsterGoal::Move || (distanceToEnemy >= 5 && !FlipCoin(4))) {
@@ -2920,7 +2920,7 @@ void HorkDemonAi(Monster &monster)
 
 	if (monster.goal == MonsterGoal::Normal) {
 		if ((distanceToEnemy >= 3) && v < 2 * monster.intelligence + 43) {
-			Point position = monster.position.tile + monster.direction;
+			const Point position = monster.position.tile + monster.direction;
 			if (IsTileAvailable(monster, position) && ActiveMonsterCount < MaxMonsters) {
 				StartRangedSpecialAttack(monster, MissileID::HorkSpawn, 0);
 			}
@@ -3014,7 +3014,7 @@ void (*AiProc[])(Monster &monster) = {
 
 bool IsRelativeMoveOK(const Monster &monster, Point position, Direction mdir)
 {
-	Point futurePosition = position + mdir;
+	const Point futurePosition = position + mdir;
 	if (!InDungeonBounds(futurePosition) || !IsTileAvailable(monster, futurePosition))
 		return false;
 	if (mdir == Direction::East) {
@@ -3337,7 +3337,7 @@ tl::expected<void, std::string> GetLevelMTypes()
 
 			int skeletonTypeCount = 0;
 			_monster_id skeltypes[NUM_MTYPES];
-			for (_monster_id skeletonType : SkeletonTypes) {
+			for (const _monster_id skeletonType : SkeletonTypes) {
 				if (!IsMonsterAvailable(MonstersData[skeletonType]))
 					continue;
 
@@ -3367,7 +3367,7 @@ tl::expected<void, std::string> GetLevelMTypes()
 			}
 
 			if (nt != 0) {
-				int i = GenerateRnd(nt);
+				const int i = GenerateRnd(nt);
 				RETURN_IF_ERROR(AddMonsterType(typelist[i], PLACE_SCATTER));
 				typelist[i] = typelist[--nt];
 			}
@@ -3393,10 +3393,10 @@ tl::expected<void, std::string> InitMonsterSND(CMonster &monsterType)
 	};
 
 	const MonsterData &data = MonstersData[monsterType.type];
-	std::string_view soundSuffix = data.soundPath();
+	const std::string_view soundSuffix = data.soundPath();
 
 	for (int i = 0; i < 4; i++) {
-		std::string_view prefix = prefixes[i];
+		const std::string_view prefix = prefixes[i];
 		if (prefix == "s" && !data.hasSpecialSound)
 			continue;
 
@@ -3428,7 +3428,7 @@ tl::expected<void, std::string> InitMonsterGFX(CMonster &monsterType, MonsterSpr
 		}
 		const uint32_t begin = spritesData.offsets[j];
 		const uint32_t end = spritesData.offsets[j + 1];
-		auto animSpritesData = reinterpret_cast<uint8_t *>(&monsterType.animData[begin]);
+		auto *animSpritesData = reinterpret_cast<uint8_t *>(&monsterType.animData[begin]);
 		const uint16_t numLists = GetNumListsFromClxListOrSheetBuffer(animSpritesData, end - begin);
 		monsterType.anims[i].sprites = ClxSpriteListOrSheet { animSpritesData, numLists };
 		++j;
@@ -3534,7 +3534,7 @@ void WeakenNaKrul()
 	Monster &monster = Monsters[UberDiabloMonsterIndex];
 	PlayEffect(monster, MonsterSound::Death);
 	monster.armorClass -= 50;
-	int hp = monster.maxHitPoints / 2;
+	const int hp = monster.maxHitPoints / 2;
 	monster.resistance = 0;
 	monster.hitPoints = hp;
 	monster.maxHitPoints = hp;
@@ -3620,7 +3620,7 @@ tl::expected<void, std::string> SetMapMonsters(const uint16_t *dunData, Point st
 
 	WorldTileSize size = GetDunSize(dunData);
 
-	int layer2Offset = 2 + size.width * size.height;
+	const int layer2Offset = 2 + size.width * size.height;
 
 	// The rest of the layers are at dPiece scale
 	size *= static_cast<WorldTileCoord>(2);
@@ -3661,9 +3661,9 @@ void SpawnMonster(Point position, Direction dir, size_t typeIndex, bool startSpe
 	if (!MyPlayer->isLevelOwnedByLocalClient())
 		return;
 
-	size_t monsterIndex = ActiveMonsters[ActiveMonsterCount];
+	const size_t monsterIndex = ActiveMonsters[ActiveMonsterCount];
 	ActiveMonsterCount += 1;
-	uint32_t seed = GetLCGEngineState();
+	const uint32_t seed = GetLCGEngineState();
 	// Update local state immediately to increase ActiveMonsterCount instantly (this allows multiple monsters to be spawned in one game tick)
 	InitializeSpawnedMonster(position, dir, typeIndex, monsterIndex, seed, 0, 0);
 	NetSendCmdSpawnMonster(position, dir, static_cast<uint16_t>(typeIndex), static_cast<uint16_t>(monsterIndex), seed, 0, 0);
@@ -3673,7 +3673,7 @@ void LoadDeltaSpawnedMonster(size_t typeIndex, size_t monsterId, uint32_t seed, 
 {
 	SetRndSeed(seed);
 	EnsureMonsterIndexIsActive(monsterId);
-	WorldTilePosition position = GolemHoldingCell;
+	const WorldTilePosition position = GolemHoldingCell;
 	Monster &monster = Monsters[monsterId];
 	M_ClearSquares(monster);
 	InitMonster(monster, Direction::South, typeIndex, position);
@@ -3768,7 +3768,7 @@ void M_StartStand(Monster &monster, Direction md)
 
 void M_ClearSquares(const Monster &monster)
 {
-	for (Point searchTile : PointsInRectangle(Rectangle { monster.position.old, 1 })) {
+	for (const Point searchTile : PointsInRectangle(Rectangle { monster.position.old, 1 })) {
 		if (FindMonsterAtPosition(searchTile) == &monster)
 			dMonster[searchTile.x][searchTile.y] = 0;
 	}
@@ -3776,7 +3776,7 @@ void M_ClearSquares(const Monster &monster)
 
 void M_GetKnockback(Monster &monster, WorldTilePosition attackerStartPos)
 {
-	Direction dir = GetDirection(attackerStartPos, monster.position.tile);
+	const Direction dir = GetDirection(attackerStartPos, monster.position.tile);
 	if (!IsRelativeMoveOK(monster, monster.position.old, dir)) {
 		return;
 	}
@@ -3860,7 +3860,7 @@ void MonsterDeath(Monster &monster, Direction md, bool sendmsg)
 void StartMonsterDeath(Monster &monster, const Player &player, bool sendmsg)
 {
 	monster.tag(player);
-	Direction md = GetDirection(monster.position.tile, player.position.tile);
+	const Direction md = GetDirection(monster.position.tile, player.position.tile);
 	MonsterDeath(monster, md, sendmsg);
 }
 
@@ -3929,10 +3929,10 @@ void DoEnding()
 	}
 	play_movie("gendata\\diabend.smk", false);
 
-	bool bMusicOn = gbMusicOn;
+	const bool bMusicOn = gbMusicOn;
 	gbMusicOn = true;
 
-	int musicVolume = sound_get_or_set_music_volume(1);
+	const int musicVolume = sound_get_or_set_music_volume(1);
 	sound_get_or_set_music_volume(0);
 
 	music_start(TMUSIC_CATACOMBS);
@@ -4000,8 +4000,8 @@ void GolumAi(Monster &golem)
 
 	if ((golem.flags & MFLAG_NO_ENEMY) == 0) {
 		Monster &enemy = Monsters[golem.enemy];
-		int mex = golem.position.tile.x - enemy.position.future.x;
-		int mey = golem.position.tile.y - enemy.position.future.y;
+		const int mex = golem.position.tile.x - enemy.position.future.x;
+		const int mey = golem.position.tile.y - enemy.position.future.y;
 		golem.direction = GetDirection(golem.position.tile, enemy.position.tile);
 		if (std::abs(mex) < 2 && std::abs(mey) < 2) {
 			golem.enemyPosition = enemy.position.tile;
@@ -4010,11 +4010,11 @@ void GolumAi(Monster &golem)
 				enemy.position.last = golem.position.tile;
 				for (int j = 0; j < 5; j++) {
 					for (int k = 0; k < 5; k++) {
-						int mx = golem.position.tile.x + k - 2;
-						int my = golem.position.tile.y + j - 2;
+						const int mx = golem.position.tile.x + k - 2;
+						const int my = golem.position.tile.y + j - 2;
 						if (!InDungeonBounds({ mx, my }))
 							continue;
-						int enemyId = dMonster[mx][my];
+						const int enemyId = dMonster[mx][my];
 						if (enemyId > 0)
 							Monsters[enemyId - 1].activeForTicks = UINT8_MAX;
 					}
@@ -4129,7 +4129,7 @@ void ProcessMonsters()
 				monster.enemyPosition = monster.position.last;
 			} else {
 				assert(monster.enemy >= 0 && monster.enemy < MAX_PLRS);
-				Player &player = Players[monster.enemy];
+				const Player &player = Players[monster.enemy];
 				monster.enemyPosition = player.position.future;
 				if (isMonsterVisible) {
 					monster.position.last = player.position.future;
@@ -4182,8 +4182,8 @@ void FreeMonsters()
 
 bool DirOK(const Monster &monster, Direction mdir)
 {
-	Point position = monster.position.tile;
-	Point futurePosition = position + mdir;
+	const Point position = monster.position.tile;
+	const Point futurePosition = position + mdir;
 	if (!IsRelativeMoveOK(monster, position, mdir))
 		return false;
 	if (monster.leaderRelation == LeaderRelation::Leashed) {
@@ -4354,14 +4354,14 @@ void M_FallenFear(Point position)
 	for (const Point tile : PointsInRectangle(fearArea)) {
 		if (!InDungeonBounds(tile))
 			continue;
-		int m = dMonster[tile.x][tile.y];
+		const int m = dMonster[tile.x][tile.y];
 		if (m == 0)
 			continue;
 		Monster &monster = Monsters[std::abs(m) - 1];
 		if (monster.ai != MonsterAIID::Fallen || monster.hitPoints >> 6 <= 0)
 			continue;
 
-		int runDistance = std::max((8 - monster.data().level), 2);
+		const int runDistance = std::max((8 - monster.data().level), 2);
 		monster.goal = MonsterGoal::Retreat;
 		monster.goalVar1 = runDistance;
 		monster.goalVar2 = static_cast<int>(GetDirection(position, monster.position.tile));
@@ -4404,7 +4404,7 @@ void PrintMonstHistory(int mt)
 		AddInfoBoxString(fmt::format(fmt::runtime(_("Hit Points: {:d}-{:d}")), minHP, maxHP));
 	}
 	if (MonsterKillCounts[mt] >= 15) {
-		int res = (sgGameInitInfo.nDifficulty != DIFF_HELL) ? MonstersData[mt].resistance : MonstersData[mt].resistanceHell;
+		const int res = (sgGameInitInfo.nDifficulty != DIFF_HELL) ? MonstersData[mt].resistance : MonstersData[mt].resistanceHell;
 		if ((res & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING | IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING)) == 0) {
 			AddInfoBoxString(_("No magic resistance"));
 		} else {
@@ -4434,12 +4434,12 @@ void PrintMonstHistory(int mt)
 
 void PrintUniqueHistory()
 {
-	Monster &monster = Monsters[pcursmonst];
+	const Monster &monster = Monsters[pcursmonst];
 	if (*GetOptions().Gameplay.showMonsterType) {
 		AddInfoBoxString(fmt::format(fmt::runtime(_("Type: {:s}")), GetMonsterTypeText(monster.data())));
 	}
 
-	int res = monster.resistance & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING | IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING);
+	const int res = monster.resistance & (RESIST_MAGIC | RESIST_FIRE | RESIST_LIGHTNING | IMMUNE_MAGIC | IMMUNE_FIRE | IMMUNE_LIGHTNING);
 	if (res == 0) {
 		AddInfoBoxString(_("No resistances"));
 		AddInfoBoxString(_("No Immunities"));
@@ -4462,7 +4462,7 @@ void PlayEffect(Monster &monster, MonsterSound mode)
 		return;
 	}
 
-	int sndIdx = GenerateRnd(2);
+	const int sndIdx = GenerateRnd(2);
 	if (!gbSndInited || !gbSoundOn || gbBufferMsgs != 0) {
 		return;
 	}
@@ -4485,7 +4485,7 @@ void MissToMonst(Missile &missile, Point position)
 	assert(static_cast<size_t>(missile._misource) < MaxMonsters);
 	Monster &monster = Monsters[missile._misource];
 
-	Point oldPosition = missile.position.tile;
+	const Point oldPosition = missile.position.tile;
 	monster.occupyTile(position, false);
 	monster.direction = missile.getDirection();
 	monster.position.tile = position;
@@ -4507,7 +4507,7 @@ void MissToMonst(Missile &missile, Point position)
 
 		if (player->_pmode != PM_GOTHIT && player->_pmode != PM_DEATH)
 			StartPlrHit(*player, 0, true);
-		Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
+		const Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
 		if (PosOkPlayer(*player, newPosition)) {
 			player->position.tile = newPosition;
 			FixPlayerLocation(*player, player->_pdir);
@@ -4528,7 +4528,7 @@ void MissToMonst(Missile &missile, Point position)
 	if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
 		return;
 
-	Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
+	const Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
 	if (IsTileAvailable(*target, newPosition)) {
 		monster.occupyTile(newPosition, false);
 		dMonster[oldPosition.x][oldPosition.y] = 0;
@@ -4556,7 +4556,7 @@ Monster *FindMonsterAtPosition(Point position, bool ignoreMovingMonsters)
 Monster *FindUniqueMonster(UniqueMonsterType monsterType)
 {
 	for (size_t i = 0; i < ActiveMonsterCount; i++) {
-		int monsterId = ActiveMonsters[i];
+		const int monsterId = ActiveMonsters[i];
 		Monster &monster = Monsters[monsterId];
 		if (monster.uniqueType == monsterType)
 			return &monster;
@@ -4567,7 +4567,7 @@ Monster *FindUniqueMonster(UniqueMonsterType monsterType)
 Monster *FindGolemForPlayer(const Player &player)
 {
 	for (size_t i = 0; i < ActiveMonsterCount; i++) {
-		int monsterId = ActiveMonsters[i];
+		const int monsterId = ActiveMonsters[i];
 		Monster &monster = Monsters[monsterId];
 		if (monster.type().type != MT_GOLEM)
 			continue;
@@ -4730,7 +4730,7 @@ void SpawnGolem(const Player &player, Point position, uint8_t spellLevel)
 	if (golem == nullptr) {
 		if (ActiveMonsterCount >= MaxMonsters)
 			return;
-		size_t monsterIndex = ActiveMonsters[ActiveMonsterCount];
+		const size_t monsterIndex = ActiveMonsters[ActiveMonsterCount];
 		ActiveMonsterCount += 1;
 		golem = &Monsters[monsterIndex];
 	}
@@ -4738,8 +4738,8 @@ void SpawnGolem(const Player &player, Point position, uint8_t spellLevel)
 	if (golem == nullptr)
 		return;
 
-	size_t monsterIndex = golem->getId();
-	uint32_t seed = GetLCGEngineState();
+	const size_t monsterIndex = golem->getId();
+	const uint32_t seed = GetLCGEngineState();
 
 	// Update local state immediately to increase ActiveMonsterCount instantly (this allows multiple monsters to be spawned in one game tick)
 	InitializeSpawnedMonster(position, Direction::South, 0, monsterIndex, seed, player.getId(), spellLevel);
@@ -4803,8 +4803,8 @@ void Monster::setLeader(const Monster *newLeader)
 
 [[nodiscard]] unsigned Monster::distanceToEnemy() const
 {
-	int mx = position.tile.x - enemyPosition.x;
-	int my = position.tile.y - enemyPosition.y;
+	const int mx = position.tile.x - enemyPosition.x;
+	const int my = position.tile.y - enemyPosition.y;
 	return std::max(std::abs(mx), std::abs(my));
 }
 
@@ -4890,7 +4890,7 @@ MonsterMode Monster::getVisualMonsterMode() const
 {
 	if (mode != MonsterMode::Petrified)
 		return mode;
-	size_t monsterId = this->getId();
+	const size_t monsterId = this->getId();
 	for (auto &missile : Missiles) {
 		// Search the missile that will restore the original monster mode and use the saved/original monster mode from it
 		if (missile._mitype == MissileID::StoneCurse && static_cast<size_t>(missile.var2) == monsterId) {
@@ -4937,7 +4937,7 @@ unsigned int Monster::toHitSpecial(_difficulty difficulty) const
 
 void Monster::occupyTile(Point tile, bool isMoving) const
 {
-	int16_t id = static_cast<int16_t>(this->getId() + 1);
+	const int16_t id = static_cast<int16_t>(this->getId() + 1);
 	dMonster[tile.x][tile.y] = isMoving ? -id : id;
 }
 

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -45,7 +45,7 @@ void play_movie(const char *pszMovie, bool userCanClose)
 		while (movie_playing) {
 			while (movie_playing && FetchMessage(&event, &modState)) {
 				if (userCanClose) {
-					for (ControllerButtonEvent ctrlEvent : ToControllerButtonEvents(event)) {
+					for (const ControllerButtonEvent ctrlEvent : ToControllerButtonEvents(event)) {
 						if (!SkipsMovie(ctrlEvent))
 							continue;
 						movie_playing = false;

--- a/Source/mpq/mpq_reader.cpp
+++ b/Source/mpq/mpq_reader.cpp
@@ -142,7 +142,7 @@ std::size_t MpqArchive::GetBlockSize(uint32_t fileNumber, uint32_t blockNumber, 
 bool MpqArchive::HasFile(std::string_view filename) const
 {
 	std::uint32_t fileNumber;
-	int32_t error = libmpq__file_number_s(archive_, filename.data(), filename.size(), &fileNumber);
+	const int32_t error = libmpq__file_number_s(archive_, filename.data(), filename.size(), &fileNumber);
 	return error == 0;
 }
 

--- a/Source/mpq/mpq_writer.cpp
+++ b/Source/mpq/mpq_writer.cpp
@@ -384,7 +384,7 @@ bool MpqWriter::WriteFileContents(const std::byte *fileData, uint32_t fileSize, 
 	// We populate the table of sector offsets while we write the data.
 	// We can't pre-populate it because we don't know the compressed sector sizes yet.
 	// First offset is the start of the first sector, last offset is the end of the last sector.
-	std::unique_ptr<uint32_t[]> offsetTable { new uint32_t[numSectors + 1] };
+	const std::unique_ptr<uint32_t[]> offsetTable { new uint32_t[numSectors + 1] };
 
 #ifdef CAN_SEEKP_BEYOND_EOF
 	if (!stream_.Seekp(block->offset + offsetTableByteSize, SEEK_SET))
@@ -521,13 +521,13 @@ bool MpqWriter::WriteFile(std::string_view filename, const std::byte *data, size
 
 void MpqWriter::RenameFile(std::string_view name, std::string_view newName) // NOLINT(bugprone-easily-swappable-parameters)
 {
-	uint32_t index = FetchHandle(name);
+	const uint32_t index = FetchHandle(name);
 	if (index == HashEntryNotFound) {
 		return;
 	}
 
 	MpqHashEntry *hashEntry = &hashTable_[index];
-	uint32_t block = hashEntry->block;
+	const uint32_t block = hashEntry->block;
 	MpqBlockEntry *blockEntry = &blockTable_[block];
 	hashEntry->block = MpqHashEntry::DeletedBlock;
 	AddFile(newName, blockEntry, block);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -78,7 +78,7 @@ namespace devilution {
 
 void EventFailedPacket(const char *playerName)
 {
-	std::string message = fmt::format("Player '{}' sent an invalid packet.", playerName);
+	const std::string message = fmt::format("Player '{}' sent an invalid packet.", playerName);
 	EventPlrMsg(message);
 }
 
@@ -335,7 +335,7 @@ DLevel &GetDeltaLevel(uint8_t level)
 /** @brief Gets a delta level. */
 DLevel &GetDeltaLevel(const Player &player)
 {
-	uint8_t level = GetLevelForMultiplayer(player);
+	const uint8_t level = GetLevelForMultiplayer(player);
 	return GetDeltaLevel(level);
 }
 
@@ -346,9 +346,9 @@ Point GetItemPosition(Point position)
 
 	for (int k = 1; k < 50; k++) {
 		for (int j = -k; j <= k; j++) {
-			int yy = position.y + j;
+			const int yy = position.y + j;
 			for (int l = -k; l <= k; l++) {
-				int xx = position.x + l;
+				const int xx = position.x + l;
 				if (CanPut({ xx, yy }))
 					return { xx, yy };
 			}
@@ -390,7 +390,7 @@ bool WasPlayerCmdAlreadyRequested(_cmd_id bCmd, Point position = {}, uint16_t wP
 		return false;
 	}
 
-	TCmdLocParam5 newSendParam = { bCmd, static_cast<uint8_t>(position.x), static_cast<uint8_t>(position.y),
+	const TCmdLocParam5 newSendParam = { bCmd, static_cast<uint8_t>(position.x), static_cast<uint8_t>(position.y),
 		SDL_SwapLE16(wParam1), SDL_SwapLE16(wParam2), SDL_SwapLE16(wParam3), SDL_SwapLE16(wParam4), SDL_SwapLE16(wParam5) };
 
 	if (lastSentPlayerCmd.bCmd == newSendParam.bCmd && lastSentPlayerCmd.x == newSendParam.x && lastSentPlayerCmd.y == newSendParam.y
@@ -446,7 +446,7 @@ void PrePacket()
 				return;
 			}
 
-			size_t size = ParseCmd(playerId, reinterpret_cast<TCmd *>(data), remainingBytes);
+			const size_t size = ParseCmd(playerId, reinterpret_cast<TCmd *>(data), remainingBytes);
 			if (size == 0) {
 				Log("Discarding bad network message");
 				return;
@@ -582,14 +582,14 @@ const std::byte *DeltaImportObjects(const std::byte *src, const std::byte *end, 
 	if (numDeltas > MAXOBJECTS)
 		return nullptr;
 
-	size_t numBytes = (sizeof(WorldTilePosition) + sizeof(_cmd_id)) * numDeltas;
+	const size_t numBytes = (sizeof(WorldTilePosition) + sizeof(_cmd_id)) * numDeltas;
 	if (src + numBytes > end)
 		return nullptr;
 
 	dst.reserve(numDeltas);
 
 	for (unsigned i = 0; i < numDeltas; i++) {
-		WorldTilePosition objectPosition { static_cast<WorldTileCoord>(src[0]), static_cast<WorldTileCoord>(src[1]) };
+		const WorldTilePosition objectPosition { static_cast<WorldTileCoord>(src[0]), static_cast<WorldTileCoord>(src[1]) };
 		src += 2;
 		dst[objectPosition] = DObjectStr { static_cast<_cmd_id>(*src++) };
 	}
@@ -664,7 +664,7 @@ const std::byte *DeltaImportSpawnedMonsters(const std::byte *src, const std::byt
 	if (size > MaxMonsters)
 		return nullptr;
 
-	size_t requiredBytes = (sizeof(uint16_t) + sizeof(DSpawnedMonster)) * size;
+	const size_t requiredBytes = (sizeof(uint16_t) + sizeof(DSpawnedMonster)) * size;
 	if (src + requiredBytes > end)
 		return nullptr;
 
@@ -922,7 +922,7 @@ void DeltaLoadItems(const DLevel &deltaLevel)
 			continue;
 
 		if (deltaItem.bCmd == TCmdPItem::PickedUpItem) {
-			int activeItemIndex = FindGetItem(
+			const int activeItemIndex = FindGetItem(
 			    SDL_SwapLE32(deltaItem.def.dwSeed),
 			    static_cast<_item_indexes>(SDL_SwapLE16(deltaItem.def.wIndx)),
 			    SDL_SwapLE16(deltaItem.def.wCI));
@@ -934,12 +934,12 @@ void DeltaLoadItems(const DLevel &deltaLevel)
 			}
 		}
 		if (deltaItem.bCmd == TCmdPItem::DroppedItem) {
-			int ii = AllocateItem();
+			const int ii = AllocateItem();
 			auto &item = Items[ii];
 			RecreateItem(*MyPlayer, deltaItem, item);
 
-			int x = deltaItem.x;
-			int y = deltaItem.y;
+			const int x = deltaItem.x;
+			const int y = deltaItem.y;
 			item.position = GetItemPosition({ x, y });
 			dItem[item.position.x][item.position.y] = static_cast<int8_t>(ii + 1);
 			RespawnItem(Items[ii], false);
@@ -1285,8 +1285,8 @@ bool IsPItemValid(const TCmdPItem &message, const Player &player)
 	auto idx = static_cast<_item_indexes>(SDL_SwapLE16(message.def.wIndx));
 
 	if (idx != IDI_EAR) {
-		uint16_t creationFlags = SDL_SwapLE16(message.item.wCI);
-		uint32_t dwBuff = SDL_SwapLE16(message.item.dwBuff);
+		const uint16_t creationFlags = SDL_SwapLE16(message.item.wCI);
+		const uint32_t dwBuff = SDL_SwapLE16(message.item.dwBuff);
 
 		if (idx != IDI_GOLD)
 			ValidateField(creationFlags, IsCreationFlagComboValid(creationFlags));
@@ -1385,7 +1385,7 @@ int SyncDropEar(Point position, const TEar &ear)
 
 int SyncDropItem(const TCmdGItem &message)
 {
-	Point position = GetItemPosition({ message.x, message.y });
+	const Point position = GetItemPosition({ message.x, message.y });
 	if (message.def.wIndx == IDI_EAR) {
 		return SyncDropEar(
 		    position,
@@ -1399,7 +1399,7 @@ int SyncDropItem(const TCmdGItem &message)
 
 int SyncDropItem(const TCmdPItem &message)
 {
-	Point position = GetItemPosition({ message.x, message.y });
+	const Point position = GetItemPosition({ message.x, message.y });
 	if (message.def.wIndx == IDI_EAR) {
 		return SyncDropEar(
 		    position,
@@ -1433,7 +1433,7 @@ size_t OnRequestGetItem(const TCmdGItem &message, Player &player)
 
 	if (ii == -1) {
 		// No item at the target position or the key attributes don't match, so try find a matching item.
-		int activeItemIndex = FindGetItem(dwSeed, wIndx, wCI);
+		const int activeItemIndex = FindGetItem(dwSeed, wIndx, wCI);
 		if (activeItemIndex != -1) {
 			ii = ActiveItems[activeItemIndex];
 		}
@@ -1472,7 +1472,7 @@ size_t OnGetItem(const TCmdGItem &message, Player &player)
 		return sizeof(message);
 	}
 
-	bool isOnActiveLevel = GetLevelForMultiplayer(*MyPlayer) == message.bLevel;
+	const bool isOnActiveLevel = GetLevelForMultiplayer(*MyPlayer) == message.bLevel;
 	if ((!isOnActiveLevel && message.bPnum != MyPlayerId) || message.bMaster == MyPlayerId)
 		return sizeof(message);
 
@@ -1482,11 +1482,11 @@ size_t OnGetItem(const TCmdGItem &message, Player &player)
 	}
 
 	if (!isOnActiveLevel) {
-		int ii = SyncDropItem(message);
+		const int ii = SyncDropItem(message);
 		if (ii != -1)
 			InvGetItem(*MyPlayer, ii);
 	} else {
-		int activeItemIndex = FindGetItem(dwSeed, wIndx, wCI);
+		const int activeItemIndex = FindGetItem(dwSeed, wIndx, wCI);
 		InvGetItem(*MyPlayer, ActiveItems[activeItemIndex]);
 	}
 
@@ -1547,7 +1547,7 @@ size_t OnAutoGetItem(const TCmdGItem &message, Player &player)
 		return sizeof(message);
 	}
 
-	bool isOnActiveLevel = GetLevelForMultiplayer(*MyPlayer) == message.bLevel;
+	const bool isOnActiveLevel = GetLevelForMultiplayer(*MyPlayer) == message.bLevel;
 	if ((!isOnActiveLevel && message.bPnum != MyPlayerId) || message.bMaster == MyPlayerId)
 		return sizeof(message);
 
@@ -1557,7 +1557,7 @@ size_t OnAutoGetItem(const TCmdGItem &message, Player &player)
 	}
 
 	if (!isOnActiveLevel) {
-		int ii = SyncDropItem(message);
+		const int ii = SyncDropItem(message);
 		if (ii != -1)
 			AutoGetItem(*MyPlayer, &Items[ii], ii);
 	} else {
@@ -1588,7 +1588,7 @@ size_t OnPutItem(const TCmdPItem &message, Player &player)
 		BufferMessage(player, &message, sizeof(message));
 	} else if (IsPItemValid(message, player)) {
 		const Point position { message.x, message.y };
-		bool isSelf = &player == MyPlayer;
+		const bool isSelf = &player == MyPlayer;
 		const int32_t dwSeed = SDL_SwapLE32(message.def.dwSeed);
 		const uint16_t wCI = SDL_SwapLE16(message.def.wCI);
 		const auto wIndx = static_cast<_item_indexes>(SDL_SwapLE16(message.def.wIndx));
@@ -1628,7 +1628,7 @@ size_t OnSyncPutItem(const TCmdPItem &message, Player &player)
 		const uint16_t wCI = SDL_SwapLE16(message.def.wCI);
 		const auto wIndx = static_cast<_item_indexes>(SDL_SwapLE16(message.def.wIndx));
 		if (player.isOnActiveLevel()) {
-			int ii = SyncDropItem(message);
+			const int ii = SyncDropItem(message);
 			if (ii != -1) {
 				PutItemRecord(dwSeed, wCI, wIndx);
 				DeltaPutItem(message, Items[ii].position, player);
@@ -1807,7 +1807,7 @@ size_t OnAttackMonster(const TCmdParam1 &message, Player &player)
 	const uint16_t monsterIdx = SDL_SwapLE16(message.wParam1);
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && leveltype != DTYPE_TOWN && monsterIdx < MaxMonsters) {
-		Point position = Monsters[monsterIdx].position.future;
+		const Point position = Monsters[monsterIdx].position.future;
 		if (player.position.tile.WalkingDistance(position) > 1)
 			MakePlrPath(player, position, false);
 		player.destAction = ACTION_ATTACKMON;
@@ -2082,7 +2082,7 @@ size_t OnOperateObject(const TCmdLoc &message, Player &player)
 	if (gbBufferMsgs == 1) {
 		BufferMessage(player, &message, sizeof(message));
 	} else {
-		WorldTilePosition position { message.x, message.y };
+		const WorldTilePosition position { message.x, message.y };
 		assert(InDungeonBounds(position));
 		if (player.isOnActiveLevel()) {
 			Object *object = FindObjectAtPosition(position);
@@ -2102,7 +2102,7 @@ size_t OnBreakObject(const TCmdLoc &message, Player &player)
 	if (gbBufferMsgs == 1) {
 		BufferMessage(player, &message, sizeof(message));
 	} else {
-		WorldTilePosition position { message.x, message.y };
+		const WorldTilePosition position { message.x, message.y };
 		assert(InDungeonBounds(position));
 		if (player.isOnActiveLevel()) {
 			Object *object = FindObjectAtPosition(position);
@@ -2273,7 +2273,7 @@ size_t OnPlayerJoinLevel(const TCmdLocParam2 &message, Player &player)
 	}
 
 	const auto playerLevel = static_cast<uint8_t>(SDL_SwapLE16(message.wParam1));
-	bool isSetLevel = message.wParam2 != 0;
+	const bool isSetLevel = message.wParam2 != 0;
 	if (!IsValidLevel(playerLevel, isSetLevel) || !InDungeonBounds(position)) {
 		return sizeof(message);
 	}
@@ -2445,9 +2445,9 @@ size_t OnString(const TCmd &cmd, size_t maxCmdSize, Player &player)
 	const auto &message = reinterpret_cast<const TCmdString &>(cmd);
 	const size_t headerSize = sizeof(message) - sizeof(message.str);
 	const size_t maxLength = std::min<size_t>(MAX_SEND_STR_LEN, maxCmdSize - headerSize);
-	std::string_view str { message.str, maxLength };
+	const std::string_view str { message.str, maxLength };
 	const auto tokens = SplitByChar(str, '\0');
-	std::string_view playerMessage = *tokens.begin();
+	const std::string_view playerMessage = *tokens.begin();
 
 	if (gbBufferMsgs == 0)
 		SendPlrMsg(player, playerMessage);
@@ -2582,11 +2582,11 @@ size_t OnSpawnMonster(const TCmdSpawnMonster &message, const Player &player)
 
 	auto typeIndex = static_cast<size_t>(SDL_SwapLE16(message.typeIndex));
 	auto monsterId = static_cast<size_t>(SDL_SwapLE16(message.monsterId));
-	uint8_t golemOwnerPlayerId = message.golemOwnerPlayerId;
+	const uint8_t golemOwnerPlayerId = message.golemOwnerPlayerId;
 	if (golemOwnerPlayerId >= Players.size()) {
 		return sizeof(message);
 	}
-	uint8_t golemSpellLevel = std::min(message.golemSpellLevel, static_cast<uint8_t>(MaxSpellLevel + Players[golemOwnerPlayerId]._pISplLvlAdd));
+	const uint8_t golemSpellLevel = std::min(message.golemSpellLevel, static_cast<uint8_t>(MaxSpellLevel + Players[golemOwnerPlayerId]._pISplLvlAdd));
 
 	DLevel &deltaLevel = GetDeltaLevel(player);
 
@@ -2751,7 +2751,7 @@ void DeltaExportData(uint8_t pnum)
 		    + sizeof(deltaLevel.monster)                                                        /* latest monster state */
 		    + sizeof(uint16_t)                                                                  /* spawned monster count */
 		    + (sizeof(uint16_t) + sizeof(DSpawnedMonster)) * deltaLevel.spawnedMonsters.size(); /* spawned monsters */
-		std::unique_ptr<std::byte[]> dst { new std::byte[bufferSize] };
+		const std::unique_ptr<std::byte[]> dst { new std::byte[bufferSize] };
 
 		std::byte *dstEnd = &dst.get()[1];
 		*dstEnd = static_cast<std::byte>(levelNum);
@@ -2760,14 +2760,14 @@ void DeltaExportData(uint8_t pnum)
 		dstEnd = DeltaExportObject(dstEnd, deltaLevel.object);
 		dstEnd = DeltaExportMonster(dstEnd, deltaLevel.monster);
 		dstEnd = DeltaExportSpawnedMonsters(dstEnd, deltaLevel.spawnedMonsters);
-		uint32_t size = CompressData(dst.get(), dstEnd);
+		const uint32_t size = CompressData(dst.get(), dstEnd);
 		multi_send_zero_packet(pnum, CMD_DLEVEL, dst.get(), size);
 	}
 
 	std::byte dst[sizeof(DJunk) + 1];
 	std::byte *dstEnd = &dst[1];
 	dstEnd = DeltaExportJunk(dstEnd);
-	uint32_t size = CompressData(dst, dstEnd);
+	const uint32_t size = CompressData(dst, dstEnd);
 	multi_send_zero_packet(pnum, CMD_DLEVEL_JUNK, dst, size);
 
 	std::byte src[1] = { static_cast<std::byte>(0) };
@@ -2863,7 +2863,7 @@ void DeltaAddItem(int ii)
 	if (!gbIsMultiplayer)
 		return;
 
-	uint8_t localLevel = GetLevelForMultiplayer(*MyPlayer);
+	const uint8_t localLevel = GetLevelForMultiplayer(*MyPlayer);
 	DLevel &deltaLevel = GetDeltaLevel(localLevel);
 
 	for (const TCmdPItem &item : deltaLevel.item) {
@@ -2930,7 +2930,7 @@ void DeltaLoadLevel()
 	if (!gbIsMultiplayer)
 		return;
 
-	uint8_t localLevel = GetLevelForMultiplayer(*MyPlayer);
+	const uint8_t localLevel = GetLevelForMultiplayer(*MyPlayer);
 	DLevel &deltaLevel = GetDeltaLevel(localLevel);
 	if (leveltype != DTYPE_TOWN) {
 		DeltaLoadSpawnedMonsters(deltaLevel);
@@ -3144,7 +3144,7 @@ void NetSendCmdQuest(bool bHiPri, const Quest &quest)
 
 void NetSendCmdGItem(bool bHiPri, _cmd_id bCmd, const Player &player, uint8_t ii)
 {
-	uint8_t pnum = player.getId();
+	const uint8_t pnum = player.getId();
 
 	TCmdGItem cmd;
 
@@ -3185,7 +3185,7 @@ void NetSendCmdChItem(bool bHiPri, uint8_t bLoc, bool forceSpellChange)
 {
 	TCmdChItem cmd {};
 
-	Item &item = MyPlayer->InvBody[bLoc];
+	const Item &item = MyPlayer->InvBody[bLoc];
 
 	cmd.bCmd = CMD_CHANGEPLRITEMS;
 	cmd.bLoc = bLoc;
@@ -3227,7 +3227,7 @@ void NetSendCmdChInvItem(bool bHiPri, int invGridIndex)
 {
 	TCmdChItem cmd {};
 
-	int invListIndex = std::abs(MyPlayer->InvGrid[invGridIndex]) - 1;
+	const int invListIndex = std::abs(MyPlayer->InvGrid[invGridIndex]) - 1;
 	const Item &item = MyPlayer->InvList[invListIndex];
 
 	cmd.bCmd = CMD_CHANGEINVITEMS;

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -192,8 +192,8 @@ void CheckPlayerInfoTimeouts()
 		}
 
 		Uint32 &timerStart = playerInfoTimers[i];
-		bool isPlayerConnected = (player_state[i] & PS_CONNECTED) != 0;
-		bool isPlayerValid = isPlayerConnected && IsNetPlayerValid(player);
+		const bool isPlayerConnected = (player_state[i] & PS_CONNECTED) != 0;
+		const bool isPlayerValid = isPlayerConnected && IsNetPlayerValid(player);
 		if (isPlayerConnected && !isPlayerValid && timerStart == 0) {
 			timerStart = SDL_GetTicks();
 		}
@@ -348,7 +348,7 @@ void BeginTimeout()
 void HandleAllPackets(uint8_t pnum, const std::byte *data, size_t size)
 {
 	for (size_t offset = 0; offset < size;) {
-		size_t messageSize = ParseCmd(pnum, reinterpret_cast<const TCmd *>(&data[offset]), size - offset);
+		const size_t messageSize = ParseCmd(pnum, reinterpret_cast<const TCmd *>(&data[offset]), size - offset);
 		if (messageSize == 0) {
 			break;
 		}
@@ -360,7 +360,7 @@ void ProcessTmsgs()
 {
 	while (true) {
 		std::unique_ptr<std::byte[]> msg;
-		uint8_t size = tmsg_get(&msg);
+		const uint8_t size = tmsg_get(&msg);
 		if (size == 0)
 			break;
 
@@ -371,7 +371,7 @@ void ProcessTmsgs()
 void SendPlayerInfo(uint8_t pnum, _cmd_id cmd)
 {
 	PlayerNetPack packed;
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 	PackNetPlayer(packed, myPlayer);
 	multi_send_zero_packet(pnum, cmd, reinterpret_cast<std::byte *>(&packed), sizeof(PlayerNetPack));
 }
@@ -514,7 +514,7 @@ bool InitMulti(GameData *gameData)
 
 void InitGameInfo()
 {
-	xoshiro128plusplus gameGenerator = ReserveSeedSequence();
+	const xoshiro128plusplus gameGenerator = ReserveSeedSequence();
 	gameGenerator.save(sgGameInitInfo.gameSeed);
 
 	sgGameInitInfo.size = sizeof(sgGameInitInfo);
@@ -664,14 +664,14 @@ void multi_process_network_packets()
 			continue;
 		Player &player = Players[playerId];
 		if (!IsNetPlayerValid(player)) {
-			_cmd_id cmd = *(const _cmd_id *)(pkt + 1);
+			const _cmd_id cmd = *(const _cmd_id *)(pkt + 1);
 			if (gbBufferMsgs == 0 && IsNoneOf(cmd, CMD_SEND_PLRINFO, CMD_ACK_PLRINFO)) {
 				// Distrust all messages until
 				// player info is received
 				continue;
 			}
 		}
-		Point syncPosition = { pkt->px, pkt->py };
+		const Point syncPosition = { pkt->px, pkt->py };
 		player.position.last = syncPosition;
 		if (&player != MyPlayer) {
 			assert(gbBufferMsgs != 2);
@@ -679,7 +679,7 @@ void multi_process_network_packets()
 			player._pMaxHP = SDL_SwapLE32(pkt->pmhp);
 			player._pMana = SDL_SwapLE32(pkt->mana);
 			player._pMaxMana = SDL_SwapLE32(pkt->maxmana);
-			bool cond = gbBufferMsgs == 1;
+			const bool cond = gbBufferMsgs == 1;
 			player._pBaseStr = pkt->bstr;
 			player._pBaseMag = pkt->bmag;
 			player._pBaseDex = pkt->bdex;
@@ -702,7 +702,7 @@ void multi_process_network_packets()
 					if (player.position.future.WalkingDistance(player.position.tile) > 1) {
 						player.position.future = player.position.tile;
 					}
-					Point target = { pkt->targx, pkt->targy };
+					const Point target = { pkt->targx, pkt->targy };
 					if (target != Point {}) // does the client send a desired (future) position of remote player?
 						MakePlrPath(player, target, true);
 				} else {
@@ -845,7 +845,7 @@ void recv_plrinfo(Player &player, const TCmdPlrInfoHdr &header, bool recv)
 	if (&player == MyPlayer) {
 		return;
 	}
-	uint8_t pnum = player.getId();
+	const uint8_t pnum = player.getId();
 	auto &packedPlayer = PackedPlayerBuffer[pnum];
 
 	if (sgwPackPlrOffsetTbl[pnum] != SDL_SwapLE16(header.wOffset)) {

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -82,7 +82,7 @@ uint32_t nthread_send_and_recv_turn(uint32_t curTurn, int turnDelta)
 	}
 	while (curTurnsInTransit++ < gdwTurnsInTransit) {
 
-		uint32_t turnTmp = turn_upper_bit | (curTurn & 0x7FFFFFFF);
+		const uint32_t turnTmp = turn_upper_bit | (curTurn & 0x7FFFFFFF);
 		turn_upper_bit = 0;
 		uint32_t turn = turnTmp;
 
@@ -209,7 +209,7 @@ void nthread_ignore_mutex(bool bStart)
 
 bool nthread_has_500ms_passed(bool *drawGame /*= nullptr*/)
 {
-	int currentTickCount = SDL_GetTicks();
+	const int currentTickCount = SDL_GetTicks();
 	int ticksElapsed = currentTickCount - last_tick;
 	// Check if we missed multiple game ticks (> 10)
 	if (ticksElapsed > gnTickDelay * 10) {
@@ -243,13 +243,13 @@ void nthread_UpdateProgressToNextGameTick()
 {
 	if (!gbRunGame || PauseMode != 0 || (!gbIsMultiplayer && gmenu_is_active()) || !gbProcessPlayers || demo::IsRunning()) // if game is not running or paused there is no next gametick in the near future
 		return;
-	int currentTickCount = SDL_GetTicks();
-	int ticksMissing = last_tick - currentTickCount;
+	const int currentTickCount = SDL_GetTicks();
+	const int ticksMissing = last_tick - currentTickCount;
 	if (ticksMissing <= 0) {
 		ProgressToNextGameTick = AnimationInfo::baseValueFraction; // game tick is due
 		return;
 	}
-	int ticksAdvanced = gnTickDelay - ticksMissing;
+	const int ticksAdvanced = gnTickDelay - ticksMissing;
 	int32_t fraction = ticksAdvanced * AnimationInfo::baseValueFraction / gnTickDelay;
 	fraction = std::clamp<int32_t>(fraction, 0, AnimationInfo::baseValueFraction);
 	ProgressToNextGameTick = static_cast<uint8_t>(fraction);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -267,12 +267,12 @@ bool CanPlaceWallTrap(Point pos)
 
 void InitRndLocObj(int min, int max, _object_id objtype)
 {
-	int numobjs = GenerateRnd(max - min) + min;
+	const int numobjs = GenerateRnd(max - min) + min;
 
 	for (int i = 0; i < numobjs; i++) {
 		while (true) {
-			int xp = GenerateRnd(80) + 16;
-			int yp = GenerateRnd(80) + 16;
+			const int xp = GenerateRnd(80) + 16;
+			const int yp = GenerateRnd(80) + 16;
 			if (IsAreaOk(Rectangle { { xp - 1, yp - 1 }, { 3, 3 } })) {
 				AddObject(objtype, { xp, yp });
 				break;
@@ -283,11 +283,11 @@ void InitRndLocObj(int min, int max, _object_id objtype)
 
 void InitRndLocBigObj(int min, int max, _object_id objtype)
 {
-	int numobjs = GenerateRnd(max - min) + min;
+	const int numobjs = GenerateRnd(max - min) + min;
 	for (int i = 0; i < numobjs; i++) {
 		while (true) {
-			int xp = GenerateRnd(80) + 16;
-			int yp = GenerateRnd(80) + 16;
+			const int xp = GenerateRnd(80) + 16;
+			const int yp = GenerateRnd(80) + 16;
 			if (IsAreaOk(Rectangle { { xp - 1, yp - 2 }, { 3, 4 } })) {
 				AddObject(objtype, { xp, yp });
 				break;
@@ -314,7 +314,7 @@ std::optional<Point> GetRandomObjectPosition(Displacement standoff)
 
 void InitRndLocObj5x5(int min, int max, _object_id objtype)
 {
-	int numobjs = min + GenerateRnd(max - min);
+	const int numobjs = min + GenerateRnd(max - min);
 	for (int i = 0; i < numobjs; i++) {
 		std::optional<Point> position = GetRandomObjectPosition({ 2, 2 });
 		if (!position)
@@ -362,8 +362,8 @@ void AddTortures()
 
 void AddCandles()
 {
-	int tx = Quests[Q_PWATER].position.x;
-	int ty = Quests[Q_PWATER].position.y;
+	const int tx = Quests[Q_PWATER].position.x;
+	const int ty = Quests[Q_PWATER].position.y;
 	AddObject(OBJ_STORYCANDLE, { tx - 2, ty + 1 });
 	AddObject(OBJ_STORYCANDLE, { tx + 3, ty + 1 });
 	AddObject(OBJ_STORYCANDLE, { tx - 1, ty + 2 });
@@ -408,7 +408,7 @@ void InitRndBarrels()
 	}
 
 	/** number of groups of barrels to generate */
-	int numobjs = GenerateRnd(5) + 3;
+	const int numobjs = GenerateRnd(5) + 3;
 	for (int i = 0; i < numobjs; i++) {
 		int xp;
 		int yp;
@@ -430,7 +430,7 @@ void InitRndBarrels()
 			while (true) {
 				if (t >= 3)
 					break;
-				int dir = GenerateRnd(8);
+				const int dir = GenerateRnd(8);
 				xp += bxadd[dir];
 				yp += byadd[dir];
 				found = RndLocOk({ xp, yp });
@@ -452,11 +452,11 @@ void AddL2Torches()
 {
 	for (int j = 0; j < MAXDUNY; j++) {
 		for (int i = 0; i < MAXDUNX; i++) {
-			Point testPosition = { i, j };
+			const Point testPosition = { i, j };
 			if (TileContainsSetPiece(testPosition))
 				continue;
 
-			int pn = dPiece[i][j];
+			const int pn = dPiece[i][j];
 			if (pn == 0 && FlipCoin(3)) {
 				AddObject(OBJ_TORCHL2, testPosition);
 			}
@@ -565,7 +565,7 @@ void LoadMapObjects(const char *path, Point start, WorldTileRectangle mapRange =
 
 	WorldTileSize size = GetDunSize(dunData.get());
 
-	int layer2Offset = 2 + size.width * size.height;
+	const int layer2Offset = 2 + size.width * size.height;
 
 	// The rest of the layers are at dPiece scale
 	size *= static_cast<WorldTileCoord>(2);
@@ -576,7 +576,7 @@ void LoadMapObjects(const char *path, Point start, WorldTileRectangle mapRange =
 		for (WorldTileCoord i = 0; i < size.width; i++) {
 			auto objectId = static_cast<uint8_t>(SDL_SwapLE16(objectLayer[j * size.width + i]));
 			if (objectId != 0) {
-				Point mapPos = start + Displacement { i, j };
+				const Point mapPos = start + Displacement { i, j };
 				Object *mapObject = AddObject(ObjTypeConv[objectId], mapPos);
 				if (leveridx > 0 && mapObject != nullptr)
 					mapObject->InitializeLoadedObject(mapRange, leveridx);
@@ -597,7 +597,7 @@ void AddDiabObjs()
 void AddCryptObject(Object &object, int a2)
 {
 	if (a2 > 5) {
-		Player &myPlayer = *MyPlayer;
+		const Player &myPlayer = *MyPlayer;
 		switch (a2) {
 		case 6:
 			switch (myPlayer._pClass) {
@@ -723,7 +723,7 @@ void AddCryptBook(_object_id ot, int v2, Point position)
 	if (ActiveObjectCount >= MAXOBJECTS)
 		return;
 
-	int oi = AvailableObjects[0];
+	const int oi = AvailableObjects[0];
 	AvailableObjects[0] = AvailableObjects[MAXOBJECTS - 1 - ActiveObjectCount];
 	ActiveObjects[ActiveObjectCount] = oi;
 	dObject[position.x][position.y] = oi + 1;
@@ -750,8 +750,8 @@ void AddCryptStoryBook(int s)
 void AddNakrulLever()
 {
 	while (true) {
-		int xp = GenerateRnd(80) + 16;
-		int yp = GenerateRnd(80) + 16;
+		const int xp = GenerateRnd(80) + 16;
+		const int yp = GenerateRnd(80) + 16;
 		if (IsAreaOk(Rectangle { { xp - 1, yp - 1 }, { 3, 3 } })) {
 			break;
 		}
@@ -819,9 +819,9 @@ void AddStoryBooks()
 void AddHookedBodies(int freq)
 {
 	for (WorldTileCoord j = 0; j < DMAXY; j++) {
-		WorldTileCoord jj = 16 + j * 2;
+		const WorldTileCoord jj = 16 + j * 2;
 		for (WorldTileCoord i = 0; i < DMAXX; i++) {
-			WorldTileCoord ii = 16 + i * 2;
+			const WorldTileCoord ii = 16 + i * 2;
 			if (dungeon[i][j] != 1 && dungeon[i][j] != 2)
 				continue;
 			if (!FlipCoin(freq))
@@ -897,7 +897,7 @@ void AddLazStand()
 void DeleteObject(int oi, int i)
 {
 	const Object &object = Objects[oi];
-	Point position = object.position;
+	const Point position = object.position;
 	dObject[position.x][position.y] = 0;
 	AvailableObjects[-ActiveObjectCount + MAXOBJECTS] = oi;
 	ActiveObjectCount--;
@@ -950,7 +950,7 @@ void ObjSetMicro(Point position, int pn)
 
 void DoorSet(Point position, bool isLeftDoor)
 {
-	int pn = dPiece[position.x][position.y];
+	const int pn = dPiece[position.x][position.y];
 	switch (pn) {
 	case 42:
 		ObjSetMicro(position, 391);
@@ -1003,7 +1003,7 @@ void DoorSet(Point position, bool isLeftDoor)
 
 void CryptDoorSet(Point position, bool isLeftDoor)
 {
-	int pn = dPiece[position.x][position.y];
+	const int pn = dPiece[position.x][position.y];
 	switch (pn) {
 	case 74:
 		ObjSetMicro(position, 203);
@@ -1227,7 +1227,7 @@ void AddTrap(Object &trap)
 	else if (leveltype == DTYPE_CRYPT)
 		effectiveLevel -= 8;
 
-	int missileType = GenerateRnd(effectiveLevel / 3 + 1);
+	const int missileType = GenerateRnd(effectiveLevel / 3 + 1);
 	if (missileType == 0)
 		trap._oVar3 = static_cast<int8_t>(MissileID::Arrow);
 	if (missileType == 1)
@@ -1294,7 +1294,7 @@ void AddShrine(Object &shrine)
 	shrine._oRndSeed = AdvanceRndSeed();
 	shrine._oPreFlag = true;
 
-	int shrineCount = gbIsHellfire ? NumberOfShrineTypes : 26;
+	const int shrineCount = gbIsHellfire ? NumberOfShrineTypes : 26;
 	bool slist[NumberOfShrineTypes] = {};
 
 	for (int i = 0; i < shrineCount; i++) {
@@ -1306,8 +1306,8 @@ void AddShrine(Object &shrine)
 			isShrineAvailable = (shrineavail[i] != ShrineTypeMulti);
 		}
 
-		bool isEnchantedShrine = (i == ShrineEnchanted);
-		bool isCorrectLevelType = IsAnyOf(leveltype, DTYPE_CATHEDRAL, DTYPE_CATACOMBS);
+		const bool isEnchantedShrine = (i == ShrineEnchanted);
+		const bool isCorrectLevelType = IsAnyOf(leveltype, DTYPE_CATHEDRAL, DTYPE_CATACOMBS);
 
 		slist[i] = isShrineAvailable && (!isEnchantedShrine || isCorrectLevelType);
 	}
@@ -1333,9 +1333,9 @@ void AddBookcase(Object &bookcase)
 
 void AddLargeFountain(Object &fountain)
 {
-	int ox = fountain.position.x;
-	int oy = fountain.position.y;
-	uint8_t id = -(static_cast<int8_t>(fountain.GetId()) + 1);
+	const int ox = fountain.position.x;
+	const int oy = fountain.position.y;
+	const uint8_t id = -(static_cast<int8_t>(fountain.GetId()) + 1);
 	dObject[ox][oy - 1] = id;
 	dObject[ox - 1][oy] = id;
 	dObject[ox - 1][oy - 1] = id;
@@ -1436,7 +1436,7 @@ Point GetRndObjLoc(int randarea)
 void AddMushPatch()
 {
 	if (ActiveObjectCount < MAXOBJECTS) {
-		int i = AvailableObjects[0];
+		const int i = AvailableObjects[0];
 		const Point loc = GetRndObjLoc(5);
 		dObject[loc.x + 1][loc.y + 1] = -(i + 1);
 		dObject[loc.x + 2][loc.y + 1] = -(i + 1);
@@ -1594,14 +1594,14 @@ void UpdateFlameTrap(Object &trap)
 	} else if (trap._oVar4 == 0) {
 		if (trap._oVar3 == 2) {
 			int x = trap.position.x - 2;
-			int y = trap.position.y;
+			const int y = trap.position.y;
 			for (int j = 0; j < 5; j++) {
 				if (dPlayer[x][y] != 0 || dMonster[x][y] != 0)
 					trap._oVar4 = 1;
 				x++;
 			}
 		} else {
-			int x = trap.position.x;
+			const int x = trap.position.x;
 			int y = trap.position.y - 2;
 			for (int k = 0; k < 5; k++) {
 				if (dPlayer[x][y] != 0 || dMonster[x][y] != 0)
@@ -1612,13 +1612,13 @@ void UpdateFlameTrap(Object &trap)
 		if (trap._oVar4 != 0)
 			ActivateTrapLine(trap._otype, trap._oVar1);
 	} else {
-		int damage[6] = { 6, 8, 10, 12, 10, 12 };
+		const int damage[6] = { 6, 8, 10, 12, 10, 12 };
 
-		int mindam = damage[leveltype - 1];
-		int maxdam = mindam * 2;
+		const int mindam = damage[leveltype - 1];
+		const int maxdam = mindam * 2;
 
-		int x = trap.position.x;
-		int y = trap.position.y;
+		const int x = trap.position.x;
+		const int y = trap.position.y;
 		constexpr MissileID TrapMissile = MissileID::FireWallControl;
 		if (dMonster[x][y] > 0)
 			MonsterTrapHit(dMonster[x][y] - 1, mindam / 2, maxdam / 2, 0, TrapMissile, GetMissileData(TrapMissile).damageType(), false);
@@ -1644,7 +1644,7 @@ void UpdateBurningCrossDamage(Object &cross)
 	if (myPlayer._pmode == PM_DEATH)
 		return;
 
-	int8_t fireResist = myPlayer._pFireResist;
+	const int8_t fireResist = myPlayer._pFireResist;
 	if (fireResist > 0)
 		damage[leveltype - 1] -= fireResist * damage[leveltype - 1] / 100;
 
@@ -1659,9 +1659,9 @@ void UpdateBurningCrossDamage(Object &cross)
 
 void ObjSetMini(Point position, int v)
 {
-	MegaTile mega = pMegaTiles[v - 1];
+	const MegaTile mega = pMegaTiles[v - 1];
 
-	Point megaOrigin = position.megaToWorld();
+	const Point megaOrigin = position.megaToWorld();
 
 	ObjSetMicro(megaOrigin, SDL_SwapLE16(mega.micro1));
 	ObjSetMicro(megaOrigin + Direction::SouthEast, SDL_SwapLE16(mega.micro2));
@@ -1755,8 +1755,8 @@ void CloseDoor(Object &door)
 
 void OperateDoor(Object &door, bool sendflag)
 {
-	bool isCrypt = IsAnyOf(door._otype, OBJ_L5LDOOR, OBJ_L5RDOOR);
-	bool openDoor = door._oVar4 == DOOR_CLOSED;
+	const bool isCrypt = IsAnyOf(door._otype, OBJ_L5LDOOR, OBJ_L5RDOOR);
+	const bool openDoor = door._oVar4 == DOOR_CLOSED;
 
 	if (!openDoor && !IsDoorClear(door)) {
 		PlaySfxLoc(isCrypt ? SfxID::CryptDoorClose : SfxID::DoorClose, door.position);
@@ -1781,7 +1781,7 @@ void OperateDoor(Object &door, bool sendflag)
 bool AreAllLeversActivated(int leverId)
 {
 	for (int j = 0; j < ActiveObjectCount; j++) {
-		Object &lever = Objects[ActiveObjects[j]];
+		const Object &lever = Objects[ActiveObjects[j]];
 		if (lever._otype == OBJ_SWITCHSKL
 		    && lever._oVar8 == leverId
 		    && lever.canInteractWith()) {
@@ -1876,7 +1876,7 @@ void OperateBook(Player &player, Object &book, bool sendmsg)
 
 	if (setlvlnum == SL_BONECHAMB) {
 		if (sendmsg) {
-			uint8_t newSpellLevel = player._pSplLvl[static_cast<int8_t>(SpellID::Guardian)] + 1;
+			const uint8_t newSpellLevel = player._pSplLvl[static_cast<int8_t>(SpellID::Guardian)] + 1;
 			if (newSpellLevel <= MaxSpellLevel) {
 				player._pSplLvl[static_cast<int8_t>(SpellID::Guardian)] = newSpellLevel;
 				NetSendCmdParam2(true, CMD_CHANGE_SPELL_LEVEL, static_cast<uint16_t>(SpellID::Guardian), newSpellLevel);
@@ -2032,7 +2032,7 @@ void OperateChest(const Player &player, Object &chest, bool sendLootMsg)
 		}
 	}
 	if (chest.IsTrappedChest()) {
-		Direction mdir = GetDirection(chest.position, player.position.tile);
+		const Direction mdir = GetDirection(chest.position, player.position.tile);
 		MissileID mtype;
 		switch (chest._oVar4) {
 		case 0:
@@ -2085,7 +2085,7 @@ void OperateMushroomPatch(const Player &player, Object &mushroomPatch)
 	mushroomPatch._oAnimFrame++;
 
 	PlaySfxLoc(SfxID::ChestOpen, mushroomPatch.position);
-	Point pos = GetSuperItemLoc(mushroomPatch.position);
+	const Point pos = GetSuperItemLoc(mushroomPatch.position);
 
 	if (&player == MyPlayer) {
 		SpawnQuestItem(IDI_MUSHROOM, pos, 0, SelectionRegion::None, true);
@@ -2118,7 +2118,7 @@ void OperateInnSignChest(const Player &player, Object &questContainer, bool send
 	PlaySfxLoc(SfxID::ChestOpen, questContainer.position);
 
 	if (sendmsg) {
-		Point pos = GetSuperItemLoc(questContainer.position);
+		const Point pos = GetSuperItemLoc(questContainer.position);
 		SpawnQuestItem(IDI_BANNER, pos, 0, SelectionRegion::None, true);
 		NetSendCmdLoc(MyPlayerId, true, CMD_OPERATEOBJ, questContainer.position);
 	}
@@ -2303,7 +2303,7 @@ void OperateShrineHidden(DiabloGenerator &rng, Player &player)
 			}
 			if (cnt == 0)
 				break;
-			int r = rng.generateRnd(NUM_INVLOC);
+			const int r = rng.generateRnd(NUM_INVLOC);
 			if (player.InvBody[r].isEmpty() || player.InvBody[r]._iMaxDur == DUR_INDESTRUCTIBLE || player.InvBody[r]._iMaxDur == 0)
 				continue;
 
@@ -2437,7 +2437,7 @@ void OperateShrineEnchanted(DiabloGenerator &rng, Player &player)
 
 	int cnt = 0;
 	uint64_t spell = 1;
-	uint64_t spells = player._pMemSpells;
+	const uint64_t spells = player._pMemSpells;
 	for (uint16_t j = 0; j < SpellsData.size(); j++) {
 		if ((spell & spells) != 0)
 			cnt++;
@@ -2452,7 +2452,7 @@ void OperateShrineEnchanted(DiabloGenerator &rng, Player &player)
 		spell = 1;
 		for (uint8_t j = static_cast<uint8_t>(SpellID::Firebolt); j < SpellsData.size(); j++) {
 			if ((player._pMemSpells & spell) != 0 && player._pSplLvl[j] < MaxSpellLevel && j != spellToReduce) {
-				uint8_t newSpellLevel = static_cast<uint8_t>(player._pSplLvl[j] + 1);
+				const uint8_t newSpellLevel = static_cast<uint8_t>(player._pSplLvl[j] + 1);
 				player._pSplLvl[j] = newSpellLevel;
 				NetSendCmdParam2(true, CMD_CHANGE_SPELL_LEVEL, j, newSpellLevel);
 			}
@@ -2460,7 +2460,7 @@ void OperateShrineEnchanted(DiabloGenerator &rng, Player &player)
 		}
 
 		if (player._pSplLvl[spellToReduce] > 0) {
-			uint8_t newSpellLevel = static_cast<uint8_t>(player._pSplLvl[spellToReduce] - 1);
+			const uint8_t newSpellLevel = static_cast<uint8_t>(player._pSplLvl[spellToReduce] - 1);
 			player._pSplLvl[spellToReduce] = newSpellLevel;
 			NetSendCmdParam2(true, CMD_CHANGE_SPELL_LEVEL, spellToReduce, newSpellLevel);
 		}
@@ -2502,9 +2502,9 @@ void OperateShrineCostOfWisdom(Player &player, SpellID spellId, diablo_message m
 
 	player._pMemSpells |= GetSpellBitmask(spellId);
 
-	uint8_t curSpellLevel = player._pSplLvl[static_cast<int8_t>(spellId)];
+	const uint8_t curSpellLevel = player._pSplLvl[static_cast<int8_t>(spellId)];
 	if (curSpellLevel < MaxSpellLevel) {
-		uint8_t newSpellLevel = std::min(static_cast<uint8_t>(curSpellLevel + 2), MaxSpellLevel);
+		const uint8_t newSpellLevel = std::min(static_cast<uint8_t>(curSpellLevel + 2), MaxSpellLevel);
 		player._pSplLvl[static_cast<int8_t>(spellId)] = newSpellLevel;
 		NetSendCmdParam2(true, CMD_CHANGE_SPELL_LEVEL, static_cast<uint16_t>(spellId), newSpellLevel);
 	}
@@ -2518,9 +2518,9 @@ void OperateShrineCostOfWisdom(Player &player, SpellID spellId, diablo_message m
 		}
 	}
 
-	uint32_t t = player._pMaxManaBase / 10;
-	int v1 = player._pMana - player._pManaBase;
-	int v2 = player._pMaxMana - player._pMaxManaBase;
+	const uint32_t t = player._pMaxManaBase / 10;
+	const int v1 = player._pMana - player._pManaBase;
+	const int v2 = player._pMaxMana - player._pMaxManaBase;
 	player._pManaBase -= t;
 	player._pMana -= t;
 	player._pMaxMana -= t;
@@ -2760,12 +2760,12 @@ void OperateShrineTainted(DiabloGenerator &rng, const Player &player)
 		return;
 	}
 
-	int r = rng.generateRnd(4);
+	const int r = rng.generateRnd(4);
 
-	int v1 = r == 0 ? 1 : -1;
-	int v2 = r == 1 ? 1 : -1;
-	int v3 = r == 2 ? 1 : -1;
-	int v4 = r == 3 ? 1 : -1;
+	const int v1 = r == 0 ? 1 : -1;
+	const int v2 = r == 1 ? 1 : -1;
+	const int v3 = r == 2 ? 1 : -1;
+	const int v4 = r == 3 ? 1 : -1;
 
 	Player &myPlayer = *MyPlayer;
 
@@ -2857,7 +2857,7 @@ void OperateShrineMendicant(Player &player)
 	if (&player != MyPlayer)
 		return;
 
-	int gold = player._pGold / 2;
+	const int gold = player._pGold / 2;
 	player.addExperience(gold);
 	TakePlrsMoney(gold);
 
@@ -2934,9 +2934,9 @@ void OperateShrineSolar(Player &player)
 	if (&player != MyPlayer)
 		return;
 
-	time_t timeResult = time(nullptr);
+	const time_t timeResult = time(nullptr);
 	const std::tm *localtimeResult = localtime(&timeResult);
-	int hour = localtimeResult != nullptr ? localtimeResult->tm_hour : 20;
+	const int hour = localtimeResult != nullptr ? localtimeResult->tm_hour : 20;
 	if (hour >= 20 || hour < 4) {
 		InitDiabloMsg(EMSG_SHRINE_SOLAR4);
 		ModifyPlrVit(player, 2);
@@ -3168,7 +3168,7 @@ void OperateArmorStand(Object &armorStand, bool sendmsg, bool sendLootMsg)
 	armorStand.selectionRegion = SelectionRegion::None;
 	armorStand._oAnimFrame++;
 	SetRndSeed(armorStand._oRndSeed);
-	bool uniqueRnd = !FlipCoin();
+	const bool uniqueRnd = !FlipCoin();
 	if (currlevel <= 5) {
 		CreateTypeItem(armorStand.position, true, ItemType::LightArmor, IMISC_NONE, sendLootMsg, false);
 	} else if (currlevel >= 6 && currlevel <= 9) {
@@ -3185,7 +3185,7 @@ void OperateArmorStand(Object &armorStand, bool sendmsg, bool sendLootMsg)
 int FindValidShrine()
 {
 	for (;;) {
-		int rv = GenerateRnd(gbIsHellfire ? NumberOfShrineTypes : 26);
+		const int rv = GenerateRnd(gbIsHellfire ? NumberOfShrineTypes : 26);
 		if ((rv == ShrineEnchanted && !IsAnyOf(leveltype, DTYPE_CATHEDRAL, DTYPE_CATACOMBS)) || rv == ShrineThaumaturgic)
 			continue;
 		if (gbIsMultiplayer && shrineavail[rv] == ShrineTypeSingle)
@@ -3321,7 +3321,7 @@ void OperateWeaponRack(Object &weaponRack, bool sendmsg, bool sendLootMsg)
 		return;
 	SetRndSeed(weaponRack._oRndSeed);
 
-	ItemType weaponType { PickRandomlyAmong({ ItemType::Sword, ItemType::Axe, ItemType::Bow, ItemType::Mace }) };
+	const ItemType weaponType { PickRandomlyAmong({ ItemType::Sword, ItemType::Axe, ItemType::Bow, ItemType::Mace }) };
 
 	weaponRack.selectionRegion = SelectionRegion::None;
 	weaponRack._oAnimFrame++;
@@ -3400,7 +3400,7 @@ void OperateLazStand(Object &stand)
 
 	stand._oAnimFrame++;
 	stand.selectionRegion = SelectionRegion::None;
-	Point pos = GetSuperItemLoc(stand.position);
+	const Point pos = GetSuperItemLoc(stand.position);
 	SpawnQuestItem(IDI_LAZSTAFF, pos, 0, SelectionRegion::None, true);
 	NetSendCmdLoc(MyPlayerId, false, CMD_OPERATEOBJ, stand.position);
 }
@@ -3563,7 +3563,7 @@ void SyncPedestal(const Object &pedestal)
 
 void UpdatePedestalState(Object &pedestal)
 {
-	int addedStones = Quests[Q_BLOOD]._qvar2;
+	const int addedStones = Quests[Q_BLOOD]._qvar2;
 	pedestal._oAnimFrame += addedStones;
 	pedestal._oVar6 += addedStones;
 	SyncPedestal(pedestal);
@@ -3593,7 +3593,7 @@ void ResyncDoors(WorldTilePosition p1, WorldTilePosition p2, bool sendmsg)
 			continue;
 		SyncDoor(*obj);
 		if (sendmsg) {
-			bool isOpen = obj->_oVar4 == DOOR_OPEN;
+			const bool isOpen = obj->_oVar4 == DOOR_OPEN;
 			NetSendCmdLoc(MyPlayerId, true, isOpen ? CMD_OPENDOOR : CMD_CLOSEDOOR, obj->position);
 		}
 	}
@@ -3746,7 +3746,7 @@ void AddL1Objs(int x1, int y1, int x2, int y2)
 {
 	for (int j = y1; j < y2; j++) {
 		for (int i = x1; i < x2; i++) {
-			int pn = dPiece[i][j];
+			const int pn = dPiece[i][j];
 			if (pn == 269)
 				AddObject(OBJ_L1LIGHT, { i, j });
 			if (pn == 43 || pn == 50 || pn == 213)
@@ -3761,7 +3761,7 @@ void AddL2Objs(int x1, int y1, int x2, int y2)
 {
 	for (int j = y1; j < y2; j++) {
 		for (int i = x1; i < x2; i++) {
-			int pn = dPiece[i][j];
+			const int pn = dPiece[i][j];
 			if (pn == 12 || pn == 540)
 				AddObject(OBJ_L2LDOOR, { i, j });
 			if (pn == 16 || pn == 541)
@@ -3774,7 +3774,7 @@ void AddL3Objs(int x1, int y1, int x2, int y2)
 {
 	for (int j = y1; j < y2; j++) {
 		for (int i = x1; i < x2; i++) {
-			int pn = dPiece[i][j];
+			const int pn = dPiece[i][j];
 			if (pn == 530)
 				AddObject(OBJ_L3LDOOR, { i, j });
 			if (pn == 533)
@@ -3787,7 +3787,7 @@ void AddCryptObjects(int x1, int y1, int x2, int y2)
 {
 	for (int j = y1; j < y2; j++) {
 		for (int i = x1; i < x2; i++) {
-			int pn = dPiece[i][j];
+			const int pn = dPiece[i][j];
 			if (pn == 76)
 				AddObject(OBJ_L5LDOOR, { i, j });
 			if (pn == 79)
@@ -3798,7 +3798,7 @@ void AddCryptObjects(int x1, int y1, int x2, int y2)
 
 void AddSlainHero()
 {
-	Point rndObjLoc = GetRndObjLoc(5);
+	const Point rndObjLoc = GetRndObjLoc(5);
 	AddObject(OBJ_SLAINHERO, rndObjLoc + Displacement { 2, 2 });
 }
 
@@ -3963,7 +3963,7 @@ void SetMapObjects(const uint16_t *dunData, int startx, int starty)
 
 	WorldTileSize size = GetDunSize(dunData);
 
-	int layer2Offset = 2 + size.width * size.height;
+	const int layer2Offset = 2 + size.width * size.height;
 
 	// The rest of the layers are at dPiece scale
 	size *= static_cast<WorldTileCoord>(2);
@@ -3997,7 +3997,7 @@ Object *AddObject(_object_id objType, Point objPos)
 	if (ActiveObjectCount >= MAXOBJECTS)
 		return nullptr;
 
-	int oi = AvailableObjects[0];
+	const int oi = AvailableObjects[0];
 	AvailableObjects[0] = AvailableObjects[MAXOBJECTS - 1 - ActiveObjectCount];
 	ActiveObjects[ActiveObjectCount] = oi;
 	dObject[objPos.x][objPos.y] = oi + 1;
@@ -4165,7 +4165,7 @@ void OperateTrap(Object &trap)
 		return;
 
 	// default to firing at the trigger object
-	Point triggerPosition = { trap._oVar1, trap._oVar2 };
+	const Point triggerPosition = { trap._oVar1, trap._oVar2 };
 	Point target = triggerPosition;
 
 	auto searchArea = PointsInRectangle(Rectangle { target, 1 });
@@ -4176,7 +4176,7 @@ void OperateTrap(Object &trap)
 		target = *foundPosition;
 	}
 
-	Direction dir = GetDirection(trap.position, target);
+	const Direction dir = GetDirection(trap.position, target);
 	AddMissile(trap.position, target, dir, static_cast<MissileID>(trap._oVar3), TARGET_PLAYERS, -1, 0, 0);
 	PlaySfxLoc(SfxID::TriggerTrap, triggerPosition);
 }
@@ -4264,7 +4264,7 @@ void ProcessObjects()
 	}
 
 	for (int i = 0; i < ActiveObjectCount;) {
-		int oi = ActiveObjects[i];
+		const int oi = ActiveObjects[i];
 		if (Objects[oi]._oDelFlag) {
 			DeleteObject(oi, i);
 		} else {
@@ -4284,7 +4284,7 @@ void RedoPlayerVision()
 
 void MonstCheckDoors(const Monster &monster)
 {
-	for (Direction dir : { Direction::NorthEast, Direction::SouthWest, Direction::North, Direction::East, Direction::South, Direction::West, Direction::NorthWest, Direction::SouthEast }) {
+	for (const Direction dir : { Direction::NorthEast, Direction::SouthWest, Direction::North, Direction::East, Direction::South, Direction::West, Direction::NorthWest, Direction::SouthEast }) {
 		Object *object = FindObjectAtPosition(monster.position.tile + dir);
 		if (object == nullptr)
 			continue;
@@ -4307,10 +4307,10 @@ void ObjChangeMap(int x1, int y1, int x2, int y2)
 		}
 	}
 
-	WorldTilePosition mega1 { static_cast<WorldTileCoord>(x1), static_cast<WorldTileCoord>(y1) };
-	WorldTilePosition mega2 { static_cast<WorldTileCoord>(x2), static_cast<WorldTileCoord>(y2) };
-	WorldTilePosition world1 = mega1.megaToWorld();
-	WorldTilePosition world2 = mega2.megaToWorld() + Displacement { 1, 1 };
+	const WorldTilePosition mega1 { static_cast<WorldTileCoord>(x1), static_cast<WorldTileCoord>(y1) };
+	const WorldTilePosition mega2 { static_cast<WorldTileCoord>(x2), static_cast<WorldTileCoord>(y2) };
+	const WorldTilePosition world1 = mega1.megaToWorld();
+	const WorldTilePosition world2 = mega2.megaToWorld() + Displacement { 1, 1 };
 	if (leveltype == DTYPE_CATHEDRAL) {
 		ObjL1Special(world1.x, world1.y, world2.x, world2.y);
 		AddL1Objs(world1.x, world1.y, world2.x, world2.y);
@@ -4337,10 +4337,10 @@ void ObjChangeMapResync(int x1, int y1, int x2, int y2)
 		}
 	}
 
-	WorldTilePosition mega1 { static_cast<WorldTileCoord>(x1), static_cast<WorldTileCoord>(y1) };
-	WorldTilePosition mega2 { static_cast<WorldTileCoord>(x2), static_cast<WorldTileCoord>(y2) };
-	WorldTilePosition world1 = mega1.megaToWorld();
-	WorldTilePosition world2 = mega2.megaToWorld() + Displacement { 1, 1 };
+	const WorldTilePosition mega1 { static_cast<WorldTileCoord>(x1), static_cast<WorldTileCoord>(y1) };
+	const WorldTilePosition mega2 { static_cast<WorldTileCoord>(x2), static_cast<WorldTileCoord>(y2) };
+	const WorldTilePosition world1 = mega1.megaToWorld();
+	const WorldTilePosition world2 = mega2.megaToWorld() + Displacement { 1, 1 };
 	if (leveltype == DTYPE_CATHEDRAL) {
 		ObjL1Special(world1.x, world1.y, world2.x, world2.y);
 	}
@@ -4362,7 +4362,7 @@ _item_indexes ItemMiscIdIdx(item_misc_id imiscid)
 
 void OperateObject(Player &player, Object &object)
 {
-	bool sendmsg = &player == MyPlayer;
+	const bool sendmsg = &player == MyPlayer;
 
 	switch (object._otype) {
 	case OBJ_L1LDOOR:
@@ -4565,7 +4565,7 @@ void DeltaSyncCloseObj(Object &object)
 
 void SyncOpObject(Player &player, int cmd, Object &object)
 {
-	bool sendmsg = &player == MyPlayer;
+	const bool sendmsg = &player == MyPlayer;
 
 	switch (object._otype) {
 	case OBJ_L1LDOOR:

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -221,7 +221,7 @@ void LoadOptions()
 	ini->getUtf8Buf("Network", "Previous Host", options.Network.szPreviousHost, sizeof(options.Network.szPreviousHost));
 
 	for (size_t i = 0; i < QuickMessages.size(); i++) {
-		std::span<const Ini::Value> values = ini->get("NetMsg", QuickMessages[i].key);
+		const std::span<const Ini::Value> values = ini->get("NetMsg", QuickMessages[i].key);
 		std::vector<std::string> &result = options.Chat.szHotKeyMsgs[i];
 		result.clear();
 		result.reserve(values.size());
@@ -574,7 +574,7 @@ OptionEntryResampler::OptionEntryResampler()
 }
 void OptionEntryResampler::LoadFromIni(std::string_view category)
 {
-	std::string_view resamplerStr = ini->getString(category, key);
+	const std::string_view resamplerStr = ini->getString(category, key);
 	if (!resamplerStr.empty()) {
 		std::optional<Resampler> resampler = ResamplerFromString(resamplerStr);
 		if (resampler) {
@@ -660,7 +660,7 @@ std::string_view OptionEntryAudioDevice::GetListDescription(size_t index) const
 size_t OptionEntryAudioDevice::GetActiveListIndex() const
 {
 	for (size_t i = 0; i < GetListSize(); i++) {
-		std::string_view deviceName = GetDeviceName(i);
+		const std::string_view deviceName = GetDeviceName(i);
 		if (deviceName == deviceName_)
 			return i;
 	}
@@ -923,7 +923,7 @@ void OptionEntryLanguageCode::LoadFromIni(std::string_view category)
 	for (auto localeIter = locales.rbegin(); localeIter != locales.rend(); localeIter++) {
 		auto regionSeparator = localeIter->find('_');
 		if (regionSeparator != std::string::npos) {
-			std::string neutralLocale = localeIter->substr(0, regionSeparator);
+			const std::string neutralLocale = localeIter->substr(0, regionSeparator);
 			if (std::find(locales.rbegin(), localeIter, neutralLocale) == localeIter) {
 				localeIter = std::make_reverse_iterator(locales.insert(localeIter.base(), neutralLocale));
 			}
@@ -1387,13 +1387,13 @@ void PadmapperOptions::Action::UpdateValueDescription() const
 		boundInputShortDescription = "";
 		return;
 	}
-	std::string_view buttonName = ToString(GamepadType, boundInput.button);
+	const std::string_view buttonName = ToString(GamepadType, boundInput.button);
 	if (boundInput.modifier == ControllerButton_NONE) {
 		boundInputDescription = std::string(buttonName);
 		boundInputShortDescription = std::string(Shorten(buttonName));
 		return;
 	}
-	std::string_view modifierName = ToString(GamepadType, boundInput.modifier);
+	const std::string_view modifierName = ToString(GamepadType, boundInput.modifier);
 	boundInputDescription = StrCat(modifierName, "+", buttonName);
 	boundInputShortDescription = StrCat(Shorten(modifierName), "+", Shorten(buttonName));
 }
@@ -1474,7 +1474,7 @@ const PadmapperOptions::Action *PadmapperOptions::findAction(ControllerButton bu
 	// To give preference to button combinations,
 	// first pass ignores mappings where no modifier is bound
 	for (const Action &action : actions) {
-		ControllerButtonCombo combo = action.boundInput;
+		const ControllerButtonCombo combo = action.boundInput;
 		if (combo.modifier == ControllerButton_NONE)
 			continue;
 		if (button != combo.button)
@@ -1487,7 +1487,7 @@ const PadmapperOptions::Action *PadmapperOptions::findAction(ControllerButton bu
 	}
 
 	for (const Action &action : actions) {
-		ControllerButtonCombo combo = action.boundInput;
+		const ControllerButtonCombo combo = action.boundInput;
 		if (combo.modifier != ControllerButton_NONE)
 			continue;
 		if (button != combo.button)
@@ -1566,7 +1566,7 @@ std::forward_list<ModOptions::ModEntry> &ModOptions::GetModEntries()
 	if (modEntries)
 		return *modEntries;
 
-	std::vector<std::string> modNames = ini->getKeys(key);
+	const std::vector<std::string> modNames = ini->getKeys(key);
 
 	std::forward_list<ModOptions::ModEntry> &newModEntries = modEntries.emplace();
 	for (auto &modName : modNames) {

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -43,7 +43,7 @@ namespace {
 
 void EventFailedJoinAttempt(const char *playerName)
 {
-	std::string message = fmt::format("Player '{}' sent invalid player data during attempt to join the game.", playerName);
+	const std::string message = fmt::format("Player '{}' sent invalid player data during attempt to join the game.", playerName);
 	EventPlrMsg(message);
 }
 
@@ -305,10 +305,10 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 	}
 
 	if (idx == IDI_EAR) {
-		uint16_t ic = SDL_SwapLE16(packedItem.iCreateInfo);
-		uint32_t iseed = SDL_SwapLE32(packedItem.iSeed);
-		uint16_t ivalue = SDL_SwapLE16(packedItem.wValue);
-		int32_t ibuff = SDL_SwapLE32(packedItem.dwBuff);
+		const uint16_t ic = SDL_SwapLE16(packedItem.iCreateInfo);
+		const uint32_t iseed = SDL_SwapLE32(packedItem.iSeed);
+		const uint16_t ivalue = SDL_SwapLE16(packedItem.wValue);
+		const int32_t ibuff = SDL_SwapLE32(packedItem.dwBuff);
 
 		char heroName[17];
 		heroName[0] = static_cast<char>((ic >> 8) & 0x7F);
@@ -346,7 +346,7 @@ void UnPackItem(const ItemPack &packedItem, const Player &player, Item &item, bo
 
 void UnPackPlayer(const PlayerPack &packed, Player &player)
 {
-	Point position { packed.px, packed.py };
+	const Point position { packed.px, packed.py };
 
 	player = {};
 	player.setCharacterLevel(packed.pLevel);
@@ -410,7 +410,7 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 		player._pSplLvl[static_cast<uint8_t>(SpellID::Nova)] = 0;
 	}
 
-	bool isHellfire = packed.bIsHellfire != 0;
+	const bool isHellfire = packed.bIsHellfire != 0;
 
 	for (int i = 0; i < NUM_INVLOC; i++)
 		UnPackItem(packed.InvBody[i], player, player.InvBody[i], isHellfire);
@@ -435,7 +435,7 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 bool UnPackNetItem(const Player &player, const ItemNetPack &packedItem, Item &item)
 {
 	item = {};
-	_item_indexes idx = static_cast<_item_indexes>(SDL_SwapLE16(packedItem.def.wIndx));
+	const _item_indexes idx = static_cast<_item_indexes>(SDL_SwapLE16(packedItem.def.wIndx));
 	if (idx < 0 || idx > IDI_LAST)
 		return true;
 	if (idx == IDI_EAR) {
@@ -443,8 +443,8 @@ bool UnPackNetItem(const Player &player, const ItemNetPack &packedItem, Item &it
 		return true;
 	}
 
-	uint16_t creationFlags = SDL_SwapLE16(packedItem.item.wCI);
-	uint32_t dwBuff = SDL_SwapLE16(packedItem.item.dwBuff);
+	const uint16_t creationFlags = SDL_SwapLE16(packedItem.item.wCI);
+	const uint32_t dwBuff = SDL_SwapLE16(packedItem.item.dwBuff);
 	if (idx != IDI_GOLD)
 		ValidateField(creationFlags, IsCreationFlagComboValid(creationFlags));
 	if ((creationFlags & CF_TOWN) != 0)
@@ -467,18 +467,18 @@ bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 	ValidateField(packed.pClass, packed.pClass < enum_size<HeroClass>::value);
 	player._pClass = static_cast<HeroClass>(packed.pClass);
 
-	Point position { packed.px, packed.py };
+	const Point position { packed.px, packed.py };
 	ValidateFields(position.x, position.y, InDungeonBounds(position));
 	ValidateField(packed.plrlevel, packed.plrlevel < NUMLEVELS);
 	ValidateField(packed.pLevel, packed.pLevel >= 1 && packed.pLevel <= player.getMaxCharacterLevel());
 
-	int32_t baseHpMax = SDL_SwapLE32(packed.pMaxHPBase);
-	int32_t baseHp = SDL_SwapLE32(packed.pHPBase);
-	int32_t hpMax = SDL_SwapLE32(packed.pMaxHP);
+	const int32_t baseHpMax = SDL_SwapLE32(packed.pMaxHPBase);
+	const int32_t baseHp = SDL_SwapLE32(packed.pHPBase);
+	const int32_t hpMax = SDL_SwapLE32(packed.pMaxHP);
 	ValidateFields(baseHp, baseHpMax, baseHp >= (baseHpMax - hpMax) && baseHp <= baseHpMax);
 
-	int32_t baseManaMax = SDL_SwapLE32(packed.pMaxManaBase);
-	int32_t baseMana = SDL_SwapLE32(packed.pManaBase);
+	const int32_t baseManaMax = SDL_SwapLE32(packed.pMaxManaBase);
+	const int32_t baseMana = SDL_SwapLE32(packed.pManaBase);
 	ValidateFields(baseMana, baseManaMax, baseMana <= baseManaMax);
 
 	ValidateFields(packed.pClass, packed.pBaseStr, packed.pBaseStr <= player.GetMaximumAttributeValue(CharacterAttribute::Strength));
@@ -567,9 +567,9 @@ bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 			return false;
 		if (item.isEmpty())
 			continue;
-		Size beltItemSize = GetInventorySize(item);
-		int8_t beltItemType = static_cast<int8_t>(item._itype);
-		bool beltItemUsable = item.isUsable();
+		const Size beltItemSize = GetInventorySize(item);
+		const int8_t beltItemType = static_cast<int8_t>(item._itype);
+		const bool beltItemUsable = item.isUsable();
 		ValidateFields(beltItemSize.width, beltItemSize.height, (beltItemSize == Size { 1, 1 }));
 		ValidateField(beltItemType, item._itype != ItemType::Gold);
 		ValidateField(beltItemUsable, beltItemUsable);

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -56,8 +56,8 @@ UiFlags GetBaseStatColor(CharacterAttribute attr)
 UiFlags GetCurrentStatColor(CharacterAttribute attr)
 {
 	UiFlags style = UiFlags::ColorWhite;
-	int current = InspectPlayer->GetCurrentAttributeValue(attr);
-	int base = InspectPlayer->GetBaseAttributeValue(attr);
+	const int current = InspectPlayer->GetCurrentAttributeValue(attr);
+	const int base = InspectPlayer->GetBaseAttributeValue(attr);
 	if (current > base)
 		style = UiFlags::ColorBlue;
 	if (current < base)
@@ -95,8 +95,8 @@ std::pair<int, int> GetDamage()
 	} else {
 		damageMod += InspectPlayer->_pDamageMod;
 	}
-	int mindam = InspectPlayer->_pIMinDam + InspectPlayer->_pIBonusDam * InspectPlayer->_pIMinDam / 100 + damageMod;
-	int maxdam = InspectPlayer->_pIMaxDam + InspectPlayer->_pIBonusDam * InspectPlayer->_pIMaxDam / 100 + damageMod;
+	const int mindam = InspectPlayer->_pIMinDam + InspectPlayer->_pIBonusDam * InspectPlayer->_pIMinDam / 100 + damageMod;
+	const int maxdam = InspectPlayer->_pIMaxDam + InspectPlayer->_pIBonusDam * InspectPlayer->_pIMaxDam / 100 + damageMod;
 	return { mindam, maxdam };
 }
 
@@ -141,7 +141,7 @@ PanelEntry panelEntries[] = {
 	        if (InspectPlayer->isMaxCharacterLevel()) {
 		        return StyledText { UiFlags::ColorWhitegold, std::string(_("None")) };
 	        }
-	        uint32_t nextExperienceThreshold = InspectPlayer->getNextExperienceThreshold();
+	        const uint32_t nextExperienceThreshold = InspectPlayer->getNextExperienceThreshold();
 	        return StyledText { UiFlags::ColorWhite, FormatInteger(nextExperienceThreshold) };
 	    } },
 
@@ -273,7 +273,7 @@ void DrawStatButtons(const Surface &out)
 tl::expected<void, std::string> LoadCharPanel()
 {
 	ASSIGN_OR_RETURN(OptionalOwnedClxSpriteList background, LoadClxWithStatus("data\\charbg.clx"));
-	OwnedSurface out((*background)[0].width(), (*background)[0].height());
+	const OwnedSurface out((*background)[0].width(), (*background)[0].height());
 	RenderClxSprite(out, (*background)[0], { 0, 0 });
 	background = std::nullopt;
 
@@ -284,7 +284,7 @@ tl::expected<void, std::string> LoadCharPanel()
 
 		const bool isSmallFontTall = IsSmallFontTall();
 		const int attributeHeadersY = isSmallFontTall ? 112 : 114;
-		for (unsigned i : AttributeHeaderEntryIndices) {
+		for (const unsigned i : AttributeHeaderEntryIndices) {
 			panelEntries[i].position.y = attributeHeadersY;
 		}
 		panelEntries[GoldHeaderEntryIndex].position.y = isSmallFontTall ? 105 : 106;
@@ -308,11 +308,11 @@ void FreeCharPanel()
 
 void DrawChr(const Surface &out)
 {
-	Point pos = GetPanelPosition(UiPanels::Character, { 0, 0 });
+	const Point pos = GetPanelPosition(UiPanels::Character, { 0, 0 });
 	RenderClxSprite(out, (*Panel)[0], pos);
 	for (auto &entry : panelEntries) {
 		if (entry.statDisplayFunc) {
-			StyledText tmp = (*entry.statDisplayFunc)();
+			const StyledText tmp = (*entry.statDisplayFunc)();
 			DrawString(
 			    out,
 			    tmp.text,

--- a/Source/panels/mainpanel.cpp
+++ b/Source/panels/mainpanel.cpp
@@ -52,12 +52,12 @@ void DrawButtonOnPanel(Point position, std::string_view text, int frame)
 
 void RenderMainButton(const Surface &out, int buttonId, std::string_view text, int frame)
 {
-	Point panelPosition { MainPanelButtonRect[buttonId].position + Displacement { 4, 17 } };
+	const Point panelPosition { MainPanelButtonRect[buttonId].position + Displacement { 4, 17 } };
 	DrawButtonOnPanel(panelPosition, text, frame);
 	if (IsChatAvailable())
 		DrawButtonOnPanel(panelPosition + Displacement { 0, GetMainPanel().size.height + 16 }, text, frame);
 
-	Point position { 0, 19 * buttonId };
+	const Point position { 0, 19 * buttonId };
 	int spacing = 2;
 	int width = std::min<int>(GetLineWidth(text, GameFont12, spacing), (*PanelButton)[0].width());
 	if (width > 38) {
@@ -78,7 +78,7 @@ tl::expected<void, std::string> LoadMainPanel()
 		ASSIGN_OR_RETURN(OptionalOwnedClxSpriteList background, LoadClxWithStatus("data\\panel8bucp.clx"));
 		out.emplace((*background)[0].width(), (*background)[0].height() * NumButtonSprites);
 		int y = 0;
-		for (ClxSprite sprite : ClxSpriteList(*background)) {
+		for (const ClxSprite sprite : ClxSpriteList(*background)) {
 			RenderClxSprite(*out, sprite, { 0, y });
 			y += sprite.height();
 		}
@@ -103,19 +103,19 @@ tl::expected<void, std::string> LoadMainPanel()
 
 		constexpr size_t NumOtherPlayers = 3;
 		// Render the unpressed voice buttons to BottomBuffer.
-		std::string_view text = _("voice");
+		const std::string_view text = _("voice");
 		const int textWidth = GetLineWidth(text, GameFont12, 1);
 		for (size_t i = 0; i < NumOtherPlayers; ++i) {
-			Point position { 176, static_cast<int>(GetMainPanel().size.height + 101 + 18 * i) };
+			const Point position { 176, static_cast<int>(GetMainPanel().size.height + 101 + 18 * i) };
 			RenderClxSprite(*BottomBuffer, (*talkButton)[0], position);
-			int width = std::min<int>(textWidth, (*PanelButton)[0].width());
+			const int width = std::min<int>(textWidth, (*PanelButton)[0].width());
 			RenderClxSprite(BottomBuffer->subregion(position.x + (talkButtonWidth - width) / 2, position.y + 6, width, 9), (*PanelButtonGrime)[1], { 0, 0 });
 			DrawButtonText(*BottomBuffer, text, { position, { talkButtonWidth, 0 } }, UiFlags::ColorButtonface);
 		}
 
 		const int talkButtonHeight = (*talkButton)[0].height();
 		constexpr uint16_t NumTalkButtonSprites = 3;
-		OwnedSurface talkSurface(talkButtonWidth, talkButtonHeight * NumTalkButtonSprites);
+		const OwnedSurface talkSurface(talkButtonWidth, talkButtonHeight * NumTalkButtonSprites);
 
 		// Prerender translated versions of the other button states for voice buttons
 		RenderClxSprite(talkSurface, (*talkButton)[0], { 0, 0 });                    // background for unpressed mute button
@@ -124,12 +124,12 @@ tl::expected<void, std::string> LoadMainPanel()
 
 		talkButton = std::nullopt;
 
-		int muteWidth = GetLineWidth(_("mute"), GameFont12, 2);
+		const int muteWidth = GetLineWidth(_("mute"), GameFont12, 2);
 		RenderClxSprite(talkSurface.subregion((talkButtonWidth - muteWidth) / 2, 6, muteWidth, 9), (*PanelButtonGrime)[1], { 0, 0 });
 		DrawButtonText(talkSurface, _("mute"), { { 0, 0 }, { talkButtonWidth, 0 } }, UiFlags::ColorButtonface);
 		RenderClxSprite(talkSurface.subregion((talkButtonWidth - muteWidth) / 2, 23, muteWidth, 9), (*PanelButtonGrime)[1], { 0, 0 });
 		DrawButtonText(talkSurface, _("mute"), { { 0, 17 }, { talkButtonWidth, 0 } }, UiFlags::ColorButtonpushed);
-		int voiceWidth = GetLineWidth(_("voice"), GameFont12, 2);
+		const int voiceWidth = GetLineWidth(_("voice"), GameFont12, 2);
 		RenderClxSprite(talkSurface.subregion((talkButtonWidth - voiceWidth) / 2, 39, voiceWidth, 9), (*PanelButtonGrime)[1], { 0, 0 });
 		DrawButtonText(talkSurface, _("voice"), { { 0, 33 }, { talkButtonWidth, 0 } }, UiFlags::ColorButtonpushed);
 		TalkButton = SurfaceToClx(talkSurface, NumTalkButtonSprites);

--- a/Source/panels/partypanel.cpp
+++ b/Source/panels/partypanel.cpp
@@ -68,7 +68,7 @@ void DrawMemberFrame(const Surface &out, OwnedClxSpriteList &frame, Point pos)
 	FillRect(out, pos.x, pos.y, PortraitFrameSize.width, PortraitFrameSize.height, FrameBackgroundColor);
 
 	// Now draw the frame border
-	Size adjustedFrame = { FrameSections.width - 1, FrameSections.height - 1 };
+	const Size adjustedFrame = { FrameSections.width - 1, FrameSections.height - 1 };
 	for (int x = 0; x <= adjustedFrame.width; x++) {
 		for (int y = 0; y <= adjustedFrame.height; y++) {
 			// Get what section of the frame we're drawing
@@ -137,7 +137,7 @@ tl::expected<void, std::string> LoadPartyPanel()
 {
 	ASSIGN_OR_RETURN(OwnedClxSpriteList frame, LoadCelWithStatus("data\\textslid", FrameSpriteSize));
 	ASSIGN_OR_RETURN(PlayerTags, LoadClxWithStatus("data\\monstertags.clx"));
-	OwnedSurface out(PortraitFrameSize.width, PortraitFrameSize.height + HealthBarHeight);
+	const OwnedSurface out(PortraitFrameSize.width, PortraitFrameSize.height + HealthBarHeight);
 
 	// Draw the health bar background
 	DrawBar(out, { { 0, 0 }, { PortraitFrameSize.width, HealthBarHeight } }, PAL16_GRAY + 10);
@@ -182,21 +182,21 @@ void DrawPartyMemberInfoPanel(const Surface &out)
 			continue;
 #endif
 		// Get the rect of the portrait to use later
-		Rectangle currentPortraitRect = { pos, PortraitFrameSize };
+		const Rectangle currentPortraitRect = { pos, PortraitFrameSize };
 
-		Surface gameScreen = out.subregionY(0, gnViewportHeight);
+		const Surface gameScreen = out.subregionY(0, gnViewportHeight);
 
 		// Draw the characters frame
 		RenderClxSprite(gameScreen, (*PartyMemberFrame)[0], pos);
 
 		// If the player is using mana shield change the value we use to mana
 		//	If not use their hitpoints like normal
-		int healthOrMana = (player.pManaShield) ? player._pMana : player._pHitPoints;
-		int maxHealthOrMana = (player.pManaShield) ? player._pMaxMana : player._pMaxHP;
+		const int healthOrMana = (player.pManaShield) ? player._pMana : player._pHitPoints;
+		const int maxHealthOrMana = (player.pManaShield) ? player._pMaxMana : player._pMaxHP;
 
 		// Get the players remaining life
-		int lifeTicks = ((healthOrMana * PortraitFrameSize.width) + (maxHealthOrMana / 2)) / maxHealthOrMana;
-		uint8_t hpBarColor = (player.pManaShield) ? PAL8_BLUE + 3 : PAL8_RED + 4;
+		const int lifeTicks = ((healthOrMana * PortraitFrameSize.width) + (maxHealthOrMana / 2)) / maxHealthOrMana;
+		const uint8_t hpBarColor = (player.pManaShield) ? PAL8_BLUE + 3 : PAL8_RED + 4;
 		// Now draw the characters remaining life
 		DrawBar(gameScreen, { pos, { lifeTicks, HealthBarHeight } }, hpBarColor);
 
@@ -204,18 +204,18 @@ void DrawPartyMemberInfoPanel(const Surface &out)
 		pos.y += HealthBarHeight;
 
 		// Get the players current portrait sprite
-		ClxSprite playerPortraitSprite = GetPlayerPortraitSprite(player);
+		const ClxSprite playerPortraitSprite = GetPlayerPortraitSprite(player);
 		// Get the offset of the sprite based on the players class so it get's rendered in the correct position
-		PartySpriteOffset offsets = GetClassSpriteOffset(player._pClass);
+		const PartySpriteOffset offsets = GetClassSpriteOffset(player._pClass);
 		Point offset = (player.isOnLevel(0)) ? offsets.inTownOffset : offsets.inDungeonOffset;
 
 		if (player._pHitPoints <= 0 && IsPlayerUnarmed(player))
 			offset = offsets.isDeadOffset;
 
 		// Calculate the players portait position
-		Point portraitPos = { ((-(playerPortraitSprite.width() / 2)) + (PortraitFrameSize.width / 2)) + offset.x, offset.y };
+		const Point portraitPos = { ((-(playerPortraitSprite.width() / 2)) + (PortraitFrameSize.width / 2)) + offset.x, offset.y };
 		// Get a subregion of the surface so the portrait doesn't get drawn over the frame
-		Surface frameSubregion = gameScreen.subregion(
+		const Surface frameSubregion = gameScreen.subregion(
 		    pos.x + FrameBorderSize,
 		    pos.y + FrameBorderSize,
 		    PortraitFrameSize.width - (FrameBorderSize * 2),
@@ -234,7 +234,7 @@ void DrawPartyMemberInfoPanel(const Surface &out)
 
 		if ((player.getId() + 1U) < (*PlayerTags).numSprites()) {
 			// Draw the player tag
-			int tagWidth = (*PlayerTags)[player.getId() + 1].width();
+			const int tagWidth = (*PlayerTags)[player.getId() + 1].width();
 			RenderClxSprite(
 			    frameSubregion,
 			    (*PlayerTags)[player.getId() + 1],
@@ -271,7 +271,7 @@ void DrawPartyMemberInfoPanel(const Surface &out)
 		}
 
 		// Get the current players name width
-		int width = GetLineWidth(player._pName);
+		const int width = GetLineWidth(player._pName);
 		// Now check to see if it's the current longest name
 		if (width >= currentLongestNameWidth)
 			currentLongestNameWidth = width;

--- a/Source/panels/spell_book.cpp
+++ b/Source/panels/spell_book.cpp
@@ -74,7 +74,7 @@ void PrintSBookStr(const Surface &out, Point position, std::string_view text, Ui
 
 SpellType GetSBookTrans(SpellID ii, bool townok)
 {
-	Player &player = *InspectPlayer;
+	const Player &player = *InspectPlayer;
 	if (ii == GetPlayerStartingLoadoutForClass(player._pClass).skill)
 		return SpellType::Skill;
 	SpellType st = SpellType::Spell;
@@ -145,17 +145,17 @@ void DrawSpellBook(const Surface &out)
 	        + (SpellbookTab == 2 || SpellbookTab == 3 ? 1 : 0);
 
 	ClxDraw(out, GetPanelPosition(UiPanels::Spell, { SpellBookButtonX + buttonX, SpellBookButtonY }), (*spellBookButtons)[SpellbookTab]);
-	Player &player = *InspectPlayer;
-	uint64_t spl = player._pMemSpells | player._pISpells | player._pAblSpells;
+	const Player &player = *InspectPlayer;
+	const uint64_t spl = player._pMemSpells | player._pISpells | player._pAblSpells;
 
 	const int lineHeight = 18;
 
 	int yp = 12;
 	const int textPaddingTop = 7;
 	for (size_t pageEntry = 0; pageEntry < SpellBookPageEntries; pageEntry++) {
-		SpellID sn = GetSpellFromSpellPage(SpellbookTab, pageEntry);
+		const SpellID sn = GetSpellFromSpellPage(SpellbookTab, pageEntry);
 		if (IsValidSpell(sn) && (spl & GetSpellBitmask(sn)) != 0) {
-			SpellType st = GetSBookTrans(sn, true);
+			const SpellType st = GetSBookTrans(sn, true);
 			SetSpellTrans(st);
 			const Point spellCellPosition = GetPanelPosition(UiPanels::Spell, { 11, yp + SpellBookDescription.height });
 			DrawSmallSpellIcon(out, spellCellPosition, sn);
@@ -196,11 +196,11 @@ void CheckSBook()
 	// Spell icons/buttons are 37x38 pixels, laid out from 11,18 with a 5 pixel margin between each icon. This is close
 	// enough to the height of the space given to spell descriptions that we can reuse that value and subtract the
 	// padding from the end of the area.
-	Rectangle iconArea = { GetPanelPosition(UiPanels::Spell, { 11, 18 }), Size { 37, SpellBookDescription.height * 7 - 5 } };
+	const Rectangle iconArea = { GetPanelPosition(UiPanels::Spell, { 11, 18 }), Size { 37, SpellBookDescription.height * 7 - 5 } };
 	if (iconArea.contains(MousePosition) && !IsInspectingPlayer()) {
-		SpellID sn = GetSpellFromSpellPage(SpellbookTab, (MousePosition.y - iconArea.position.y) / SpellBookDescription.height);
+		const SpellID sn = GetSpellFromSpellPage(SpellbookTab, (MousePosition.y - iconArea.position.y) / SpellBookDescription.height);
 		Player &player = *InspectPlayer;
-		uint64_t spl = player._pMemSpells | player._pISpells | player._pAblSpells;
+		const uint64_t spl = player._pMemSpells | player._pISpells | player._pAblSpells;
 		if (IsValidSpell(sn) && (spl & GetSpellBitmask(sn)) != 0) {
 			SpellType st = SpellType::Spell;
 			if ((player._pISpells & GetSpellBitmask(sn)) != 0) {
@@ -221,7 +221,7 @@ void CheckSBook()
 	// instead justifies the buttons and puts the gap between buttons 2/3. See DrawSpellBook
 	const int buttonWidth = SpellBookButtonWidth();
 	// Tabs are drawn in a row near the bottom of the panel
-	Rectangle tabArea = { GetPanelPosition(UiPanels::Spell, { 7, 320 }), Size { 305, 29 } };
+	const Rectangle tabArea = { GetPanelPosition(UiPanels::Spell, { 7, 320 }), Size { 305, 29 } };
 	if (tabArea.contains(MousePosition)) {
 		int hitColumn = MousePosition.x - tabArea.position.x;
 		// Clicking on the gutter currently activates tab 3. Could make it do nothing by checking for == here and return early.

--- a/Source/panels/spell_list.cpp
+++ b/Source/panels/spell_list.cpp
@@ -51,7 +51,7 @@ bool GetSpellListSelection(SpellID &pSpell, SpellType &pSplType)
 {
 	pSpell = SpellID::Invalid;
 	pSplType = SpellType::Invalid;
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	for (auto &spellListItem : GetSpellListItems()) {
 		if (spellListItem.isSelected) {
@@ -68,7 +68,7 @@ bool GetSpellListSelection(SpellID &pSpell, SpellType &pSplType)
 
 std::optional<std::string_view> GetHotkeyName(SpellID spellId, SpellType spellType, bool useShortName = false)
 {
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 	for (size_t t = 0; t < NumHotkeys; t++) {
 		if (myPlayer._pSplHotKey[t] != spellId || myPlayer._pSplTHotKey[t] != spellType)
 			continue;
@@ -84,7 +84,7 @@ std::optional<std::string_view> GetHotkeyName(SpellID spellId, SpellType spellTy
 
 void DrawSpell(const Surface &out)
 {
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 	SpellID spl = myPlayer._pRSpell;
 	SpellType st = myPlayer._pRSplType;
 
@@ -94,7 +94,7 @@ void DrawSpell(const Surface &out)
 	}
 
 	if (st == SpellType::Spell) {
-		int tlvl = myPlayer.GetSpellLevel(spl);
+		const int tlvl = myPlayer.GetSpellLevel(spl);
 		if (CheckSpell(*MyPlayer, spl, st, true) != SpellCheckResult::Success)
 			st = SpellType::Invalid;
 		if (tlvl <= 0)
@@ -207,7 +207,7 @@ std::vector<SpellListItem> GetSpellListItems()
 	int y = mainPanelPosition.y - 17;
 
 	for (auto i : enum_values<SpellType>()) {
-		Player &myPlayer = *MyPlayer;
+		const Player &myPlayer = *MyPlayer;
 		switch (static_cast<SpellType>(i)) {
 		case SpellType::Skill:
 			mask = myPlayer._pAblSpells;
@@ -228,9 +228,9 @@ std::vector<SpellListItem> GetSpellListItems()
 		for (uint64_t spl = 1; static_cast<size_t>(j) < SpellsData.size(); spl <<= 1, j++) {
 			if ((mask & spl) == 0)
 				continue;
-			int lx = x;
-			int ly = y - SPLICONLENGTH;
-			bool isSelected = (MousePosition.x >= lx && MousePosition.x < lx + SPLICONLENGTH && MousePosition.y >= ly && MousePosition.y < ly + SPLICONLENGTH);
+			const int lx = x;
+			const int ly = y - SPLICONLENGTH;
+			const bool isSelected = (MousePosition.x >= lx && MousePosition.x < lx + SPLICONLENGTH && MousePosition.y >= ly && MousePosition.y < ly + SPLICONLENGTH);
 			spellListItems.emplace_back(SpellListItem { { x, y }, static_cast<SpellType>(i), static_cast<SpellID>(j), isSelected });
 			x -= SPLICONLENGTH;
 			if (x == mainPanelPosition.x + 12 - SPLICONLENGTH) {
@@ -294,7 +294,7 @@ bool IsValidSpeedSpell(size_t slot)
 {
 	uint64_t spells;
 
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	const SpellID spellId = myPlayer._pSplHotKey[slot];
 	if (!IsValidSpell(spellId)) {
@@ -340,7 +340,7 @@ void DoSpeedBook()
 	int x = xo + SPLICONLENGTH / 2;
 	int y = yo - SPLICONLENGTH / 2;
 
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	if (IsValidSpell(myPlayer._pRSpell)) {
 		for (auto i : enum_values<SpellType>()) {

--- a/Source/platform/locale.cpp
+++ b/Source/platform/locale.cpp
@@ -196,7 +196,7 @@ std::vector<std::string> GetLocales()
 			locales.emplace_back(languages.substr(0, languages.find_first_of(".")));
 	} else {
 		do {
-			size_t separatorPos = languages.find_first_of(":");
+			const size_t separatorPos = languages.find_first_of(":");
 			if (separatorPos != 0)
 				locales.emplace_back(std::string(languages.substr(0, separatorPos)));
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -98,8 +98,8 @@ constexpr std::array<const DirectionSettings, 8> WalkSettings { {
 
 bool PlrDirOK(const Player &player, Direction dir)
 {
-	Point position = player.position.tile;
-	Point futurePosition = position + dir;
+	const Point position = player.position.tile;
+	const Point futurePosition = position + dir;
 	if (futurePosition.x < 0 || !PosOkPlayer(player, futurePosition)) {
 		return false;
 	}
@@ -287,7 +287,7 @@ void RespawnDeadItem(Item &&itm, Point target)
 	if (ActiveItemCount >= MAXITEMS)
 		return;
 
-	int ii = AllocateItem();
+	const int ii = AllocateItem();
 	Item &item = Items[ii];
 
 	dItem[target.x][target.y] = ii + 1;
@@ -347,7 +347,7 @@ int DropGold(Player &player, int amount, bool skipFullStacks)
 
 void DropHalfPlayersGold(Player &player)
 {
-	int remainingGold = DropGold(player, player._pGold / 2, true);
+	const int remainingGold = DropGold(player, player._pGold / 2, true);
 	if (remainingGold > 0) {
 		DropGold(player, remainingGold, false);
 	}
@@ -357,7 +357,7 @@ void DropHalfPlayersGold(Player &player)
 
 void InitLevelChange(Player &player)
 {
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	RemoveEnemyReferences(player);
 	RemovePlrMissiles(player);
@@ -553,11 +553,11 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 
 	if (gbIsHellfire && HasAllOf(player._pIFlags, ItemSpecialEffect::FireDamage | ItemSpecialEffect::LightningDamage)) {
 		// Fixed off by 1 error from Hellfire
-		int midam = RandomIntBetween(player._pIFMinDam, player._pIFMaxDam);
+		const int midam = RandomIntBetween(player._pIFMinDam, player._pIFMaxDam);
 		AddMissile(player.position.tile, player.position.temp, player._pdir, MissileID::SpectralArrow, TARGET_MONSTERS, player, midam, 0);
 	}
-	int mind = player._pIMinDam;
-	int maxd = player._pIMaxDam;
+	const int mind = player._pIMinDam;
+	const int maxd = player._pIMaxDam;
 	int dam = RandomIntBetween(mind, maxd);
 	dam += dam * player._pIBonusDam / 100;
 	dam += player._pIBonusDamMod;
@@ -701,7 +701,7 @@ bool PlrHitPlr(Player &attacker, Player &target)
 		return false;
 	}
 
-	int hit = GenerateRnd(100);
+	const int hit = GenerateRnd(100);
 
 	int hper = attacker.GetMeleeToHit() - target.GetArmor();
 	hper = std::clamp(hper, 5, 95);
@@ -719,13 +719,13 @@ bool PlrHitPlr(Player &attacker, Player &target)
 	}
 
 	if (blk < blkper) {
-		Direction dir = GetDirection(target.position.tile, attacker.position.tile);
+		const Direction dir = GetDirection(target.position.tile, attacker.position.tile);
 		StartPlrBlock(target, dir);
 		return true;
 	}
 
-	int mind = attacker._pIMinDam;
-	int maxd = attacker._pIMaxDam;
+	const int mind = attacker._pIMinDam;
+	const int maxd = attacker._pIMaxDam;
 	int dam = RandomIntBetween(mind, maxd);
 	dam += (dam * attacker._pIBonusDam) / 100;
 	dam += attacker._pIBonusDamMod + attacker._pDamageMod;
@@ -735,9 +735,9 @@ bool PlrHitPlr(Player &attacker, Player &target)
 			dam *= 2;
 		}
 	}
-	int skdam = dam << 6;
+	const int skdam = dam << 6;
 	if (HasAnyOf(attacker._pIFlags, ItemSpecialEffect::RandomStealLife)) {
-		int tac = GenerateRnd(skdam / 8);
+		const int tac = GenerateRnd(skdam / 8);
 		attacker._pHitPoints += tac;
 		if (attacker._pHitPoints > attacker._pMaxHP) {
 			attacker._pHitPoints = attacker._pMaxHP;
@@ -855,11 +855,11 @@ bool DoRangeAttack(Player &player)
 		int xoff = 0;
 		int yoff = 0;
 		if (arrows != 1) {
-			int angle = arrow == 0 ? -1 : 1;
-			int x = player.position.temp.x - player.position.tile.x;
+			const int angle = arrow == 0 ? -1 : 1;
+			const int x = player.position.temp.x - player.position.tile.x;
 			if (x != 0)
 				yoff = x < 0 ? angle : -angle;
-			int y = player.position.temp.y - player.position.tile.y;
+			const int y = player.position.temp.y - player.position.tile.y;
 			if (y != 0)
 				xoff = y < 0 ? -angle : angle;
 		}
@@ -1047,7 +1047,7 @@ bool DoDeath(Player &player)
 
 bool IsPlayerAdjacentToObject(Player &player, Object &object)
 {
-	int x = std::abs(player.position.tile.x - object.position.x);
+	const int x = std::abs(player.position.tile.x - object.position.x);
 	int y = std::abs(player.position.tile.y - object.position.y);
 	if (y > 1 && object.position.y >= 1 && FindObjectAtPosition(object.position + Direction::NorthEast) == &object) {
 		// special case for activating a large object from the north-east side
@@ -1063,7 +1063,7 @@ void TryDisarm(const Player &player, Object &object)
 	if (!object._oTrapFlag) {
 		return;
 	}
-	int trapdisper = 2 * player._pDexterity - 5 * currlevel;
+	const int trapdisper = 2 * player._pDexterity - 5 * currlevel;
 	if (GenerateRnd(100) > trapdisper) {
 		return;
 	}
@@ -1089,7 +1089,7 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 	Object *object;
 	Item *item;
 
-	int targetId = player.destParam1;
+	const int targetId = player.destParam1;
 
 	switch (player.destAction) {
 	case ACTION_ATTACKMON:
@@ -1486,7 +1486,7 @@ PlayerWeaponGraphic GetPlayerWeaponGraphic(player_graphic graphic, PlayerWeaponG
 
 uint16_t GetPlayerSpriteWidth(HeroClass cls, player_graphic graphic, PlayerWeaponGraphic weaponGraphic)
 {
-	PlayerSpriteData spriteData = PlayersSpriteData[static_cast<size_t>(cls)];
+	const PlayerSpriteData spriteData = PlayersSpriteData[static_cast<size_t>(cls)];
 
 	switch (graphic) {
 	case player_graphic::Stand:
@@ -1518,7 +1518,7 @@ uint16_t GetPlayerSpriteWidth(HeroClass cls, player_graphic graphic, PlayerWeapo
 void Player::CalcScrolls()
 {
 	_pScrlSpells = 0;
-	for (Item &item : InventoryAndBeltPlayerItemsRange { *this }) {
+	for (const Item &item : InventoryAndBeltPlayerItemsRange { *this }) {
 		if (item.isScroll() && item._iStatFlag) {
 			_pScrlSpells |= GetSpellBitmask(item._iSpell);
 		}
@@ -1541,7 +1541,7 @@ void Player::RemoveInvItem(int iv, bool calcScrolls)
 	if (this == MyPlayer) {
 		// Locate the first grid index containing this item and notify remote clients
 		for (size_t i = 0; i < InventoryGridCells; i++) {
-			int8_t itemIndex = InvGrid[i];
+			const int8_t itemIndex = InvGrid[i];
 			if (std::abs(itemIndex) - 1 == iv) {
 				NetSendCmdParam1(false, CMD_DELINVITEMS, static_cast<uint16_t>(i));
 				break;
@@ -1683,7 +1683,7 @@ int Player::GetPositionPathIndex(Point pos)
 
 void Player::Say(HeroSpeech speechId) const
 {
-	SfxID soundEffect = herosounds[static_cast<size_t>(_pClass)][static_cast<size_t>(speechId)];
+	const SfxID soundEffect = herosounds[static_cast<size_t>(_pClass)][static_cast<size_t>(speechId)];
 
 	if (soundEffect == SfxID::None)
 		return;
@@ -1693,7 +1693,7 @@ void Player::Say(HeroSpeech speechId) const
 
 void Player::SaySpecific(HeroSpeech speechId) const
 {
-	SfxID soundEffect = herosounds[static_cast<size_t>(_pClass)][static_cast<size_t>(speechId)];
+	const SfxID soundEffect = herosounds[static_cast<size_t>(_pClass)][static_cast<size_t>(speechId)];
 
 	if (soundEffect == SfxID::None || effect_is_playing(soundEffect))
 		return;
@@ -1726,7 +1726,7 @@ int Player::GetManaShieldDamageReduction()
 
 void Player::RestorePartialLife()
 {
-	int wholeHitpoints = _pMaxHP >> 6;
+	const int wholeHitpoints = _pMaxHP >> 6;
 	int l = ((wholeHitpoints / 8) + GenerateRnd(wholeHitpoints / 4)) << 6;
 	if (IsAnyOf(_pClass, HeroClass::Warrior, HeroClass::Barbarian))
 		l *= 2;
@@ -1738,7 +1738,7 @@ void Player::RestorePartialLife()
 
 void Player::RestorePartialMana()
 {
-	int wholeManaPoints = _pMaxMana >> 6;
+	const int wholeManaPoints = _pMaxMana >> 6;
 	int l = ((wholeManaPoints / 8) + GenerateRnd(wholeManaPoints / 4)) << 6;
 	if (_pClass == HeroClass::Sorcerer)
 		l *= 2;
@@ -1752,7 +1752,7 @@ void Player::RestorePartialMana()
 
 void Player::ReadySpellFromEquipment(inv_body_loc bodyLocation, bool forceSpell)
 {
-	Item &item = InvBody[bodyLocation];
+	const Item &item = InvBody[bodyLocation];
 	if (item._itype == ItemType::Staff && IsValidSpell(item._iSpell) && item._iCharges > 0 && item._iStatFlag) {
 		if (forceSpell || _pRSpell == SpellID::Invalid || _pRSplType == SpellType::Invalid) {
 			_pRSpell = item._iSpell;
@@ -1850,19 +1850,19 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 
 	switch (cmdId) {
 	case _cmd_id::CMD_RATTACKID: {
-		Monster &monster = Monsters[wParam1];
+		const Monster &monster = Monsters[wParam1];
 		dir = GetDirection(position.future, monster.position.future);
 		graphic = player_graphic::Attack;
 		break;
 	}
 	case _cmd_id::CMD_SPELLID: {
-		Monster &monster = Monsters[wParam1];
+		const Monster &monster = Monsters[wParam1];
 		dir = GetDirection(position.future, monster.position.future);
 		graphic = GetPlayerGraphicForSpell(static_cast<SpellID>(wParam2));
 		break;
 	}
 	case _cmd_id::CMD_ATTACKID: {
-		Monster &monster = Monsters[wParam1];
+		const Monster &monster = Monsters[wParam1];
 		point = monster.position.future;
 		minimalWalkDistance = 2;
 		if (!CanTalkToMonst(monster)) {
@@ -1872,19 +1872,19 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 		break;
 	}
 	case _cmd_id::CMD_RATTACKPID: {
-		Player &targetPlayer = Players[wParam1];
+		const Player &targetPlayer = Players[wParam1];
 		dir = GetDirection(position.future, targetPlayer.position.future);
 		graphic = player_graphic::Attack;
 		break;
 	}
 	case _cmd_id::CMD_SPELLPID: {
-		Player &targetPlayer = Players[wParam1];
+		const Player &targetPlayer = Players[wParam1];
 		dir = GetDirection(position.future, targetPlayer.position.future);
 		graphic = GetPlayerGraphicForSpell(static_cast<SpellID>(wParam2));
 		break;
 	}
 	case _cmd_id::CMD_ATTACKPID: {
-		Player &targetPlayer = Players[wParam1];
+		const Player &targetPlayer = Players[wParam1];
 		point = targetPlayer.position.future;
 		minimalWalkDistance = 2;
 		dir = GetDirection(position.future, targetPlayer.position.future);
@@ -1925,7 +1925,7 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 
 	if (minimalWalkDistance >= 0 && position.future != point) {
 		int8_t testWalkPath[MaxPathLengthPlayer];
-		int steps = FindPath(CanStep, [this](Point tile) { return PosOkPlayer(*this, tile); }, position.future, point, testWalkPath, MaxPathLengthPlayer);
+		const int steps = FindPath(CanStep, [this](Point tile) { return PosOkPlayer(*this, tile); }, position.future, point, testWalkPath, MaxPathLengthPlayer);
 		if (steps == 0) {
 			// Can't walk to desired location => stand still
 			return;
@@ -1967,7 +1967,7 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 		return;
 
 	LoadPlrGFX(*this, *graphic);
-	ClxSpriteList sprites = AnimationData[static_cast<size_t>(*graphic)].spritesForDirection(dir);
+	const ClxSpriteList sprites = AnimationData[static_cast<size_t>(*graphic)].spritesForDirection(dir);
 	if (!previewCelSprite || *previewCelSprite != sprites[0]) {
 		previewCelSprite = sprites[0];
 		progressToNextGameTickWhenPreviewWasSet = ProgressToNextGameTick;
@@ -2043,7 +2043,7 @@ Player *PlayerAtPosition(Point position, bool ignoreMovingPlayers /*= false*/)
 
 ClxSprite GetPlayerPortraitSprite(Player &player)
 {
-	bool inDungeon = (player.plrlevel != 0);
+	const bool inDungeon = (player.plrlevel != 0);
 
 	const HeroClass cls = GetPlayerSpriteClass(player._pClass);
 	const PlayerWeaponGraphic animWeaponId = GetPlayerWeaponGraphic(player_graphic::Stand, static_cast<PlayerWeaponGraphic>(player._pgfxnum & 0xF));
@@ -2068,7 +2068,7 @@ ClxSprite GetPlayerPortraitSprite(Player &player)
 	char pszName[256];
 	*fmt::format_to(pszName, R"(plrgfx\{0}\{1}\{1}{2})", path, std::string_view(prefix, 3), szCel) = 0;
 
-	std::string spritePath { pszName };
+	const std::string spritePath { pszName };
 	// Check to see if the sprite has updated.
 	if (player.PartyInfoSpriteLocations[inDungeon] != spritePath) {
 		// The sprite has changed so store the new location
@@ -2081,7 +2081,7 @@ ClxSprite GetPlayerPortraitSprite(Player &player)
 		player.PartyInfoSprites[inDungeon] = LoadCl2Sheet(pszName, animationWidth);
 	}
 
-	ClxSpriteList spriteList = (*player.PartyInfoSprites[inDungeon])[static_cast<size_t>(Direction::South)];
+	const ClxSpriteList spriteList = (*player.PartyInfoSprites[inDungeon])[static_cast<size_t>(Direction::South)];
 	return spriteList[(graphic == player_graphic::Stand) ? 0 : spriteList.numSprites() - 1];
 }
 
@@ -2223,8 +2223,8 @@ void NewPlrAnim(Player &player, player_graphic graphic, Direction dir, Animation
 
 void SetPlrAnims(Player &player)
 {
-	HeroClass pc = player._pClass;
-	PlayerAnimData plrAtkAnimData = PlayersAnimData[static_cast<uint8_t>(pc)];
+	const HeroClass pc = player._pClass;
+	const PlayerAnimData plrAtkAnimData = PlayersAnimData[static_cast<uint8_t>(pc)];
 	auto gn = static_cast<PlayerWeaponGraphic>(player._pgfxnum & 0xFU);
 
 	if (leveltype == DTYPE_TOWN) {
@@ -2278,7 +2278,7 @@ void SetPlrAnims(Player &player)
 	player._pDFrames = plrAtkAnimData.deathFrames;
 	player._pSFrames = plrAtkAnimData.castingFrames;
 	player._pSFNum = plrAtkAnimData.castingActionFrame;
-	int armorGraphicIndex = player._pgfxnum & ~0xFU;
+	const int armorGraphicIndex = player._pgfxnum & ~0xFU;
 	if (IsAnyOf(pc, HeroClass::Warrior, HeroClass::Barbarian)) {
 		if (gn == PlayerWeaponGraphic::Bow && leveltype != DTYPE_TOWN)
 			player._pNFrames = 8;
@@ -2382,7 +2382,7 @@ void NextPlrLevel(Player &player)
 	} else {
 		player._pStatPts += 5;
 	}
-	int hp = player.getClassAttributes().lvlLife;
+	const int hp = player.getClassAttributes().lvlLife;
 
 	player._pMaxHP += hp;
 	player._pHitPoints = player._pMaxHP;
@@ -2393,7 +2393,7 @@ void NextPlrLevel(Player &player)
 		RedrawComponent(PanelDrawComponent::Health);
 	}
 
-	int mana = player.getClassAttributes().lvlMana;
+	const int mana = player.getClassAttributes().lvlMana;
 
 	player._pMaxMana += mana;
 	player._pMaxManaBase += mana;
@@ -2462,7 +2462,7 @@ void AddPlrMonstExper(int lvl, unsigned exp, char pmask)
 	}
 
 	if (totplrs != 0) {
-		unsigned e = exp / totplrs;
+		const unsigned e = exp / totplrs;
 		if ((pmask & (1 << MyPlayerId)) != 0)
 			MyPlayer->addExperience(e, lvl);
 	}
@@ -2642,7 +2642,7 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 		return;
 	}
 
-	Direction pd = player._pdir;
+	const Direction pd = player._pdir;
 
 	int8_t skippedAnimationFrames = 0;
 	if (HasAnyOf(player._pIFlags, ItemSpecialEffect::FastestHitRecovery)) {
@@ -2801,7 +2801,7 @@ void StripTopGold(Player &player)
 		return;
 	if (AutoPlaceItemInBelt(player, player.HoldItem))
 		return;
-	std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, player._pdir);
+	const std::optional<Point> itemTile = FindAdjacentPositionForItem(player.position.tile, player._pdir);
 	if (itemTile)
 		return;
 	DeadItem(player, std::move(player.HoldItem), { 0, 0 });
@@ -2815,7 +2815,7 @@ void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP /*
 		AddFloatingNumber(damageType, player, totalDamage);
 	}
 	if (totalDamage > 0 && player.pManaShield && HasNoneOf(player._pIFlags, ItemSpecialEffect::NoMana)) {
-		uint8_t manaShieldLevel = player._pSplLvl[static_cast<int8_t>(SpellID::ManaShield)];
+		const uint8_t manaShieldLevel = player._pSplLvl[static_cast<int8_t>(SpellID::ManaShield)];
 		if (manaShieldLevel > 0) {
 			totalDamage += totalDamage / -player.GetManaShieldDamageReduction();
 		}
@@ -2847,7 +2847,7 @@ void ApplyPlrDamage(DamageType damageType, Player &player, int dam, int minHP /*
 		player._pHitPoints = player._pMaxHP;
 		player._pHPBase = player._pMaxHPBase;
 	}
-	int minHitPoints = minHP << 6;
+	const int minHitPoints = minHP << 6;
 	if (player._pHitPoints < minHitPoints) {
 		SetPlayerHitPoints(player, minHitPoints);
 	}
@@ -3196,7 +3196,7 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 	const int spellFrom = 0;
 	if (IsWallSpell(spellID)) {
 		LastPlayerAction = PlayerActionType::Spell;
-		Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
+		const Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
 		NetSendCmdLocParam4(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellFrom);
 	} else if (pcursmonst != -1 && !isShiftHeld) {
 		LastPlayerAction = PlayerActionType::SpellMonsterTarget;
@@ -3210,7 +3210,7 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 			// Check if the player is attempting to queue Teleport onto a tile that is currently being targeted with Teleport, or a nearby tile
 			if (cursPosition.WalkingDistance(myPlayer.position.temp) <= 1) {
 				// Get the relative displacement from the player's current position to the cursor position
-				WorldTileDisplacement relativeMove = cursPosition - static_cast<Point>(myPlayer.position.tile);
+				const WorldTileDisplacement relativeMove = cursPosition - static_cast<Point>(myPlayer.position.tile);
 				// Target the tile the relative distance away from the player's targeted Teleport tile
 				targetedTile = myPlayer.position.temp + relativeMove;
 			}
@@ -3234,14 +3234,14 @@ void SyncInitPlrPos(Player &player)
 
 	const WorldTileDisplacement offset[9] = { { 0, 0 }, { 1, 0 }, { 0, 1 }, { 1, 1 }, { 2, 0 }, { 0, 2 }, { 1, 2 }, { 2, 1 }, { 2, 2 } };
 
-	Point position = [&]() {
+	const Point position = [&]() {
 		for (int i = 0; i < 8; i++) {
 			Point position = player.position.tile + offset[i];
 			if (PosOkPlayer(player, position))
 				return position;
 		}
 
-		std::optional<Point> nearPosition = FindClosestValidPosition(
+		const std::optional<Point> nearPosition = FindClosestValidPosition(
 		    [&player](Point testPosition) {
 			    for (int i = 0; i < numtrigs; i++) {
 				    if (trigs[i].position == testPosition)
@@ -3276,7 +3276,7 @@ void SyncInitPlr(Player &player)
 void CheckStats(Player &player)
 {
 	for (auto attribute : enum_values<CharacterAttribute>()) {
-		int maxStatPoint = player.GetMaximumAttributeValue(attribute);
+		const int maxStatPoint = player.GetMaximumAttributeValue(attribute);
 		switch (attribute) {
 		case CharacterAttribute::Strength:
 			player._pBaseStr = std::clamp(player._pBaseStr, 0, maxStatPoint);

--- a/Source/playerdat.cpp
+++ b/Source/playerdat.cpp
@@ -107,7 +107,7 @@ void ReloadExperienceData()
 		bool skipRecord = false;
 
 		FieldIterator fieldIt = record.begin();
-		FieldIterator endField = record.end();
+		const FieldIterator endField = record.end();
 		for (auto &column : columns) {
 			fieldIt += column.skipLength;
 
@@ -241,7 +241,7 @@ void LoadClassesAttributes()
 	ClassAttributesPerClass.reserve(classPaths.size());
 	PlayersCombatData.clear();
 	PlayersCombatData.reserve(classPaths.size());
-	for (std::string_view path : classPaths) {
+	for (const std::string_view path : classPaths) {
 		LoadClassData(path, ClassAttributesPerClass.emplace_back(), PlayersCombatData.emplace_back());
 	}
 }

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -76,7 +76,7 @@ void SendPlrMsg(Player &player, std::string_view text)
 {
 	PlayerMessage &message = GetNextMessage();
 
-	std::string from = fmt::format(fmt::runtime(_("{:s} (lvl {:d}): ")), player._pName, player.getCharacterLevel());
+	const std::string from = fmt::format(fmt::runtime(_("{:s} (lvl {:d}): ")), player._pName, player.getCharacterLevel());
 
 	message.style = UiFlags::ColorWhite;
 	message.time = SDL_GetTicks();
@@ -112,14 +112,14 @@ void DrawPlrMsg(const Surface &out)
 
 	width = std::min(540, width);
 
-	for (PlayerMessage &message : Messages) {
+	for (const PlayerMessage &message : Messages) {
 		if (message.text.empty())
 			break;
 		if (!ChatFlag && SDL_GetTicks() - message.time >= 10000)
 			break;
 
 		std::string text = WordWrapString(message.text, width);
-		int chatlines = CountLinesOfText(text);
+		const int chatlines = CountLinesOfText(text);
 		y -= message.lineHeight * chatlines;
 
 		DrawHalfTransparentRectTo(out, x - 3, y, width + 6, message.lineHeight * chatlines);

--- a/Source/portal.cpp
+++ b/Source/portal.cpp
@@ -65,7 +65,7 @@ void SyncPortals()
 	for (int i = 0; i < MAXPORTAL; i++) {
 		if (!Portals[i].open)
 			continue;
-		Player &player = Players[i];
+		const Player &player = Players[i];
 		if (leveltype == DTYPE_TOWN)
 			AddPortalMissile(player, PortalTownPosition[i], true);
 		else {

--- a/Source/portals/validation.cpp
+++ b/Source/portals/validation.cpp
@@ -28,7 +28,7 @@ dungeon_type GetQuestLevelType(_setlevels questLevel)
 
 dungeon_type GetSetLevelType(_setlevels setLevel)
 {
-	bool isArenaLevel = setLevel >= SL_FIRST_ARENA && setLevel <= SL_LAST;
+	const bool isArenaLevel = setLevel >= SL_FIRST_ARENA && setLevel <= SL_LAST;
 	return isArenaLevel ? GetArenaLevelType(setLevel) : GetQuestLevelType(setLevel);
 }
 
@@ -38,7 +38,7 @@ bool IsPortalDeltaValid(WorldTilePosition location, uint8_t level, uint8_t ltype
 {
 	if (!InDungeonBounds(location))
 		return false;
-	dungeon_type levelType = static_cast<dungeon_type>(ltype);
+	const dungeon_type levelType = static_cast<dungeon_type>(ltype);
 	if (levelType == DTYPE_NONE)
 		return false;
 	if (isOnSetLevel)

--- a/Source/qol/autopickup.cpp
+++ b/Source/qol/autopickup.cpp
@@ -17,7 +17,7 @@ namespace {
 
 bool HasRoomForGold()
 {
-	for (int idx : MyPlayer->InvGrid) {
+	for (const int idx : MyPlayer->InvGrid) {
 		// Secondary item cell. No need to check those as we'll go through the main item cells anyway.
 		if (idx < 0)
 			continue;
@@ -98,9 +98,9 @@ void AutoPickup(const Player &player)
 		return;
 
 	for (auto pathDir : PathDirs) {
-		Point tile = player.position.tile + pathDir;
+		const Point tile = player.position.tile + pathDir;
 		if (dItem[tile.x][tile.y] != 0) {
-			int itemIndex = dItem[tile.x][tile.y] - 1;
+			const int itemIndex = dItem[tile.x][tile.y] - 1;
 			auto &item = Items[itemIndex];
 			if (DoPickup(item)) {
 				NetSendCmdGItem(true, CMD_REQUESTAGITEM, player, itemIndex);

--- a/Source/qol/chatlog.cpp
+++ b/Source/qol/chatlog.cpp
@@ -117,18 +117,18 @@ void ToggleChatLog()
 void AddMessageToChatLog(std::string_view message, Player *player, UiFlags flags)
 {
 	MessageCounter++;
-	time_t timeResult = time(nullptr);
+	const time_t timeResult = time(nullptr);
 	const std::tm *localtimeResult = localtime(&timeResult);
 	std::string timestamp = localtimeResult != nullptr ? fmt::format("[#{:d}] {:02}:{:02}:{:02}", MessageCounter, localtimeResult->tm_hour, localtimeResult->tm_min, localtimeResult->tm_sec)
 	                                                   : fmt::format("[#{:d}] ", MessageCounter);
-	size_t oldSize = ChatLogLines.size();
+	const size_t oldSize = ChatLogLines.size();
 	if (player == nullptr) {
 		ChatLogLines.emplace_back(MultiColoredText { "{0} {1}", { { timestamp, UiFlags::ColorRed }, { std::string(message), flags } } });
 	} else {
 		std::string playerInfo = fmt::format(fmt::runtime(_("{:s} (lvl {:d}): ")), player->_pName, player->getCharacterLevel());
 		UiFlags nameColor = player == MyPlayer ? UiFlags::ColorWhitegold : UiFlags::ColorBlue;
-		std::string prefix = timestamp + " - " + playerInfo;
-		std::string text = WordWrapString(prefix + std::string(message), ContentTextWidth);
+		const std::string prefix = timestamp + " - " + playerInfo;
+		const std::string text = WordWrapString(prefix + std::string(message), ContentTextWidth);
 		std::vector<std::string> lines;
 		std::stringstream ss(text);
 
@@ -142,7 +142,7 @@ void AddMessageToChatLog(std::string_view message, Player *player, UiFlags flags
 		ChatLogLines.emplace_back(MultiColoredText { "{0} - {1}{2}", { { timestamp, UiFlags::ColorRed }, { playerInfo, nameColor }, { lines[0], UiFlags::ColorWhite } } });
 	}
 
-	size_t diff = ChatLogLines.size() - oldSize;
+	const size_t diff = ChatLogLines.size() - oldSize;
 	// only autoscroll when on top of the log
 	if (SkipLines != 0) {
 		SkipLines += diff;
@@ -169,10 +169,10 @@ void DrawChatLog(const Surface &out)
 	    { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } },
 	    { .flags = (UnreadFlag ? UiFlags::ColorRed : UiFlags::ColorWhitegold) | UiFlags::AlignCenter });
 
-	time_t timeResult = time(nullptr);
+	const time_t timeResult = time(nullptr);
 	const std::tm *localtimeResult = localtime(&timeResult);
 	if (localtimeResult != nullptr) {
-		std::string timestamp = fmt::format("{:02}:{:02}:{:02}", localtimeResult->tm_hour, localtimeResult->tm_min, localtimeResult->tm_sec);
+		const std::string timestamp = fmt::format("{:02}:{:02}:{:02}", localtimeResult->tm_hour, localtimeResult->tm_min, localtimeResult->tm_sec);
 		DrawString(out, timestamp, { { sx, sy + PaddingTop + blankLineHeight }, { ContentTextWidth, lineHeight } },
 		    { .flags = UiFlags::ColorWhitegold });
 	}
@@ -185,7 +185,7 @@ void DrawChatLog(const Surface &out)
 	for (int i = 0; i < numLines; i++) {
 		if (i + SkipLines >= ChatLogLines.size())
 			break;
-		MultiColoredText &text = ChatLogLines[ChatLogLines.size() - (i + SkipLines + 1)];
+		const MultiColoredText &text = ChatLogLines[ChatLogLines.size() - (i + SkipLines + 1)];
 		const std::string_view line = text.text;
 
 		std::vector<DrawStringFormatArg> args;

--- a/Source/qol/floatingnumbers.cpp
+++ b/Source/qol/floatingnumbers.cpp
@@ -33,7 +33,7 @@ std::deque<FloatingNumber> FloatingQueue;
 void ClearExpiredNumbers()
 {
 	while (!FloatingQueue.empty()) {
-		FloatingNumber &num = FloatingQueue.front();
+		const FloatingNumber &num = FloatingQueue.front();
 		if (num.time > SDL_GetTicks())
 			break;
 
@@ -94,7 +94,7 @@ void UpdateFloatingData(FloatingNumber &num)
 void AddFloatingNumber(Point pos, Displacement offset, DamageType type, int value, size_t index, bool damageToPlayer)
 {
 	// 45 deg angles to avoid jitter caused by px alignment
-	Displacement goodAngles[] = {
+	const Displacement goodAngles[] = {
 		{ 0, -140 },
 		{ 100, -100 },
 		{ -100, -100 },
@@ -184,10 +184,10 @@ void DrawFloatingNumbers(const Surface &out, Point viewPosition, Displacement of
 
 		Point screenPosition { worldOffset.deltaX, worldOffset.deltaY };
 
-		int lineWidth = GetLineWidth(floatingNum.text, GetGameFontSizeByDamage(floatingNum.value));
+		const int lineWidth = GetLineWidth(floatingNum.text, GetGameFontSizeByDamage(floatingNum.value));
 		screenPosition.x -= lineWidth / 2;
-		uint32_t timeLeft = floatingNum.time - SDL_GetTicks();
-		float mul = 1 - (timeLeft / 2500.0f);
+		const uint32_t timeLeft = floatingNum.time - SDL_GetTicks();
+		const float mul = 1 - (timeLeft / 2500.0f);
 		screenPosition += floatingNum.endOffset * mul;
 
 		DrawString(out, floatingNum.text, Rectangle { screenPosition, { lineWidth, 0 } },

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -117,7 +117,7 @@ void AddItemToLabelQueue(int id, Point position)
 
 	int nameWidth = GetLineWidth(textOnGround);
 	nameWidth += MarginX * 2;
-	int index = ItemCAnimTbl[item._iCurs];
+	const int index = ItemCAnimTbl[item._iCurs];
 	if (!labelCenterOffsets[index]) {
 		const auto [xBegin, xEnd] = ClxMeasureSolidHorizontalBounds((*item.AnimInfo.sprites)[item.AnimInfo.currentFrame]);
 		labelCenterOffsets[index].emplace((xBegin + xEnd) / 2);
@@ -163,7 +163,7 @@ void DrawItemNameLabels(const Surface &out)
 			canShow = true;
 			for (unsigned j = 0; j < i; ++j) {
 				ItemLabel &a = labelQueue[i];
-				ItemLabel &b = labelQueue[j];
+				const ItemLabel &b = labelQueue[j];
 				if (std::abs(b.pos.y - a.pos.y) < labelHeight + BorderY) {
 					const int widthA = a.width + BorderX + MarginX * 2;
 					const int widthB = b.width + BorderX + MarginX * 2;
@@ -187,7 +187,7 @@ void DrawItemNameLabels(const Surface &out)
 	}
 
 	for (const ItemLabel &label : labelQueue) {
-		Item &item = Items[label.id];
+		const Item &item = Items[label.id];
 
 		if (MousePosition.x >= label.pos.x && MousePosition.x < label.pos.x + label.width
 		    && MousePosition.y >= label.pos.y && MousePosition.y < label.pos.y + labelHeight) {

--- a/Source/qol/monhealthbar.cpp
+++ b/Source/qol/monhealthbar.cpp
@@ -110,7 +110,7 @@ void DrawMonsterHealthBar(const Surface &out)
 
 	RenderClxSprite(out, (*healthBox)[0], position);
 	DrawHalfTransparentRectTo(out, position.x + border, position.y + border, width - (border * 2), height - (border * 2));
-	int barProgress = (barWidth * currLife) / monster.maxHitPoints;
+	const int barProgress = (barWidth * currLife) / monster.maxHitPoints;
 	if (barProgress != 0) {
 		RenderClxSprite(
 		    out.subregion(position.x + border + 1, position.y + border + 1, barProgress, height - (border * 2) - 2),
@@ -134,11 +134,11 @@ void DrawMonsterHealthBar(const Surface &out)
 	};
 
 	if (*GetOptions().Gameplay.showMonsterType) {
-		Uint8 borderColor = GetBorderColor(monster.data().monsterClass);
-		int borderWidth = width - (border * 2);
+		const Uint8 borderColor = GetBorderColor(monster.data().monsterClass);
+		const int borderWidth = width - (border * 2);
 		UnsafeDrawHorizontalLine(out, { position.x + border, position.y + border }, borderWidth, borderColor);
 		UnsafeDrawHorizontalLine(out, { position.x + border, position.y + height - border - 1 }, borderWidth, borderColor);
-		int borderHeight = height - (border * 2) - 2;
+		const int borderHeight = height - (border * 2) - 2;
 		UnsafeDrawVerticalLine(out, { position.x + border, position.y + border + 1 }, borderHeight, borderColor);
 		UnsafeDrawVerticalLine(out, { position.x + width - border - 1, position.y + border + 1 }, borderHeight, borderColor);
 	}
@@ -159,8 +159,8 @@ void DrawMonsterHealthBar(const Surface &out)
 		DrawString(out, StrCat("x", multiplier), { position, { width - 2, height } },
 		    { .flags = UiFlags::ColorWhite | UiFlags::AlignRight | UiFlags::VerticalCenter });
 	if (monster.isUnique() || MonsterKillCounts[monster.type().type] >= 15) {
-		monster_resistance immunes[] = { IMMUNE_MAGIC, IMMUNE_FIRE, IMMUNE_LIGHTNING };
-		monster_resistance resists[] = { RESIST_MAGIC, RESIST_FIRE, RESIST_LIGHTNING };
+		const monster_resistance immunes[] = { IMMUNE_MAGIC, IMMUNE_FIRE, IMMUNE_LIGHTNING };
+		const monster_resistance resists[] = { RESIST_MAGIC, RESIST_FIRE, RESIST_LIGHTNING };
 
 		int resOffset = 5;
 		for (size_t i = 0; i < 3; i++) {

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -64,7 +64,7 @@ OptionalOwnedClxSpriteList StashNavButtonArt;
  */
 void AddItemToStashGrid(unsigned page, Point position, uint16_t stashListIndex, Size itemSize)
 {
-	for (Point point : PointsInRectangle(Rectangle { position, itemSize })) {
+	for (const Point point : PointsInRectangle(Rectangle { position, itemSize })) {
 		Stash.stashGrids[page][point.x][point.y] = stashListIndex + 1;
 	}
 }
@@ -72,7 +72,7 @@ void AddItemToStashGrid(unsigned page, Point position, uint16_t stashListIndex, 
 std::optional<Point> FindTargetSlotUnderItemCursor(Point cursorPosition, Size itemSize)
 {
 	for (auto point : StashGridRange) {
-		Rectangle cell {
+		const Rectangle cell {
 			GetStashSlotCoord(point),
 			InventorySlotSizeInPixels + 1
 		};
@@ -133,12 +133,12 @@ void CheckStashPaste(Point cursorPosition)
 	if (!targetSlot)
 		return;
 
-	Point firstSlot = *targetSlot;
+	const Point firstSlot = *targetSlot;
 
 	// Check that no more than 1 item is replaced by the move
 	StashStruct::StashCell stashIndex = StashStruct::EmptyCell;
-	for (Point point : PointsInRectangle(Rectangle { firstSlot, itemSize })) {
-		StashStruct::StashCell iv = Stash.GetItemIdAtPosition(point);
+	for (const Point point : PointsInRectangle(Rectangle { firstSlot, itemSize })) {
+		const StashStruct::StashCell iv = Stash.GetItemIdAtPosition(point);
 		if (iv == StashStruct::EmptyCell || stashIndex == iv)
 			continue;
 		if (stashIndex == StashStruct::EmptyCell) {
@@ -186,7 +186,7 @@ void CheckStashCut(Point cursorPosition, bool automaticMove)
 	Point slot = InvalidStashPoint;
 
 	for (auto point : StashGridRange) {
-		Rectangle cell {
+		const Rectangle cell {
 			GetStashSlotCoord(point),
 			InventorySlotSizeInPixels + 1
 		};
@@ -206,9 +206,9 @@ void CheckStashCut(Point cursorPosition, bool automaticMove)
 	holdItem.clear();
 
 	bool automaticallyMoved = false;
-	bool automaticallyEquipped = false;
+	const bool automaticallyEquipped = false;
 
-	StashStruct::StashCell iv = Stash.GetItemIdAtPosition(slot);
+	const StashStruct::StashCell iv = Stash.GetItemIdAtPosition(slot);
 	if (iv != StashStruct::EmptyCell) {
 		holdItem = Stash.stashList[iv];
 		if (automaticMove) {
@@ -285,7 +285,7 @@ void TransferItemToInventory(Player &player, uint16_t itemId)
 		return;
 	}
 
-	Item &item = Stash.stashList[itemId];
+	const Item &item = Stash.stashList[itemId];
 	if (item.isEmpty()) {
 		return;
 	}
@@ -353,47 +353,47 @@ void DrawStash(const Surface &out)
 	RenderClxSprite(out, (*StashPanelArt)[0], GetPanelPosition(UiPanels::Stash));
 
 	if (StashButtonPressed != -1) {
-		Point stashButton = GetPanelPosition(UiPanels::Stash, StashButtonRect[StashButtonPressed].position);
+		const Point stashButton = GetPanelPosition(UiPanels::Stash, StashButtonRect[StashButtonPressed].position);
 		RenderClxSprite(out, (*StashNavButtonArt)[StashButtonPressed], stashButton);
 	}
 
 	constexpr Displacement offset { 0, INV_SLOT_SIZE_PX - 1 };
 
 	for (auto slot : StashGridRange) {
-		StashStruct::StashCell itemId = Stash.GetItemIdAtPosition(slot);
+		const StashStruct::StashCell itemId = Stash.GetItemIdAtPosition(slot);
 		if (itemId == StashStruct::EmptyCell) {
 			continue; // No item in the given slot
 		}
-		Item &item = Stash.stashList[itemId];
+		const Item &item = Stash.stashList[itemId];
 		InvDrawSlotBack(out, GetStashSlotCoord(slot) + offset, InventorySlotSizeInPixels, item._iMagical);
 	}
 
 	for (auto slot : StashGridRange) {
-		StashStruct::StashCell itemId = Stash.GetItemIdAtPosition(slot);
+		const StashStruct::StashCell itemId = Stash.GetItemIdAtPosition(slot);
 		if (itemId == StashStruct::EmptyCell) {
 			continue; // No item in the given slot
 		}
 
-		Item &item = Stash.stashList[itemId];
+		const Item &item = Stash.stashList[itemId];
 		if (item.position != slot) {
 			continue; // Not the first slot of the item
 		}
 
-		int frame = item._iCurs + CURSOR_FIRSTITEM;
+		const int frame = item._iCurs + CURSOR_FIRSTITEM;
 
 		const Point position = GetStashSlotCoord(item.position) + offset;
 		const ClxSprite sprite = GetInvItemSprite(frame);
 
 		if (pcursstashitem == itemId) {
-			uint8_t color = GetOutlineColor(item, true);
+			const uint8_t color = GetOutlineColor(item, true);
 			ClxDrawOutline(out, color, position, sprite);
 		}
 
 		DrawItem(item, out, position, sprite);
 	}
 
-	Point position = GetPanelPosition(UiPanels::Stash);
-	UiFlags style = UiFlags::VerticalCenter | UiFlags::ColorWhite;
+	const Point position = GetPanelPosition(UiPanels::Stash);
+	const UiFlags style = UiFlags::VerticalCenter | UiFlags::ColorWhite;
 
 	DrawString(out, StrCat(Stash.GetPage() + 1), { position + Displacement { 132, 0 }, { 57, 11 } },
 	    { .flags = UiFlags::AlignCenter | style });
@@ -416,7 +416,7 @@ uint16_t CheckStashHLight(Point mousePosition)
 {
 	Point slot = InvalidStashPoint;
 	for (auto point : StashGridRange) {
-		Rectangle cell {
+		const Rectangle cell {
 			GetStashSlotCoord(point),
 			InventorySlotSizeInPixels + 1
 		};
@@ -432,12 +432,12 @@ uint16_t CheckStashHLight(Point mousePosition)
 
 	InfoColor = UiFlags::ColorWhite;
 
-	StashStruct::StashCell itemId = Stash.GetItemIdAtPosition(slot);
+	const StashStruct::StashCell itemId = Stash.GetItemIdAtPosition(slot);
 	if (itemId == StashStruct::EmptyCell) {
 		return -1;
 	}
 
-	Item &item = Stash.stashList[itemId];
+	const Item &item = Stash.stashList[itemId];
 	if (item.isEmpty()) {
 		return -1;
 	}
@@ -529,7 +529,7 @@ void StashStruct::RemoveStashItem(StashStruct::StashCell iv)
 	}
 
 	// If the item at the end of stash array isn't the one we removed, we need to swap its position in the array with the removed item
-	StashStruct::StashCell lastItemIndex = static_cast<StashStruct::StashCell>(stashList.size() - 1);
+	const StashStruct::StashCell lastItemIndex = static_cast<StashStruct::StashCell>(stashList.size() - 1);
 	if (lastItemIndex != iv) {
 		stashList[iv] = stashList[lastItemIndex];
 
@@ -587,7 +587,7 @@ void StartGoldWithdraw()
 	if (ChatFlag)
 		ResetChat();
 
-	Point start = GetPanelPosition(UiPanels::Stash, { 67, 128 });
+	const Point start = GetPanelPosition(UiPanels::Stash, { 67, 128 });
 	SDL_Rect rect = MakeSdlRect(start.x, start.y, 180, 20);
 	SDL_SetTextInputRect(&rect);
 
@@ -692,7 +692,7 @@ bool AutoPlaceItemInStash(Player &player, const Item &item, bool persistItem)
 		return true;
 	}
 
-	Size itemSize = GetInventorySize(item);
+	const Size itemSize = GetInventorySize(item);
 
 	// Try to add the item to the current active page and if it's not possible move forward
 	for (unsigned pageCounter = 0; pageCounter < CountStashPages; pageCounter++) {
@@ -705,7 +705,7 @@ bool AutoPlaceItemInStash(Player &player, const Item &item, bool persistItem)
 			// Check that all needed slots are free
 			bool isSpaceFree = true;
 			for (auto itemPoint : PointsInRectangle(Rectangle { stashPosition, itemSize })) {
-				uint16_t iv = Stash.stashGrids[pageIndex][itemPoint.x][itemPoint.y];
+				const uint16_t iv = Stash.stashGrids[pageIndex][itemPoint.x][itemPoint.y];
 				if (iv != 0) {
 					isSpaceFree = false;
 					break;
@@ -715,7 +715,7 @@ bool AutoPlaceItemInStash(Player &player, const Item &item, bool persistItem)
 				continue;
 			if (persistItem) {
 				Stash.stashList.push_back(item);
-				uint16_t stashIndex = static_cast<uint16_t>(Stash.stashList.size() - 1);
+				const uint16_t stashIndex = static_cast<uint16_t>(Stash.stashList.size() - 1);
 				Stash.stashList[stashIndex].position = stashPosition + Displacement { 0, itemSize.height - 1 };
 				AddItemToStashGrid(pageIndex, stashPosition, stashIndex, itemSize);
 				Stash.dirty = true;

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -103,13 +103,13 @@ void DrawXPBar(const Surface &out)
 	if (player._pExperience < prevXp)
 		return;
 
-	uint64_t prevXpDelta1 = player._pExperience - prevXp;
-	uint64_t prevXpDelta = GetNextExperienceThresholdForLevel(charLevel) - prevXp;
-	uint64_t fullBar = BarWidth * prevXpDelta1 / prevXpDelta;
+	const uint64_t prevXpDelta1 = player._pExperience - prevXp;
+	const uint64_t prevXpDelta = GetNextExperienceThresholdForLevel(charLevel) - prevXp;
+	const uint64_t fullBar = BarWidth * prevXpDelta1 / prevXpDelta;
 
 	// Figure out how much to fill the last pixel of the XP bar, to make it gradually appear with gained XP
-	uint64_t onePx = prevXpDelta / BarWidth + 1;
-	uint64_t lastFullPx = fullBar * prevXpDelta / BarWidth;
+	const uint64_t onePx = prevXpDelta / BarWidth + 1;
+	const uint64_t lastFullPx = fullBar * prevXpDelta / BarWidth;
 
 	const uint64_t fade = (prevXpDelta1 - lastFullPx) * (SilverGradient.size() - 1) / onePx;
 
@@ -151,7 +151,7 @@ bool CheckXPBarInfo()
 	InfoColor = UiFlags::ColorWhite;
 
 	AddInfoBoxString(fmt::format(fmt::runtime(_("Experience: {:s}")), FormatInteger(player._pExperience)));
-	uint32_t nextExperienceThreshold = player.getNextExperienceThreshold();
+	const uint32_t nextExperienceThreshold = player.getNextExperienceThreshold();
 	AddInfoBoxString(fmt::format(fmt::runtime(_("Next Level: {:s}")), FormatInteger(nextExperienceThreshold)));
 	AddInfoBoxString(fmt::format(fmt::runtime(_("{:s} to Level {:d}")), FormatInteger(nextExperienceThreshold - player._pExperience), charLevel + 1));
 

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -111,7 +111,7 @@ const char *const QuestTriggerNames[5] = {
  */
 void DrawButcher()
 {
-	Point position = SetPiece.position.megaToWorld() + Displacement { 3, 3 };
+	const Point position = SetPiece.position.megaToWorld() + Displacement { 3, 3 };
 	DRLG_RectTrans({ position, { 7, 7 } });
 }
 
@@ -144,7 +144,7 @@ void DrawLTBanner(Point position)
 {
 	auto dunData = LoadFileInMem<uint16_t>("levels\\l1data\\banner1.dun");
 
-	WorldTileSize size = GetDunSize(dunData.get());
+	const WorldTileSize size = GetDunSize(dunData.get());
 
 	SetPiece = { position, size };
 
@@ -184,7 +184,7 @@ int QuestLogMouseToEntry()
 	innerArea.position += Displacement(GetLeftPanel().position.x, GetLeftPanel().position.y);
 	if (!innerArea.contains(MousePosition) || (EncounteredQuestCount == 0))
 		return -1;
-	int y = MousePosition.y - innerArea.position.y;
+	const int y = MousePosition.y - innerArea.position.y;
 	for (int i = 0; i < FirstFinishedQuest; i++) {
 		if ((y >= ListYOffset + i * LineSpacing)
 		    && (y < ListYOffset + i * LineSpacing + LineHeight)) {
@@ -196,7 +196,7 @@ int QuestLogMouseToEntry()
 
 void PrintQLString(const Surface &out, int x, int y, std::string_view str, bool marked, bool disabled = false)
 {
-	int width = GetLineWidth(str);
+	const int width = GetLineWidth(str);
 	x += std::max((257 - width) / 2, 0);
 	if (marked) {
 		ClxDraw(out, GetPanelPosition(UiPanels::Quest, { x - 20, y + 13 }), (*pSPentSpn2Cels)[PentSpn2Spin()]);
@@ -331,7 +331,7 @@ void CheckQuests()
 	    && setlevel
 	    && setlvlnum == SL_VILEBETRAYER
 	    && quest._qvar2 == 4) {
-		Point portalLocation { 35, 32 };
+		const Point portalLocation { 35, 32 };
 		AddMissile(portalLocation, portalLocation, Direction::South, MissileID::RedPortal, TARGET_MONSTERS, *MyPlayer, 0, 0);
 		quest._qvar2 = 3;
 	}
@@ -375,7 +375,7 @@ bool ForceQuests()
 
 	for (auto &quest : Quests) {
 		if (quest._qidx != Q_BETRAYER && currlevel == quest._qlevel && quest._qslvl != 0) {
-			int ql = quest._qslvl - 1;
+			const int ql = quest._qslvl - 1;
 
 			if (EntranceBoundaryContains(quest.position, cursPosition)) {
 				InfoString = fmt::format(fmt::runtime(_(/* TRANSLATORS: Used for Quest Portals. {:s} is a Map Name */ "To {:s}")), _(QuestTriggerNames[ql]));
@@ -393,7 +393,7 @@ void CheckQuestKill(const Monster &monster, bool sendmsg)
 	if (gbIsSpawn)
 		return;
 
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	if (monster.type().type == MT_SKING) {
 		auto &quest = Quests[Q_SKELKING];
@@ -694,7 +694,7 @@ void ResyncQuests()
 	    && !setlevel
 	    && Quests[Q_DIABLO]._qactive == QUEST_ACTIVE
 	    && gbIsMultiplayer) {
-		Point posPentagram = Quests[Q_DIABLO].position;
+		const Point posPentagram = Quests[Q_DIABLO].position;
 		ObjChangeMapResync(posPentagram.x, posPentagram.y, posPentagram.x + 5, posPentagram.y + 5);
 		InitL4Triggers();
 	}
@@ -787,7 +787,7 @@ void ResyncQuests()
 
 void DrawQuestLog(const Surface &out)
 {
-	int l = QuestLogMouseToEntry();
+	const int l = QuestLogMouseToEntry();
 	if (l >= 0) {
 		SelectedQuest = l;
 	}
@@ -828,16 +828,16 @@ void StartQuestlog()
 	std::sort(&EncounteredQuests[0], &EncounteredQuests[FirstFinishedQuest], sortQuestIdx);
 	std::sort(&EncounteredQuests[FirstFinishedQuest], &EncounteredQuests[EncounteredQuestCount], sortQuestIdx);
 
-	bool twoBlocks = FirstFinishedQuest != 0 && FirstFinishedQuest < EncounteredQuestCount;
+	const bool twoBlocks = FirstFinishedQuest != 0 && FirstFinishedQuest < EncounteredQuestCount;
 
 	ListYOffset = 0;
 	FinishedQuestOffset = !twoBlocks ? 0 : LineHeight / 2;
 
-	int overallMinHeight = EncounteredQuestCount * LineHeight + FinishedQuestOffset;
-	int space = InnerPanel.size.height;
+	const int overallMinHeight = EncounteredQuestCount * LineHeight + FinishedQuestOffset;
+	const int space = InnerPanel.size.height;
 
 	if (EncounteredQuestCount > 0) {
-		int additionalSpace = space - overallMinHeight;
+		const int additionalSpace = space - overallMinHeight;
 		int addLineSpacing = additionalSpace / EncounteredQuestCount;
 		addLineSpacing = std::min(MaxSpacing - LineHeight, addLineSpacing);
 		LineSpacing = LineHeight + addLineSpacing;
@@ -847,7 +847,7 @@ void StartQuestlog()
 			FinishedQuestOffset = std::max(4, additionalSepSpace);
 		}
 
-		int overallHeight = EncounteredQuestCount * LineSpacing + FinishedQuestOffset;
+		const int overallHeight = EncounteredQuestCount * LineSpacing + FinishedQuestOffset;
 		ListYOffset += (space - overallHeight) / 2;
 	}
 
@@ -891,7 +891,7 @@ void QuestlogEnter()
 
 void QuestlogESC()
 {
-	int l = QuestLogMouseToEntry();
+	const int l = QuestLogMouseToEntry();
 	if (l != -1) {
 		QuestlogEnter();
 	}
@@ -903,7 +903,7 @@ void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2, int16_t qmsg)
 		return;
 
 	auto &quest = Quests[q];
-	quest_state oldQuestState = quest._qactive;
+	const quest_state oldQuestState = quest._qactive;
 	if (quest._qactive != QUEST_DONE) {
 		if (s > quest._qactive || (IsAnyOf(s, QUEST_ACTIVE, QUEST_DONE) && IsAnyOf(quest._qactive, QUEST_HIVE_TEASE1, QUEST_HIVE_TEASE2, QUEST_HIVE_ACTIVE)))
 			quest._qactive = s;
@@ -918,7 +918,7 @@ void SetMultiQuest(int q, quest_state s, bool log, int v1, int v2, int16_t qmsg)
 		// Ensure that changes on another client is also updated on our own
 		ResyncQuests();
 
-		bool questGotCompleted = oldQuestState != QUEST_DONE && quest._qactive == QUEST_DONE;
+		const bool questGotCompleted = oldQuestState != QUEST_DONE && quest._qactive == QUEST_DONE;
 		// Ensure that water also changes for remote players
 		if (quest._qidx == Q_PWATER && questGotCompleted && MyPlayer->isOnLevel(quest._qslvl))
 			StartPWaterPurify();

--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -38,7 +38,7 @@ void SHA1ProcessMessageBlock(SHA1Context *context)
 	std::uint32_t e = context->state[4];
 
 	for (int i = 0; i < 20; i++) {
-		std::uint32_t temp = SHA1CircularShift(a, 5) + ((b & c) | ((~b) & d)) + e + w[i] + 0x5A827999;
+		const std::uint32_t temp = SHA1CircularShift(a, 5) + ((b & c) | ((~b) & d)) + e + w[i] + 0x5A827999;
 		e = d;
 		d = c;
 		c = SHA1CircularShift(b, 30);
@@ -47,7 +47,7 @@ void SHA1ProcessMessageBlock(SHA1Context *context)
 	}
 
 	for (int i = 20; i < 40; i++) {
-		std::uint32_t temp = SHA1CircularShift(a, 5) + (b ^ c ^ d) + e + w[i] + 0x6ED9EBA1;
+		const std::uint32_t temp = SHA1CircularShift(a, 5) + (b ^ c ^ d) + e + w[i] + 0x6ED9EBA1;
 		e = d;
 		d = c;
 		c = SHA1CircularShift(b, 30);
@@ -56,7 +56,7 @@ void SHA1ProcessMessageBlock(SHA1Context *context)
 	}
 
 	for (int i = 40; i < 60; i++) {
-		std::uint32_t temp = SHA1CircularShift(a, 5) + ((b & c) | (b & d) | (c & d)) + e + w[i] + 0x8F1BBCDC;
+		const std::uint32_t temp = SHA1CircularShift(a, 5) + ((b & c) | (b & d) | (c & d)) + e + w[i] + 0x8F1BBCDC;
 		e = d;
 		d = c;
 		c = SHA1CircularShift(b, 30);
@@ -65,7 +65,7 @@ void SHA1ProcessMessageBlock(SHA1Context *context)
 	}
 
 	for (int i = 60; i < 80; i++) {
-		std::uint32_t temp = SHA1CircularShift(a, 5) + (b ^ c ^ d) + e + w[i] + 0xCA62C1D6;
+		const std::uint32_t temp = SHA1CircularShift(a, 5) + (b ^ c ^ d) + e + w[i] + 0xCA62C1D6;
 		e = d;
 		d = c;
 		c = SHA1CircularShift(b, 30);

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -108,7 +108,7 @@ int GetManaAmount(const Player &player, SpellID sn)
 	int adj = 0;
 
 	// spell level
-	int sl = std::max(player.GetSpellLevel(sn) - 1, 0);
+	const int sl = std::max(player.GetSpellLevel(sn) - 1, 0);
 
 	if (sl > 0) {
 		adj = sl * GetSpellData(sn).sManaAdj;

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -206,7 +206,7 @@ void DrawSSlider(const Surface &out, int y1, int y2)
 {
 	const Point uiPosition = GetUIRectangle().position;
 	int yd1 = y1 * 12 + 44 + uiPosition.y;
-	int yd2 = y2 * 12 + 44 + uiPosition.y;
+	const int yd2 = y2 * 12 + 44 + uiPosition.y;
 	if (CountdownScrollUp != -1)
 		ClxDraw(out, { uiPosition.x + 601, yd1 }, (*pSTextSlidCels)[11]);
 	else
@@ -269,7 +269,7 @@ void AddOptionsBackButton()
 void AddItemListBackButton(bool selectable = false)
 {
 	const int line = BackButtonLine();
-	std::string_view text = _("Back");
+	const std::string_view text = _("Back");
 	if (!selectable && IsSmallFontTall()) {
 		AddSText(0, line, text, UiFlags::ColorWhite | UiFlags::AlignRight, selectable);
 	} else {
@@ -362,7 +362,7 @@ void ScrollVendorStore(Item *itemData, int storeLimit, int idx, int selling = tr
 	for (int l = 5; l < 20 && idx < storeLimit; l += 4) {
 		const Item &item = itemData[idx];
 		if (!item.isEmpty()) {
-			UiFlags itemColor = item.getTextColorWithStatCheck();
+			const UiFlags itemColor = item.getTextColorWithStatCheck();
 			AddSText(20, l, item.getName(), itemColor, true, item._iCurs, true);
 			AddSTextVal(l, item._iIdentified ? item._iIvalue : item._ivalue);
 			PrintStoreItem(item, l + 1, itemColor, true);
@@ -930,7 +930,7 @@ void StoreConfirm(Item &item)
 	HasScrollbar = false;
 	ClearSText(5, 23);
 
-	UiFlags itemColor = item.getTextColorWithStatCheck();
+	const UiFlags itemColor = item.getTextColorWithStatCheck();
 	AddSText(20, 8, item.getName(), itemColor, false);
 	AddSTextVal(8, item._iIvalue);
 	PrintStoreItem(item, 9, itemColor);
@@ -997,7 +997,7 @@ void SStartBoyBuy()
 	AddSLine(3);
 
 	BoyItem._iStatFlag = MyPlayer->CanUseItem(BoyItem);
-	UiFlags itemColor = BoyItem.getTextColorWithStatCheck();
+	const UiFlags itemColor = BoyItem.getTextColorWithStatCheck();
 	AddSText(20, 10, BoyItem.getName(), itemColor, true, BoyItem._iCurs, true);
 	if (gbIsHellfire)
 		AddSTextVal(10, BoyItem._iIvalue - (BoyItem._iIvalue / 4));
@@ -1196,7 +1196,7 @@ void StartStorytellerIdentifyShow(Item &item)
 	HasScrollbar = false;
 	ClearSText(5, 23);
 
-	UiFlags itemColor = item.getTextColorWithStatCheck();
+	const UiFlags itemColor = item.getTextColorWithStatCheck();
 
 	AddSText(0, 7, _("This item is:"), UiFlags::ColorWhite | UiFlags::AlignCenter, false);
 	AddSText(20, 11, item.getName(), itemColor, false);
@@ -1235,7 +1235,7 @@ void StartTalk()
 		la = 2;
 	}
 
-	int sn2 = sn - 2;
+	const int sn2 = sn - 2;
 
 	for (auto &quest : Quests) {
 		if (quest._qactive == QUEST_ACTIVE && QuestDialogTable[TownerId][quest._qidx] != TEXT_NONE && quest._qlog) {
@@ -1345,7 +1345,7 @@ void SmithBuyEnter()
 	OldScrollPos = ScrollPos;
 	OldActiveStore = TalkID::SmithBuy;
 
-	int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
+	const int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
 	if (!PlayerCanAfford(SmithItems[idx]._iIvalue)) {
 		StartStore(TalkID::NoMoney);
 		return;
@@ -1421,10 +1421,10 @@ void SmithPremiumBuyEnter()
 
 bool StoreGoldFit(Item &item)
 {
-	int cost = item._iIvalue;
+	const int cost = item._iIvalue;
 
-	Size itemSize = GetInventorySize(item);
-	int itemRoomForGold = itemSize.width * itemSize.height * MaxGold;
+	const Size itemSize = GetInventorySize(item);
+	const int itemRoomForGold = itemSize.width * itemSize.height * MaxGold;
 
 	if (cost <= itemRoomForGold) {
 		return true;
@@ -1446,7 +1446,7 @@ void StoreSellItem()
 	else
 		myPlayer.RemoveSpdBarItem(-(PlayerItemIndexes[idx] + 1));
 
-	int cost = PlayerItems[idx]._iIvalue;
+	const int cost = PlayerItems[idx]._iIvalue;
 	CurrentItemIndex--;
 	if (idx != CurrentItemIndex) {
 		while (idx < CurrentItemIndex) {
@@ -1473,7 +1473,7 @@ void SmithSellEnter()
 	OldActiveStore = TalkID::SmithSell;
 	OldScrollPos = ScrollPos;
 
-	int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
+	const int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
 
 	if (!StoreGoldFit(PlayerItems[idx])) {
 		StartStore(TalkID::NoRoom);
@@ -1489,10 +1489,10 @@ void SmithSellEnter()
  */
 void SmithRepairItem(int price)
 {
-	int idx = OldScrollPos + ((OldTextLine - PreviousScrollPos) / 4);
+	const int idx = OldScrollPos + ((OldTextLine - PreviousScrollPos) / 4);
 	PlayerItems[idx]._iDurability = PlayerItems[idx]._iMaxDur;
 
-	int8_t i = PlayerItemIndexes[idx];
+	const int8_t i = PlayerItemIndexes[idx];
 
 	Player &myPlayer = *MyPlayer;
 
@@ -1525,7 +1525,7 @@ void SmithRepairEnter()
 	OldTextLine = CurrentTextLine;
 	OldScrollPos = ScrollPos;
 
-	int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
+	const int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
 
 	if (!PlayerCanAfford(PlayerItems[idx]._iIvalue)) {
 		StartStore(TalkID::NoMoney);
@@ -1599,7 +1599,7 @@ void WitchBuyEnter()
 	OldScrollPos = ScrollPos;
 	OldActiveStore = TalkID::WitchBuy;
 
-	int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
+	const int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
 
 	if (!PlayerCanAfford(WitchItems[idx]._iIvalue)) {
 		StartStore(TalkID::NoMoney);
@@ -1627,7 +1627,7 @@ void WitchSellEnter()
 	OldActiveStore = TalkID::WitchSell;
 	OldScrollPos = ScrollPos;
 
-	int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
+	const int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
 
 	if (!StoreGoldFit(PlayerItems[idx])) {
 		StartStore(TalkID::NoRoom);
@@ -1643,12 +1643,12 @@ void WitchSellEnter()
  */
 void WitchRechargeItem(int price)
 {
-	int idx = OldScrollPos + ((OldTextLine - PreviousScrollPos) / 4);
+	const int idx = OldScrollPos + ((OldTextLine - PreviousScrollPos) / 4);
 	PlayerItems[idx]._iCharges = PlayerItems[idx]._iMaxCharges;
 
 	Player &myPlayer = *MyPlayer;
 
-	int8_t i = PlayerItemIndexes[idx];
+	const int8_t i = PlayerItemIndexes[idx];
 	if (i < 0) {
 		myPlayer.InvBody[INVLOC_HAND_LEFT]._iCharges = myPlayer.InvBody[INVLOC_HAND_LEFT]._iMaxCharges;
 		NetSendCmdChItem(true, INVLOC_HAND_LEFT);
@@ -1673,7 +1673,7 @@ void WitchRechargeEnter()
 	OldTextLine = CurrentTextLine;
 	OldScrollPos = ScrollPos;
 
-	int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
+	const int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
 
 	if (!PlayerCanAfford(PlayerItems[idx]._iIvalue)) {
 		StartStore(TalkID::NoMoney);
@@ -1793,7 +1793,7 @@ void StorytellerIdentifyItem(Item &item)
 {
 	Player &myPlayer = *MyPlayer;
 
-	int8_t idx = PlayerItemIndexes[((OldTextLine - PreviousScrollPos) / 4) + OldScrollPos];
+	const int8_t idx = PlayerItemIndexes[((OldTextLine - PreviousScrollPos) / 4) + OldScrollPos];
 	if (idx < 0) {
 		if (idx == -1)
 			myPlayer.InvBody[INVLOC_HEAD]._iIdentified = true;
@@ -1898,7 +1898,7 @@ void HealerBuyEnter()
 	OldScrollPos = ScrollPos;
 	OldActiveStore = TalkID::HealerBuy;
 
-	int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
+	const int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
 
 	if (!PlayerCanAfford(HealerItems[idx]._iIvalue)) {
 		StartStore(TalkID::NoMoney);
@@ -1944,7 +1944,7 @@ void StorytellerIdentifyEnter()
 	OldTextLine = CurrentTextLine;
 	OldScrollPos = ScrollPos;
 
-	int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
+	const int idx = ScrollPos + ((CurrentTextLine - PreviousScrollPos) / 4);
 
 	if (!PlayerCanAfford(PlayerItems[idx]._iIvalue)) {
 		StartStore(TalkID::NoMoney);
@@ -2072,7 +2072,7 @@ int TakeGold(Player &player, int cost, bool skipMaxPiles)
 
 void DrawSelector(const Surface &out, const Rectangle &rect, std::string_view text, UiFlags flags)
 {
-	int lineWidth = GetLineWidth(text);
+	const int lineWidth = GetLineWidth(text);
 
 	int x1 = rect.position.x - 20;
 	if (HasAnyOf(flags, UiFlags::AlignCenter))
@@ -2097,7 +2097,7 @@ void AddStoreHoldRepair(Item *itm, int8_t i)
 	item = &PlayerItems[CurrentItemIndex];
 	PlayerItems[CurrentItemIndex] = *itm;
 
-	int due = item->_iMaxDur - item->_iDurability;
+	const int due = item->_iMaxDur - item->_iDurability;
 	if (item->_iMagical != ITEM_QUALITY_NORMAL && item->_iIdentified) {
 		v = 30 * item->_iIvalue * due / (item->_iMaxDur * 100 * 2);
 		if (v == 0)
@@ -2130,7 +2130,7 @@ void InitStores()
 
 void SetupTownStores()
 {
-	Player &myPlayer = *MyPlayer;
+	const Player &myPlayer = *MyPlayer;
 
 	int l = myPlayer.getCharacterLevel() / 2;
 	if (!gbIsMultiplayer) {
@@ -2722,7 +2722,7 @@ void CheckStoreBtn()
 
 		if (HasScrollbar && MousePosition.x > 600 + uiPosition.x) {
 			// Scroll bar is always measured in terms of the small line height.
-			int y = relativeY / SmallLineHeight;
+			const int y = relativeY / SmallLineHeight;
 			if (y == 4) {
 				if (CountdownScrollUp <= 0) {
 					StoreUp();

--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -304,8 +304,8 @@ bool SVidPlayBegin(const char *filename, int flags)
 
 #ifndef USE_SDL1
 	if (renderer != nullptr) {
-		int renderWidth = static_cast<int>(SVidWidth);
-		int renderHeight = static_cast<int>(SVidHeight);
+		const int renderWidth = static_cast<int>(SVidWidth);
+		const int renderHeight = static_cast<int>(SVidHeight);
 		texture = SDLWrap::CreateTexture(renderer, DEVILUTIONX_DISPLAY_TEXTURE_FORMAT, SDL_TEXTUREACCESS_STREAMING, renderWidth, renderHeight);
 		if (SDL_RenderSetLogicalSize(renderer, renderWidth, renderHeight) <= -1) {
 			ErrSdl();
@@ -373,7 +373,7 @@ bool SVidPlayContinue()
 	if (!BlitFrame())
 		return false;
 
-	uint64_t now = GetTicksSmk();
+	const uint64_t now = GetTicksSmk();
 	if (now < SVidFrameEnd) {
 		SDL_Delay(static_cast<Uint32>(TimeSmkToMs(SVidFrameEnd - now))); // wait with next frame if the system is too fast
 	}

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -28,7 +28,7 @@ void SyncOneMonster()
 {
 	for (size_t i = 0; i < ActiveMonsterCount; i++) {
 		const unsigned m = ActiveMonsters[i];
-		Monster &monster = Monsters[m];
+		const Monster &monster = Monsters[m];
 		sgnMonsterPriority[m] = MyPlayer->position.tile.ManhattanDistance(monster.position.tile);
 		if (monster.activeForTicks == 0) {
 			sgnMonsterPriority[m] += 0x1000;
@@ -182,7 +182,7 @@ void SyncMonster(bool isOwner, const TSyncMonster &monsterSync)
 
 	if (monster.position.tile.WalkingDistance(position) <= 2) {
 		if (!monster.isWalking()) {
-			Direction md = GetDirection(monster.position.tile, position);
+			const Direction md = GetDirection(monster.position.tile, position);
 			if (DirOK(monster, md)) {
 				M_ClearSquares(monster);
 				monster.occupyTile(monster.position.tile, false);
@@ -197,7 +197,7 @@ void SyncMonster(bool isOwner, const TSyncMonster &monsterSync)
 		if (monster.lightId != NO_LIGHT)
 			ChangeLightXY(monster.lightId, position);
 		decode_enemy(monster, enemyId);
-		Direction md = GetDirection(position, monster.enemyPosition);
+		const Direction md = GetDirection(position, monster.enemyPosition);
 		M_StartStand(monster, md);
 		monster.activeForTicks = std::numeric_limits<uint8_t>::max();
 	}
@@ -290,14 +290,14 @@ size_t OnSyncData(const TSyncHeader &header, size_t maxCmdSize, const Player &pl
 	}
 
 	assert(header.wLen % sizeof(TSyncMonster) == 0);
-	int monsterCount = static_cast<int>(wLen / sizeof(TSyncMonster));
+	const int monsterCount = static_cast<int>(wLen / sizeof(TSyncMonster));
 
-	uint8_t level = header.bLevel;
-	bool syncLocalLevel = !MyPlayer->_pLvlChanging && GetLevelForMultiplayer(*MyPlayer) == level;
+	const uint8_t level = header.bLevel;
+	const bool syncLocalLevel = !MyPlayer->_pLvlChanging && GetLevelForMultiplayer(*MyPlayer) == level;
 
 	if (IsValidLevelForMultiplayer(level)) {
 		const auto *monsterSyncs = reinterpret_cast<const TSyncMonster *>(&header + 1);
-		bool isOwner = player.getId() > MyPlayerId;
+		const bool isOwner = player.getId() > MyPlayerId;
 
 		for (int i = 0; i < monsterCount; i++) {
 			if (!IsTSyncMonsterValid(monsterSyncs[i]))

--- a/Source/tmsg.cpp
+++ b/Source/tmsg.cpp
@@ -41,7 +41,7 @@ uint8_t tmsg_get(std::unique_ptr<std::byte[]> *msg)
 	if ((int)(head.time - SDL_GetTicks()) >= 0)
 		return 0;
 
-	uint8_t len = head.len;
+	const uint8_t len = head.len;
 	*msg = std::move(head.body);
 	TimedMsgList.pop_front();
 	return len;
@@ -49,7 +49,7 @@ uint8_t tmsg_get(std::unique_ptr<std::byte[]> *msg)
 
 void tmsg_add(const std::byte *msg, uint8_t len)
 {
-	uint32_t time = SDL_GetTicks() + gnTickDelay * 10;
+	const uint32_t time = SDL_GetTicks() + gnTickDelay * 10;
 	TimedMsgList.emplace_back(time, msg, len);
 }
 

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -216,7 +216,7 @@ void InitCows(Towner &towner, const TownerData &townerData)
 	towner._tAnimFrame = GenerateRnd(11);
 
 	const Point position = townerData.position;
-	int16_t cowId = dMonster[position.x][position.y];
+	const int16_t cowId = dMonster[position.x][position.y];
 
 	// Cows are large sprites so take up multiple tiles. Vanilla Diablo/Hellfire allowed the player to stand adjacent
 	//  to a cow facing an ordinal direction (the two top-right cows) which leads to visual clipping. It's easier to

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -81,7 +81,7 @@ void RepeatPlayerAction()
 	if (!myPlayer.CanChangeAction())
 		return;
 
-	bool rangedAttack = myPlayer.UsesRangedWeapon();
+	const bool rangedAttack = myPlayer.UsesRangedWeapon();
 	switch (LastPlayerAction) {
 	case PlayerActionType::Attack:
 		if (InDungeonBounds(cursPosition))

--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -92,14 +92,14 @@ void CalculatePreferredWindowSize(int &width, int &height)
 	}
 
 	if (*GetOptions().Graphics.integerScaling) {
-		int factor = std::min(mode.w / width, mode.h / height);
+		const int factor = std::min(mode.w / width, mode.h / height);
 		width = mode.w / factor;
 		height = mode.h / factor;
 		return;
 	}
 
-	float wFactor = (float)mode.w / width;
-	float hFactor = (float)mode.h / height;
+	const float wFactor = (float)mode.w / width;
+	const float hFactor = (float)mode.h / height;
 
 	if (wFactor > hFactor) {
 		width = mode.w * height / mode.h;
@@ -114,15 +114,15 @@ SDL_DisplayMode GetNearestDisplayMode(Size preferredSize)
 	if (SDL_GetWindowDisplayMode(ghMainWnd, &nearestDisplayMode) != 0)
 		ErrSdl();
 
-	int displayIndex = SDL_GetWindowDisplayIndex(ghMainWnd);
-	int modeCount = SDL_GetNumDisplayModes(displayIndex);
+	const int displayIndex = SDL_GetWindowDisplayIndex(ghMainWnd);
+	const int modeCount = SDL_GetNumDisplayModes(displayIndex);
 	for (int modeIndex = 0; modeIndex < modeCount; modeIndex++) {
 		SDL_DisplayMode displayMode;
 		if (SDL_GetDisplayMode(displayIndex, modeIndex, &displayMode) != 0)
 			continue;
 
-		int diffHeight = std::abs(nearestDisplayMode.h - preferredSize.height) - std::abs(displayMode.h - preferredSize.height);
-		int diffWidth = std::abs(nearestDisplayMode.w - preferredSize.width) - std::abs(displayMode.w - preferredSize.width);
+		const int diffHeight = std::abs(nearestDisplayMode.h - preferredSize.height) - std::abs(displayMode.h - preferredSize.height);
+		const int diffWidth = std::abs(nearestDisplayMode.w - preferredSize.width) - std::abs(displayMode.w - preferredSize.width);
 		if (diffHeight < 0)
 			continue;
 		if (diffHeight == 0 && diffWidth < 0)
@@ -175,7 +175,7 @@ void UpdateAvailableResolutions()
 	GraphicsOptions &graphicsOptions = GetOptions().Graphics;
 
 	std::vector<Size> sizes;
-	float scaleFactor = GetDpiScalingFactor();
+	const float scaleFactor = GetDpiScalingFactor();
 
 	// Add resolutions
 	bool supportsAnyResolution = false;
@@ -216,7 +216,7 @@ void UpdateAvailableResolutions()
 		const int width = sizes[0].width;
 		const int height = sizes[0].height;
 		const int commonHeights[] = { 480, 540, 720, 960, 1080, 1440, 2160 };
-		for (int commonHeight : commonHeights) {
+		for (const int commonHeight : commonHeights) {
 			if (commonHeight > height)
 				break;
 			sizes.emplace_back(Size { commonHeight * 4 / 3, commonHeight });
@@ -316,8 +316,8 @@ float GetDpiScalingFactor()
 	int windowHeight;
 	SDL_GetWindowSize(ghMainWnd, &windowWidth, &windowHeight);
 
-	float hfactor = static_cast<float>(renderWidth) / windowWidth;
-	float vhfactor = static_cast<float>(renderHeight) / windowHeight;
+	const float hfactor = static_cast<float>(renderWidth) / windowWidth;
+	const float vhfactor = static_cast<float>(renderHeight) / windowHeight;
 
 	return std::min(hfactor, vhfactor);
 #endif
@@ -571,8 +571,8 @@ void SetFullscreenMode()
 	// update the display mode of the window before changing the
 	// fullscreen mode so that the display mode only has to change once
 	if (*GetOptions().Graphics.fullscreen && !*GetOptions().Graphics.upscale) {
-		Size windowSize = GetPreferredWindowSize();
-		SDL_DisplayMode displayMode = GetNearestDisplayMode(windowSize);
+		const Size windowSize = GetPreferredWindowSize();
+		const SDL_DisplayMode displayMode = GetNearestDisplayMode(windowSize);
 		if (SDL_SetWindowDisplayMode(ghMainWnd, &displayMode) != 0) {
 			ErrSdl();
 		}
@@ -588,7 +588,7 @@ void SetFullscreenMode()
 
 	if (!*GetOptions().Graphics.fullscreen) {
 		SDL_RestoreWindow(ghMainWnd); // Avoid window being maximized before resizing
-		Size windowSize = GetPreferredWindowSize();
+		const Size windowSize = GetPreferredWindowSize();
 		SDL_SetWindowSize(ghMainWnd, windowSize.width, windowSize.height);
 	}
 	if (!*GetOptions().Graphics.upscale) {
@@ -607,23 +607,23 @@ void ResizeWindow()
 	if (ghMainWnd == nullptr)
 		return;
 
-	Size windowSize = GetPreferredWindowSize();
+	const Size windowSize = GetPreferredWindowSize();
 
 #ifdef USE_SDL1
 	SetVideoModeToPrimary(*GetOptions().Graphics.fullscreen, windowSize.width, windowSize.height);
 #else
 	// For "true fullscreen" windows, the window resizes automatically based on the display mode
-	bool trueFullscreen = *GetOptions().Graphics.fullscreen && !*GetOptions().Graphics.upscale;
+	const bool trueFullscreen = *GetOptions().Graphics.fullscreen && !*GetOptions().Graphics.upscale;
 	if (trueFullscreen) {
-		SDL_DisplayMode displayMode = GetNearestDisplayMode(windowSize);
+		const SDL_DisplayMode displayMode = GetNearestDisplayMode(windowSize);
 		if (SDL_SetWindowDisplayMode(ghMainWnd, &displayMode) != 0)
 			ErrSdl();
 	}
 
 	// Handle switching between "fake fullscreen" and "true fullscreen" when upscale is toggled
-	bool upscaleChanged = *GetOptions().Graphics.upscale != (renderer != nullptr);
+	const bool upscaleChanged = *GetOptions().Graphics.upscale != (renderer != nullptr);
 	if (upscaleChanged && *GetOptions().Graphics.fullscreen) {
-		Uint32 flags = *GetOptions().Graphics.upscale ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_FULLSCREEN;
+		const Uint32 flags = *GetOptions().Graphics.upscale ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_FULLSCREEN;
 		if (SDL_SetWindowFullscreen(ghMainWnd, flags) != 0)
 			ErrSdl();
 		if (!*GetOptions().Graphics.fullscreen)

--- a/Source/utils/language.cpp
+++ b/Source/utils/language.cpp
@@ -215,7 +215,7 @@ void ParsePluralForms(std::string_view string)
 	if (eqPos == std::string_view::npos)
 		return;
 
-	std::string_view value = string.substr(eqPos + 1);
+	const std::string_view value = string.substr(eqPos + 1);
 	if (value.empty() || value[0] < '0')
 		return;
 
@@ -296,7 +296,7 @@ std::string_view LanguageParticularTranslate(std::string_view context, std::stri
 
 std::string_view LanguagePluralTranslate(const char *singular, std::string_view plural, int count)
 {
-	int n = GetLocalPluralId(count);
+	const int n = GetLocalPluralId(count);
 
 	auto it = translation[n].find(singular);
 	if (it == translation[n].end()) {
@@ -417,7 +417,7 @@ void LanguageInitialize()
 	}
 
 	// Read entries of source strings
-	std::unique_ptr<MoEntry[]> src { new MoEntry[head.nbMappings] };
+	const std::unique_ptr<MoEntry[]> src { new MoEntry[head.nbMappings] };
 	if (readWholeFile
 	        ? !CopyData(src.get(), data.get(), fileSize, head.srcOffset, head.nbMappings * sizeof(MoEntry))
 	        : !handle.seek(head.srcOffset) || !handle.read(src.get(), head.nbMappings * sizeof(MoEntry))) {
@@ -428,7 +428,7 @@ void LanguageInitialize()
 	}
 
 	// Read entries of target strings
-	std::unique_ptr<MoEntry[]> dst { new MoEntry[head.nbMappings] };
+	const std::unique_ptr<MoEntry[]> dst { new MoEntry[head.nbMappings] };
 	if (readWholeFile
 	        ? !CopyData(dst.get(), data.get(), fileSize, head.dstOffset, head.nbMappings * sizeof(MoEntry))
 	        : !handle.seek(head.dstOffset) || !handle.read(dst.get(), head.nbMappings * sizeof(MoEntry))) {

--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -44,7 +44,7 @@ void AddTrailingSlash(std::string &path)
 
 std::string FromSDL(char *s)
 {
-	SDLUniquePtr<char> pinned(s);
+	const SDLUniquePtr<char> pinned(s);
 	std::string result = (s != nullptr ? s : "");
 	if (s == nullptr) {
 		Log("{}", SDL_GetError());

--- a/Source/utils/utf8.cpp
+++ b/Source/utils/utf8.cpp
@@ -12,7 +12,7 @@ namespace devilution {
 char32_t DecodeFirstUtf8CodePoint(std::string_view input, std::size_t *len)
 {
 	SBUInteger index = 0;
-	SBCodepoint result = SBCodepointDecodeNextFromUTF8(
+	const SBCodepoint result = SBCodepointDecodeNextFromUTF8(
 	    reinterpret_cast<const SBUInt8 *>(input.data()), static_cast<SBUInteger>(input.size()), &index);
 	*len = index;
 	return result;

--- a/test/.clang-format
+++ b/test/.clang-format
@@ -10,3 +10,4 @@ UseTab: ForIndentation
 SortIncludes: true
 NamespaceIndentation: None
 FixNamespaceComments: true
+QualifierAlignment: Left

--- a/test/animationinfo_test.cpp
+++ b/test/animationinfo_test.cpp
@@ -100,18 +100,18 @@ void RunAnimationTest(const std::vector<TestData *> &vecTestData)
 	for (TestData *x : vecTestData) {
 		switch (x->type()) {
 		case TestDataType::SetNewAnimation: {
-			auto setNewAnimationData = static_cast<SetNewAnimationData *>(x);
+			auto *setNewAnimationData = static_cast<SetNewAnimationData *>(x);
 			animInfo.setNewAnimation(std::nullopt, setNewAnimationData->_NumberOfFrames, setNewAnimationData->_DelayLen, setNewAnimationData->_Params, setNewAnimationData->_NumSkippedFrames, setNewAnimationData->_DistributeFramesBeforeFrame);
 		} break;
 		case TestDataType::GameTick: {
-			auto gameTickData = static_cast<GameTickData *>(x);
+			auto *gameTickData = static_cast<GameTickData *>(x);
 			currentGameTick += 1;
 			animInfo.processAnimation();
 			EXPECT_EQ(animInfo.currentFrame, gameTickData->_ExpectedAnimationFrame);
 			EXPECT_EQ(animInfo.tickCounterOfCurrentFrame, gameTickData->_ExpectedAnimationCnt);
 		} break;
 		case TestDataType::Rendering: {
-			auto renderingData = static_cast<RenderingData *>(x);
+			auto *renderingData = static_cast<RenderingData *>(x);
 			ProgressToNextGameTick = static_cast<uint8_t>(renderingData->_fProgressToNextGameTick * AnimationInfo::baseValueFraction);
 			EXPECT_EQ(animInfo.getFrameToUseForRendering(), renderingData->_ExpectedRenderingFrame)
 			    << std::fixed << std::setprecision(2)

--- a/test/clx_render_benchmark.cpp
+++ b/test/clx_render_benchmark.cpp
@@ -15,14 +15,14 @@ namespace {
 
 void BM_RenderSmallClx(benchmark::State &state)
 {
-	SDLSurfaceUniquePtr sdl_surface = SDLWrap::CreateRGBSurfaceWithFormat(
+	const SDLSurfaceUniquePtr sdl_surface = SDLWrap::CreateRGBSurfaceWithFormat(
 	    /*flags=*/0, /*width=*/640, /*height=*/480, /*depth=*/8, SDL_PIXELFORMAT_INDEX8);
 	if (sdl_surface == nullptr) {
 		LogError("Failed to create SDL Surface: {}", SDL_GetError());
 		exit(1);
 	}
-	Surface out = Surface(sdl_surface.get());
-	OwnedClxSpriteList sprites = LoadClx("data\\resistance.clx");
+	const Surface out = Surface(sdl_surface.get());
+	const OwnedClxSpriteList sprites = LoadClx("data\\resistance.clx");
 
 	const size_t numSprites = sprites.numSprites();
 	for (auto _ : state) {
@@ -38,14 +38,14 @@ void BM_RenderSmallClx(benchmark::State &state)
 
 void BM_RenderLargeClx(benchmark::State &state)
 {
-	SDLSurfaceUniquePtr sdl_surface = SDLWrap::CreateRGBSurfaceWithFormat(
+	const SDLSurfaceUniquePtr sdl_surface = SDLWrap::CreateRGBSurfaceWithFormat(
 	    /*flags=*/0, /*width=*/640, /*height=*/480, /*depth=*/8, SDL_PIXELFORMAT_INDEX8);
 	if (sdl_surface == nullptr) {
 		LogError("Failed to create SDL Surface: {}", SDL_GetError());
 		exit(1);
 	}
-	Surface out = Surface(sdl_surface.get());
-	OwnedClxSpriteList sprites = LoadClx("ui_art\\dvl_lrpopup.clx");
+	const Surface out = Surface(sdl_surface.get());
+	const OwnedClxSpriteList sprites = LoadClx("ui_art\\dvl_lrpopup.clx");
 
 	for (auto _ : state) {
 		RenderClxSprite(out, sprites[0], Point { 100, 100 });

--- a/test/crawl_test.cpp
+++ b/test/crawl_test.cpp
@@ -20,8 +20,8 @@ TEST(CrawlTest, BasicTest)
 
 	constexpr int MaxCrawlRadius = 18;
 	Crawl(0, MaxCrawlRadius, [&](Displacement displacement) {
-		int dx = x + displacement.deltaX;
-		int dy = y + displacement.deltaY;
+		const int dx = x + displacement.deltaX;
+		const int dy = y + displacement.deltaY;
 		EXPECT_EQ(added[dx][dy], false) << "displacement " << displacement.deltaX << ":" << displacement.deltaY << " added twice";
 		added[dx][dy] = true;
 		return false;

--- a/test/data_file_test.cpp
+++ b/test/data_file_test.cpp
@@ -11,7 +11,7 @@
 namespace devilution {
 auto LoadDataFile(std::string_view file)
 {
-	std::string unitTestFolderCompletePath = paths::BasePath() + "/test/fixtures/";
+	const std::string unitTestFolderCompletePath = paths::BasePath() + "/test/fixtures/";
 	paths::SetAssetsPath(unitTestFolderCompletePath);
 	return DataFile::load(file);
 }
@@ -59,10 +59,10 @@ TEST(DataFileTest, LoadCRFile)
 	auto result = LoadDataFile("txtdata\\cr.tsv");
 	ASSERT_TRUE(result.has_value()) << "Unable to load cr.tsv";
 
-	DataFile &dataFile = result.value();
+	const DataFile &dataFile = result.value();
 	EXPECT_EQ(dataFile.size(), 33) << "File size should be reported in code units";
 
-	std::vector<std::vector<std::string_view>> expectedFields {
+	const std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },
 		{ "", "2", "3" },
 		{ "1", "2", "" },
@@ -77,10 +77,10 @@ TEST(DataFileTest, LoadWindowsFile)
 	auto result = LoadDataFile("txtdata\\crlf.tsv");
 	ASSERT_TRUE(result.has_value()) << "Unable to load crlf.tsv";
 
-	DataFile &dataFile = result.value();
+	const DataFile &dataFile = result.value();
 	EXPECT_EQ(dataFile.size(), 37) << "File size should be reported in code units";
 
-	std::vector<std::vector<std::string_view>> expectedFields {
+	const std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },
 		{ "", "2", "3" },
 		{ "1", "2", "" },
@@ -95,10 +95,10 @@ TEST(DataFileTest, LoadTypicalFile)
 	auto result = LoadDataFile("txtdata\\lf.tsv");
 	ASSERT_TRUE(result.has_value()) << "Unable to load lf.tsv";
 
-	DataFile &dataFile = result.value();
+	const DataFile &dataFile = result.value();
 	EXPECT_EQ(dataFile.size(), 33) << "File size should be reported in code units";
 
-	std::vector<std::vector<std::string_view>> expectedFields {
+	const std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },
 		{ "", "2", "3" },
 		{ "1", "2", "" },
@@ -113,10 +113,10 @@ TEST(DataFileTest, LoadFileWithNoTrailingNewline)
 	auto result = LoadDataFile("txtdata\\lf_no_trail.tsv");
 	ASSERT_TRUE(result.has_value()) << "Unable to load lf_no_trail.tsv";
 
-	DataFile &dataFile = result.value();
+	const DataFile &dataFile = result.value();
 	EXPECT_EQ(dataFile.size(), 32) << "File size should be reported in code units";
 
-	std::vector<std::vector<std::string_view>> expectedFields {
+	const std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },
 		{ "", "2", "3" },
 		{ "1", "2", "" },
@@ -147,10 +147,10 @@ TEST(DataFileTest, LoadEmptyFile)
 		FAIL() << "Unable to load empty.tsv, error: " << mapError(result.error());
 	}
 
-	DataFile &dataFile = result.value();
+	const DataFile &dataFile = result.value();
 	EXPECT_EQ(dataFile.size(), 0) << "File size should be reported in code units";
 
-	std::vector<std::vector<std::string_view>> expectedFields {
+	const std::vector<std::vector<std::string_view>> expectedFields {
 		{ "" },
 	};
 
@@ -164,10 +164,10 @@ TEST(DataFileTest, LoadEmptyFileWithBOM)
 		FAIL() << "Unable to load empty_with_utf8_bom.tsv, error: " << mapError(result.error());
 	}
 
-	DataFile &dataFile = result.value();
+	const DataFile &dataFile = result.value();
 	EXPECT_EQ(dataFile.size(), 0) << "Loading a file containing a UTF8 byte order marker should strip that prefix";
 
-	std::vector<std::vector<std::string_view>> expectedFields {
+	const std::vector<std::vector<std::string_view>> expectedFields {
 		{ "" },
 	};
 
@@ -179,10 +179,10 @@ TEST(DataFileTest, LoadUtf8WithBOM)
 	auto result = LoadDataFile("txtdata\\utf8_bom.tsv");
 	ASSERT_TRUE(result.has_value()) << "Unable to load utf8_bom.tsv";
 
-	DataFile &dataFile = result.value();
+	const DataFile &dataFile = result.value();
 	EXPECT_EQ(dataFile.size(), 33) << "Loading a file containing a UTF8 byte order marker should strip that prefix";
 
-	std::vector<std::vector<std::string_view>> expectedFields {
+	const std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },
 		{ "", "2", "3" },
 		{ "1", "2", "" },
@@ -295,7 +295,7 @@ TEST(DataFileTest, IterateOverRecords)
 	auto result = LoadDataFile("txtdata\\lf.tsv");
 	ASSERT_TRUE(result.has_value()) << "Unable to load lf.tsv";
 
-	DataFile &dataFile = result.value();
+	const DataFile &dataFile = result.value();
 
 	std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },
@@ -362,7 +362,7 @@ TEST(DataFileTest, DiscardAllAfterFirstField)
 	auto loadDataResult = LoadDataFile("txtdata\\lf.tsv");
 	ASSERT_TRUE(loadDataResult.has_value()) << "Unable to load lf.tsv";
 
-	DataFile &dataFile = loadDataResult.value();
+	const DataFile &dataFile = loadDataResult.value();
 
 	std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },
@@ -394,7 +394,7 @@ TEST(DataFileTest, DiscardAllAfterFirstFieldIterator)
 	auto result = LoadDataFile("txtdata\\lf.tsv");
 	ASSERT_TRUE(result.has_value()) << "Unable to load lf.tsv";
 
-	DataFile &dataFile = result.value();
+	const DataFile &dataFile = result.value();
 
 	std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },
@@ -419,7 +419,7 @@ TEST(DataFileTest, DiscardAllUpToLastField)
 	auto loadDataResult = LoadDataFile("txtdata\\lf.tsv");
 	ASSERT_TRUE(loadDataResult.has_value()) << "Unable to load lf.tsv";
 
-	DataFile &dataFile = loadDataResult.value();
+	const DataFile &dataFile = loadDataResult.value();
 
 	std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },
@@ -456,7 +456,7 @@ TEST(DataFileTest, SkipFieldIterator)
 	auto loadDataResult = LoadDataFile("txtdata\\lf.tsv");
 	ASSERT_TRUE(loadDataResult.has_value()) << "Unable to load lf.tsv";
 
-	DataFile &dataFile = loadDataResult.value();
+	const DataFile &dataFile = loadDataResult.value();
 
 	std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },
@@ -496,7 +496,7 @@ TEST(DataFileTest, SkipRowIterator)
 	auto loadDataResult = LoadDataFile("txtdata\\lf.tsv");
 	ASSERT_TRUE(loadDataResult.has_value()) << "Unable to load lf.tsv";
 
-	DataFile &dataFile = loadDataResult.value();
+	const DataFile &dataFile = loadDataResult.value();
 
 	std::vector<std::vector<std::string_view>> expectedFields {
 		{ "Test", "Empty", "Values" },

--- a/test/drlg_common_test.cpp
+++ b/test/drlg_common_test.cpp
@@ -18,7 +18,7 @@ TEST(DrlgTest, RectangleRangeIterator)
 
 	int counter = 0;
 	// Iterate over a 9 tile area in the top left of the region.
-	for (WorldTilePosition position : PointsInRectangle(topLeftArea)) {
+	for (const WorldTilePosition position : PointsInRectangle(topLeftArea)) {
 		region[position.x][position.y] = ++counter;
 	}
 
@@ -46,7 +46,7 @@ TEST(DrlgTest, RectangleRangeIterator)
 	region = {};
 	counter = 0;
 
-	for (WorldTilePosition position : PointsInRectangleColMajor(topLeftArea)) {
+	for (const WorldTilePosition position : PointsInRectangleColMajor(topLeftArea)) {
 		region[position.x][position.y] = ++counter;
 	}
 

--- a/test/dun_render_benchmark.cpp
+++ b/test/dun_render_benchmark.cpp
@@ -69,9 +69,9 @@ void InitOnce()
 
 void RunForTileMaskLight(benchmark::State &state, TileType tileType, MaskType maskType, const uint8_t *lightTable)
 {
-	Surface out = Surface(SdlSurface.get());
+	const Surface out = Surface(SdlSurface.get());
 	std::array<std::array<uint8_t, LightTableSize>, NumLightingLevels> lightTables;
-	Lightmap lightmap(/*outBuffer=*/nullptr, /*lightmapBuffer=*/ {}, /*pitch=*/1, lightTables, FullyLitLightTable, FullyDarkLightTable);
+	const Lightmap lightmap(/*outBuffer=*/nullptr, /*lightmapBuffer=*/ {}, /*pitch=*/1, lightTables, FullyLitLightTable, FullyDarkLightTable);
 	const std::span<const LevelCelBlock> tiles = Tiles[tileType];
 	for (auto _ : state) {
 		for (const LevelCelBlock &levelCelBlock : tiles) {
@@ -125,7 +125,7 @@ DEFINE_FOR_TILE_TYPE(RightTrapezoid)
 void BM_RenderBlackTile(benchmark::State &state)
 {
 	InitOnce();
-	Surface out = Surface(SdlSurface.get());
+	const Surface out = Surface(SdlSurface.get());
 	for (auto _ : state) {
 		world_draw_black_tile(out, 320, 240);
 		uint8_t color = out[Point { 310, 200 }];

--- a/test/items_test.cpp
+++ b/test/items_test.cpp
@@ -43,10 +43,10 @@ void GenerateAllUniques(bool hellfire, const size_t expectedUniques)
 	LoadItemData();
 
 	std::mt19937 betterRng;
-	std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());
+	const std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());
 
 	// Get seed for test run from time. If a test run fails, remember the seed and hardcode it here.
-	uint32_t testRunSeed = static_cast<uint32_t>(time(nullptr));
+	const uint32_t testRunSeed = static_cast<uint32_t>(time(nullptr));
 	betterRng.seed(testRunSeed);
 
 	std::set<int> foundUniques;

--- a/test/light_render_benchmark.cpp
+++ b/test/light_render_benchmark.cpp
@@ -29,13 +29,13 @@ void BM_BuildLightmap(benchmark::State &state)
 		std::fclose(lightFile);
 	}
 
-	SDLSurfaceUniquePtr sdl_surface = SDLWrap::CreateRGBSurfaceWithFormat(
+	const SDLSurfaceUniquePtr sdl_surface = SDLWrap::CreateRGBSurfaceWithFormat(
 	    /*flags=*/0, /*width=*/640, /*height=*/480, /*depth=*/8, SDL_PIXELFORMAT_INDEX8);
 	if (sdl_surface == nullptr) {
 		std::fprintf(stderr, "Failed to create SDL Surface: %s\n", SDL_GetError());
 		exit(1);
 	}
-	Surface out = Surface(sdl_surface.get());
+	const Surface out = Surface(sdl_surface.get());
 
 	const Point tilePosition { 48, 44 };
 	const Point targetBufferPosition { 0, -17 };
@@ -47,7 +47,7 @@ void BM_BuildLightmap(benchmark::State &state)
 	const uint16_t outPitch = out.pitch();
 
 	for (auto _ : state) {
-		Lightmap lightmap = Lightmap::build(/*perPixelLighting=*/true,
+		const Lightmap lightmap = Lightmap::build(/*perPixelLighting=*/true,
 		    tilePosition, targetBufferPosition,
 		    viewportWidth, viewportHeight, rows, columns,
 		    outBuffer, outPitch, lightTables, lightTables[0].data(), lightTables.back().data(),

--- a/test/math_test.cpp
+++ b/test/math_test.cpp
@@ -21,7 +21,7 @@ TEST(MathTest, WorldScreenTransformation)
 
 	// Most screen to world transformations will have a further displacement applied, this is a simple case of
 	// selecting a tile on the edge of the world with the default origin
-	Displacement cursorPosition = { 342, -150 };
+	const Displacement cursorPosition = { 342, -150 };
 	EXPECT_EQ(cursorPosition.screenToWorld(), Displacement(0, 10));
 
 	// Screen > World transforms lose information, so cannot be reversed exactly using ints

--- a/test/missiles_test.cpp
+++ b/test/missiles_test.cpp
@@ -45,7 +45,7 @@ TEST(Missiles, RotateBlockedMissileArrow)
 	*MyPlayer = {};
 	LoadMissileData();
 
-	devilution::Player &player = Players[0];
+	const devilution::Player &player = Players[0];
 	// missile can be a copy or a reference, there's no nullptr check and the functions that use it don't expect the instance to be part of a global structure so it doesn't really matter for this use.
 	Missile missile = *AddMissile({ 0, 0 }, { 0, 0 }, Direction::South, MissileID::Arrow, TARGET_MONSTERS, player, 0, 0);
 

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -152,7 +152,7 @@ typedef struct TestItemStruct {
 
 static void TestItemNameGeneration(const Item &item)
 {
-	bool allowIdentified = (item._iMiscId != IMISC_EAR); // Ears can't be identified. Item::getName() doesn't handle it, so don't test it.
+	const bool allowIdentified = (item._iMiscId != IMISC_EAR); // Ears can't be identified. Item::getName() doesn't handle it, so don't test it.
 	ASSERT_EQ(allowIdentified & item._iIdentified, item._iIdentified);
 
 	Item testItem = item;
@@ -165,7 +165,7 @@ static void TestItemNameGeneration(const Item &item)
 
 		// Check that UpdateHellfireFlag ensures that dwBuff is updated to get the correct name
 		if (item._iMagical == ITEM_QUALITY_MAGIC) {
-			bool isHellfireItem = (testItem.dwBuff & CF_HELLFIRE);
+			const bool isHellfireItem = (testItem.dwBuff & CF_HELLFIRE);
 			testItem.dwBuff = 0;
 			UpdateHellfireFlag(testItem, testItem._iIName);
 
@@ -1010,7 +1010,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_class)
 
 TEST_F(NetPackTest, UnPackNetPlayer_invalid_oob)
 {
-	WorldTilePosition position = MyPlayer->position.tile;
+	const WorldTilePosition position = MyPlayer->position.tile;
 
 	MyPlayer->position.tile.x = MAXDUNX + 1;
 	ASSERT_FALSE(TestNetPackValidation());
@@ -1322,7 +1322,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_pregenItemFlags)
 			continue;
 		if (IsAnyOf(item.IDidx, IDI_GOLD, IDI_EAR))
 			continue;
-		uint16_t createInfo = item._iCreateInfo;
+		const uint16_t createInfo = item._iCreateInfo;
 		item._iCreateInfo |= CF_PREGEN;
 		ASSERT_FALSE(TestNetPackValidation());
 		item._iCreateInfo = createInfo;
@@ -1342,7 +1342,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_usefulItemFlags)
 			continue;
 		if ((item._iCreateInfo & CF_USEFUL) != CF_USEFUL)
 			continue;
-		uint16_t createInfo = item._iCreateInfo;
+		const uint16_t createInfo = item._iCreateInfo;
 		item._iCreateInfo |= CF_ONLYGOOD;
 		ASSERT_FALSE(TestNetPackValidation());
 		item._iCreateInfo = createInfo;
@@ -1362,7 +1362,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_townItemFlags)
 			continue;
 		if ((item._iCreateInfo & CF_TOWN) == 0)
 			continue;
-		uint16_t createInfo = item._iCreateInfo;
+		const uint16_t createInfo = item._iCreateInfo;
 		item._iCreateInfo |= CF_ONLYGOOD;
 		ASSERT_FALSE(TestNetPackValidation());
 		item._iCreateInfo = createInfo;
@@ -1383,8 +1383,8 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_townItemLevel)
 			continue;
 		if ((item._iCreateInfo & CF_TOWN) == 0)
 			continue;
-		uint16_t createInfo = item._iCreateInfo;
-		bool BoyItem = (item._iCreateInfo & CF_BOY) != 0;
+		const uint16_t createInfo = item._iCreateInfo;
+		const bool BoyItem = (item._iCreateInfo & CF_BOY) != 0;
 		item._iCreateInfo &= ~CF_LEVEL;
 		item._iCreateInfo |= BoyItem ? MyPlayer->getMaxCharacterLevel() + 1 : 31;
 		ASSERT_FALSE(TestNetPackValidation());
@@ -1408,7 +1408,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_uniqueMonsterItemLevel)
 			continue;
 		if ((item._iCreateInfo & CF_USEFUL) != CF_UPER15)
 			continue;
-		uint16_t createInfo = item._iCreateInfo;
+		const uint16_t createInfo = item._iCreateInfo;
 		item._iCreateInfo &= ~CF_LEVEL;
 		item._iCreateInfo |= 31;
 		ASSERT_FALSE(TestNetPackValidation());
@@ -1431,7 +1431,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_monsterItemLevel)
 			continue;
 		if ((item._iCreateInfo & CF_USEFUL) == CF_UPER15)
 			continue;
-		uint16_t createInfo = item._iCreateInfo;
+		const uint16_t createInfo = item._iCreateInfo;
 		item._iCreateInfo &= ~CF_LEVEL;
 		item._iCreateInfo |= 31;
 		ASSERT_FALSE(TestNetPackValidation());

--- a/test/palette_blending_benchmark.cpp
+++ b/test/palette_blending_benchmark.cpp
@@ -51,7 +51,7 @@ void BM_FindNearestNeighbor(benchmark::State &state)
 {
 	std::array<SDL_Color, 256> palette;
 	GeneratePalette(palette.data());
-	PaletteKdTree tree(palette.data(), -1, -1);
+	const PaletteKdTree tree(palette.data(), -1, -1);
 
 	for (auto _ : state) {
 		for (int r = 0; r < 256; ++r) {

--- a/test/parse_int_test.cpp
+++ b/test/parse_int_test.cpp
@@ -121,7 +121,7 @@ TEST(ParseInt, ParseFixed6)
 	ASSERT_TRUE(result.has_value()) << "A fixed point value with no integer part is accepted";
 	EXPECT_EQ(result.value(), 32);
 
-	std::string_view badString { "-." };
+	const std::string_view badString { "-." };
 	const char *endOfParse = nullptr;
 	result = ParseFixed6<int>(badString, &endOfParse);
 	ASSERT_FALSE(result.has_value()) << "To match std::from_chars ParseFixed6 should fail to parse a decimal string with no digits, even if it starts with a minus sign.";

--- a/test/path_benchmark.cpp
+++ b/test/path_benchmark.cpp
@@ -21,7 +21,7 @@ struct Map {
 std::pair<Point, Point> FindStartDest(const Map &m)
 {
 	Point start, dest;
-	for (Point p : PointsInRectangle(Rectangle(Point { 0, 0 }, m.size))) {
+	for (const Point p : PointsInRectangle(Rectangle(Point { 0, 0 }, m.size))) {
 		switch (m[p]) {
 		case 'S':
 			start = p;

--- a/test/path_test.cpp
+++ b/test/path_test.cpp
@@ -155,7 +155,7 @@ TEST(PathTest, LongPaths)
 	CheckPath({ 56, 56 }, { 0, 0 }, {});
 
 	// Longest possible path used to be 24 steps meaning tiles 24 units away are reachable
-	Point startingPosition { 56, 56 };
+	const Point startingPosition { 56, 56 };
 	CheckPath(startingPosition, startingPosition + Displacement { 24, 24 }, std::vector<std::string>(24, "↘"));
 
 	// But trying to navigate 25 units fails
@@ -167,7 +167,7 @@ TEST(PathTest, FindClosest)
 	{
 		std::array<std::array<int, 101>, 101> searchedTiles {};
 
-		std::optional<Point> nearPosition = FindClosestValidPosition(
+		const std::optional<Point> nearPosition = FindClosestValidPosition(
 		    [&searchedTiles](Point testPosition) {
 			    searchedTiles[testPosition.x][testPosition.y]++;
 			    return false;
@@ -189,7 +189,7 @@ TEST(PathTest, FindClosest)
 	{
 		std::array<std::array<int, 5>, 5> searchedTiles {};
 
-		std::optional<Point> nearPosition = FindClosestValidPosition(
+		const std::optional<Point> nearPosition = FindClosestValidPosition(
 		    [&searchedTiles](Point testPosition) {
 			    searchedTiles[testPosition.x][testPosition.y]++;
 			    return false;
@@ -213,7 +213,7 @@ TEST(PathTest, FindClosest)
 	{
 		std::array<std::array<int, 3>, 3> searchedTiles {};
 
-		std::optional<Point> nearPosition = FindClosestValidPosition(
+		const std::optional<Point> nearPosition = FindClosestValidPosition(
 		    [&searchedTiles](Point testPosition) {
 			    searchedTiles[testPosition.x][testPosition.y]++;
 			    return false;
@@ -236,7 +236,7 @@ TEST(PathTest, FindClosest)
 	{
 		std::array<std::array<int, 7>, 7> searchedTiles {};
 
-		std::optional<Point> nearPosition = FindClosestValidPosition(
+		const std::optional<Point> nearPosition = FindClosestValidPosition(
 		    [&searchedTiles](Point testPosition) {
 			    searchedTiles[testPosition.x][testPosition.y]++;
 			    return false;

--- a/test/random_test.cpp
+++ b/test/random_test.cpp
@@ -274,7 +274,7 @@ TEST(RandomTest, NegativeReturnValues)
 	SetRndSeed(1457187811);
 	EXPECT_EQ(GenerateRnd(31), -1) << "Unexpected return value for a limit of 31";
 
-	for (int i : { 9, 10, 12, 13, 14, 15, 18, 20, 21, 24, 26, 28, 30 }) {
+	for (const int i : { 9, 10, 12, 13, 14, 15, 18, 20, 21, 24, 26, 28, 30 }) {
 		SetRndSeed(1457187811);
 		EXPECT_EQ(GenerateRnd(i), -8) << "Unexpected return value for a limit of " << i;
 	}

--- a/test/rectangle_test.cpp
+++ b/test/rectangle_test.cpp
@@ -8,7 +8,7 @@ namespace {
 
 TEST(RectangleTest, Contains_LargerSize)
 {
-	RectangleOf<uint8_t> rect { { 0, 0 }, { 10, 20 } };
+	const RectangleOf<uint8_t> rect { { 0, 0 }, { 10, 20 } };
 	EXPECT_TRUE(rect.contains(Point(9, 9)));
 	EXPECT_FALSE(rect.contains(Point(-1, -1)));
 	EXPECT_FALSE(rect.contains(Point(257, 257)));
@@ -16,7 +16,7 @@ TEST(RectangleTest, Contains_LargerSize)
 
 TEST(RectangleTest, Contains_UnsignedRectangle_SignedPointSameSize)
 {
-	RectangleOf<uint8_t> rect { { 0, 0 }, { 255, 255 } };
+	const RectangleOf<uint8_t> rect { { 0, 0 }, { 255, 255 } };
 	EXPECT_TRUE(rect.contains(PointOf<int8_t>(5, 5)));
 	EXPECT_FALSE(rect.contains(PointOf<int8_t>(-1, -1)));
 	EXPECT_FALSE(rect.contains(PointOf<int8_t>(-2, -2)));
@@ -24,7 +24,7 @@ TEST(RectangleTest, Contains_UnsignedRectangle_SignedPointSameSize)
 
 TEST(RectangleTest, Contains_SignedRectangle_UnsignedPointSameSize)
 {
-	RectangleOf<int8_t> rect { { -10, -10 }, { 127, 127 } };
+	const RectangleOf<int8_t> rect { { -10, -10 }, { 127, 127 } };
 	EXPECT_TRUE(rect.contains(PointOf<uint8_t>(0, 0)));
 	EXPECT_FALSE(rect.contains(PointOf<uint8_t>(255, 255)));
 }

--- a/test/static_vector_test.cpp
+++ b/test/static_vector_test.cpp
@@ -15,7 +15,7 @@ TEST(StaticVector, StaticVector_push_back)
 	StaticVector<size_t, MAX_SIZE> container;
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
-	size_t size = RandomIntBetween(10, MAX_SIZE);
+	const size_t size = RandomIntBetween(10, MAX_SIZE);
 
 	for (size_t i = 0; i < size; i++) {
 		container.push_back(i);
@@ -31,7 +31,7 @@ TEST(StaticVector, StaticVector_push_back_full)
 {
 	StaticVector<size_t, MAX_SIZE> container;
 
-	size_t size = MAX_SIZE;
+	const size_t size = MAX_SIZE;
 	for (size_t i = 0; i < size; i++) {
 		container.push_back(i);
 	}
@@ -98,7 +98,7 @@ TEST(StaticVector, StaticVector_erase_random)
 	std::vector<size_t> expected;
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
-	size_t size = RandomIntBetween(10, MAX_SIZE);
+	const size_t size = RandomIntBetween(10, MAX_SIZE);
 	size_t erasures = RandomIntBetween(1, static_cast<int32_t>(size) - 1, true);
 
 	for (size_t i = 0; i < size; i++) {
@@ -107,7 +107,7 @@ TEST(StaticVector, StaticVector_erase_random)
 	}
 
 	while (erasures-- > 0) {
-		size_t idx = RandomIntLessThan(static_cast<int32_t>(container.size()));
+		const size_t idx = RandomIntLessThan(static_cast<int32_t>(container.size()));
 		container.erase(container.begin() + idx);
 		expected.erase(expected.begin() + idx);
 	}
@@ -121,7 +121,7 @@ TEST(StaticVector, StaticVector_erase_random)
 TEST(StaticVector, StaticVector_erase_range)
 {
 	StaticVector<size_t, MAX_SIZE> container;
-	std::vector<size_t> erase_idx;
+	const std::vector<size_t> erase_idx;
 	std::vector<size_t> expected;
 
 	SetRndSeed(testing::UnitTest::GetInstance()->random_seed());
@@ -140,8 +140,8 @@ TEST(StaticVector, StaticVector_erase_range)
 		EXPECT_EQ(container[i], expected[i]);
 	}
 
-	int32_t from = RandomIntBetween(0, static_cast<int32_t>(container.size()) - 1);
-	int32_t to = RandomIntBetween(from + 1, static_cast<int32_t>(container.size()));
+	const int32_t from = RandomIntBetween(0, static_cast<int32_t>(container.size()) - 1);
+	const int32_t to = RandomIntBetween(from + 1, static_cast<int32_t>(container.size()));
 	container.erase(container.begin() + from, container.begin() + to);
 	for (int32_t i = to - from; i > 0; i--) {
 		expected.erase(expected.begin() + from);

--- a/test/timedemo_test.cpp
+++ b/test/timedemo_test.cpp
@@ -44,7 +44,7 @@ void RunTimedemo(std::string timedemoFolderName)
 	// Please provide them so that the tests can run successfully
 	ASSERT_TRUE(HaveMainData());
 
-	std::string unitTestFolderCompletePath = paths::BasePath() + "test/fixtures/timedemo/" + timedemoFolderName;
+	const std::string unitTestFolderCompletePath = paths::BasePath() + "test/fixtures/timedemo/" + timedemoFolderName;
 	paths::SetPrefPath(unitTestFolderCompletePath);
 	paths::SetConfigPath(unitTestFolderCompletePath);
 
@@ -83,7 +83,7 @@ void RunTimedemo(std::string timedemoFolderName)
 
 	StartGame(false, true);
 
-	HeroCompareResult result = pfile_compare_hero_demo(demoNumber, true);
+	const HeroCompareResult result = pfile_compare_hero_demo(demoNumber, true);
 	ASSERT_EQ(result.status, HeroCompareResult::Same) << result.message;
 	ASSERT_FALSE(gbRunGame);
 	gbRunGame = false;

--- a/test/utf8_test.cpp
+++ b/test/utf8_test.cpp
@@ -9,7 +9,7 @@ namespace {
 TEST(DecodeFirstUtf8CodePointTest, OneByteCodePoint)
 {
 	size_t len;
-	char32_t cp = DecodeFirstUtf8CodePoint("a", &len);
+	const char32_t cp = DecodeFirstUtf8CodePoint("a", &len);
 	EXPECT_EQ(cp, U'a');
 	EXPECT_EQ(len, 1);
 }
@@ -17,7 +17,7 @@ TEST(DecodeFirstUtf8CodePointTest, OneByteCodePoint)
 TEST(DecodeFirstUtf8CodePointTest, TwoByteCodePoint)
 {
 	size_t len;
-	char32_t cp = DecodeFirstUtf8CodePoint("ж", &len);
+	const char32_t cp = DecodeFirstUtf8CodePoint("ж", &len);
 	EXPECT_EQ(cp, U'ж');
 	EXPECT_EQ(len, 2);
 }
@@ -25,7 +25,7 @@ TEST(DecodeFirstUtf8CodePointTest, TwoByteCodePoint)
 TEST(DecodeFirstUtf8CodePointTest, ThreeByteCodePoint)
 {
 	size_t len;
-	char32_t cp = DecodeFirstUtf8CodePoint("€", &len);
+	const char32_t cp = DecodeFirstUtf8CodePoint("€", &len);
 	EXPECT_EQ(cp, U'€');
 	EXPECT_EQ(len, 3);
 }
@@ -33,7 +33,7 @@ TEST(DecodeFirstUtf8CodePointTest, ThreeByteCodePoint)
 TEST(DecodeFirstUtf8CodePointTest, FourByteCodePoint)
 {
 	size_t len;
-	char32_t cp = DecodeFirstUtf8CodePoint("💡", &len);
+	const char32_t cp = DecodeFirstUtf8CodePoint("💡", &len);
 	EXPECT_EQ(cp, U'💡');
 	EXPECT_EQ(len, 4);
 }
@@ -41,7 +41,7 @@ TEST(DecodeFirstUtf8CodePointTest, FourByteCodePoint)
 TEST(DecodeFirstUtf8CodePointTest, InvalidCodePoint)
 {
 	size_t len;
-	char32_t cp = DecodeFirstUtf8CodePoint("\xc3\x28", &len);
+	const char32_t cp = DecodeFirstUtf8CodePoint("\xc3\x28", &len);
 	EXPECT_EQ(cp, Utf8DecodeError);
 	EXPECT_EQ(len, 1);
 }

--- a/test/vision_test.cpp
+++ b/test/vision_test.cpp
@@ -46,7 +46,7 @@ void initEnvironment()
 	buildWallsAround(env, pos, box_radius);
 
 	// Place objects
-	for (auto &o : objects) {
+	for (const auto &o : objects) {
 		env[o.first.x][o.first.y] = '#';
 	}
 
@@ -98,7 +98,7 @@ TEST(VisionTest, VisibleObjects)
 {
 	doVision();
 
-	for (auto &o : objects) {
+	for (const auto &o : objects) {
 		if (o.second)
 			// Visible object
 			EXPECT_EQ(vis[o.first.x][o.first.y], '#') << "Expext visible wall or object";

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -402,10 +402,10 @@ TEST(Writehero, pfile_write_hero)
 
 	uintmax_t fileSize;
 	ASSERT_TRUE(GetFileSize(savePath.c_str(), &fileSize));
-	size_t size = static_cast<size_t>(fileSize);
+	const size_t size = static_cast<size_t>(fileSize);
 	FILE *f = OpenFile(savePath.c_str(), "rb");
 	ASSERT_TRUE(f != nullptr);
-	std::unique_ptr<char[]> data { new char[size] };
+	const std::unique_ptr<char[]> data { new char[size] };
 	ASSERT_EQ(std::fread(data.get(), size, 1, f), 1);
 	std::fclose(f);
 


### PR DESCRIPTION
These changes are made using clang-tidy and clang-format, dropping some changes that where either not trivial or caused build issues on various targets. Doing so in an effort to minimize manual changes in this PR.