### PR TITLE
magic_enum: Customize enums where they're declared

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -345,6 +345,7 @@ add_devilutionx_object_library(libdevilutionx_game_mode
 )
 target_link_dependencies(libdevilutionx_game_mode PRIVATE
   tl
+  magic_enum::magic_enum
   libdevilutionx_options
 )
 
@@ -374,6 +375,7 @@ add_devilutionx_object_library(libdevilutionx_init
   init.cpp
 )
 target_link_dependencies(libdevilutionx_init PUBLIC
+  magic_enum::magic_enum
   libdevilutionx_assets
   libdevilutionx_config
   libdevilutionx_mpq
@@ -462,6 +464,7 @@ add_devilutionx_object_library(libdevilutionx_lighting
 target_link_dependencies(libdevilutionx_lighting PUBLIC
   DevilutionX::SDL
   fmt::fmt
+  magic_enum::magic_enum
   tl
   unordered_dense::unordered_dense
   libdevilutionx_vision
@@ -600,6 +603,7 @@ add_devilutionx_object_library(libdevilutionx_options
 target_link_dependencies(libdevilutionx_options PUBLIC
   DevilutionX::SDL
   fmt::fmt
+  magic_enum::magic_enum
   tl
   unordered_dense::unordered_dense
   libdevilutionx_controller_buttons
@@ -639,6 +643,7 @@ target_link_dependencies(libdevilutionx_player
   PUBLIC
   DevilutionX::SDL
   fmt::fmt
+  magic_enum::magic_enum
   tl
   unordered_dense::unordered_dense
   libdevilutionx_game_mode
@@ -724,6 +729,16 @@ if(NOSOUND)
   add_devilutionx_object_library(libdevilutionx_sound
     effects_stubs.cpp
     engine/sound_stubs.cpp
+  )
+  target_link_dependencies(libdevilutionx_sound PUBLIC
+    DevilutionX::SDL
+    fmt::fmt
+    magic_enum::magic_enum
+    tl
+    unordered_dense::unordered_dense
+    libdevilutionx_options
+    libdevilutionx_random
+    libdevilutionx_sdl2_to_1_2_backports
   )
 else()
   add_devilutionx_object_library(libdevilutionx_sound

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -22,12 +22,6 @@
 #include "player.h"
 #include "utils/is_of.hpp"
 
-template <>
-struct magic_enum::customize::enum_range<devilution::SfxID> {
-	static constexpr int min = static_cast<int>(devilution::SfxID::None);
-	static constexpr int max = static_cast<int>(devilution::SfxID::LAST);
-};
-
 namespace devilution {
 
 int sfxdelay;

--- a/Source/monstdat.cpp
+++ b/Source/monstdat.cpp
@@ -29,18 +29,6 @@
 #include "textdat.h"
 #include "utils/language.h"
 
-template <>
-struct magic_enum::customize::enum_range<devilution::_monster_id> {
-	static constexpr int min = devilution::MT_INVALID;
-	static constexpr int max = devilution::NUM_DEFAULT_MTYPES;
-};
-
-template <>
-struct magic_enum::customize::enum_range<devilution::monster_resistance> {
-	static constexpr int min = 0;
-	static constexpr int max = 128;
-};
-
 namespace devilution {
 
 namespace {

--- a/Source/monstdat.h
+++ b/Source/monstdat.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include <magic_enum/magic_enum.hpp>
+
 #include "cursor.h"
 #include "textdat.h"
 
@@ -349,3 +351,15 @@ void LoadMonsterData();
 size_t GetNumMonsterSprites();
 
 } // namespace devilution
+
+template <>
+struct magic_enum::customize::enum_range<devilution::_monster_id> {
+	static constexpr int min = devilution::MT_INVALID;
+	static constexpr int max = devilution::NUM_DEFAULT_MTYPES;
+};
+
+template <>
+struct magic_enum::customize::enum_range<devilution::monster_resistance> {
+	static constexpr int min = 0;
+	static constexpr int max = 128;
+};

--- a/Source/sound_effect_enums.h
+++ b/Source/sound_effect_enums.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include <magic_enum/magic_enum.hpp>
+
 namespace devilution {
 
 enum class HeroSpeech : uint8_t {
@@ -1039,3 +1041,9 @@ enum sfx_flag : uint8_t {
 };
 
 } // namespace devilution
+
+template <>
+struct magic_enum::customize::enum_range<devilution::SfxID> {
+	static constexpr int min = static_cast<int>(devilution::SfxID::None);
+	static constexpr int max = static_cast<int>(devilution::SfxID::LAST);
+};

--- a/Source/textdat.cpp
+++ b/Source/textdat.cpp
@@ -14,12 +14,6 @@
 #include "effects.h"
 #include "utils/language.h"
 
-template <>
-struct magic_enum::customize::enum_range<devilution::_speech_id> {
-	static constexpr int min = devilution::TEXT_NONE;
-	static constexpr int max = devilution::NUM_DEFAULT_TEXT_IDS;
-};
-
 namespace devilution {
 
 /* todo: move text out of struct */

--- a/Source/textdat.h
+++ b/Source/textdat.h
@@ -5,11 +5,11 @@
  */
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <string>
 
 #include <expected.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 #include "sound_effect_enums.h"
 
@@ -440,3 +440,9 @@ tl::expected<_speech_id, std::string> ParseSpeechId(std::string_view value);
 void LoadTextData();
 
 } // namespace devilution
+
+template <>
+struct magic_enum::customize::enum_range<devilution::_speech_id> {
+	static constexpr int min = devilution::TEXT_NONE;
+	static constexpr int max = devilution::NUM_DEFAULT_TEXT_IDS;
+};


### PR DESCRIPTION
This necessitates dependencies on `magic_enum` in more places but avoids obscure hard-to-debug errors, such as the one seen in the DOS port PR.