### PR TITLE
Add Lua API for mana shield persistence across level changes

### DIFF
--- a/CMake/Assets.cmake
+++ b/CMake/Assets.cmake
@@ -159,6 +159,7 @@ set(devilutionx_assets
   lua/devilutionx/events.lua
   lua/inspect.lua
   lua/mods/clock/init.lua
+  lua/mods/persist_mana_shield/init.lua
   lua/repl_prelude.lua
   plrgfx/warrior/whu/whufm.trn
   plrgfx/warrior/whu/whulm.trn

--- a/CMake/Tests.cmake
+++ b/CMake/Tests.cmake
@@ -25,6 +25,8 @@ set(tests
   effects_test
   inv_test
   items_test
+  lua_player_test
+  mana_shield_integration_test
   math_test
   missiles_test
   multi_logging_test

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -122,6 +122,7 @@ set(libdevilutionx_SRCS
   lua/modules/dev/towners.cpp
   lua/modules/i18n.cpp
   lua/modules/items.cpp
+  lua/modules/level.cpp
   lua/modules/log.cpp
   lua/modules/monsters.cpp
   lua/modules/player.cpp
@@ -651,6 +652,7 @@ target_link_dependencies(libdevilutionx_player
   DevilutionX::SDL
   fmt::fmt
   magic_enum::magic_enum
+  sol2::sol2
   tl
   unordered_dense::unordered_dense
   libdevilutionx_game_mode

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -3433,6 +3433,7 @@ tl::expected<void, std::string> LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	CompleteProgress();
 
 	LoadGameLevelCalculateCursor();
+	LuaEvent("EnterLevel");
 	return {};
 }
 

--- a/Source/lua/lua_global.cpp
+++ b/Source/lua/lua_global.cpp
@@ -16,6 +16,7 @@
 #include "lua/modules/hellfire.hpp"
 #include "lua/modules/i18n.hpp"
 #include "lua/modules/items.hpp"
+#include "lua/modules/level.hpp"
 #include "lua/modules/log.hpp"
 #include "lua/modules/monsters.hpp"
 #include "lua/modules/player.hpp"
@@ -276,6 +277,7 @@ void LuaInitialize()
 	    "devilutionx.version", PROJECT_VERSION,
 	    "devilutionx.i18n", LuaI18nModule(lua),
 	    "devilutionx.items", LuaItemModule(lua),
+	    "devilutionx.level", LuaLevelModule(lua),
 	    "devilutionx.log", LuaLogModule(lua),
 	    "devilutionx.audio", LuaAudioModule(lua),
 	    "devilutionx.monsters", LuaMonstersModule(lua),

--- a/Source/lua/modules/level.cpp
+++ b/Source/lua/modules/level.cpp
@@ -1,0 +1,32 @@
+#include "lua/modules/level.hpp"
+
+#include <sol/sol.hpp>
+
+#include "levels/gendung.h"
+#include "lua/metadoc.hpp"
+
+namespace devilution {
+
+sol::table LuaLevelModule(sol::state_view &lua)
+{
+	sol::table table = lua.create_table();
+
+	LuaSetDocFn(table, "type", "() -> integer",
+	    "Returns the current level type (TOWN, CATHEDRAL, etc.)",
+	    []() {
+		    return leveltype;
+	    });
+
+	// Dungeon type constants
+	table["TOWN"] = DTYPE_TOWN;
+	table["CATHEDRAL"] = DTYPE_CATHEDRAL;
+	table["CATACOMBS"] = DTYPE_CATACOMBS;
+	table["CAVES"] = DTYPE_CAVES;
+	table["HELL"] = DTYPE_HELL;
+	table["NEST"] = DTYPE_NEST;
+	table["CRYPT"] = DTYPE_CRYPT;
+
+	return table;
+}
+
+} // namespace devilution

--- a/Source/lua/modules/level.hpp
+++ b/Source/lua/modules/level.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <sol/sol.hpp>
+
+namespace devilution {
+
+sol::table LuaLevelModule(sol::state_view &lua);
+
+} // namespace devilution

--- a/Source/lua/modules/player.cpp
+++ b/Source/lua/modules/player.cpp
@@ -9,6 +9,8 @@
 #include "inv.h"
 #include "items.h"
 #include "lua/metadoc.hpp"
+#include "msg.h"
+#include "multi.h"
 #include "player.h"
 
 namespace devilution {
@@ -93,6 +95,12 @@ void InitPlayerUserType(sol::state_view &lua)
 		    player._pMana = player._pMaxMana;
 		    player._pManaBase = player._pMaxManaBase;
 	    });
+	LuaSetDocProperty(playerType, "manaShield", "boolean", "Whether mana shield is active (writeable)", [](const Player &player) { return player.pManaShield; }, [](Player &player, bool value) {
+		    if (value == player.pManaShield)
+			    return;
+		    player.pManaShield = value;
+		    if (gbIsMultiplayer && &player == MyPlayer)
+			    NetSendCmd(true, value ? CMD_SETSHIELD : CMD_REMSHIELD); });
 }
 } // namespace
 

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1618,6 +1618,16 @@ void ModOptions::SetHellfireEnabled(bool enableHellfire)
 	}
 }
 
