### PR TITLE
Add a `--log-to-file` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -465,3 +465,6 @@ uwp-project/Assets/gendata
 uwp-project/Assets/ui_art
 !uwp-project/devilutionX_TemporaryKey.pfx
 /.s390x-ccache/
+
+# Temporary directory for prep scripts and other purposes.
+/tmp/


### PR DESCRIPTION
Useful for platforms like DOS where it's not necessarily easy to redirect the log output.