### PR TITLE
Linux_x86_64_test.yml: Switch to Ninja

### DIFF
--- a/.github/workflows/Linux_x86_64_test.yml
+++ b/.github/workflows/Linux_x86_64_test.yml
@@ -36,14 +36,14 @@ jobs:
       uses: actions/cache@v4
       with:
         path: build
-        key: ${{ github.workflow }}-v2-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v2-
+        key: ${{ github.workflow }}-v3-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v3-
 
     # We specify `-DDEVILUTIONX_SYSTEM_BENCHMARK=OFF` to work around the following error:
     # lto1: fatal error: bytecode stream in file ‘/usr/lib/x86_64-linux-gnu/libbenchmark_main.a’ generated with LTO version 11.2 instead of the expected 11.3
     - name: Build tests
       run: |
-        cmake -S. -Bbuild -DENABLE_CODECOVERAGE=ON -DDEVILUTIONX_SYSTEM_BENCHMARK=OFF
+        cmake -S. -Bbuild -G Ninja -DENABLE_CODECOVERAGE=ON -DDEVILUTIONX_SYSTEM_BENCHMARK=OFF
         wget -qnc https://github.com/diasurgical/devilutionx-assets/releases/download/v2/spawn.mpq -P build
         cmake --build build -j $(nproc)
 


### PR DESCRIPTION
I suspect there is a bug in make or CMake resulting in failures such as https://github.com/diasurgical/DevilutionX/actions/runs/18358278148/job/52295813861, switching to Ninja seems to fix it.

Sending this now to make things green, and will look into a proper fix later.