### PR TITLE
Fix Error for Unique Monsters with Indices > 127

### DIFF
--- a/Source/monster.h
+++ b/Source/monster.h
@@ -336,7 +336,7 @@ struct Monster { // note: missing field _mAFNum
 	std::string_view name() const
 	{
 		if (uniqueType != UniqueMonsterType::None)
-			return pgettext("monster", UniqueMonstersData[static_cast<int8_t>(uniqueType)].mName);
+			return pgettext("monster", UniqueMonstersData[static_cast<size_t>(uniqueType)].mName);
 
 		return pgettext("monster", data().name);
 	}
@@ -390,7 +390,7 @@ struct Monster { // note: missing field _mAFNum
 	{
 		unsigned int baseLevel = data().level;
 		if (isUnique()) {
-			baseLevel = UniqueMonstersData[static_cast<int8_t>(uniqueType)].mlevel;
+			baseLevel = UniqueMonstersData[static_cast<size_t>(uniqueType)].mlevel;
 			if (baseLevel != 0) {
 				baseLevel *= 2;
 			} else {


### PR DESCRIPTION
Unique monster IDs are stored in a uint8_t, which means that we should be able to have up to 254 unique monsters (ID 255 is reserved for representing the monster having no unique monster ID). However, because two lines in the code cast the unique monster ID to an int8_t, we get errors for unique monsters with ID beyond 127.

This PR fixes that, by changing those casts, so that we properly support unique monster indices from 127-254, almost doubling the amount of unique monster indices available for modding.