### PR TITLE
Show an appropriate error message when wrong password is entered (TCP)

### DIFF
--- a/Source/dvlnet/frame_queue.h
+++ b/Source/dvlnet/frame_queue.h
@@ -17,6 +17,7 @@ typedef uint32_t framesize_t;
 
 class frame_queue {
 public:
+	constexpr static framesize_t frame_size_mask = 0xFFFF;
 	constexpr static framesize_t max_frame_size = 0xFFFF;
 
 private:
@@ -29,10 +30,11 @@ private:
 
 public:
 	tl::expected<bool, PacketError> PacketReady();
+	uint16_t ReadPacketFlags();
 	tl::expected<buffer_t, PacketError> ReadPacket();
 	void Write(buffer_t buf);
 
-	static tl::expected<buffer_t, PacketError> MakeFrame(buffer_t packetbuf);
+	static tl::expected<buffer_t, PacketError> MakeFrame(buffer_t packetbuf, uint16_t flags = 0);
 };
 
 } // namespace net

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -168,6 +168,10 @@ void tcp_client::HandleReceive(const asio::error_code &error, size_t bytesRead)
 		}
 		if (!*ready)
 			break;
+		if (recv_queue.ReadPacketFlags() == TcpErrorCodeFlags) {
+			HandleTcpErrorCode();
+			return;
+		}
 		tl::expected<void, PacketError> result
 		    = recv_queue.ReadPacket()
 		          .and_then([this](buffer_t &&pktData) { return pktfty->make_packet(pktData); })
@@ -191,6 +195,27 @@ void tcp_client::HandleSend(const asio::error_code &error, size_t bytesSent)
 {
 	if (error)
 		RaiseIoHandlerError(error.message());
+}
+
+void tcp_client::HandleTcpErrorCode()
+{
+	tl::expected<buffer_t, PacketError> packet = recv_queue.ReadPacket();
+	if (!packet.has_value()) {
+		RaiseIoHandlerError(packet.error());
+		return;
+	}
+
+	buffer_t pktData = *packet;
+	if (pktData.size() != 1) {
+		RaiseIoHandlerError(PacketError());
+		return;
+	}
+
+	PacketError::ErrorCode code = static_cast<PacketError::ErrorCode>(pktData[0]);
+	if (code == PacketError::ErrorCode::DecryptionFailed)
+		RaiseIoHandlerError(_("Server failed to decrypt your packet. Check if you typed the password correctly."));
+	else
+		RaiseIoHandlerError(fmt::format("Unknown error code received from server: {:#04x}", pktData[0]));
 }
 
 tl::expected<void, PacketError> tcp_client::send(packet &pkt)

--- a/Source/dvlnet/tcp_client.h
+++ b/Source/dvlnet/tcp_client.h
@@ -57,6 +57,7 @@ private:
 	void HandleReceive(const asio::error_code &error, size_t bytesRead);
 	void StartReceive();
 	void HandleSend(const asio::error_code &error, size_t bytesSent);
+	void HandleTcpErrorCode();
 
 	void RaiseIoHandlerError(const PacketError &error);
 };

--- a/Source/dvlnet/tcp_server.h
+++ b/Source/dvlnet/tcp_server.h
@@ -28,6 +28,8 @@
 
 namespace devilution::net {
 
+constexpr uint16_t TcpErrorCodeFlags = 0x8000;
+
 inline PacketError ServerError()
 {
 	return PacketError("Invalid player ID");
@@ -82,6 +84,8 @@ private:
 	tl::expected<void, PacketError> HandleReceivePacket(packet &pkt);
 	tl::expected<void, PacketError> SendPacket(packet &pkt);
 	tl::expected<void, PacketError> StartSend(const scc &con, packet &pkt);
+	tl::expected<void, PacketError> StartSend(const scc &con, PacketError::ErrorCode errorCode);
+	tl::expected<void, PacketError> StartSend(const scc &con, buffer_t pktData, uint16_t flags);
 	void HandleSend(const scc &con, const asio::error_code &ec, size_t bytesSent);
 	void StartTimeout(const scc &con);
 	void HandleTimeout(const scc &con, const asio::error_code &ec);


### PR DESCRIPTION
<img width="778" height="514" alt="image" src="https://github.com/user-attachments/assets/63511509-f0bf-4c16-abf7-437e4576fe6f" />

As mentioned in #8007, this change requires an extension of the protocol to support an unencrypted response message to be sent from the TCP server to the TCP client. Since the packet type is encrypted alongside the message, I couldn't use the packet factory to create that protocol extension. Instead, I looked at the frame queue since it was already encoding an unencrypted packet length. For whatever reason, the packet length is encoded as a 4-byte integer even though the maximum packet size is 65535 bytes. I decided to hijack the two unused bytes in the packet length to encode protocol-specific flags.

This particular error message is irrelevant for ZeroTier because a player that is attempting to join a ZT game can't even see the host's game unless they get the password right. On the other hand, if a TCP server receives a packet it can't decrypt, it means the player attempting to join the game likely entered the correct IP address. In that case, it's safe to assume they just entered the password wrong and send a packet back to indicate it.

This resolves #8007