### PR TITLE
Simplifying MinGW instructions

### DIFF
--- a/.github/workflows/Windows_MinGW_x64.yml
+++ b/.github/workflows/Windows_MinGW_x64.yml
@@ -30,7 +30,6 @@ jobs:
       run: >
         sudo apt-get update &&
         sudo apt-get install -y cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 libz-mingw-w64-dev gettext dpkg-dev wget git sudo smpq &&
-        sudo rm /usr/x86_64-w64-mingw32/lib/libz.dll.a &&
         sudo Packaging/windows/mingw-prep64.sh
 
     - name: Configure CMake

--- a/.github/workflows/Windows_MinGW_x86.yml
+++ b/.github/workflows/Windows_MinGW_x86.yml
@@ -30,7 +30,6 @@ jobs:
       run: >
         sudo apt update &&
         sudo apt install -y cmake gcc-mingw-w64-i686 g++-mingw-w64-i686 pkg-config-mingw-w64-i686 libz-mingw-w64-dev gettext dpkg-dev wget git sudo smpq &&
-        sudo rm /usr/i686-w64-mingw32/lib/libz.dll.a &&
         sudo Packaging/windows/mingw-prep.sh
 
     - name: Configure CMake

--- a/Packaging/windows/mingw-prep.sh
+++ b/Packaging/windows/mingw-prep.sh
@@ -51,3 +51,6 @@ find "${MINGW_PREFIX}/lib/pkgconfig/" -name '*.pc' -exec \
 # Fixup CMake prefix:
 find "${MINGW_PREFIX}" -name '*.cmake' -exec \
   $SUDO sed -i "s|/opt/local/${MINGW_ARCH}|${MINGW_PREFIX}|" '{}' \;
+
+# Fixup zlib linking:
+$SUDO mv "${MINGW_PREFIX}/lib/libz.dll.a" "${MINGW_PREFIX}/lib/libz.dll.a.bak"

--- a/docs/building.md
+++ b/docs/building.md
@@ -178,7 +178,7 @@ cd devilutionx
 ```bash
 # Install MinGW build tools
 sudo apt-get update
-sudo apt-get install cmake git libz-mingw-w64-dev mingw-w64 mingw-w64-tools wget
+sudo apt-get install cmake git libz-mingw-w64-dev mingw-w64 mingw-w64-tools smpq wget
 ```
 
 ### 32-bit

--- a/docs/building.md
+++ b/docs/building.md
@@ -182,8 +182,11 @@ sudo apt-get install cmake git libz-mingw-w64-dev mingw-w64 mingw-w64-tools smpq
 ```
 
 ### 32-bit
+The 32-bit build depends on the 32-bit MinGW Development Libraries for [SDL2](https://www.libsdl.org/download-2.0.php) and [libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.12.tar.gz). These dependencies will need to be placed in the appropriate subfolders under `/usr/i686-w64-mingw32`.
 
-In addition to the 32-bit MinGW build tools, the build process depends on the 32-bit MinGW Development Libraries for [SDL2](https://www.libsdl.org/download-2.0.php) and [libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.12.tar.gz). These dependencies will need to be placed in the appropriate subfolders under `/usr/i686-w64-mingw32`. This can be done automatically by running [`Packaging/windows/mingw-prep.sh`](/Packaging/windows/mingw-prep.sh).
+When linking zlib, libpng will always prefer dynamically linking with `libz.dll.a` if it can be found. We recommend renaming or deleting `libz.dll.a` to force libpng to use static linkage. This will prevent errors about missing dlls when you attempt to run the game.
+
+These can be done automatically by running [`Packaging/windows/mingw-prep.sh`](/Packaging/windows/mingw-prep.sh).
 
 ```bash
 # Download the 32-bit development libraries for SDL2 and libsodium
