### PR TITLE
Fix run animation in town

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -138,8 +138,8 @@ void StartWalkAnimation(Player &player, Direction dir, bool pmWillBeCalled)
 {
 	int8_t skippedFrames = -2;
 	if (leveltype == DTYPE_TOWN && sgGameInitInfo.bRunInTown != 0)
-		skippedFrames = 2;
-	if (pmWillBeCalled)
+		skippedFrames = 3;
+	else if (pmWillBeCalled)
 		skippedFrames += 1;
 	NewPlrAnim(player, player_graphic::Walk, dir, AnimationDistributionFlags::ProcessAnimationPending, skippedFrames);
 }


### PR DESCRIPTION
The character used to run with different animation lengths from the starting point to the steady point.

The result was a very weird running start, as if the character was walking for first tile, then running for the next tiles, instead of just taking the pace right from the start.

This fixes it by not taking into account `pmWillBeCalled` for deciding the number of skipped frames when running.