### PR TITLE
Require smpq for CPACK on non-Apple platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,10 +183,10 @@ endif()
 
 # By default, devilutionx.mpq is built only if smpq is installed and MPQ support is enabled.
 if(SUPPORTS_MPQ AND NOT UNPACKED_MPQS)
-  if(NOT DEFINED BUILD_ASSETS_MPQ AND NOT SRC_DIST)
-    find_program(SMPQ smpq)
-  elseif(BUILD_ASSETS_MPQ)
+  if(BUILD_ASSETS_MPQ OR (CPACK STREQUAL "ON" AND (WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Linux")))
     find_program(SMPQ smpq REQUIRED)
+  elseif(NOT DEFINED BUILD_ASSETS_MPQ AND NOT SRC_DIST)
+    find_program(SMPQ smpq)
   endif()
   if(SMPQ)
     set(_has_smpq ON)


### PR DESCRIPTION
## Summary
- Packaging was silently producing incomplete packages when smpq was missing on Windows and Linux
- Now CMake configuration fails with a clear error instead of building a package without the MPQ file

## Test plan
- [x] Configure with `CPACK=ON` without smpq installed on Linux/Windows - should fail
- [x] Configure with `CPACK=ON` with smpq installed - should succeed
- [x] Apple builds unaffected (they don't include the MPQ in the DMG)
- [x] Console builds (Switch, Vita, etc.) unaffected (they don't use CPack)