### PR TITLE
dos: Clean up paths for better logging

### DIFF
--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -330,7 +330,7 @@ std::vector<std::string> GetMPQSearchPaths()
 	if (paths[0] == paths[1] || (paths.size() == 3 && (paths[0] == paths[2] || paths[1] == paths[2])))
 		paths.pop_back();
 
-#if (defined(__unix__) || defined(__APPLE__)) && !defined(__ANDROID__)
+#if (defined(__unix__) || defined(__APPLE__)) && !defined(__ANDROID__) && !defined(__DJGPP__)
 	// `XDG_DATA_HOME` is usually the root path of `paths::PrefPath()`, so we only
 	// add `XDG_DATA_DIRS`.
 	const char *xdgDataDirs = std::getenv("XDG_DATA_DIRS");

--- a/Source/utils/file_util.h
+++ b/Source/utils/file_util.h
@@ -9,7 +9,7 @@
 
 namespace devilution {
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__DJGPP__)
 constexpr char DirectorySeparator = '\\';
 #define DIRECTORY_SEPARATOR_STR "\\"
 #else

--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -42,7 +42,7 @@ void AddTrailingSlash(std::string &path)
 		path += DirectorySeparator;
 }
 
-std::string FromSDL(char *s)
+[[maybe_unused]] std::string FromSDL(char *s)
 {
 	const SDLUniquePtr<char> pinned(s);
 	std::string result = (s != nullptr ? s : "");
@@ -72,7 +72,11 @@ const std::string &NxdkGetPrefPath()
 const std::string &BasePath()
 {
 	if (!basePath) {
+#if defined(__DJGPP__)
+		basePath = std::string();
+#else
 		basePath = FromSDL(SDL_GetBasePath());
+#endif
 	}
 	return *basePath;
 }
@@ -80,13 +84,15 @@ const std::string &BasePath()
 const std::string &PrefPath()
 {
 	if (!prefPath) {
-#if defined(__IPHONEOS__)
+#if defined(__DJGPP__)
+		prefPath = std::string();
+#elif defined(__IPHONEOS__)
 		prefPath = FromSDL(IOSGetPrefPath());
 #elif defined(NXDK)
 		prefPath = NxdkGetPrefPath();
 #else
 		prefPath = FromSDL(SDL_GetPrefPath("diasurgical", "devilution"));
-#if !defined(__amigaos__)
+#if !defined(__amigaos__) && !defined(__DJGPP__)
 		if (FileExistsAndIsWriteable("diablo.ini")) {
 			prefPath = std::string();
 		}
@@ -99,13 +105,15 @@ const std::string &PrefPath()
 const std::string &ConfigPath()
 {
 	if (!configPath) {
-#if defined(__IPHONEOS__)
+#if defined(__DJGPP__)
+		configPath = std::string();
+#elif defined(__IPHONEOS__)
 		configPath = FromSDL(IOSGetPrefPath());
 #elif defined(NXDK)
 		configPath = NxdkGetPrefPath();
 #else
 		configPath = FromSDL(SDL_GetPrefPath("diasurgical", "devilution"));
-#if !defined(__amigaos__)
+#if !defined(__amigaos__) && !defined(__DJGPP__)
 		if (FileExistsAndIsWriteable("diablo.ini")) {
 			configPath = std::string();
 		}
@@ -118,8 +126,8 @@ const std::string &ConfigPath()
 const std::string &AssetsPath()
 {
 	if (!assetsPath) {
-#if __EMSCRIPTEN__
-		assetsPath.emplace("assets/");
+#if __EMSCRIPTEN__ || defined(__DJGPP__)
+		assetsPath.emplace("assets" DIRECTORY_SEPARATOR_STR);
 #elif defined(NXDK)
 		assetsPath.emplace("D:\\assets\\");
 #elif defined(__3DS__) || defined(__SWITCH__)


### PR DESCRIPTION
1. Prevents warnings in `--verbose` mode from unimplemented `SDL_GetBase/PrefPath`. These were the first 4 "This operation is not supported" messages that were logged previously.

2. Removes Linux directories from MPQ search paths on DOS.

3. Uses backslash directory separator on DOS. DJGPP libc supports both but this is DOS, we should use backslash.

Now the `--verbose` SDL_LOG.txt looks much cleaner:

```
VERBOSE: Paths:
    base:
    pref:
  config:
  assets: assets\
VERBOSE: MPQ search paths:
     1. ''
VERBOSE:   Found: devx in
VERBOSE: Missing: fonts
DEBUG: DOS: Keyboard ISR code size is 48 bytes
DEBUG: Unknown pixel format
DEBUG: SVGA: Ignoring mode 0x102: Bad attributes
DEBUG: SVGA: Ignoring mode 0x104: Bad attributes
DEBUG: SVGA: Ignoring mode 0x106: Bad attributes
DEBUG: SVGA: Ignoring mode 0x107: No double-buffering
DEBUG: SVGA: Ignoring mode 0x112: No double-buffering
DEBUG: SVGA: Ignoring mode 0x115: No double-buffering
DEBUG: SVGA: Ignoring mode 0x116: No double-buffering
DEBUG: SVGA: Ignoring mode 0x117: No double-buffering
DEBUG: SVGA: Ignoring mode 0x209: No double-buffering
DEBUG: SVGA: Ignoring mode 0x20A: No double-buffering
DEBUG: SVGA: Ignoring mode 0x225: No double-buffering
DEBUG: SVGA: VBE lists 42 modes
VERBOSE: Removed file: Diablo1ReadOnlyTest.foo
VERBOSE: Paths:
    base:
    pref:
  config:
  assets: assets\
VERBOSE: MPQ search paths:
     1. ''
VERBOSE: Paths:
    base:
    pref:
  config:
  assets: assets\
VERBOSE: MPQ search paths:
     1. ''
VERBOSE:   Found: DIABDAT in
VERBOSE: Missing: hfbard
VERBOSE: Missing: hfbarb
DEBUG: That operation is not supported
VERBOSE: Control: device None -> KeyboardAndMouse, mode None -> KeyboardAndMouse
```