### PR TITLE
Fix mingw-prep.sh sdl2 not working for non-sudo

### DIFF
--- a/Packaging/windows/mingw-prep.sh
+++ b/Packaging/windows/mingw-prep.sh
@@ -38,7 +38,7 @@ cd "tmp-mingw-${MINGW_ARCH}-prep"
 wget -q https://www.libsdl.org/release/SDL2-devel-${SDLDEV_VERS}-mingw.tar.gz -OSDL2-devel-${SDLDEV_VERS}-mingw.tar.gz
 tar -xzf SDL2-devel-${SDLDEV_VERS}-mingw.tar.gz
 sed -i '/$(CROSS_PATH)\/cmake/ s/^/#/' SDL2*/Makefile
-CROSS_PATH=/usr ARCHITECTURES=${MINGW_ARCH} $SUDO make -eC SDL2*/ cross
+$SUDO make -C SDL2*/ cross CROSS_PATH=/usr ARCHITECTURES=${MINGW_ARCH}
 
 wget -q https://github.com/jedisct1/libsodium/releases/download/${SODIUM_VERS}-RELEASE/libsodium-${SODIUM_VERS}-mingw.tar.gz -Olibsodium-${SODIUM_VERS}-mingw.tar.gz
 tar -xzf libsodium-${SODIUM_VERS}-mingw.tar.gz --no-same-owner


### PR DESCRIPTION
When running mingw-prep without sudo it would not load the env variables into the sdl2 make.