### PR TITLE
Fix MSVC warnings

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -62,11 +62,11 @@ T SwapLE(T in)
 {
 	switch (sizeof(T)) {
 	case 2:
-		return Swap16LE(in);
+		return static_cast<T>(Swap16LE(static_cast<uint16_t>(in)));
 	case 4:
-		return Swap32LE(in);
+		return static_cast<T>(Swap32LE(static_cast<uint32_t>(in)));
 	case 8:
-		return Swap64LE(in);
+		return static_cast<T>(Swap64LE(in));
 	default:
 		return in;
 	}

--- a/Source/panels/console.cpp
+++ b/Source/panels/console.cpp
@@ -591,7 +591,7 @@ void DrawConsole(const Surface &out)
 
 	if (FirstRender) {
 		SDL_Rect sdlInputRect = MakeSdlRect(InputRect);
-		SDL_SetTextInputArea(ghMainWnd, &sdlInputRect, ConsoleInputState.cursorPosition());
+		SDL_SetTextInputArea(ghMainWnd, &sdlInputRect, static_cast<int>(ConsoleInputState.cursorPosition()));
 		SDLC_StartTextInput(ghMainWnd);
 		FirstRender = false;
 		if (ConsoleLines.empty()) {

--- a/Source/utils/log.hpp
+++ b/Source/utils/log.hpp
@@ -55,15 +55,16 @@ std::string format(std::string_view fmt, Args &&...args)
 	{
 		return fmt::format(fmt::runtime(fmt), std::forward<Args>(args)...);
 	}
+#if FMT_EXCEPTIONS
 	FMT_CATCH(const fmt::format_error &e)
 	{
-		std::string error;
-#if FMT_EXCEPTIONS
 		// e.what() is undefined if exceptions are disabled, so we wrap it
 		// with an `FMT_EXCEPTIONS` check.
-		error = e.what();
+		std::string error = e.what();
 #else
-		error = "unknown (FMT_EXCEPTIONS disabled)";
+	FMT_CATCH(const fmt::format_error)
+	{
+		std::string error = "unknown (FMT_EXCEPTIONS disabled)";
 #endif
 		std::string fullError = StrCat("Format error, fmt: ", fmt, " error: ", error);
 		SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, "%s", error.c_str());

--- a/Source/utils/sdl2_to_1_2_backports.cpp
+++ b/Source/utils/sdl2_to_1_2_backports.cpp
@@ -384,8 +384,8 @@ int SDL_BlitScaled(SDL_Surface *src, SDL_Rect *srcrect,
 	if (NULL == dstrect) {
 		dst_x0 = 0;
 		dst_y0 = 0;
-		dst_x1 = dst_w - 1;
-		dst_y1 = dst_h - 1;
+		dst_x1 = static_cast<float>(dst_w - 1);
+		dst_y1 = static_cast<float>(dst_h - 1);
 	} else {
 		dst_x0 = dstrect->x;
 		dst_y0 = dstrect->y;
@@ -396,8 +396,8 @@ int SDL_BlitScaled(SDL_Surface *src, SDL_Rect *srcrect,
 	if (NULL == srcrect) {
 		src_x0 = 0;
 		src_y0 = 0;
-		src_x1 = src_w - 1;
-		src_y1 = src_h - 1;
+		src_x1 = static_cast<float>(src_w - 1);
+		src_y1 = static_cast<float>(src_h - 1);
 	} else {
 		src_x0 = srcrect->x;
 		src_y0 = srcrect->y;
@@ -413,7 +413,7 @@ int SDL_BlitScaled(SDL_Surface *src, SDL_Rect *srcrect,
 
 		if (src_x1 >= src->w) {
 			dst_x1 -= (src_x1 - src->w + 1) * scaling_w;
-			src_x1 = src->w - 1;
+			src_x1 = static_cast<float>(src->w - 1);
 		}
 
 		if (src_y0 < 0) {
@@ -423,7 +423,7 @@ int SDL_BlitScaled(SDL_Surface *src, SDL_Rect *srcrect,
 
 		if (src_y1 >= src->h) {
 			dst_y1 -= (src_y1 - src->h + 1) * scaling_h;
-			src_y1 = src->h - 1;
+			src_y1 = static_cast<float>(src->h - 1);
 		}
 	}
 
@@ -442,7 +442,7 @@ int SDL_BlitScaled(SDL_Surface *src, SDL_Rect *srcrect,
 
 	if (dst_x1 >= dst->clip_rect.w) {
 		src_x1 -= (dst_x1 - dst->clip_rect.w + 1) / scaling_w;
-		dst_x1 = dst->clip_rect.w - 1;
+		dst_x1 = static_cast<float>(dst->clip_rect.w - 1);
 	}
 
 	if (dst_y0 < 0) {
@@ -452,7 +452,7 @@ int SDL_BlitScaled(SDL_Surface *src, SDL_Rect *srcrect,
 
 	if (dst_y1 >= dst->clip_rect.h) {
 		src_y1 -= (dst_y1 - dst->clip_rect.h + 1) / scaling_h;
-		dst_y1 = dst->clip_rect.h - 1;
+		dst_y1 = static_cast<float>(dst->clip_rect.h - 1);
 	}
 
 	/* Translate back to surface coordinates */


### PR DESCRIPTION
Fixes all MSVC warnings.
Tested x64-Debug-SDL2, x64-Release-SDL2, x86-Debug-SDL2, x64-Debug-SDL1.

Question: is there a better warning fix for loadsave.cpp changes?