### PR TITLE
Add Runes to Speedbook

### DIFF
--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1352,6 +1352,11 @@ void CheckPanelInfo()
 				AddInfoBoxString(fmt::format(fmt::runtime(_("Staff of {:s}")), pgettext("spell", GetSpellData(spellId).sNameText)));
 				AddInfoBoxString(fmt::format(fmt::runtime(ngettext("{:d} Charge", "{:d} Charges", myPlayer.InvBody[INVLOC_HAND_LEFT]._iCharges)), myPlayer.InvBody[INVLOC_HAND_LEFT]._iCharges));
 				break;
+			case SpellType::Rune: {
+				auto [runeName, runeCount] = GetRuneInfoStringAndCount(myPlayer, spellId);
+				AddInfoBoxString(runeName);
+				AddInfoBoxString(fmt::format(fmt::runtime(ngettext("{:d} Rune", "{:d} Runes", runeCount)), runeCount));
+			} break;
 			case SpellType::Invalid:
 				break;
 			}

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1331,6 +1331,7 @@ bool AutoPlaceItemInBelt(Player &player, const Item &item, bool persistItem, boo
 			if (persistItem) {
 				beltItem = item;
 				player.CalcScrolls();
+				player.CalcRunes();
 				RedrawComponent(PanelDrawComponent::Belt);
 				if (sendNetworkMessage) {
 					const auto beltIndex = static_cast<int>(std::distance<const Item *>(&player.SpdList[0], &beltItem));
@@ -1403,6 +1404,7 @@ bool AutoPlaceItemInInventory(Player &player, const Item &item, bool sendNetwork
 
 		AddItemToInvGrid(player, *targetSlot, player._pNumInv, itemSize, sendNetworkMessage);
 		player.CalcScrolls();
+		player.CalcRunes();
 
 		return true;
 	}

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3119,16 +3119,6 @@ void GetItemAttrs(Item &item, _item_indexes itemData, int lvl)
 	item._iMiscId = baseItemData.iMiscId;
 	item._iSpell = baseItemData.iSpell;
 	item._iMagical = ITEM_QUALITY_NORMAL;
-	if (item._iMiscId == IMISC_RUNEF)
-		item._iSpell = SpellID::RuneOfFire;
-	else if (item._iMiscId == IMISC_RUNEL)
-		item._iSpell = SpellID::RuneOfLight;
-	else if (item._iMiscId == IMISC_GR_RUNEL)
-		item._iSpell = SpellID::RuneOfNova;
-	else if (item._iMiscId == IMISC_GR_RUNEF)
-		item._iSpell = SpellID::RuneOfImmolation;
-	else if (item._iMiscId == IMISC_RUNES)
-		item._iSpell = SpellID::RuneOfStone;
 	item._ivalue = baseItemData.iValue;
 	item._iIvalue = baseItemData.iValue;
 	item._iDurability = baseItemData.iDurability;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2894,6 +2894,7 @@ void CalcPlrInv(Player &player, bool loadgfx)
 			item.updateRequiredStatsCacheForPlayer(player);
 		}
 		player.CalcScrolls();
+		player.CalcRunes();
 		if (IsStashOpen) {
 			// If stash is open, ensure the items are displayed correctly
 			Stash.RefreshItemStatFlags();
@@ -3118,6 +3119,16 @@ void GetItemAttrs(Item &item, _item_indexes itemData, int lvl)
 	item._iMiscId = baseItemData.iMiscId;
 	item._iSpell = baseItemData.iSpell;
 	item._iMagical = ITEM_QUALITY_NORMAL;
+	if (item._iMiscId == IMISC_RUNEF)
+		item._iSpell = SpellID::RuneOfFire;
+	else if (item._iMiscId == IMISC_RUNEL)
+		item._iSpell = SpellID::RuneOfLight;
+	else if (item._iMiscId == IMISC_GR_RUNEL)
+		item._iSpell = SpellID::RuneOfNova;
+	else if (item._iMiscId == IMISC_GR_RUNEF)
+		item._iSpell = SpellID::RuneOfImmolation;
+	else if (item._iMiscId == IMISC_RUNES)
+		item._iSpell = SpellID::RuneOfStone;
 	item._ivalue = baseItemData.iValue;
 	item._iIvalue = baseItemData.iValue;
 	item._iDurability = baseItemData.iDurability;

--- a/Source/panels/spell_icons.cpp
+++ b/Source/panels/spell_icons.cpp
@@ -74,11 +74,11 @@ const SpellIcon SpellITbl[] = {
 /* SpellID::Berserk          */ SpellIcon::Berserk,
 /* SpellID::RingOfFire       */ SpellIcon::RingOfFire,
 /* SpellID::Search           */ SpellIcon::Search,
-/* SpellID::RuneOfFire       */ SpellIcon::PentaStar,
-/* SpellID::RuneOfLight      */ SpellIcon::PentaStar,
-/* SpellID::RuneOfNova       */ SpellIcon::PentaStar,
-/* SpellID::RuneOfImmolation */ SpellIcon::PentaStar,
-/* SpellID::RuneOfStone      */ SpellIcon::PentaStar,
+/* SpellID::RuneOfFire       */ SpellIcon::Fireball,
+/* SpellID::RuneOfLight      */ SpellIcon::LightningWall,
+/* SpellID::RuneOfNova       */ SpellIcon::Nova,
+/* SpellID::RuneOfImmolation */ SpellIcon::Immolation,
+/* SpellID::RuneOfStone      */ SpellIcon::StoneCurse,
 	// clang-format on
 };
 
@@ -202,6 +202,16 @@ void SetSpellTrans(SpellType t)
 		for (int i = PAL16_ORANGE; i < PAL16_ORANGE + 16; i++) {
 			SplTransTbl[PAL16_BEIGE - PAL16_ORANGE + i] = i;
 			SplTransTbl[PAL16_YELLOW - PAL16_ORANGE + i] = i;
+		}
+		break;
+	case SpellType::Rune:
+		SplTransTbl[PAL8_YELLOW] = 0;
+		SplTransTbl[PAL8_YELLOW + 1] = +3;
+		SplTransTbl[PAL8_YELLOW + 2] = +5;
+		for (int i = 0; i < 16; i++) {
+			SplTransTbl[PAL16_BEIGE + i] = i;
+			SplTransTbl[PAL16_YELLOW + i] = i;
+			SplTransTbl[PAL16_ORANGE + i] = i;
 		}
 		break;
 	case SpellType::Invalid:

--- a/Source/panels/spell_list.hpp
+++ b/Source/panels/spell_list.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <cstddef>
+#include <string_view>
 #include <vector>
 
 #include "engine/point.hpp"
 #include "engine/surface.hpp"
+#include "player.h"
 #include "spelldat.h"
 
 namespace devilution {
@@ -27,6 +29,7 @@ void SetSpell();
 void SetSpeedSpell(size_t slot);
 bool IsValidSpeedSpell(size_t slot);
 void ToggleSpell(size_t slot);
+std::pair<std::string_view, int> GetRuneInfoStringAndCount(const devilution::Player &player, devilution::SpellID spellId);
 
 /**
  * Draws the "Speed Book": the rows of known spells for quick-setting a spell that

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1534,7 +1534,10 @@ void Player::CalcRunes()
 	_pRuneSpells = 0;
 	for (const Item &item : InventoryAndBeltPlayerItemsRange { *this }) {
 		if (item.isRune() && item._iStatFlag) {
-			_pRuneSpells |= GetSpellBitmask(item._iSpell);
+			for (SpellID spell : { SpellID::RuneOfFire, SpellID::RuneOfLight, SpellID::RuneOfNova, SpellID::RuneOfImmolation, SpellID::RuneOfStone }) {
+				if (item.isRuneOf(spell))
+					_pRuneSpells |= GetSpellBitmask(spell);
+			}
 		}
 	}
 	EnsureValidReadiedSpell(*this);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1550,7 +1550,7 @@ bool Player::CanUseItem(const Item &item) const
 	    && _pDexterity >= item._iMinDex;
 }
 
-void Player::RemoveInvItem(int iv, bool calcScrolls, bool calcRunes)
+void Player::RemoveInvItem(int iv, bool calcScrolls)
 {
 	if (this == MyPlayer) {
 		// Locate the first grid index containing this item and notify remote clients
@@ -1592,8 +1592,6 @@ void Player::RemoveInvItem(int iv, bool calcScrolls, bool calcRunes)
 
 	if (calcScrolls) {
 		CalcScrolls();
-	}
-	if (calcRunes) {
 		CalcRunes();
 	}
 }

--- a/Source/player.h
+++ b/Source/player.h
@@ -463,9 +463,8 @@ public:
 	 * @brief Remove an item from player inventory
 	 * @param iv invList index of item to be removed
 	 * @param calcScrolls If true, CalcScrolls() gets called after removing item
-	 * @param calcRunes If true, CalcRunes() gets called after removing item
 	 */
-	void RemoveInvItem(int iv, bool calcScrolls = true, bool calcRunes = true);
+	void RemoveInvItem(int iv, bool calcScrolls = true);
 
 	/**
 	 * @brief Returns the network identifier for this player

--- a/Source/player.h
+++ b/Source/player.h
@@ -341,6 +341,7 @@ public:
 	uint64_t _pAblSpells;
 	/** @brief Bitmask of spells available via scrolls */
 	uint64_t _pScrlSpells;
+	uint64_t _pRuneSpells;
 	SpellFlag _pSpellFlags;
 	SpellID _pSplHotKey[NumHotkeys];
 	SpellType _pSplTHotKey[NumHotkeys];
@@ -410,6 +411,8 @@ public:
 
 	void CalcScrolls();
 
+	void CalcRunes();
+
 	bool CanUseItem(const Item &item) const;
 
 	bool CanCleave()
@@ -460,8 +463,9 @@ public:
 	 * @brief Remove an item from player inventory
 	 * @param iv invList index of item to be removed
 	 * @param calcScrolls If true, CalcScrolls() gets called after removing item
+	 * @param calcRunes If true, CalcRunes() gets called after removing item
 	 */
-	void RemoveInvItem(int iv, bool calcScrolls = true);
+	void RemoveInvItem(int iv, bool calcScrolls = true, bool calcRunes = true);
 
 	/**
 	 * @brief Returns the network identifier for this player

--- a/Source/spelldat.h
+++ b/Source/spelldat.h
@@ -24,7 +24,8 @@ enum class SpellType : uint8_t {
 	Spell,
 	Scroll,
 	Charges,
-	LAST = Charges,
+	Rune,
+	LAST = Rune,
 	Invalid,
 };
 

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -44,6 +44,9 @@ bool IsReadiedSpellValid(const Player &player)
 	case SpellType::Scroll:
 		return (player._pScrlSpells & GetSpellBitmask(player._pRSpell)) != 0;
 
+	case SpellType::Rune:
+		return (player._pRuneSpells & GetSpellBitmask(player._pRSpell)) != 0;
+
 	default:
 		return false;
 	}
@@ -153,6 +156,9 @@ void ConsumeSpell(Player &player, SpellID sn)
 	case SpellType::Scroll:
 		ConsumeScroll(player);
 		break;
+	case SpellType::Rune:
+		ConsumeScroll(player);
+		break;
 	case SpellType::Charges:
 		ConsumeStaffCharge(player);
 		break;
@@ -228,7 +234,11 @@ void CastSpell(Player &player, SpellID spl, WorldTilePosition src, WorldTilePosi
 		}
 	}
 	if (!fizzled) {
-		ConsumeSpell(player, spl);
+		if (player.executedSpell.spellType == SpellType::Rune) {
+			ConsumeScroll(player);
+		} else {
+			ConsumeSpell(player, spl);
+		}
 	}
 }
 


### PR DESCRIPTION
# Add Runes to Speedbook Implementation

## Summary

The "Add Runes to Speedbook" feature extends the game's spellbook and quick spell selection system to support Rune spells. This allows players to view, select, and assign Rune spells in the Speedbook UI, similar to other spell types.  This implementation will help to bridge the gap for controller and mobile players in regards to having a subpar experience with this particular aspect of the game..

---

## Technical Details

### Changed Files

- `Source/control.cpp`
- `Source/inv.cpp`
- `Source/items.cpp`
- `Source/panels/spell_icons.cpp`
- `Source/panels/spell_list.cpp`
- `Source/panels/spell_list.hpp`
- `Source/player.cpp`
- `Source/player.h`
- `Source/spelldat.h`
- `Source/spells.cpp`

### Key Implementation Points

#### 1. **Spell Type and ID Extensions**
   - `spelldat.h`:
     - Added `Rune` to `SpellType` enum.
     - Added Rune spell IDs (e.g., `RuneOfFire`, `RuneOfLight`, etc.) to `SpellID`.

#### 2. **Player Data Structure**
   - `player.h` / `player.cpp`:
     - Added support for tracking Rune spells in player data (`_pRuneSpells`).
     - Updated logic for spell assignment and validation to include Rune spells.

#### 3. **Spellbook and Speedbook UI**
   - `panels/spell_list.cpp` / `panels/spell_list.hpp`:
     - Modified spell list logic to include Rune spells in the Speedbook.
     - Added functions to display Rune spell info and count.
     - Updated selection and hotkey assignment logic for Rune spells.

#### 4. **Spell Icon Mapping**
   - `panels/spell_icons.cpp`:
     - Mapped new Rune spell IDs to appropriate icons for display in the UI.

#### 5. **Spell Validation and Usage**
   - `spells.cpp`:
     - Updated spell validation logic to recognize Rune spells as valid for quick selection and casting.

#### 6. **Inventory and Item Handling**
   - `inv.cpp` / `items.cpp`:
     - Ensured Rune spells are properly handled in inventory and item logic, if applicable.

#### 7. **Control Panel Integration**
   - `control.cpp`:
     - Integrated Rune spell selection and display into the main control panel logic.

---

## How It Works

- Rune spells now appear in the Speedbook UI alongside other spell types.
- Players can assign Rune spells to quick slots and use them via hotkeys.
- The UI displays Rune spell icons and counts, and supports selection and toggling.
- All relevant player, spell, and UI logic has been updated to treat Runes just like Scrolls

<img width="1616" height="924" alt="image" src="https://github.com/user-attachments/assets/7f614552-66c4-4286-9fcd-5cd103925631" />

<img width="1741" height="970" alt="image" src="https://github.com/user-attachments/assets/4c990563-b1dc-42ba-89bb-1d7a642a2340" />

https://github.com/user-attachments/assets/84b4d8bb-23cb-454d-9694-c58cd9f7de8b