@@ -193,24 +196,18 @@ Packaging/windows/mingw-prep.sh
 ```
 
 ### 64-bit
+The 64-bit build depends on the 64-bit MinGW Development Libraries of [SDL2](https://www.libsdl.org/download-2.0.php) and [libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.12.tar.gz). These dependencies will need to be placed in the appropriate subfolders under `/usr/x86_64-w64-mingw32`.
 
-In addition to the 64-bit MinGW build tools, the build process depends on the 64-bit MinGW Development Libraries of [SDL2](https://www.libsdl.org/download-2.0.php) and [libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.12.tar.gz). These dependencies will need to be placed in the appropriate subfolders under `/usr/x86_64-w64-mingw32`. This can be done automatically by running [`Packaging/windows/mingw-prep64.sh`](/Packaging/windows/mingw-prep64.sh).
+When linking zlib, libpng will always prefer dynamically linking with `libz.dll.a` if it can be found. We recommend renaming or deleting `libz.dll.a` to force libpng to use static linkage. This will prevent errors about missing dlls when you attempt to run the game.
+
+These can be done automatically by running [`Packaging/windows/mingw-prep64.sh`](/Packaging/windows/mingw-prep64.sh).
 
 ```bash
 # Download the 64-bit development libraries for SDL2 and libsodium
 # as well as the headers for zlib and place them in subfolders under
 # /usr/x86_64-w64-mingw32
 Packaging/windows/mingw-prep64.sh
-```
-
-### Before compiling
-
-When linking zlib, libpng will always prefer dynamically linking with `libz.dll.a` if it can be found. We recommend renaming or deleting `libz.dll.a` to force libpng to use static linkage. This will prevent errors about missing dlls when you attempt to run the game.
-
-```bash
-sudo mv /usr/i686-w64-mingw32/lib/libz.dll.a /usr/i686-w64-mingw32/lib/libz.dll.a.bak
-sudo mv /usr/x86_64-w64-mingw32/lib/libz.dll.a /usr/x86_64-w64-mingw32/lib/libz.dll.a.bak
-```
+```  
 
 ### Compiling
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -175,13 +175,16 @@ cd devilutionx
 
 ### Installing dependencies on WSL, Debian and Ubuntu
 
+#### MinGW build tools
+
 ```bash
 # Install MinGW build tools
 sudo apt-get update
 sudo apt-get install cmake git libz-mingw-w64-dev mingw-w64 mingw-w64-tools smpq wget
 ```
 
