### PR TITLE
Don't hardcode the number of Towners in gamepad targeting logic

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -221,13 +221,13 @@ void FindItemOrObject()
 
 void CheckTownersNearby()
 {
-	for (int i = 0; i < 16; i++) {
+	for (size_t i = 0; i < GetNumTowners(); i++) {
 		const int distance = GetDistance(Towners[i].position, 2);
 		if (distance == 0)
 			continue;
 		if (!IsTownerPresent(Towners[i]._ttype))
 			continue;
-		pcursmonst = i;
+		pcursmonst = static_cast<int>(i);
 	}
 }
 


### PR DESCRIPTION
Fixes a segfault when using gamepad in town. The `Towners` array may not have 16 entries since now it loads records from `towners.tsv`.