### PR TITLE
Add latency data to ZT public game descriptions

### DIFF
--- a/Source/DiabloUI/multi/selgame.cpp
+++ b/Source/DiabloUI/multi/selgame.cpp
@@ -288,6 +288,11 @@ void selgame_GameSelection_Focus(size_t value)
 				infoString.append(playerName);
 				infoString += ' ';
 			}
+			infoString += '\n';
+			if (gameInfo.peerIsRelayed.value_or(false))
+				infoString.append(fmt::format(fmt::runtime(_("Latency: {:d} ms (RELAYED)")), gameInfo.latency.value_or(0)));
+			else
+				infoString.append(fmt::format(fmt::runtime(_("Latency: {:d} ms")), gameInfo.latency.value_or(0)));
 		} else {
 			infoString.append(GetErrorMessageIncompatibility(gameInfo.gameData));
 		}

--- a/Source/dvlnet/base_protocol.h
+++ b/Source/dvlnet/base_protocol.h
@@ -551,8 +551,10 @@ std::vector<GameInfo> base_protocol<P>::get_gamelist()
 	std::vector<GameInfo> ret;
 	ret.reserve(game_list.size());
 	for (const auto &[name, gameInfo] : game_list) {
-		const auto &[gameData, players, _] = gameInfo;
-		ret.push_back(GameInfo { name, gameData, players });
+		const auto &[gameData, players, endpoint] = gameInfo;
+		std::optional<int> latency = proto.get_latency_to(endpoint);
+		std::optional<bool> isRelayed = proto.is_peer_relayed(endpoint);
+		ret.push_back(GameInfo { name, gameData, players, latency, isRelayed });
 	}
 	c_sort(ret, [](const GameInfo &a, const GameInfo &b) { return a.name < b.name; });
 	return ret;

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -45,6 +45,8 @@ struct GameInfo {
 	std::string name;
 	GameData gameData;
 	std::vector<std::string> players;
+	std::optional<int> latency;
+	std::optional<bool> peerIsRelayed;
 };
 
 extern bool gbSomebodyWonGameKludge;


### PR DESCRIPTION
It's the ping to the "host"; that is, the client who sends the info reply packet. And since you are not in-game with this client, you can't get echo latency because there is no TCP connection through which to send echo packets. So ZT latency is all we can show here.

<img width="778" height="514" alt="image" src="https://github.com/user-attachments/assets/ebcceb19-a5a1-44a5-b75a-37b52b70743d" />

This resolves #8097