### PR TITLE
Party Panel: Fix Second Column and Shrink Gaps for Single Column in 480p

### DIFF
--- a/Source/panels/partypanel.cpp
+++ b/Source/panels/partypanel.cpp
@@ -291,6 +291,10 @@ void DrawPartyMemberInfoPanel(const Surface &out)
 		if (pos.y >= GetMainPanel().position.y - PortraitFrameSize.height - 10) {
 			// If so we need to draw the next set of portraits back at the top and to the right of the original position
 			pos.y = PartyPanelPos.y;
+			if (AutomapActive)
+				pos.y += (FrameGap * 4);
+			if (*GetOptions().Graphics.showFPS)
+				pos.y += FrameGap;
 			// Add the current longest name width to the X position
 			pos.x += currentLongestNameWidth + (FrameGap / 2);
 		}


### PR DESCRIPTION
Before
<img width="640" height="480" alt="Screenshot from 2025-10-04-15-25-14" src="https://github.com/user-attachments/assets/aa5c0dce-85ce-4eac-9738-bd02adc14a4a" />
<img width="640" height="480" alt="Screenshot from 2025-10-04-15-25-26" src="https://github.com/user-attachments/assets/4e28f809-95ac-42ff-8de3-02911ad83f1d" />

After
<img width="640" height="480" alt="Screenshot from 2025-10-04-15-21-24" src="https://github.com/user-attachments/assets/1e08ab74-fa33-40a5-aa68-2694eb850a57" />
<img width="640" height="480" alt="Screenshot from 2025-10-04-15-21-10" src="https://github.com/user-attachments/assets/306f95f2-7d4c-4919-89e4-672c8cde830c" />
