### PR TITLE
Added Lua Bindings for Adding New Items

### DIFF
--- a/Source/itemdat.cpp
+++ b/Source/itemdat.cpp
@@ -519,14 +519,13 @@ tl::expected<goodorevil, std::string> ParseAffixAlignment(std::string_view value
 	return tl::make_unexpected("Unknown enum value");
 }
 
-void LoadItemDat()
+} // namespace
+
+void LoadItemDatFromFile(DataFile &dataFile, std::string_view filename)
 {
-	const std::string_view filename = "txtdata\\items\\itemdat.tsv";
-	DataFile dataFile = DataFile::loadOrDie(filename);
 	dataFile.skipHeaderOrDie(filename);
 
-	AllItemsList.clear();
-	AllItemsList.reserve(dataFile.numRecords());
+	AllItemsList.reserve(AllItemsList.size() + dataFile.numRecords());
 	for (DataFileRecord record : dataFile) {
 		RecordReader reader { record, filename };
 		ItemData &item = AllItemsList.emplace_back();
@@ -555,6 +554,19 @@ void LoadItemDat()
 		reader.readInt("value", item.iValue);
 	}
 	AllItemsList.shrink_to_fit();
+}
+
+namespace {
+
+void LoadItemDat()
+{
+	const std::string_view filename = "txtdata\\items\\itemdat.tsv";
+	DataFile dataFile = DataFile::loadOrDie(filename);
+
+	AllItemsList.clear();
+	LoadItemDatFromFile(dataFile, filename);
+
+	LuaEvent("ItemDataLoaded");
 }
 
 void ReadItemPower(RecordReader &reader, std::string_view fieldName, ItemPower &power)

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -376,6 +376,8 @@ enum unique_base_item : int8_t {
 	UITYPE_LGTFORGE,
 	UITYPE_LAZSTAFF,
 	UITYPE_BOVINE,
+	NUM_DEFAULT_UITYPES,
+	NUM_MAX_UITYPES = std::numeric_limits<int8_t>::max(),
 	UITYPE_INVALID = -1,
 };
 

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -80,7 +80,7 @@ enum _item_indexes : int16_t { // TODO defines all indexes in AllItemsList
 	IDI_SORCERER_DIABLO,
 	IDI_ARENAPOT,
 
-	IDI_LAST = IDI_ARENAPOT,
+	IDI_NUM_DEFAULT_ITEMS,
 	IDI_NONE = -1,
 };
 
@@ -511,6 +511,7 @@ struct ItemData {
 	SpellID iSpell;
 	bool iUsable;
 	uint16_t iValue;
+	int32_t iMappingId;
 };
 
 enum item_effect_type : int8_t {
@@ -647,12 +648,13 @@ struct UniqueItem {
 };
 
 extern DVL_API_FOR_TEST std::vector<ItemData> AllItemsList;
+extern ankerl::unordered_dense::map<int32_t, int16_t> ItemMappingIdsToIndices;
 extern std::vector<PLStruct> ItemPrefixes;
 extern std::vector<PLStruct> ItemSuffixes;
 extern DVL_API_FOR_TEST std::vector<UniqueItem> UniqueItems;
 extern ankerl::unordered_dense::map<int32_t, int32_t> UniqueItemMappingIdsToIndices;
 
-void LoadItemDatFromFile(DataFile &dataFile, std::string_view filename);
+void LoadItemDatFromFile(DataFile &dataFile, std::string_view filename, int32_t baseMappingId);
 void LoadUniqueItemDatFromFile(DataFile &dataFile, std::string_view filename, int32_t baseMappingId);
 void LoadItemData();
 

--- a/Source/itemdat.h
+++ b/Source/itemdat.h
@@ -650,6 +650,7 @@ extern std::vector<PLStruct> ItemSuffixes;
 extern DVL_API_FOR_TEST std::vector<UniqueItem> UniqueItems;
 extern ankerl::unordered_dense::map<int32_t, int32_t> UniqueItemMappingIdsToIndices;
 
+void LoadItemDatFromFile(DataFile &dataFile, std::string_view filename);
 void LoadUniqueItemDatFromFile(DataFile &dataFile, std::string_view filename, int32_t baseMappingId);
 void LoadItemData();
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1351,8 +1351,8 @@ _item_indexes GetItemIndexForDroppableItem(bool considerDropRate, tl::function_r
 	ril.clear();
 
 	unsigned cumulativeWeight = 0;
-	for (std::underlying_type_t<_item_indexes> i = IDI_GOLD; i <= IDI_LAST; i++) {
-		if (!IsItemAvailable(i))
+	for (size_t i = 0; i < AllItemsList.size(); i++) {
+		if (!IsItemAvailable(static_cast<int>(i)))
 			continue;
 		const ItemData &item = AllItemsList[i];
 		if (item.dropRate == 0)
@@ -2369,7 +2369,7 @@ std::string GetTranslatedItemNameMagical(const Item &item, bool hellfireItem, bo
 
 bool IsItemAvailable(int i)
 {
-	if (i < 0 || i > IDI_LAST)
+	if (i < 0 || i >= static_cast<int>(AllItemsList.size()))
 		return false;
 
 	if (gbIsSpawn) {

--- a/Source/lua/modules/dev/items.cpp
+++ b/Source/lua/modules/dev/items.cpp
@@ -135,8 +135,8 @@ std::string DebugSpawnUniqueItem(std::string itemName)
 	if (!foundUnique) return "No unique item found!";
 
 	_item_indexes uniqueBaseIndex = IDI_GOLD;
-	for (std::underlying_type_t<_item_indexes> j = IDI_GOLD; j <= IDI_LAST; j++) {
-		if (!IsItemAvailable(j))
+	for (size_t j = 0; j < AllItemsList.size(); j++) {
+		if (!IsItemAvailable(static_cast<int>(j)))
 			continue;
 		if (AllItemsList[j].iItemId == uniqueItem.UIItemId) {
 			uniqueBaseIndex = static_cast<_item_indexes>(j);

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -453,10 +453,10 @@ void RegisterItemSpecialEffectHfEnum(sol::state_view &lua)
 	    });
 }
 
-void AddItemDataFromTsv(const std::string_view path)
+void AddItemDataFromTsv(const std::string_view path, const int32_t baseMappingId)
 {
 	DataFile dataFile = DataFile::loadOrDie(path);
-	LoadItemDatFromFile(dataFile, path);
+	LoadItemDatFromFile(dataFile, path, baseMappingId);
 }
 
 void AddUniqueItemDataFromTsv(const std::string_view path, const int32_t baseMappingId)
@@ -482,7 +482,7 @@ sol::table LuaItemModule(sol::state_view &lua)
 
 	sol::table table = lua.create_table();
 
-	LuaSetDocFn(table, "addItemDataFromTsv", "(path: string)", AddItemDataFromTsv);
+	LuaSetDocFn(table, "addItemDataFromTsv", "(path: string, baseMappingId: number)", AddItemDataFromTsv);
 	LuaSetDocFn(table, "addUniqueItemDataFromTsv", "(path: string, baseMappingId: number)", AddUniqueItemDataFromTsv);
 
 	return table;

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -346,7 +346,6 @@ void RegisterItemIndexEnum(sol::state_view &lua)
 	        { "RuneOfStone", IDI_RUNEOFSTONE },
 	        { "SorcererDiablo", IDI_SORCERER_DIABLO },
 	        { "ArenaPotion", IDI_ARENAPOT },
-	        { "Last", IDI_LAST },
 	        { "None", IDI_NONE },
 	    });
 }

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -453,6 +453,12 @@ void RegisterItemSpecialEffectHfEnum(sol::state_view &lua)
 	    });
 }
 
+void AddItemDataFromTsv(const std::string_view path)
+{
+	DataFile dataFile = DataFile::loadOrDie(path);
+	LoadItemDatFromFile(dataFile, path);
+}
+
 void AddUniqueItemDataFromTsv(const std::string_view path, const int32_t baseMappingId)
 {
 	DataFile dataFile = DataFile::loadOrDie(path);
@@ -476,6 +482,7 @@ sol::table LuaItemModule(sol::state_view &lua)
 
 	sol::table table = lua.create_table();
 
+	LuaSetDocFn(table, "addItemDataFromTsv", "(path: string)", AddItemDataFromTsv);
 	LuaSetDocFn(table, "addUniqueItemDataFromTsv", "(path: string, baseMappingId: number)", AddUniqueItemDataFromTsv);
 
 	return table;

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -436,7 +436,7 @@ bool UnPackNetItem(const Player &player, const ItemNetPack &packedItem, Item &it
 {
 	item = {};
 	const _item_indexes idx = static_cast<_item_indexes>(SDL_SwapLE16(packedItem.def.wIndx));
-	if (idx < 0 || idx > IDI_LAST)
+	if (idx < 0 || idx >= static_cast<_item_indexes>(AllItemsList.size()))
 		return true;
 	if (idx == IDI_EAR) {
 		RecreateEar(item, SDL_SwapLE16(packedItem.ear.wCI), SDL_SwapLE32(packedItem.ear.dwSeed), packedItem.ear.bCursval, packedItem.ear.heroname);

--- a/assets/lua/devilutionx/events.lua
+++ b/assets/lua/devilutionx/events.lua
@@ -44,6 +44,10 @@ local events = {
   LoadModsComplete = CreateEvent(),
   __doc_LoadModsComplete = "Called after all mods have been loaded.",
 
+  ---Called after the item data TSV file has been loaded.
+  ItemDataLoaded = CreateEvent(),
+  __doc_ItemDataLoaded = "Called after the item data TSV file has been loaded.",
+
   ---Called after the unique item data TSV file has been loaded.
   UniqueItemDataLoaded = CreateEvent(),
   __doc_UniqueItemDataLoaded = "Called after the unique item data TSV file has been loaded.",

--- a/test/items_test.cpp
+++ b/test/items_test.cpp
@@ -62,8 +62,8 @@ void GenerateAllUniques(bool hellfire, const size_t expectedUniques)
 			continue;
 
 		_item_indexes uniqueBaseIndex = IDI_GOLD;
-		for (std::underlying_type_t<_item_indexes> j = IDI_GOLD; j <= IDI_LAST; j++) {
-			if (!IsItemAvailable(j))
+		for (size_t j = 0; j < AllItemsList.size(); j++) {
+			if (!IsItemAvailable(static_cast<int>(j)))
 				continue;
 			if (AllItemsList[j].iItemId != uniqueItem.UIItemId)
 				continue;


### PR DESCRIPTION
This PR adds Lua bindings for adding new item types via TSV file loading, similar to the Lua bindings for e.g. adding new monsters or unique items.

As with the add unique item Lua bindings, it also uses mapping IDs when saving/loading the item type, to make it easier to combine different item-adding mods without issue. This only affects added item types: for the default ones, the mapping ID equals their index.

Item type TSV definitions can now add new "uniqueBaseItem" entries as well. The way this is done is the following:
```
		reader.read("uniqueBaseItem", item.iItemId, ParseOrAddUniqueBaseItem);
```

When parsing item types, if the unique base item is already present, its ID is just obtained. Otherwise, if it is not present, it will be added to the new "AdditionalUniqueBaseItemStringsToIndices" map (after which it can be obtained via `ParseUniqueBaseItem()`).