### PR TITLE
Skip tests gracefully when MPQ assets are missing

### DIFF
--- a/test/inv_test.cpp
+++ b/test/inv_test.cpp
@@ -9,12 +9,17 @@
 namespace devilution {
 namespace {
 
+constexpr const char MissingMpqAssetsSkipReason[] = "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test suite";
+
 class InvTest : public ::testing::Test {
 public:
 	void SetUp() override
 	{
 		Players.resize(1);
 		MyPlayer = &Players[0];
+		if (missingMpqAssets_) {
+			GTEST_SKIP() << MissingMpqAssetsSkipReason;
+		}
 	}
 
 	static void SetUpTestSuite()
@@ -22,15 +27,21 @@ public:
 		LoadCoreArchives();
 		LoadGameArchives();
 
-		// The tests need spawn.mpq or diabdat.mpq
-		// Please provide them so that the tests can run successfully
-		ASSERT_TRUE(HaveMainData());
+		missingMpqAssets_ = !HaveMainData();
+		if (missingMpqAssets_) {
+			return;
+		}
 
 		InitCursor();
 		LoadSpellData();
 		LoadItemData();
 	}
+
+private:
+	static bool missingMpqAssets_;
 };
+
+bool InvTest::missingMpqAssets_ = false;
 
 /* Set up a given item as a spell scroll, allowing for its usage. */
 void set_up_scroll(Item &item, SpellID spell)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,8 +1,82 @@
 #include <gtest/gtest.h>
 
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
 #include "headless_mode.hpp"
 #include "options.h"
 #include "utils/paths.h"
+
+namespace {
+
+// Custom listener to track and report skipped tests with reasons
+class SkippedTestListener : public testing::EmptyTestEventListener {
+	std::unordered_map<std::string, int> skipReasons;
+	int totalSkipped = 0;
+
+	void OnTestPartResult(const testing::TestPartResult &test_part_result) override
+	{
+		if (test_part_result.skipped()) {
+			totalSkipped++;
+			std::string reason = test_part_result.message();
+			if (reason.empty()) {
+				reason = "No reason provided";
+			}
+			skipReasons[reason]++;
+		}
+	}
+
+	void OnTestProgramEnd(const testing::UnitTest & /*unit_test*/) override
+	{
+		if (totalSkipped > 0) {
+			std::cout << "\n";
+			std::cout << "========================================\n";
+			std::cout << "Test Skip Summary\n";
+			std::cout << "========================================\n";
+			std::cout << "Total tests skipped: " << totalSkipped << "\n\n";
+
+			// Show skip reasons, with most specific reasons first
+			bool hasMpqReason = false;
+			bool hasNoReason = false;
+			int mpqSkipCount = 0;
+			int noReasonCount = 0;
+
+			for (const auto &[reason, count] : skipReasons) {
+				if (reason.find("MPQ assets") != std::string::npos) {
+					hasMpqReason = true;
+					mpqSkipCount += count;
+					continue;
+				}
+				if (reason == "No reason provided") {
+					hasNoReason = true;
+					noReasonCount += count;
+					continue;
+				}
+				std::cout << "  • " << count << " test" << (count > 1 ? "s" : "") << " skipped: " << reason << "\n";
+			}
+
+			// Combine MPQ-related skips for clearer output
+			if (hasMpqReason) {
+				int totalMpqRelated = mpqSkipCount + (hasNoReason ? noReasonCount : 0);
+				std::cout << "  • " << totalMpqRelated << " test" << (totalMpqRelated > 1 ? "s" : "")
+				          << " skipped: MPQ assets (spawn.mpq or DIABDAT.MPQ) not found\n";
+				if (hasNoReason && noReasonCount > 0) {
+					std::cout << "    (" << noReasonCount << " test" << (noReasonCount > 1 ? "s" : "")
+					          << " automatically skipped due to test suite setup failure)\n";
+				}
+			} else if (hasNoReason) {
+				// Only "No reason provided" - show it as-is
+				std::cout << "  • " << noReasonCount << " test" << (noReasonCount > 1 ? "s" : "")
+				          << " skipped: " << "No reason provided" << "\n";
+			}
+
+			std::cout << "========================================\n";
+		}
+	}
+};
+
+} // namespace
 
 int main(int argc, char **argv)
 {
@@ -20,5 +94,10 @@ int main(int argc, char **argv)
 #endif
 
 	testing::InitGoogleTest(&argc, argv);
+
+	// Add custom listener to track and report skipped tests
+	testing::TestEventListeners &listeners = testing::UnitTest::GetInstance()->listeners();
+	listeners.Append(new SkippedTestListener());
+
 	return RUN_ALL_TESTS();
 }

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -15,6 +15,8 @@
 namespace devilution {
 namespace {
 
+constexpr const char MissingMpqAssetsSkipReason[] = "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test suite";
+
 void SwapLE(ItemPack &pack)
 {
 	pack.iSeed = Swap32LE(pack.iSeed);
@@ -894,6 +896,10 @@ class NetPackTest : public ::testing::Test {
 public:
 	void SetUp() override
 	{
+		if (missingMpqAssets_) {
+			GTEST_SKIP() << MissingMpqAssetsSkipReason;
+		}
+
 		Players.resize(2);
 		MyPlayer = &Players[0];
 		gbIsMultiplayer = true;
@@ -976,9 +982,10 @@ public:
 		LoadCoreArchives();
 		LoadGameArchives();
 
-		// The tests need spawn.mpq or diabdat.mpq
-		// Please provide them so that the tests can run successfully
-		ASSERT_TRUE(HaveMainData());
+		missingMpqAssets_ = !HaveMainData();
+		if (missingMpqAssets_) {
+			return;
+		}
 
 		SetHellfireState(false);
 		InitCursor();
@@ -987,7 +994,12 @@ public:
 		LoadMonsterData();
 		LoadItemData();
 	}
+
+private:
+	static bool missingMpqAssets_;
 };
+
+bool NetPackTest::missingMpqAssets_ = false;
 
 bool TestNetPackValidation()
 {

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -86,7 +86,9 @@ TEST(Player, PM_DoGotHit)
 {
 	LoadCoreArchives();
 	LoadGameArchives();
-	ASSERT_TRUE(HaveMainData());
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
 	LoadPlayerDataFiles();
 
 	Players.resize(1);
@@ -191,8 +193,9 @@ TEST(Player, CreatePlayer)
 	LoadGameArchives();
 
 	// The tests need spawn.mpq or diabdat.mpq
-	// Please provide them so that the tests can run successfully
-	ASSERT_TRUE(HaveMainData());
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
 
 	LoadPlayerDataFiles();
 	LoadMonsterData();

--- a/test/timedemo_test.cpp
+++ b/test/timedemo_test.cpp
@@ -48,8 +48,9 @@ void RunTimedemo(std::string timedemoFolderName)
 	LoadGameArchives();
 
 	// The tests need spawn.mpq or diabdat.mpq
-	// Please provide them so that the tests can run successfully
-	ASSERT_TRUE(HaveMainData());
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
 
 	const std::string unitTestFolderCompletePath = paths::BasePath() + "test/fixtures/timedemo/" + timedemoFolderName;
 	paths::SetPrefPath(unitTestFolderCompletePath);

--- a/test/vendor_test.cpp
+++ b/test/vendor_test.cpp
@@ -16,6 +16,7 @@ using ::testing::AnyOf;
 using ::testing::Eq;
 
 constexpr int SEED = 75357;
+constexpr const char MissingMpqAssetsSkipReason[] = "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test suite";
 
 std::string itemtype_str(ItemType type);
 std::string misctype_str(item_misc_id type);
@@ -78,6 +79,10 @@ class VendorTest : public ::testing::Test {
 public:
 	void SetUp() override
 	{
+		if (missingMpqAssets_) {
+			GTEST_SKIP() << MissingMpqAssetsSkipReason;
+		}
+
 		Players.resize(1);
 		MyPlayer = &Players[0];
 		gbIsHellfire = false;
@@ -90,12 +95,20 @@ public:
 	{
 		LoadCoreArchives();
 		LoadGameArchives();
-		ASSERT_TRUE(HaveMainData());
+		missingMpqAssets_ = !HaveMainData();
+		if (missingMpqAssets_) {
+			return;
+		}
 		LoadPlayerDataFiles();
 		LoadItemData();
 		LoadSpellData();
 	}
+
+private:
+	static bool missingMpqAssets_;
 };
+
+bool VendorTest::missingMpqAssets_ = false;
 
 std::string itemtype_str(ItemType type)
 {

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -368,8 +368,9 @@ TEST(Writehero, pfile_write_hero)
 	LoadGameArchives();
 
 	// The tests need spawn.mpq or diabdat.mpq
-	// Please provide them so that the tests can run successfully
-	ASSERT_TRUE(HaveMainData());
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
 
 	const std::string savePath = paths::BasePath() + "multi_0.sv";
 	paths::SetPrefPath(paths::BasePath());


### PR DESCRIPTION
## Summary
- add a GoogleTest listener that aggregates skip reasons (with a dedicated heading when MPQ assets are missing)
- replace `ASSERT_TRUE(HaveMainData())` with `GTEST_SKIP()` in every test that needs DIABDAT.MPQ/spawn.mpq
- guard MPQ-dependent fixtures so each test skips cleanly when the suite setup detects missing assets

## Testing
- `ctest -R InvTest --output-on-failure`
- `ctest -R NetPackTest --output-on-failure`
- `ctest -R VendorTest --output-on-failure`
- `./inv_test` (with DIABDAT.MPQ temporarily removed) → verifies the skip summary output
