### PR TITLE
SDL3: Fix nearest-neighbor scaling

### DIFF
--- a/Source/engine/dx.cpp
+++ b/Source/engine/dx.cpp
@@ -243,28 +243,14 @@ void RenderPresent()
 #ifndef USE_SDL1
 	if (renderer != nullptr) {
 #ifdef USE_SDL3
-		if (!SDL_UpdateTexture(texture.get(), nullptr, surface->pixels, surface->pitch)) ErrSdl();
-#else
-		if (SDL_UpdateTexture(texture.get(), nullptr, surface->pixels, surface->pitch) <= -1) ErrSdl();
-#endif
-
-			// Clear buffer to avoid artifacts in case the window was resized
-			// TODO only do this if window was resized
-#ifdef USE_SDL3
 		if (!SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255)) ErrSdl();
-#else
-		if (SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255) <= -1) ErrSdl();
-#endif
-
-#ifdef USE_SDL3
 		if (!SDL_RenderClear(renderer)) ErrSdl();
-#else
-		if (SDL_RenderClear(renderer) <= -1) ErrSdl();
-#endif
-
-#ifdef USE_SDL3
+		if (!SDL_UpdateTexture(texture.get(), nullptr, surface->pixels, surface->pitch)) ErrSdl();
 		if (!SDL_RenderTexture(renderer, texture.get(), nullptr, nullptr)) ErrSdl();
 #else
+		if (SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255) <= -1) ErrSdl();
+		if (SDL_RenderClear(renderer) <= -1) ErrSdl();
+		if (SDL_UpdateTexture(texture.get(), nullptr, surface->pixels, surface->pitch) <= -1) ErrSdl();
 		if (SDL_RenderCopy(renderer, texture.get(), nullptr, nullptr) <= -1) ErrSdl();
 #endif
 

--- a/Source/hwcursor.cpp
+++ b/Source/hwcursor.cpp
@@ -144,7 +144,7 @@ bool SetHardwareCursorFromSurface(SDL_Surface *surface, HotpointPosition hotpoin
 			    size.width, size.height, scaledSize.width, scaledSize.height);
 #endif
 #ifdef USE_SDL3
-			SDL_BlitSurfaceScaled(converted.get(), nullptr, scaledSurface.get(), nullptr, SDL_SCALEMODE_NEAREST);
+			SDL_BlitSurfaceScaled(converted.get(), nullptr, scaledSurface.get(), nullptr, SDL_SCALEMODE_PIXELART);
 #else
 			SDL_BlitScaled(converted.get(), nullptr, scaledSurface.get(), nullptr);
 #endif

--- a/Source/utils/sdl_compat.h
+++ b/Source/utils/sdl_compat.h
@@ -236,7 +236,7 @@ inline const SDL_GamepadDeviceEvent &SDLC_EventGamepadDevice(const SDL_Event &ev
 
 #define SDLC_SURFACE_BITSPERPIXEL(surface) surface->format->BitsPerPixel
 
-inline bool SDLC_PushEvent(SDL_Event *event) { return SDL_PushEvent(event) == 0; }
+inline bool SDLC_PushEvent(SDL_Event *event) { return SDL_PushEvent(event) == 1; }
 
 inline
 #ifdef USE_SDL1


### PR DESCRIPTION
For some reason, setting the scaling on just `texture` still results in bluriness. However, setting the default scaling mode on the renderer fixes it.

Also, does a few more things the SDL3 way.