### PR TITLE
Fix compiler warning about cases not handled in switch

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -760,7 +760,7 @@ bool TryGrowWall(int id, MissileID type, Point position, Direction growDirection
 	case Direction::South:
 	case Direction::West:
 	case Direction::North:
-	case Direction::East:
+	case Direction::East: {
 		Point gapPos = position + Displacement(Right(growDirection)) - Displacement(growDirection);
 		if (CanPlaceWall(gapPos)) {
 			Missile *missile = PlaceWall(id, type, gapPos, direction, spellLevel, damage);
@@ -773,6 +773,9 @@ bool TryGrowWall(int id, MissileID type, Point position, Direction growDirection
 				assert(gapPos == missile->position.tile); // Check that the tile we checked against (CanPlaceWall) didn't change
 			}
 		}
+		break;
+	}
+	default:
 		break;
 	}
 


### PR DESCRIPTION
```
[ 73%] Building CXX object Source/CMakeFiles/libdevilutionx.dir/missiles.cpp.o
.../DevilutionX/Source/missiles.cpp: In function ‘bool devilution::{anonymous}::TryGrowWall(int, devilution::MissileID, devilution::Point, devilution::Direction, devilution::Direction, int, int)’:
.../DevilutionX/Source/missiles.cpp:759:16: warning: enumeration value ‘SouthWest’ not handled in switch [-Wswitch]
  759 |         switch (growDirection) {
      |                ^
.../DevilutionX/Source/missiles.cpp:759:16: warning: enumeration value ‘NorthWest’ not handled in switch [-Wswitch]
.../DevilutionX/Source/missiles.cpp:759:16: warning: enumeration value ‘NorthEast’ not handled in switch [-Wswitch]
.../DevilutionX/Source/missiles.cpp:759:16: warning: enumeration value ‘SouthEast’ not handled in switch [-Wswitch]
.../DevilutionX/Source/missiles.cpp:759:16: warning: enumeration value ‘NoDirection’ not handled in switch [-Wswitch]
```