### PR TITLE
[1.5] Avoid sending PT_DISCONNECT packet to dropped player

### DIFF
--- a/Source/dvlnet/base.cpp
+++ b/Source/dvlnet/base.cpp
@@ -409,10 +409,14 @@ bool base::SNetLeaveGame(int type)
 
 bool base::SNetDropPlayer(int playerid, uint32_t flags)
 {
+	const plr_t plr = static_cast<plr_t>(playerid);
 	auto pkt = pktfty->make_packet<PT_DISCONNECT>(plr_self,
 	    PLR_BROADCAST,
-	    static_cast<plr_t>(playerid),
+	    plr,
 	    static_cast<leaveinfo_t>(flags));
+	// Disconnect at the network layer first so we
+	// don't send players their own disconnect packet
+	DisconnectNet(plr);
 	send(*pkt);
 	RecvLocal(*pkt);
 	return true;

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -123,6 +123,12 @@ void tcp_client::send(packet &pkt)
 	});
 }
 
+void tcp_client::DisconnectNet(plr_t plr)
+{
+	if (local_server != nullptr)
+		local_server->DisconnectNet(plr);
+}
+
 bool tcp_client::SNetLeaveGame(int type)
 {
 	auto ret = base::SNetLeaveGame(type);

--- a/Source/dvlnet/tcp_client.h
+++ b/Source/dvlnet/tcp_client.h
@@ -23,6 +23,7 @@ public:
 
 	void poll() override;
 	void send(packet &pkt) override;
+	void DisconnectNet(plr_t plr) override;
 
 	bool SNetLeaveGame(int type) override;
 

--- a/Source/dvlnet/tcp_server.h
+++ b/Source/dvlnet/tcp_server.h
@@ -30,6 +30,7 @@ public:
 	tcp_server(asio::io_context &ioc, const std::string &bindaddr,
 	    unsigned short port, packet_factory &pktfty);
 	std::string LocalhostSelf();
+	void DisconnectNet(plr_t plr);
 	void Close();
 	virtual ~tcp_server();
 


### PR DESCRIPTION
Backport the first commit of #6829 to the 1.5 branch