### PR TITLE
Fix Dual Wielding

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -578,26 +578,23 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 		}
 	}
 
-	ItemType phanditype = ItemType::None;
-	if (player.InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Sword || player.InvBody[INVLOC_HAND_RIGHT]._itype == ItemType::Sword) {
-		phanditype = ItemType::Sword;
-	}
-	if (player.InvBody[INVLOC_HAND_LEFT]._itype == ItemType::Mace || player.InvBody[INVLOC_HAND_RIGHT]._itype == ItemType::Mace) {
-		phanditype = ItemType::Mace;
-	}
+	const ItemType leftHandType = player.InvBody[INVLOC_HAND_LEFT]._itype;
+	const ItemType rightHandType = player.InvBody[INVLOC_HAND_RIGHT]._itype;
 
 	switch (monster.data().monsterClass) {
 	case MonsterClass::Undead:
-		if (phanditype == ItemType::Sword) {
+		if (IsAnyOf(ItemType::Sword, leftHandType, rightHandType)) {
 			dam -= dam / 2;
-		} else if (phanditype == ItemType::Mace) {
+		}
+		if (IsAnyOf(ItemType::Mace, leftHandType, rightHandType)) {
 			dam += dam / 2;
 		}
 		break;
 	case MonsterClass::Animal:
-		if (phanditype == ItemType::Mace) {
+		if (IsAnyOf(ItemType::Mace, leftHandType, rightHandType)) {
 			dam -= dam / 2;
-		} else if (phanditype == ItemType::Sword) {
+		}
+		if (IsAnyOf(ItemType::Sword, leftHandType, rightHandType)) {
 			dam += dam / 2;
 		}
 		break;


### PR DESCRIPTION
Alternative to https://github.com/diasurgical/DevilutionX/pull/8242.

This approach applies *both* effects of weapon item type vs monster type while dual wielding. Previously, if a Bard wields both a Sword and Mace, regardless of which hand is which, the game always treats it as if the Bard is wielding a Mace, nerfing damage against Animals and buffing damage against Undead.

The way dual wielding works in Diablo/Hellfire is quite "unique", compared to dual wielding in other ARPGs. The character does not interchange swings, but attacks with both weapons simultaneously (no "per hand" damage or other calculations). Therefore, this PR applies both the effect of a Sword against a monster type AND a Mace against a monster type if both respective item types are equipped, the same as how the affix powers from both weapons are applied every hit.

As a result of of using both a Sword and Mace simulataneously the damage output against either an Animal or Undead monster is 75%.