### PR TITLE
Fix scrolling issue in shops when SDL is at least 2

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -789,7 +789,7 @@ void GameEventHandler(const SDL_Event &event, uint16_t modState)
 		return;
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	case SDL_EVENT_MOUSE_WHEEL:
-		if (SDLC_EventWheelIntY(event)) { // Up
+		if (SDLC_EventWheelIntY(event) > 0) { // Up
 			if (IsPlayerInStore()) {
 				StoreUp();
 			} else if (QuestLogIsOpen) {
@@ -807,7 +807,7 @@ void GameEventHandler(const SDL_Event &event, uint16_t modState)
 			} else {
 				KeymapperPress(MouseScrollUpButton);
 			}
-		} else if (SDLC_EventWheelIntY(event)) { // down
+		} else if (SDLC_EventWheelIntY(event) < 0) { // down
 			if (IsPlayerInStore()) {
 				StoreDown();
 			} else if (QuestLogIsOpen) {
@@ -3471,3 +3471,4 @@ void PrintScreen(SDL_Keycode vkey)
 }
 
 } // namespace devilution
+


### PR DESCRIPTION
I noticed that scrolling using the mouse wheel stopped working in shops on the main branch, and this change seemed to fix it for me.

Bug: Scrolling with the mouse wheel doesn't visually update the shop list, but you still hear the noise of mousing over items, etc.

Fixed: Scrolling with the mouse wheel in shops works as expected