### PR TITLE
CONTROLS: Upgrades Gamepad logic to allow for manual aiming

### DIFF
--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -59,7 +59,17 @@ void InvalidateInventorySlot();
 void FocusOnInventory();
 void PerformSpellAction();
 void QuickCast(size_t slot);
+void GamepadAim(int dx, int dy);
+void SetPointAndClick(bool value);
+bool IsPointAndClick();
 
 extern int speedspellcount;
+
+struct AimState {
+	bool active = false;
+	Point screen { 0, 0 };
+};
+
+AimState &GetAimState();
 
 } // namespace devilution

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2030,6 +2030,46 @@ void InitKeymapActions()
 	    [] {
 		    ReorganizeInventory(*MyPlayer);
 	    });
+	options.Keymapper.AddAction(
+	    "AimUp",
+	    N_("Aim up"),
+	    N_("Move aim cursor up one tile."),
+	    SDLK_UNKNOWN,
+	    [] { GamepadAim(0, -1);
+			const auto &a = GetAimState();
+			SetCursorPos(a.screen);
+			ControlMode = ControlTypes::KeyboardAndMouse;
+			SetPointAndClick(true); });
+	options.Keymapper.AddAction(
+	    "AimDown",
+	    N_("Aim down"),
+	    N_("Move aim cursor down one tile."),
+	    SDLK_UNKNOWN,
+	    [] { GamepadAim(0, +1);
+			const auto &a = GetAimState();
+			SetCursorPos(a.screen);
+			ControlMode = ControlTypes::KeyboardAndMouse;
+			SetPointAndClick(true); });
+	options.Keymapper.AddAction(
+	    "AimLeft",
+	    N_("Aim left"),
+	    N_("Move aim cursor left one tile."),
+	    SDLK_UNKNOWN,
+	    [] { GamepadAim(-1, 0);
+			const auto &a = GetAimState();
+			SetCursorPos(a.screen);
+			ControlMode = ControlTypes::KeyboardAndMouse;
+			SetPointAndClick(true); });
+	options.Keymapper.AddAction(
+	    "AimRight",
+	    N_("Aim right"),
+	    N_("Move aim cursor right one tile."),
+	    SDLK_UNKNOWN,
+	    [] { GamepadAim(+1, 0);
+			const auto &a = GetAimState();
+			SetCursorPos(a.screen);
+			ControlMode = ControlTypes::KeyboardAndMouse;
+			SetPointAndClick(true); });
 #ifdef _DEBUG
 	options.Keymapper.AddAction(
 	    "OpenConsole",
@@ -2542,6 +2582,46 @@ void InitPadmapActions()
 	    [] {
 		    ToggleChatLog();
 	    });
+	options.Padmapper.AddAction(
+	    "AimUp",
+	    N_("Aim up"),
+	    N_("Move aim cursor up one tile."),
+	    ControllerButton_NONE,
+	    [] { GamepadAim(0, -1);
+			const auto &a = GetAimState();
+			SetCursorPos(a.screen);
+			ControlMode = ControlTypes::KeyboardAndMouse;
+			SetPointAndClick(true); });
+	options.Padmapper.AddAction(
+	    "AimDown",
+	    N_("Aim down"),
+	    N_("Move aim cursor down one tile."),
+	    ControllerButton_NONE,
+	    [] { GamepadAim(0, +1);
+			const auto &a = GetAimState();
+			SetCursorPos(a.screen);
+			ControlMode = ControlTypes::KeyboardAndMouse;
+			SetPointAndClick(true); });
+	options.Padmapper.AddAction(
+	    "AimLeft",
+	    N_("Aim left"),
+	    N_("Move aim cursor left one tile."),
+	    ControllerButton_NONE,
+	    [] { GamepadAim(-1, 0);
+			const auto &a = GetAimState();
+			SetCursorPos(a.screen);
+			ControlMode = ControlTypes::KeyboardAndMouse;
+			SetPointAndClick(true); });
+	options.Padmapper.AddAction(
+	    "AimRight",
+	    N_("Aim right"),
+	    N_("Move aim cursor right one tile."),
+	    ControllerButton_NONE,
+	    [] { GamepadAim(+1, 0);
+			const auto &a = GetAimState();
+			SetCursorPos(a.screen);
+			ControlMode = ControlTypes::KeyboardAndMouse;
+			SetPointAndClick(true); });
 	options.Padmapper.CommitActions();
 }
 


### PR DESCRIPTION
# Controller manual aim (right-stick & pad/key maps) — cast at empty tiles and use interactive spells like KB+M

## Summary
The original controller flow relied heavily on auto-targeting and didn’t provide a practical way to **manually aim** and cast at **empty tiles** as well as enabling the utilization of interactive spell mechanics that did not reliably work before in a sensible manner.
This PR adds a simple, robust manual-aim path so controller players can aim exactly like KB+M users—using the **right stick** or **mapped button combos**—**without** changing existing auto-targeting behavior.

## What this enables
- Cast ground/empty-tile spells precisely with a gamepad.
- Use runes/scrolls at a chosen tile.
- **Telekinesis works from controller** (cast telekinesis, aim with rightstick, use secondary action to interact)
- Auto-targeting remains untouched when you’re not manually aiming.

## Touched files & functions (surgical)

### `plrctrls.h/.cpp`
- Added `struct AimState { bool active; Point screen; }` + `AimState &GetAimState()`.
- Added `void SetPointAndClick(bool)`, `bool IsPointAndClick()`.
- New `void GamepadAim(int dx, int dy)` (±1 = one tile; clamps; seeds from current mouse).
- `HandleRightStickMotion()`: when the stick moves, warp the OS cursor to `AimState.screen`, set `ControlMode = KeyboardAndMouse`, and `SetPointAndClick(true)` for the tick.
- `WalkInDir(...)`: any movement/rotation clears sticky aim (`SetPointAndClick(false)`), preventing drift toward the cursor (fixes Stand-Ground spin).
- `PerformSpellAction()` / `QuickCast(...)`: only call controller retargeting when **not** in K&M and **not** `IsPointAndClick()`, so casts go to the aimed cursor tile.
- `PerformSecondaryAction()`: route cursor-based actions (e.g., Telekinesis, Identify, Repair, Recharge, Disarm, Oil, Resurrect, Town Portal, Heal Other) through the aimed cursor.

### `diablo.cpp`
- Keymap/Padmap actions: `AimUp/Down/Left/Right` → `GamepadAim(±1,0)/(0,±1)`, then `SetCursorPos(GetAimState().screen)`, `ControlMode = KeyboardAndMouse`, `SetPointAndClick(true)` so mapped inputs behave identically to the stick.

## Behavior
- If you manually aim (stick or mapped buttons), the cursor persists on that tile and casts target **that** tile; the hero turns toward it.
- If you don’t aim, controller auto-targeting works exactly as before.
- Starting to move cancels manual aim so movement logic can’t pull you toward the cursor.
