### PR TITLE
Clear old dmg builds before each build

### DIFF
--- a/.github/workflows/macOS_x86_64.yml
+++ b/.github/workflows/macOS_x86_64.yml
@@ -41,6 +41,10 @@ jobs:
         key: ${{ github.workflow }}-v2-${{ github.sha }}
         restore-keys: ${{ github.workflow }}-v2-
 
+    - name: Clean previous DMG
+      working-directory: ${{github.workspace}}
+      run: rm -f build/*.dmg
+
     - name: Build
       working-directory: ${{github.workspace}}
       shell: bash


### PR DESCRIPTION
This should hopeful fix failed builds like these: https://github.com/diasurgical/DevilutionX/actions/runs/16998253027/job/48194106729?pr=8119