### PR TITLE
[Bugfix] Fix MissToMonst knockback bug

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4549,6 +4549,7 @@ void MissToMonst(Missile &missile, Point position)
 		if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE)) {
 			MonsterAttackPlayer(monster, *player, chanceToHit, monster.minDamageSpecial, monster.maxDamageSpecial);
 		} else {
+			// Knockback
 			const Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
 
 			if (PosOkPlayer(*player, newPosition)) {
@@ -4559,8 +4560,10 @@ void MissToMonst(Missile &missile, Point position)
 				SetPlayerOld(*player);
 			}
 
+			// Damage
 			MonsterAttackPlayer(monster, *player, chanceToHit, monster.minDamageSpecial, monster.maxDamageSpecial);
 
+			// Hit Recovery
 			if (player->_pmode != PM_GOTHIT && player->_pmode != PM_DEATH)
 				StartPlrHit(*player, 0, true); // Guarantee player enters hit recovery if the attack itself already didn't inflict it
 		}
@@ -4573,6 +4576,7 @@ void MissToMonst(Missile &missile, Point position)
 		if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE)) {
 			MonsterAttackMonster(monster, *target, chanceToHit, monster.minDamageSpecial, monster.maxDamageSpecial);
 		} else {
+			// Knockback
 			const Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
 
 			if (IsTileAvailable(*target, newPosition)) {
@@ -4582,6 +4586,7 @@ void MissToMonst(Missile &missile, Point position)
 				monster.position.future = newPosition;
 			}
 
+			// Damage
 			MonsterAttackMonster(monster, *target, chanceToHit, monster.minDamageSpecial, monster.maxDamageSpecial);
 		}
 	}

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4551,6 +4551,10 @@ void MissToMonst(Missile &missile, Point position)
 
 		if (player->_pmode != PM_GOTHIT && player->_pmode != PM_DEATH)
 			StartPlrHit(*player, 0, true);
+
+		if (player->hasNoLife())
+			return;
+
 		const Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
 		if (PosOkPlayer(*player, newPosition)) {
 			player->position.tile = newPosition;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -4528,6 +4528,7 @@ void MissToMonst(Missile &missile, Point position)
 {
 	assert(static_cast<size_t>(missile._misource) < MaxMonsters);
 	Monster &monster = Monsters[missile._misource];
+	int chanceToHit = 500;
 
 	const Point oldPosition = missile.position.tile;
 	monster.occupyTile(position, false);
@@ -4541,47 +4542,48 @@ void MissToMonst(Missile &missile, Point position)
 
 	if ((monster.flags & MFLAG_TARGETS_MONSTER) == 0) {
 		Player *player = PlayerAtPosition(oldPosition, true);
+
 		if (player == nullptr)
 			return;
 
-		MonsterAttackPlayer(monster, *player, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
+		if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE)) {
+			MonsterAttackPlayer(monster, *player, chanceToHit, monster.minDamageSpecial, monster.maxDamageSpecial);
+		} else {
+			const Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
 
-		if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
-			return;
+			if (PosOkPlayer(*player, newPosition)) {
+				player->position.tile = newPosition;
+				FixPlayerLocation(*player, player->_pdir);
+				FixPlrWalkTags(*player);
+				player->occupyTile(newPosition, false);
+				SetPlayerOld(*player);
+			}
 
-		if (player->_pmode != PM_GOTHIT && player->_pmode != PM_DEATH)
-			StartPlrHit(*player, 0, true);
+			MonsterAttackPlayer(monster, *player, chanceToHit, monster.minDamageSpecial, monster.maxDamageSpecial);
 
-		if (player->hasNoLife())
-			return;
-
-		const Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
-		if (PosOkPlayer(*player, newPosition)) {
-			player->position.tile = newPosition;
-			FixPlayerLocation(*player, player->_pdir);
-			FixPlrWalkTags(*player);
-			player->occupyTile(newPosition, false);
-			SetPlayerOld(*player);
+			if (player->_pmode != PM_GOTHIT && player->_pmode != PM_DEATH)
+				StartPlrHit(*player, 0, true); // Guarantee player enters hit recovery if the attack itself already didn't inflict it
 		}
-		return;
-	}
+	} else {
+		Monster *target = FindMonsterAtPosition(oldPosition, true);
 
-	Monster *target = FindMonsterAtPosition(oldPosition, true);
+		if (target == nullptr)
+			return;
 
-	if (target == nullptr)
-		return;
+		if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE)) {
+			MonsterAttackMonster(monster, *target, chanceToHit, monster.minDamageSpecial, monster.maxDamageSpecial);
+		} else {
+			const Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
 
-	MonsterAttackMonster(monster, *target, 500, monster.minDamageSpecial, monster.maxDamageSpecial);
+			if (IsTileAvailable(*target, newPosition)) {
+				monster.occupyTile(newPosition, false);
+				dMonster[oldPosition.x][oldPosition.y] = 0;
+				monster.position.tile = newPosition;
+				monster.position.future = newPosition;
+			}
 
-	if (IsAnyOf(monster.type().type, MT_NSNAKE, MT_RSNAKE, MT_BSNAKE, MT_GSNAKE))
-		return;
-
-	const Point newPosition = oldPosition + GetDirection(missile.position.start, oldPosition);
-	if (IsTileAvailable(*target, newPosition)) {
-		monster.occupyTile(newPosition, false);
-		dMonster[oldPosition.x][oldPosition.y] = 0;
-		monster.position.tile = newPosition;
-		monster.position.future = newPosition;
+			MonsterAttackMonster(monster, *target, chanceToHit, monster.minDamageSpecial, monster.maxDamageSpecial);
+		}
 	}
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Bug Fixes
+
+#### Gameplay
+
+- Players killed by charging monsters are able to be knocked back after death
+
 ## DevilutionX 1.5.2
 
 ### Bug Fixes


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/DevilutionX/issues/8039
Prevents charging monsters from readding a dead player to `dPlayer`. Also reorganizes code for clarity and consistency. I'm not certain if the same bug can happen with `dMonster`, but this PR would prevent it, if it did.

The problem:
1. Player dies from the charging monster (`MissToMonst`).
2. `FixPlrWalkTags` is called during death to remove the player from `dPlayer`.
3. `MissToMonst` proceeds to knockback, and readds the player via `player->occupyTile`.
4. Monsters are now able to continue knocking the corpse around.