### PR TITLE
Allow Providing the Item Cursor Frame Number instead of ID in itemdat

### DIFF
--- a/Source/itemdat.cpp
+++ b/Source/itemdat.cpp
@@ -245,13 +245,9 @@ tl::expected<item_cursor_graphic, std::string> ParseItemCursorGraphic(std::strin
 	if (value == "") return ICURS_DEFAULT;
 
 	// also support providing the item cursor icon frame number directly
-	uint8_t numericalValue = 0;
-	const std::from_chars_result result = std::from_chars(value.data(), value.data() + value.size(), numericalValue);
-	if (result.ec == std::errc()) {
-		return static_cast<item_cursor_graphic>(numericalValue);
-	}
-
-	return tl::make_unexpected("Unknown enum value");
+	return ParseInt<uint8_t>(value)
+	    .map([](auto numericalValue) { return static_cast<item_cursor_graphic>(numericalValue); })
+	    .map_error([](auto) { return std::string("Unknown enum value"); });
 }
 
 tl::expected<ItemType, std::string> ParseItemType(std::string_view value)

--- a/Source/itemdat.cpp
+++ b/Source/itemdat.cpp
@@ -6,6 +6,7 @@
 
 #include "itemdat.h"
 
+#include <charconv>
 #include <string_view>
 #include <vector>
 
@@ -242,6 +243,14 @@ tl::expected<item_cursor_graphic, std::string> ParseItemCursorGraphic(std::strin
 	if (value == "DEMON_PLATE_ARMOR") return ICURS_DEMON_PLATE_ARMOR;
 	if (value == "BOVINE") return ICURS_BOVINE;
 	if (value == "") return ICURS_DEFAULT;
+
+	// also support providing the item cursor icon frame number directly
+	uint8_t numericalValue = 0;
+	const std::from_chars_result result = std::from_chars(value.data(), value.data() + value.size(), numericalValue);
+	if (result.ec == std::errc()) {
+		return static_cast<item_cursor_graphic>(numericalValue);
+	}
+
 	return tl::make_unexpected("Unknown enum value");
 }
 


### PR DESCRIPTION
This PR makes it so that for the item cursor column of item types and unique items, frame numbers can be used instead of item cursor ID strings. This allows them to use the item cursor graphics which are available in Diablo, but have no ID for their frame in the source code (as occurs with a lot of the unused cursor graphics).