-### 32-bit
+#### 32-bit
+
 The 32-bit build depends on the 32-bit MinGW Development Libraries for [SDL2](https://www.libsdl.org/download-2.0.php) and [libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.12.tar.gz). These dependencies will need to be placed in the appropriate subfolders under `/usr/i686-w64-mingw32`.
 
 When linking zlib, libpng will always prefer dynamically linking with `libz.dll.a` if it can be found. We recommend renaming or deleting `libz.dll.a` to force libpng to use static linkage. This will prevent errors about missing dlls when you attempt to run the game.
@@ -195,7 +198,8 @@ These can be done automatically by running [`Packaging/windows/mingw-prep.sh`](/
 Packaging/windows/mingw-prep.sh
 ```
 
-### 64-bit
+#### 64-bit
+
 The 64-bit build depends on the 64-bit MinGW Development Libraries of [SDL2](https://www.libsdl.org/download-2.0.php) and [libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.12.tar.gz). These dependencies will need to be placed in the appropriate subfolders under `/usr/x86_64-w64-mingw32`.
 
 When linking zlib, libpng will always prefer dynamically linking with `libz.dll.a` if it can be found. We recommend renaming or deleting `libz.dll.a` to force libpng to use static linkage. This will prevent errors about missing dlls when you attempt to run the game.
@@ -213,7 +217,7 @@ Packaging/windows/mingw-prep64.sh
 
 By compiling the `package` target, the build will produce the `devilutionx.zip` archive which should contain all the dlls necessary to run the game. If you encounter any errors suggesting a dll is missing, try extracting the dlls from the zip archive.
 
-### 32-bit
+#### 32-bit
 
 ```bash
 # Configure the project to disable unit tests,
@@ -228,7 +232,7 @@ cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/mingwcc.toolchain.cm
 cmake --build build -j $(getconf _NPROCESSORS_ONLN) --target package
 ```
 
-### 64-bit
+#### 64-bit
 
 ```bash
 # Configure the project to disable unit tests,

--- a/docs/building.md
+++ b/docs/building.md
@@ -191,6 +191,11 @@ When linking zlib, libpng will always prefer dynamically linking with `libz.dll.
 
 These can be done automatically by running [`Packaging/windows/mingw-prep.sh`](/Packaging/windows/mingw-prep.sh).
 
+Note: If your `i686-w64-mingw32` directory is not in `/usr` (e.g. when on
+Debian), the mingw-prep scripts and the CMake command won't work. You need
+adjust the mingw-prep scripts and pass `-DCROSS_PREFIX=/path` to CMake to set
+the path to the parent of the `i686-w64-mingw32` directory.
+
 ```bash
 # Download the 32-bit development libraries for SDL2 and libsodium
 # as well as the headers for zlib and place them in subfolders under
@@ -205,6 +210,11 @@ The 64-bit build depends on the 64-bit MinGW Development Libraries of [SDL2](htt
 When linking zlib, libpng will always prefer dynamically linking with `libz.dll.a` if it can be found. We recommend renaming or deleting `libz.dll.a` to force libpng to use static linkage. This will prevent errors about missing dlls when you attempt to run the game.
 
 These can be done automatically by running [`Packaging/windows/mingw-prep64.sh`](/Packaging/windows/mingw-prep64.sh).
+
+Note: If your `x86_64-w64-mingw32` directory is not in `/usr` (e.g. when
+on Debian), the mingw-prep scripts and the CMake command won't work. You need
+adjust the mingw-prep scripts and pass `-DCROSS_PREFIX=/path` to CMake to set
+the path to the parent of the `x86_64-w64-mingw32` directory.  
 
 ```bash
 # Download the 64-bit development libraries for SDL2 and libsodium
@@ -247,9 +257,6 @@ cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/mingwcc64.toolchain.
 cmake --build build -j $(getconf _NPROCESSORS_ONLN) --target package
 ```
 
-Note: If your `(i686|x86_64)-w64-mingw32` directory is not in `/usr` (e.g. when on Debian), the mingw-prep scripts and the CMake
-command won't work. You need adjust the mingw-prep scripts and pass `-DCROSS_PREFIX=/path` to CMake to set the path to the parent
-of the `(i686|x86_64)-w64-mingw32` directory.
 </details>
 <details><summary>Windows via Visual Studio</summary>
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -175,14 +175,17 @@ cd devilutionx
 
 ### Installing dependencies on WSL, Debian and Ubuntu
 
+```bash
+# Install MinGW build tools
+sudo apt-get update
+sudo apt-get install cmake git libz-mingw-w64-dev mingw-w64 mingw-w64-tools wget
+```
+
 ### 32-bit
 
 In addition to the 32-bit MinGW build tools, the build process depends on the 32-bit MinGW Development Libraries for [SDL2](https://www.libsdl.org/download-2.0.php) and [libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.12.tar.gz). These dependencies will need to be placed in the appropriate subfolders under `/usr/i686-w64-mingw32`. This can be done automatically by running [`Packaging/windows/mingw-prep.sh`](/Packaging/windows/mingw-prep.sh).
 
 ```bash
-# Install the 32-bit MinGW build tools
-sudo apt install cmake gcc-mingw-w64-i686 g++-mingw-w64-i686 pkg-config-mingw-w64-i686 libz-mingw-w64-dev git wget
-
 # Download the 32-bit development libraries for SDL2 and libsodium
 # as well as the headers for zlib and place them in subfolders under
 # /usr/i686-w64-mingw32
@@ -194,9 +197,6 @@ Packaging/windows/mingw-prep.sh
 In addition to the 64-bit MinGW build tools, the build process depends on the 64-bit MinGW Development Libraries of [SDL2](https://www.libsdl.org/download-2.0.php) and [libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.12.tar.gz). These dependencies will need to be placed in the appropriate subfolders under `/usr/x86_64-w64-mingw32`. This can be done automatically by running [`Packaging/windows/mingw-prep64.sh`](/Packaging/windows/mingw-prep64.sh).
 
 ```bash
-# Install the 64-bit MinGW build tools
-sudo apt install cmake gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 pkg-config-mingw-w64-x86-64 libz-mingw-w64-dev git wget
-
 # Download the 64-bit development libraries for SDL2 and libsodium
 # as well as the headers for zlib and place them in subfolders under
 # /usr/x86_64-w64-mingw32

--- a/docs/building.md
+++ b/docs/building.md
@@ -171,6 +171,7 @@ sudo apt-get install git
 git clone https://github.com/diasurgical/devilutionx
 cd devilutionx
 ```
+
 </details>
 
 ### Installing dependencies on WSL, Debian and Ubuntu
@@ -183,7 +184,7 @@ sudo apt-get update
 sudo apt-get install cmake git libz-mingw-w64-dev mingw-w64 mingw-w64-tools smpq wget
 ```
 
-#### 32-bit
+<details><summary>MinGW 32-bit</summary>
 
 The 32-bit build depends on the 32-bit MinGW Development Libraries for [SDL2](https://www.libsdl.org/download-2.0.php) and [libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.12.tar.gz). These dependencies will need to be placed in the appropriate subfolders under `/usr/i686-w64-mingw32`.
 
@@ -203,7 +204,26 @@ the path to the parent of the `i686-w64-mingw32` directory.
 Packaging/windows/mingw-prep.sh
 ```
 
-#### 64-bit
+### Compiling
+
+By compiling the `package` target, the build will produce the `devilutionx.zip` archive which should contain all the dlls necessary to run the game. If you encounter any errors suggesting a dll is missing, try extracting the dlls from the zip archive.
+
+```bash
+# Configure the project to disable unit tests,
+# statically link bzip2 and libsodium,
+# and enable Discord integration
+cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/mingwcc.toolchain.cmake \
+    -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DDEVILUTIONX_SYSTEM_BZIP2=OFF \
+    -DDEVILUTIONX_STATIC_LIBSODIUM=ON -DDISCORD_INTEGRATION=ON
+
+# Build the "package" target which produces devilutionx.zip
+# containing all the necessary dlls to run the game
+cmake --build build -j $(getconf _NPROCESSORS_ONLN) --target package
+```
+
+</details>
+
+<details open><summary>MinGW 64-bit</summary>
 
 The 64-bit build depends on the 64-bit MinGW Development Libraries of [SDL2](https://www.libsdl.org/download-2.0.php) and [libsodium](https://github.com/jedisct1/libsodium/releases) as well as headers for [zlib](https://zlib.net/zlib-1.2.12.tar.gz). These dependencies will need to be placed in the appropriate subfolders under `/usr/x86_64-w64-mingw32`.
 
@@ -225,25 +245,6 @@ Packaging/windows/mingw-prep64.sh
 
 ### Compiling
 
-By compiling the `package` target, the build will produce the `devilutionx.zip` archive which should contain all the dlls necessary to run the game. If you encounter any errors suggesting a dll is missing, try extracting the dlls from the zip archive.
-
-#### 32-bit
-
-```bash
-# Configure the project to disable unit tests,
-# statically link bzip2 and libsodium,
-# and enable Discord integration
-cmake -S. -Bbuild -DCMAKE_TOOLCHAIN_FILE=../CMake/platforms/mingwcc.toolchain.cmake \
-    -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DDEVILUTIONX_SYSTEM_BZIP2=OFF \
-    -DDEVILUTIONX_STATIC_LIBSODIUM=ON -DDISCORD_INTEGRATION=ON
-
-# Build the "package" target which produces devilutionx.zip
-# containing all the necessary dlls to run the game
-cmake --build build -j $(getconf _NPROCESSORS_ONLN) --target package
-```
-
-#### 64-bit
-
 ```bash
 # Configure the project to disable unit tests,
 # statically link bzip2 and libsodium,
@@ -258,6 +259,9 @@ cmake --build build -j $(getconf _NPROCESSORS_ONLN) --target package
 ```
 
 </details>
+
+</details>
+
 <details><summary>Windows via Visual Studio</summary>
 
 ### Installing dependencies

--- a/docs/building.md
+++ b/docs/building.md
@@ -167,7 +167,7 @@ You can launch WSL anytime by typing wsl or ubuntu in a Command Prompt or Powers
 In a WSL terminal run these commands to get the source code for DevilutionX
 
 ```
-sudo apt install git
+sudo apt-get install git
 git clone https://github.com/diasurgical/devilutionx
 cd devilutionx
 ```


### PR DESCRIPTION
- mingw-w64 installs gcc and g++ in i686 and x86-64, so have that simpler instruction instead of breaking it out separately.
- pkg-config-mingw-w64-(i686|x86-64) both select mingw-w64-tools to install, so just preselect to simplify.
- cmake --target package no longer works without smpq.
- move mv libz.dll.a command from an instruction to a command in mingw-prep
- reorganize for a simple read and default to opening 64-bit when opening the mingw heading