### PR TITLE
[Engine] Refactor StartNewLvl

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2680,7 +2680,8 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("shift-base")))
 #endif
-void StartPlayerKill(Player &player, DeathReason deathReason)
+void
+StartPlayerKill(Player &player, DeathReason deathReason)
 {
 	if (player.hasNoLife() && player._pmode == PM_DEATH) {
 		return;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2680,8 +2680,7 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("shift-base")))
 #endif
-void
-StartPlayerKill(Player &player, DeathReason deathReason)
+void StartPlayerKill(Player &player, DeathReason deathReason)
 {
 	if (player.hasNoLife() && player._pmode == PM_DEATH) {
 		return;
@@ -2893,11 +2892,7 @@ void RemovePlrMissiles(const Player &player)
 	}
 }
 
-#if defined(__clang__) || defined(__GNUC__)
-__attribute__((no_sanitize("shift-base")))
-#endif
-void
-StartNewLvl(Player &player, interface_mode fom, int lvl)
+void StartNewLvl(Player &player, interface_mode fom, int lvl)
 {
 	InitLevelChange(player);
 
@@ -2914,7 +2909,10 @@ StartNewLvl(Player &player, interface_mode fom, int lvl)
 		player.setLevel(setlvlnum);
 		break;
 	case WM_DIABTWARPUP:
-		MyPlayer->pTownWarps |= 1 << (leveltype - 2);
+		assert(leveltype >= DTYPE_CATACOMBS && leveltype <= DTYPE_HELL);
+		const unsigned warpIndex = static_cast<unsigned>(leveltype - 2);
+		const uint8_t warpMask = static_cast<uint8_t>(1u << warpIndex);
+		MyPlayer->pTownWarps |= warpMask;
 		player.setLevel(lvl);
 		break;
 	case WM_DIABRETOWN:

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2908,13 +2908,14 @@ void StartNewLvl(Player &player, interface_mode fom, int lvl)
 			setlvlnum = (_setlevels)lvl;
 		player.setLevel(setlvlnum);
 		break;
-	case WM_DIABTWARPUP:
+	case WM_DIABTWARPUP: {
 		assert(leveltype >= DTYPE_CATACOMBS && leveltype <= DTYPE_HELL);
 		const unsigned warpIndex = static_cast<unsigned>(leveltype - 2);
 		const uint8_t warpMask = static_cast<uint8_t>(1u << warpIndex);
 		MyPlayer->pTownWarps |= warpMask;
 		player.setLevel(lvl);
 		break;
+	}
 	case WM_DIABRETOWN:
 		break;
 	default:


### PR DESCRIPTION
Removes the need for the `no_sanitize("shift-base")` attribute.