### PR TITLE
Process network packets independent of the game's tick rate

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -917,6 +917,7 @@ void RunGameLoop(interface_mode uMsg)
 		if (!runGameLoop) {
 			if (processInput)
 				ProcessInput();
+			DvlNet_ProcessNetworkPackets();
 			if (!drawGame)
 				continue;
 			RedrawViewport();
@@ -924,7 +925,7 @@ void RunGameLoop(interface_mode uMsg)
 			continue;
 		}
 
-		multi_process_network_packets();
+		ProcessGameMessagePackets();
 		if (game_loop(gbGameLoopStartup))
 			diablo_color_cyc_logic();
 		gbGameLoopStartup = false;

--- a/Source/dvlnet/abstract_net.h
+++ b/Source/dvlnet/abstract_net.h
@@ -34,6 +34,10 @@ public:
 
 	virtual std::string make_default_gamename() = 0;
 
+	virtual void process_network_packets()
+	{
+	}
+
 	virtual void setup_password(std::string passwd)
 	{
 	}

--- a/Source/dvlnet/base.cpp
+++ b/Source/dvlnet/base.cpp
@@ -18,6 +18,14 @@
 namespace devilution {
 namespace net {
 
+void base::process_network_packets()
+{
+	tl::expected<void, PacketError> result = poll();
+	if (!result.has_value()) {
+		LogVerbose("Error polling network: {}", result.error().what());
+	}
+}
+
 void base::setup_gameinfo(buffer_t info)
 {
 	game_init_info = std::move(info);
@@ -233,7 +241,7 @@ bool base::SNetReceiveMessage(uint8_t *sender, void **data, size_t *size)
 			SendEchoRequest(i);
 		lastEchoTime = now;
 	}
-	poll();
+	process_network_packets();
 	if (message_queue.empty())
 		return false;
 	message_last = message_queue.front();
@@ -292,7 +300,7 @@ bool base::AllTurnsArrived()
 
 bool base::SNetReceiveTurns(char **data, size_t *size, uint32_t *status)
 {
-	poll();
+	process_network_packets();
 
 	for (size_t i = 0; i < Players.size(); ++i) {
 		status[i] = 0;
@@ -528,7 +536,7 @@ plr_t base::GetOwner()
 
 bool base::SNetGetOwnerTurnsWaiting(uint32_t *turns)
 {
-	poll();
+	process_network_packets();
 
 	const plr_t owner = GetOwner();
 	const PlayerState &playerState = playerStateTable_[owner];

--- a/Source/dvlnet/base.h
+++ b/Source/dvlnet/base.h
@@ -34,6 +34,8 @@ public:
 	virtual tl::expected<void, PacketError> send(packet &pkt) = 0;
 	virtual void DisconnectNet(plr_t plr);
 
+	void process_network_packets() override;
+
 	void setup_gameinfo(buffer_t info) override;
 
 	void setup_password(std::string pw) override;

--- a/Source/dvlnet/cdwrap.cpp
+++ b/Source/dvlnet/cdwrap.cpp
@@ -30,6 +30,11 @@ int cdwrap::join(std::string_view addrstr)
 	return dvlnet_wrap->join(addrstr);
 }
 
+void cdwrap::process_network_packets()
+{
+	dvlnet_wrap->process_network_packets();
+}
+
 void cdwrap::setup_gameinfo(buffer_t info)
 {
 	game_init_info = std::move(info);

--- a/Source/dvlnet/cdwrap.h
+++ b/Source/dvlnet/cdwrap.h
@@ -45,6 +45,7 @@ public:
 	bool SNetDropPlayer(int playerid, net::leaveinfo_t flags) override;
 	bool SNetGetOwnerTurnsWaiting(uint32_t *turns) override;
 	bool SNetGetTurnsInTransit(uint32_t *turns) override;
+	void process_network_packets() override;
 	void setup_gameinfo(buffer_t info) override;
 	std::string make_default_gamename() override;
 	bool send_info_request() override;

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -240,7 +240,7 @@ void tcp_client::DisconnectNet(plr_t plr)
 bool tcp_client::SNetLeaveGame(net::leaveinfo_t type)
 {
 	auto ret = base::SNetLeaveGame(type);
-	poll();
+	process_network_packets();
 	if (local_server != nullptr)
 		local_server->Close();
 	sock.close();

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -509,7 +509,7 @@ int WaitForTurns()
 			return 0;
 		sgbDeltaChunks++;
 	}
-	multi_process_network_packets();
+	ProcessGameMessagePackets();
 	nthread_send_and_recv_turn(0, 0);
 	if (nthread_has_500ms_passed()) {
 		nthread_recv_turns();

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -684,7 +684,7 @@ bool multi_handle_delta()
 	return true;
 }
 
-void multi_process_network_packets()
+void ProcessGameMessagePackets()
 {
 	ClearPlayerLeftState();
 	ProcessTmsgs();

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -81,7 +81,7 @@ void multi_net_ping();
  * @return Always true for singleplayer
  */
 bool multi_handle_delta();
-void multi_process_network_packets();
+void ProcessGameMessagePackets();
 void multi_send_zero_packet(uint8_t pnum, _cmd_id bCmd, const std::byte *data, size_t size);
 void NetClose();
 bool NetInit(bool bSinglePlayer);

--- a/Source/storm/storm_net.cpp
+++ b/Source/storm/storm_net.cpp
@@ -235,6 +235,11 @@ bool SNetSetBasePlayer(int /*unused*/)
 	return true;
 }
 
+void DvlNet_ProcessNetworkPackets()
+{
+	return dvlnet_inst->process_network_packets();
+}
+
 bool DvlNet_SendInfoRequest()
 {
 	return dvlnet_inst->send_info_request();

--- a/Source/storm/storm_net.hpp
+++ b/Source/storm/storm_net.hpp
@@ -139,6 +139,7 @@ bool SNetSetBasePlayer(int);
 bool SNetInitializeProvider(uint32_t provider, struct GameData *gameData);
 void SNetGetProviderCaps(struct _SNETCAPS *);
 
+void DvlNet_ProcessNetworkPackets();
 bool DvlNet_SendInfoRequest();
 void DvlNet_ClearGamelist();
 std::vector<GameInfo> DvlNet_GetGamelist();


### PR DESCRIPTION
Processing packets independent of the game's tick rate allows us to obtain a more granular latency measurement that is not locked to 50 ms intervals.

<img width="778" height="514" alt="image" src="https://github.com/user-attachments/assets/418ceb22-6fbc-443d-ae2f-94f675b2d3c8" />

We shouldn't have to worry about inadvertently triggering game logic at the wrong moment because only the `PT_MESSAGE` packet type has a direct impact on game logic. The network layer already adds `PT_MESSAGE` packets to a message queue to be retrieved by `SNetReceiveMessage()`. `SNetReceiveMessage()` is invoked by `ProcessGameMessagePackets()` on each game tick.

Summary of changes:
* Rename `multi_process_network_packets()` to `ProcessGameMessagePackets()` to differentiate it from the new function.
* Introduce `DvlNet_ProcessNetworkPackets()` to be used in the main loop when the game logic is not running.
* Use `LogVerbose()` on errors encountered when calling the `base::poll()` function, instead of ignoring them.