### PR TITLE
log.hpp: fix lack of return when FMT_EXCEPTIONS is disabled

### DIFF
--- a/Source/utils/log.hpp
+++ b/Source/utils/log.hpp
@@ -52,13 +52,17 @@ std::string format(std::string_view fmt, Args &&...args)
 	}
 	FMT_CATCH(const fmt::format_error &e)
 	{
+		std::string error;
 #if FMT_EXCEPTIONS
-		// e.what() is undefined if exceptions are disabled, so we wrap the whole block
+		// e.what() is undefined if exceptions are disabled, so we wrap it
 		// with an `FMT_EXCEPTIONS` check.
-		std::string error = StrCat("Format error, fmt: ", fmt, " error: ", e.what());
+		error = e.what();
+#else
+		error = "unknown (FMT_EXCEPTIONS disabled)";
+#endif
+		std::string fullError = StrCat("Format error, fmt: ", fmt, " error: ", error);
 		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "%s", error.c_str());
 		app_fatal(error);
-#endif
 	}
 }
 


### PR DESCRIPTION
When compiling with clang, the compiler warns about the lack of return statement in the non-void function fmt::format:

```
/home/csix/diablo/devilutionX-ironman/Source/utils/log.hpp:63:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
/home/csix/diablo/devilutionX-ironman/Source/utils/log.hpp:88:21: note: in instantiation of function template specialization 'devilution::detail::format<unsigned long &>' requested here
        auto str = detail::format(fmt, std::forward<Args>(args)...);
                           ^
/home/csix/diablo/devilutionX-ironman/Source/utils/logged_fstream.hpp:74:4: note: in instantiation of function template specialization 'devilution::LogVerbose<unsigned long &>' requested here
                        LogVerbose(LogCategory::System, fmt, args...);
                        ^
/home/csix/diablo/devilutionX-ironman/Source/utils/logged_fstream.hpp:50:10: note: in instantiation of function template specialization 'devilution::LoggedFStream::CheckError<unsigned long>' requested here
                return CheckError(std::fwrite(data, size, 1, s_) == 1,
```

This fixes it by returning a default error string.