### PR TITLE
Fix a handful of SDL2 API calls

### DIFF
--- a/Source/controls/input.h
+++ b/Source/controls/input.h
@@ -16,7 +16,7 @@ inline bool PollEvent(SDL_Event *event)
 #ifdef USE_SDL3
 	const bool result = SDL_PollEvent(event);
 #else
-	const bool result = SDL_PollEvent(event) >= 0;
+	const bool result = SDL_PollEvent(event) != 0;
 #endif
 	if (result) {
 		UnlockControllerState(*event);

--- a/Source/utils/sdl_compat.h
+++ b/Source/utils/sdl_compat.h
@@ -322,8 +322,8 @@ inline bool SDL_CursorVisible() { return SDL_ShowCursor(SDL_QUERY) == SDL_ENABLE
 inline bool SDLC_PointInRect(const SDL_Point *p, const SDL_Rect *r) { return SDL_PointInRect(p, r) == SDL_TRUE; }
 #endif
 
-inline bool SDLC_ShowCursor() { return SDL_ShowCursor(SDL_ENABLE) == 0; }
-inline bool SDLC_HideCursor() { return SDL_ShowCursor(SDL_DISABLE) == 0; }
+inline bool SDLC_ShowCursor() { return SDL_ShowCursor(SDL_ENABLE) >= 0; }
+inline bool SDLC_HideCursor() { return SDL_ShowCursor(SDL_DISABLE) >= 0; }
 
 inline size_t SDL_ReadIO(SDL_IOStream *context, void *ptr, size_t size)
 {
@@ -419,7 +419,7 @@ inline bool SDLC_SetSurfaceAndPaletteColors(SDL_Surface *surface, SDL_Palette *p
 	if (SDL_SetPaletteColors(palette, colors, firstcolor, ncolors) < 0)
 		return false;
 	if (surface->format->palette != palette)
-		return SDL_SetSurfacePalette(surface, palette);
+		return SDL_SetSurfacePalette(surface, palette) == 0;
 	return true;
 #endif
 }


### PR DESCRIPTION
I found a few places where the return values from the SDL2 API calls are no longer being handled properly. With these changes, I was able to build against SDL2 on Windows and actually play the game.