### PR TITLE
SDL3: Set app metadata

### DIFF
--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include "DiabloUI/diabloui.h"
+#include "config.h"
 #include "control.h"
 #include "controls/controller.h"
 #ifndef USE_SDL1
@@ -511,6 +512,12 @@ bool SpawnWindow(const char *lpWindowName)
 #endif
 
 #ifdef USE_SDL3
+	SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_NAME_STRING, PROJECT_NAME);
+	SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_VERSION_STRING, PROJECT_VERSION);
+	SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_IDENTIFIER_STRING, "org.diasurgical.devilutionx");
+	SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_URL_STRING, "https://devilutionx.com");
+	SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_TYPE_STRING, "game");
+
 	SDL_SetHint(SDL_HINT_RETURN_KEY_HIDES_IME, "1");
 #endif
 #if SDL_VERSION_ATLEAST(2, 0, 4) && !defined(USE_SDL3)


### PR DESCRIPTION
App metadata is a new SDL3 feature: https://wiki.libsdl.org/SDL3/SDL_SetAppMetadataProperty

One nice thing about it is that it is logged by SDL when verbose logging is enabled:
```
App name: DevilutionX
App version: 1.6.0-dev-Debug-6130351a6
App ID: org.diasurgical.devilutionx
SDL revision: release-3.2.24-0-ga8589a842
```