### PR TITLE
Overlay Text and Party Panel Realignment

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -17,6 +17,7 @@
 #include "engine/render/primitive_render.hpp"
 #include "levels/gendung.h"
 #include "levels/setmaps.h"
+#include "options.h"
 #include "player.h"
 #include "utils/attributes.h"
 #include "utils/enum_traits.h"
@@ -1410,6 +1411,10 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, cons
 void DrawAutomapText(const Surface &out)
 {
 	Point linePosition { 8, 8 };
+
+	if (*GetOptions().Graphics.showFPS) {
+		linePosition.y += 15;
+	}
 
 	if (gbIsMultiplayer) {
 		if (GameName != "0.0.0.0" && !IsLoopback) {

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -1369,7 +1369,7 @@ void DrawFPS(const Surface &out)
 		    : BufCopy(buf, fps / FpsPow10, ".", fps % FpsPow10, " FPS");
 		formatted = { buf, static_cast<std::string_view::size_type>(end - buf) };
 	};
-	DrawString(out, formatted, Point { 8, 68 }, { .flags = UiFlags::ColorRed });
+	DrawString(out, formatted, Point { 8, 8 }, { .flags = UiFlags::ColorRed });
 }
 
 /**

--- a/Source/panels/partypanel.cpp
+++ b/Source/panels/partypanel.cpp
@@ -15,6 +15,7 @@
 #include "engine/render/primitive_render.hpp"
 #include "engine/size.hpp"
 #include "inv.h"
+#include "options.h"
 #include "pfile.h"
 #include "playerdat.hpp"
 #include "qol/monhealthbar.h"
@@ -43,7 +44,7 @@ const PartySpriteOffset ClassSpriteOffsets[] = {
 OptionalOwnedClxSpriteList PartyMemberFrame;
 OptionalOwnedClxSpriteList PlayerTags;
 
-Point PartyPanelPos = { 5, 5 };
+Point PartyPanelPos = { 8, 8 };
 Rectangle PortraitFrameRects[MAX_PLRS];
 int RightClickedPortraitIndex = -1;
 constexpr int HealthBarHeight = 7;
@@ -167,7 +168,9 @@ void DrawPartyMemberInfoPanel(const Surface &out)
 
 	Point pos = PartyPanelPos;
 	if (AutomapActive)
-		pos.y += PortraitFrameSize.height + FrameGap;
+		pos.y += 60;
+	if (*GetOptions().Graphics.showFPS)
+		pos.y += 15;
 
 	int currentLongestNameWidth = PortraitFrameSize.width;
 	bool portraitUnderCursor = false;


### PR DESCRIPTION
Moves FPS to the top
Map text overlay will change it's height based if the FPS display is on
Party panel is shifted to line up with the text
Party panel will move with the other texts instead of sitting behind it.

<img width="853" height="480" alt="Screenshot from 2025-10-04-07-00-57" src="https://github.com/user-attachments/assets/c5bf67b6-209c-45fc-a9aa-31cf175f107a" />
<img width="853" height="480" alt="Screenshot from 2025-10-04-07-01-00" src="https://github.com/user-attachments/assets/daed767e-f8bf-4b2f-b85d-0fff41bfb9fe" />
<img width="853" height="480" alt="Screenshot from 2025-10-04-07-01-25" src="https://github.com/user-attachments/assets/e52ffce2-d80a-4425-81e0-5d08e460e204" />
<img width="853" height="480" alt="Screenshot from 2025-10-04-07-01-27" src="https://github.com/user-attachments/assets/6437bc5c-e725-4b83-9fb6-f2a3fa24f9ed" />
<img width="853" height="480" alt="Screenshot from 2025-10-04-07-11-08" src="https://github.com/user-attachments/assets/ee71dfc1-ad2b-403d-bcac-e10fcd48a594" />