+void ModOptions::SetModEnabled(std::string_view modName, bool enabled)
+{
+	for (auto &modEntry : GetModEntries()) {
+		if (modEntry.name == modName) {
+			modEntry.enabled.SetValue(enabled);
+			return;
+		}
+	}
+}
+
 std::forward_list<ModOptions::ModEntry> &ModOptions::GetModEntries()
 {
 	if (modEntries)

--- a/Source/options.h
+++ b/Source/options.h
@@ -851,6 +851,7 @@ struct ModOptions : OptionCategoryBase {
 	void AddModEntry(const std::string &modName);
 	void RemoveModEntry(const std::string &modName);
 	void SetHellfireEnabled(bool enableHellfire);
+	void SetModEnabled(std::string_view modName, bool enabled);
 
 private:
 	struct ModEntry {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -41,6 +41,7 @@
 #include "levels/trigs.h"
 #include "lighting.h"
 #include "loadsave.h"
+#include "lua/lua_global.hpp"
 #include "minitext.h"
 #include "missiles.h"
 #include "monster.h"
@@ -365,6 +366,9 @@ void DropHalfPlayersGold(Player &player)
 void InitLevelChange(Player &player)
 {
 	const Player &myPlayer = *MyPlayer;
+
+	if (&player == MyPlayer)
+		LuaEvent("LeavingLevel");
 
 	RemoveEnemyReferences(player);
 	RemovePlrMissiles(player);

--- a/assets/lua/devilutionx/events.lua
+++ b/assets/lua/devilutionx/events.lua
@@ -67,6 +67,14 @@ local events = {
   ---Called every frame at the end.
   GameDrawComplete = CreateEvent(),
   __doc_GameDrawComplete = "Called every frame at the end.",
+
+  ---Called before leaving the current level (before mana shield is cleared).
+  LeavingLevel = CreateEvent(),
+  __doc_LeavingLevel = "Called before leaving the current level (before mana shield is cleared).",
+
+  ---Called after entering a new level.
+  EnterLevel = CreateEvent(),
+  __doc_EnterLevel = "Called after entering a new level.",
 }
 
 ---Registers a custom event type with the given name.

--- a/assets/lua/mods/persist_mana_shield/init.lua
+++ b/assets/lua/mods/persist_mana_shield/init.lua
@@ -1,0 +1,27 @@
+-- Persist Mana Shield Mod
+-- This mod makes Mana Shield persist across level changes (except when entering town).
+
+local events = require("devilutionx.events")
+local level = require("devilutionx.level")
+local player = require("devilutionx.player")
+
+local savedManaShield = false
+
+-- Save mana shield state before leaving the level
+events.LeavingLevel.add(function()
+  local p = player.self()
+  if p ~= nil then
+    savedManaShield = p.manaShield
+  end
+end)
+
+-- Restore mana shield after entering a new level (unless in town)
+events.EnterLevel.add(function()
+  if savedManaShield and level.type() ~= level.TOWN then
+    local p = player.self()
+    if p ~= nil then
+      p.manaShield = true
+    end
+  end
+  savedManaShield = false
+end)

--- a/test/lua_player_test.cpp
+++ b/test/lua_player_test.cpp
@@ -1,0 +1,302 @@
+#include <gtest/gtest.h>
+
+#include <sol/sol.hpp>
+
+#include "levels/gendung.h"
+#include "lua/modules/level.hpp"
+#include "lua/modules/player.hpp"
+#include "player.h"
+
+using namespace devilution;
+
+class LuaPlayerModuleTest : public ::testing::Test {
+protected:
+	void SetUp() override
+	{
+		Players.resize(1);
+		MyPlayer = &Players[0];
+		MyPlayer->pManaShield = false;
+		leveltype = DTYPE_CATHEDRAL;
+	}
+
+	void TearDown() override
+	{
+		Players.clear();
+		MyPlayer = nullptr;
+	}
+};
+
+TEST_F(LuaPlayerModuleTest, ManaShieldProperty)
+{
+	sol::state lua;
+	lua.open_libraries(sol::lib::base);
+
+	sol::table playerModule = LuaPlayerModule(lua);
+
+	// Get player.self()
+	sol::protected_function selfFn = playerModule["self"];
+	ASSERT_TRUE(selfFn.valid());
+
+	auto result = selfFn();
+	ASSERT_TRUE(result.valid());
+
+	Player *player = result.get<Player *>();
+	ASSERT_EQ(player, MyPlayer);
+
+	// Test initial manaShield state
+	EXPECT_FALSE(player->pManaShield);
+
+	// Test setting manaShield via direct property access
+	player->pManaShield = true;
+	EXPECT_TRUE(player->pManaShield);
+
+	player->pManaShield = false;
+	EXPECT_FALSE(player->pManaShield);
+}
+
+TEST_F(LuaPlayerModuleTest, ManaShieldLuaPropertyAccess)
+{
+	sol::state lua;
+	lua.open_libraries(sol::lib::base);
+
+	sol::table playerModule = LuaPlayerModule(lua);
+
+	// Make player module available as global for Lua script testing
+	lua["player"] = playerModule;
+
+	// Test reading manaShield property via Lua script
+	MyPlayer->pManaShield = false;
+	{
+		auto result = lua.safe_script("return player.self().manaShield");
+		ASSERT_TRUE(result.valid());
+		EXPECT_FALSE(result.get<bool>());
+	}
+
+	// Test that setting via C++ is reflected in Lua
+	MyPlayer->pManaShield = true;
+	{
+		auto result = lua.safe_script("return player.self().manaShield");
+		ASSERT_TRUE(result.valid());
+		EXPECT_TRUE(result.get<bool>());
+	}
+
+	// Test setting manaShield via Lua script
+	// Note: This will try to send network commands, but since we're in test mode
+	// without network initialization, we just verify the property changes
+	MyPlayer->pManaShield = true;
+	{
+		// Setting to same value should be a no-op
+		auto result = lua.safe_script("player.self().manaShield = true");
+		ASSERT_TRUE(result.valid());
+		EXPECT_TRUE(MyPlayer->pManaShield);
+	}
+}
+
+class LuaLevelModuleTest : public ::testing::Test {
+protected:
+	void SetUp() override
+	{
+		leveltype = DTYPE_CATHEDRAL;
+	}
+};
+
+TEST_F(LuaLevelModuleTest, LevelTypeFunction)
+{
+	sol::state lua;
+	lua.open_libraries(sol::lib::base);
+
+	sol::table levelModule = LuaLevelModule(lua);
+
+	// Get level.type()
+	sol::protected_function typeFn = levelModule["type"];
+	ASSERT_TRUE(typeFn.valid());
+
+	// Test all dungeon types
+	leveltype = DTYPE_TOWN;
+	{
+		auto result = typeFn();
+		ASSERT_TRUE(result.valid());
+		EXPECT_EQ(result.get<int>(), DTYPE_TOWN);
+	}
+
+	leveltype = DTYPE_CATHEDRAL;
+	{
+		auto result = typeFn();
+		ASSERT_TRUE(result.valid());
+		EXPECT_EQ(result.get<int>(), DTYPE_CATHEDRAL);
+	}
+
+	leveltype = DTYPE_CATACOMBS;
+	{
+		auto result = typeFn();
+		ASSERT_TRUE(result.valid());
+		EXPECT_EQ(result.get<int>(), DTYPE_CATACOMBS);
+	}
+
+	leveltype = DTYPE_CAVES;
+	{
+		auto result = typeFn();
+		ASSERT_TRUE(result.valid());
+		EXPECT_EQ(result.get<int>(), DTYPE_CAVES);
+	}
+
+	leveltype = DTYPE_HELL;
+	{
+		auto result = typeFn();
+		ASSERT_TRUE(result.valid());
+		EXPECT_EQ(result.get<int>(), DTYPE_HELL);
+	}
+
+	leveltype = DTYPE_NEST;
+	{
+		auto result = typeFn();
+		ASSERT_TRUE(result.valid());
+		EXPECT_EQ(result.get<int>(), DTYPE_NEST);
+	}
+
+	leveltype = DTYPE_CRYPT;
+	{
+		auto result = typeFn();
+		ASSERT_TRUE(result.valid());
+		EXPECT_EQ(result.get<int>(), DTYPE_CRYPT);
+	}
+}
+
+TEST_F(LuaLevelModuleTest, LevelTypeConstants)
+{
+	sol::state lua;
+	lua.open_libraries(sol::lib::base);
+
+	sol::table levelModule = LuaLevelModule(lua);
+
+	// Verify all level type constants are exposed with shorter names
+	EXPECT_EQ(levelModule["TOWN"].get<int>(), DTYPE_TOWN);
+	EXPECT_EQ(levelModule["CATHEDRAL"].get<int>(), DTYPE_CATHEDRAL);
+	EXPECT_EQ(levelModule["CATACOMBS"].get<int>(), DTYPE_CATACOMBS);
+	EXPECT_EQ(levelModule["CAVES"].get<int>(), DTYPE_CAVES);
+	EXPECT_EQ(levelModule["HELL"].get<int>(), DTYPE_HELL);
+	EXPECT_EQ(levelModule["NEST"].get<int>(), DTYPE_NEST);
+	EXPECT_EQ(levelModule["CRYPT"].get<int>(), DTYPE_CRYPT);
+}
+
+// Regression test for mana shield persistence across level changes
+class ManaShieldPersistenceTest : public ::testing::Test {
+protected:
+	void SetUp() override
+	{
+		Players.resize(1);
+		MyPlayer = &Players[0];
+		MyPlayer->pManaShield = false;
+		leveltype = DTYPE_CATHEDRAL;
+	}
+
+	void TearDown() override
+	{
+		Players.clear();
+		MyPlayer = nullptr;
+	}
+};
+
+TEST_F(ManaShieldPersistenceTest, PersistManaShieldMod)
+{
+	sol::state lua;
+	lua.open_libraries(sol::lib::base, sol::lib::table);
+
+	// Create player and level modules
+	sol::table playerModule = LuaPlayerModule(lua);
+	sol::table levelModule = LuaLevelModule(lua);
+
+	lua["player"] = playerModule;
+	lua["level"] = levelModule;
+
+	// Track mana shield state from C++ side
+	bool savedManaShield = false;
+
+	// Create C++ callbacks that simulate the mod behavior
+	auto leavingLevelHandler = [&savedManaShield]() {
+		if (MyPlayer != nullptr) {
+			savedManaShield = MyPlayer->pManaShield;
+		}
+	};
+
+	auto enterLevelHandler = [&savedManaShield]() {
+		if (savedManaShield && leveltype != DTYPE_TOWN) {
+			if (MyPlayer != nullptr) {
+				MyPlayer->pManaShield = true;
+			}
+		}
+		savedManaShield = false;
+	};
+
+	// Test 1: Enable mana shield, leave dungeon level, enter another dungeon level
+	// Mana shield should persist
+	MyPlayer->pManaShield = true;
+	leveltype = DTYPE_CATHEDRAL;
+
+	// Simulate leaving level - mod saves mana shield state
+	leavingLevelHandler();
+
+	// Simulate C++ clearing mana shield (as InitLevelChange does)
+	MyPlayer->pManaShield = false;
+
+	// Simulate entering a new dungeon level (not town)
+	leveltype = DTYPE_CATACOMBS;
+	enterLevelHandler();
+
+	// Mana shield should be restored
+	EXPECT_TRUE(MyPlayer->pManaShield) << "Mana shield should persist from Cathedral to Catacombs";
+
+	// Test 2: Enable mana shield, leave dungeon level, enter TOWN
+	// Mana shield should NOT persist
+	MyPlayer->pManaShield = true;
+	leveltype = DTYPE_CATACOMBS;
+
+	leavingLevelHandler();
+	MyPlayer->pManaShield = false;
+
+	// Enter town
+	leveltype = DTYPE_TOWN;
+	enterLevelHandler();
+
+	// Mana shield should NOT be restored in town
+	EXPECT_FALSE(MyPlayer->pManaShield) << "Mana shield should not persist into town";
+
+	// Test 3: No mana shield active, should not restore
+	MyPlayer->pManaShield = false;
+	leveltype = DTYPE_CAVES;
+
+	leavingLevelHandler();
+
+	leveltype = DTYPE_HELL;
+	enterLevelHandler();
+
+	EXPECT_FALSE(MyPlayer->pManaShield) << "Mana shield should not be enabled if it wasn't active before";
+}
+
+// Test that Lua mod can correctly access mana shield and level type
+TEST_F(ManaShieldPersistenceTest, LuaModAccessPattern)
+{
+	// This test verifies the level module access - player module access
+	// is already covered by LuaPlayerModuleTest.ManaShieldLuaPropertyAccess
+	sol::state lua;
+	lua.open_libraries(sol::lib::base);
+
+	sol::table levelModule = LuaLevelModule(lua);
+	lua["level"] = levelModule;
+
+	// Verify reading level type via Lua
+	leveltype = DTYPE_TOWN;
+	{
+		auto result = lua.safe_script("return level.type() == level.TOWN");
+		ASSERT_TRUE(result.valid());
+		EXPECT_TRUE(result.get<bool>());
+	}
+
+	// Verify we can check "not in town" condition
+	leveltype = DTYPE_CATHEDRAL;
+	{
+		auto result = lua.safe_script("return level.type() ~= level.TOWN");
+		ASSERT_TRUE(result.valid());
+		EXPECT_TRUE(result.get<bool>());
+	}
+}

--- a/test/mana_shield_integration_test.cpp
+++ b/test/mana_shield_integration_test.cpp
@@ -1,0 +1,146 @@
+#include "player_test.h"
+
+#include <gtest/gtest.h>
+
+#include "engine/assets.hpp"
+#include "game_mode.hpp"
+#include "init.hpp"
+#include "levels/gendung.h"
+#include "lua/lua_global.hpp"
+#include "options.h"
+#include "player.h"
+#include "playerdat.hpp"
+#include "spelldat.h"
+#include "utils/paths.h"
+
+namespace devilution {
+namespace {
+
+// Set up a minimal player for testing
+void SetupTestPlayer(Player &player)
+{
+	player = {};
+	strcpy(player._pName, "ManaShieldTest");
+	player._pClass = HeroClass::Sorcerer;
+	player.pManaShield = true;
+	player._pSplLvl[static_cast<int8_t>(SpellID::ManaShield)] = 5;
+}
+
+TEST(ManaShieldIntegration, ManaShieldPersistsAcrossDungeonLevels)
+{
+	LoadCoreArchives();
+	LoadGameArchives();
+
+	// The tests need spawn.mpq or diabdat.mpq
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
+
+	paths::SetPrefPath(paths::BasePath());
+
+	gbVanilla = true;
+	gbIsHellfire = false;
+	gbIsSpawn = false;
+	gbIsMultiplayer = false;
+	leveltype = DTYPE_CATHEDRAL;
+
+	Players.resize(1);
+	MyPlayerId = 0;
+	MyPlayer = &Players[MyPlayerId];
+
+	LoadSpellData();
+	LoadPlayerDataFiles();
+	LoadItemData();
+
+	// Set up player with mana shield enabled
+	SetupTestPlayer(*MyPlayer);
+	ASSERT_TRUE(MyPlayer->pManaShield) << "Player should start with mana shield enabled";
+
+	// Initialize options and enable the persist_mana_shield mod
+	InitKeymapActions();
+	LoadOptions();
+	GetOptions().Mods.AddModEntry("persist_mana_shield");
+	GetOptions().Mods.SetModEnabled("persist_mana_shield", true);
+
+	// Initialize Lua system (this loads the mod)
+	LuaInitialize();
+
+	// Simulate level change: LeavingLevel event fires first (mod saves mana shield state)
+	LuaEvent("LeavingLevel");
+
+	// Then C++ clears mana shield (as InitLevelChange does)
+	MyPlayer->pManaShield = false;
+	ASSERT_FALSE(MyPlayer->pManaShield) << "Mana shield should be cleared after InitLevelChange";
+
+	// Change to a new dungeon level (not town)
+	leveltype = DTYPE_CATACOMBS;
+
+	// EnterLevel event fires after entering new level (mod restores mana shield)
+	LuaEvent("EnterLevel");
+
+	// With the persist_mana_shield mod enabled, mana shield should be restored
+	EXPECT_TRUE(MyPlayer->pManaShield) << "Mana shield should persist from Cathedral to Catacombs";
+
+	// Clean up
+	LuaShutdown();
+	Players.clear();
+	MyPlayer = nullptr;
+}
+
+TEST(ManaShieldIntegration, ManaShieldDoesNotPersistIntoTown)
+{
+	LoadCoreArchives();
+	LoadGameArchives();
+
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
+
+	paths::SetPrefPath(paths::BasePath());
+
+	gbVanilla = true;
+	gbIsHellfire = false;
+	gbIsSpawn = false;
+	gbIsMultiplayer = false;
+	leveltype = DTYPE_CATHEDRAL;
+
+	Players.resize(1);
+	MyPlayerId = 0;
+	MyPlayer = &Players[MyPlayerId];
+
+	LoadSpellData();
+	LoadPlayerDataFiles();
+	LoadItemData();
+
+	SetupTestPlayer(*MyPlayer);
+	ASSERT_TRUE(MyPlayer->pManaShield);
+
+	// Initialize options and enable the persist_mana_shield mod
+	InitKeymapActions();
+	LoadOptions();
+	GetOptions().Mods.AddModEntry("persist_mana_shield");
+	GetOptions().Mods.SetModEnabled("persist_mana_shield", true);
+
+	// Initialize Lua system (this loads the mod)
+	LuaInitialize();
+
+	// Simulate leaving dungeon (mod saves mana shield state)
+	LuaEvent("LeavingLevel");
+
+	// C++ clears mana shield (as InitLevelChange does)
+	MyPlayer->pManaShield = false;
+
+	// Enter town - mana shield should NOT be restored even with mod enabled
+	leveltype = DTYPE_TOWN;
+	LuaEvent("EnterLevel");
+
+	// The mod should NOT restore mana shield in town
+	EXPECT_FALSE(MyPlayer->pManaShield) << "Mana shield should not persist into town";
+
+	LuaShutdown();
+	Players.clear();
+	MyPlayer = nullptr;
+}
+
+} // namespace
+} // namespace devilution


### PR DESCRIPTION
## Summary
- Add Lua `manaShield` property (read/write) to Player usertype with proper network sync
- Add new `level` module with `type()` function and dungeon type constants
- Add `LeavingLevel` and `EnterLevel` events for level transition hooks
- Include sample `persist_mana_shield` mod demonstrating the API

## API

### Player module
```lua
local player = require("devilutionx.player")
local p = player.self()
p.manaShield = true  -- Enable mana shield
local active = p.manaShield  -- Check if mana shield is active
```

### Level module
```lua
local level = require("devilutionx.level")
local currentType = level.type()  -- Get current dungeon type

-- Available constants:
level.TOWN
level.CATHEDRAL
level.CATACOMBS
level.CAVES
level.HELL
level.NEST
level.CRYPT
```

### Events
```lua
local events = require("devilutionx.events")

events.LeavingLevel.add(function()
  -- Called before leaving current level (before mana shield is cleared)
end)

events.EnterLevel.add(function()
  -- Called after entering a new level
end)
```

## Test plan
- [x] Unit tests for manaShield property (LuaPlayerModuleTest)
- [x] Unit tests for Lua script access to manaShield (LuaPlayerModuleTest)
- [x] Unit tests for level.type() function (LuaLevelModuleTest)
- [x] Unit tests for level type constants (LuaLevelModuleTest)
- [x] Regression test for mana shield persistence logic (ManaShieldPersistenceTest)
- [x] Regression test for level module Lua access pattern (ManaShieldPersistenceTest)
- [x] Integration test with real player and Lua events (ManaShieldIntegration)
- [x] Integration test for town level type check (ManaShieldIntegration)
- [x] Manual test - mod on, mana shield stays / mod off, default behavior of clearing mana shield on level exit.