### PR TITLE
[Bugfix/Rebalance] Fix PLDam for dual wielding

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2478,6 +2478,34 @@ void InitItems()
 	initItemGetRecords();
 }
 
+int GetBonusMinDamage(const Item &item)
+{
+	if (item._iPLDam != 0) {
+		int tempDam = item._iMinDam;
+		tempDam *= item._iPLDam;
+		tempDam /= 100;
+		if (tempDam == 0)
+			tempDam = math::Sign(item._iPLDam);
+		return tempDam;
+	}
+
+	return 0;
+}
+
+int GetBonusMaxDamage(const Item &item)
+{
+	if (item._iPLDam != 0) {
+		int tempDam = item._iMaxDam;
+		tempDam *= item._iPLDam;
+		tempDam /= 100;
+		if (tempDam == 0)
+			tempDam = math::Sign(item._iPLDam);
+		return tempDam;
+	}
+
+	return 0;
+}
+
 int GetBonusAC(const Item &item)
 {
 	if (item._iPLAC != 0) {
@@ -2781,7 +2809,8 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	int maxDamage = 0;
 	int ac = 0;
 
-	int dam = 0;
+	int bonusMinDam = 0;
+	int bonusMaxDam = 0;
 	int toHit = 0;
 	int bonusAc = 0;
 
@@ -2827,7 +2856,8 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 			}
 
 			if (item._iMagical == ITEM_QUALITY_NORMAL || item._iIdentified) {
-				dam += item._iPLDam;
+				bonusMinDam += GetBonusMinDamage(item);
+				bonusMaxDam += GetBonusMaxDamage(item);
 				toHit += item._iPLToHit;
 				bonusAc += GetBonusAC(item);
 				flags |= item._iFlags;
@@ -2857,7 +2887,8 @@ void CalcPlrItemVals(Player &player, bool loadgfx)
 	CalcPlrDamage(player, minDamage, maxDamage);
 	CalcPlrPrimaryStats(player, strength, magic, dexterity, vitality);
 	player._pIAC = ac;
-	player._pIBonusDam = dam;
+	player._pIBonusMinDam = bonusMinDam;
+	player._pIBonusMaxDam = bonusMaxDam;
 	player._pIBonusToHit = toHit;
 	player._pIBonusAC = bonusAc;
 	player._pIFlags = flags;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -592,7 +592,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	player._pIMinDam = file.NextLE<int32_t>();
 	player._pIMaxDam = file.NextLE<int32_t>();
 	player._pIAC = file.NextLE<int32_t>();
-	player._pIBonusDam = file.NextLE<int32_t>();
+	file.Skip(4); // Alignment
 	player._pIBonusToHit = file.NextLE<int32_t>();
 	player._pIBonusAC = file.NextLE<int32_t>();
 	player._pIBonusDamMod = file.NextLE<int32_t>();
@@ -1449,7 +1449,7 @@ void SavePlayer(SaveHelper &file, const Player &player)
 	file.WriteLE<int32_t>(player._pIMinDam);
 	file.WriteLE<int32_t>(player._pIMaxDam);
 	file.WriteLE<int32_t>(player._pIAC);
-	file.WriteLE<int32_t>(player._pIBonusDam);
+	file.Skip(4); // Alignment
 	file.WriteLE<int32_t>(player._pIBonusToHit);
 	file.WriteLE<int32_t>(player._pIBonusAC);
 	file.WriteLE<int32_t>(player._pIBonusDamMod);

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -313,7 +313,7 @@ bool MonsterMHit(const Player &player, Monster &monster, int mindam, int maxdam,
 	}
 
 	if (missileData.isArrow() && damageType == DamageType::Physical) {
-		dam = player._pIBonusDamMod + dam * player._pIBonusDam / 100 + dam;
+		dam += player._pIBonusDamMod;
 		if (player._pClass == HeroClass::Rogue)
 			dam += player._pDamageMod;
 		else
@@ -425,7 +425,7 @@ bool Plr2PlrMHit(const Player &player, Player &target, int mindam, int maxdam, i
 		dam = RandomIntBetween(mindam, maxdam);
 		if (missileData.isArrow() && damageType == DamageType::Physical) {
 			const int damMod = IsAnyOf(player._pClass, HeroClass::Rogue) ? player._pDamageMod : player._pDamageMod / 2;
-			dam += player._pIBonusDamMod + damMod + dam * player._pIBonusDam / 100;
+			dam += player._pIBonusDamMod + damMod;
 		}
 		if (!shift)
 			dam <<= 6;
@@ -2861,8 +2861,8 @@ void ProcessElementalArrow(Missile &missile)
 			if (missile._micaster == TARGET_MONSTERS) {
 				// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
 				const Player &player = Players[p];
-				mind = player._pIMinDam;
-				maxd = player._pIMaxDam;
+				mind = player._pIMinDam + player._pIBonusMinDam;
+				maxd = player._pIMaxDam + player._pIBonusMaxDam;
 			} else {
 				// BUGFIX: damage of missile should be encoded in missile struct; monster can be dead before missile arrives.
 				const Monster &monster = Monsters[p];
@@ -2942,8 +2942,8 @@ void ProcessArrow(Missile &missile)
 	case MissileSource::Player: {
 		// BUGFIX: damage of missile should be encoded in missile struct; player can be dead/have left the game before missile arrives.
 		const Player &player = *missile.sourcePlayer();
-		mind = player._pIMinDam;
-		maxd = player._pIMaxDam;
+		mind = player._pIMinDam + player._pIBonusMinDam;
+		maxd = player._pIMaxDam + player._pIBonusMaxDam;
 	} break;
 	case MissileSource::Monster: {
 		// BUGFIX: damage of missile should be encoded in missile struct; monster can be dead before missile arrives.

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -272,7 +272,8 @@ void PackNetPlayer(PlayerNetPack &packed, const Player &player)
 	packed.pIMinDam = Swap32LE(player._pIMinDam);
 	packed.pIMaxDam = Swap32LE(player._pIMaxDam);
 	packed.pIAC = Swap32LE(player._pIAC);
-	packed.pIBonusDam = Swap32LE(player._pIBonusDam);
+	packed.pIBonusMinDam = Swap32LE(player._pIBonusMinDam);
+	packed.pIBonusMaxDam = Swap32LE(player._pIBonusMaxDam);
 	packed.pIBonusToHit = Swap32LE(player._pIBonusToHit);
 	packed.pIBonusAC = Swap32LE(player._pIBonusAC);
 	packed.pIBonusDamMod = Swap32LE(player._pIBonusDamMod);
@@ -592,7 +593,8 @@ bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 	ValidateFields(player._pIMinDam, SwapSigned32LE(packed.pIMinDam), player._pIMinDam == SwapSigned32LE(packed.pIMinDam));
 	ValidateFields(player._pIMaxDam, SwapSigned32LE(packed.pIMaxDam), player._pIMaxDam == SwapSigned32LE(packed.pIMaxDam));
 	ValidateFields(player._pIAC, SwapSigned32LE(packed.pIAC), player._pIAC == SwapSigned32LE(packed.pIAC));
-	ValidateFields(player._pIBonusDam, SwapSigned32LE(packed.pIBonusDam), player._pIBonusDam == SwapSigned32LE(packed.pIBonusDam));
+	ValidateFields(player._pIBonusMinDam, SwapSigned32LE(packed.pIBonusMinDam), player._pIBonusMinDam == SwapSigned32LE(packed.pIBonusMinDam));
+	ValidateFields(player._pIBonusMaxDam, SwapSigned32LE(packed.pIBonusMaxDam), player._pIBonusMaxDam == SwapSigned32LE(packed.pIBonusMaxDam));
 	ValidateFields(player._pIBonusToHit, SwapSigned32LE(packed.pIBonusToHit), player._pIBonusToHit == SwapSigned32LE(packed.pIBonusToHit));
 	ValidateFields(player._pIBonusAC, SwapSigned32LE(packed.pIBonusAC), player._pIBonusAC == SwapSigned32LE(packed.pIBonusAC));
 	ValidateFields(player._pIBonusDamMod, SwapSigned32LE(packed.pIBonusDamMod), player._pIBonusDamMod == SwapSigned32LE(packed.pIBonusDamMod));

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -131,7 +131,8 @@ struct PlayerNetPack {
 	int32_t pIMinDam;
 	int32_t pIMaxDam;
 	int32_t pIAC;
-	int32_t pIBonusDam;
+	int32_t pIBonusMinDam;
+	int32_t pIBonusMaxDam;
 	int32_t pIBonusToHit;
 	int32_t pIBonusAC;
 	int32_t pIBonusDamMod;

--- a/Source/panels/charpanel.cpp
+++ b/Source/panels/charpanel.cpp
@@ -95,8 +95,8 @@ std::pair<int, int> GetDamage()
 	} else {
 		damageMod += InspectPlayer->_pDamageMod;
 	}
-	const int mindam = InspectPlayer->_pIMinDam + InspectPlayer->_pIBonusDam * InspectPlayer->_pIMinDam / 100 + damageMod;
-	const int maxdam = InspectPlayer->_pIMaxDam + InspectPlayer->_pIBonusDam * InspectPlayer->_pIMaxDam / 100 + damageMod;
+	const int mindam = InspectPlayer->_pIMinDam + InspectPlayer->_pIBonusMinDam + damageMod;
+	const int maxdam = InspectPlayer->_pIMaxDam + InspectPlayer->_pIBonusMaxDam + damageMod;
 	return { mindam, maxdam };
 }
 
@@ -178,7 +178,7 @@ PanelEntry panelEntries[] = {
 	{ N_("Damage"), { RightColumnLabelX, 219 }, 57, RightColumnLabelWidth,
 	    []() {
 	        const auto [dmgMin, dmgMax] = GetDamage();
-	        return StyledText { GetValueColor(InspectPlayer->_pIBonusDam), StrCat(dmgMin, "-", dmgMax) };
+	        return StyledText { GetValueColor(InspectPlayer->_pIBonusMinDam), StrCat(dmgMin, "-", dmgMax) };
 	    } },
 
 	{ N_("Life"), { LeftColumnLabelX, 284 }, 45, LeftColumnLabelWidth,

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -563,10 +563,9 @@ bool PlrHitMonst(Player &player, Monster &monster, bool adjacentDamage = false)
 		const int midam = RandomIntBetween(player._pIFMinDam, player._pIFMaxDam);
 		AddMissile(player.position.tile, player.position.temp, player._pdir, MissileID::SpectralArrow, TARGET_MONSTERS, player, midam, 0);
 	}
-	const int mind = player._pIMinDam;
-	const int maxd = player._pIMaxDam;
+	const int mind = player._pIMinDam + player._pIBonusMinDam;
+	const int maxd = player._pIMaxDam + player._pIBonusMaxDam;
 	int dam = RandomIntBetween(mind, maxd);
-	dam += dam * player._pIBonusDam / 100;
 	dam += player._pIBonusDamMod;
 	int dam2 = dam << 6;
 	dam += player._pDamageMod;
@@ -733,10 +732,9 @@ bool PlrHitPlr(Player &attacker, Player &target)
 		return true;
 	}
 
-	const int mind = attacker._pIMinDam;
-	const int maxd = attacker._pIMaxDam;
+	const int mind = attacker._pIMinDam + attacker._pIBonusMinDam;
+	const int maxd = attacker._pIMaxDam + attacker._pIBonusMaxDam;
 	int dam = RandomIntBetween(mind, maxd);
-	dam += (dam * attacker._pIBonusDam) / 100;
 	dam += attacker._pIBonusDamMod + attacker._pDamageMod;
 
 	const ClassAttributes &classAttributes = GetClassAttributes(attacker._pClass);
@@ -2680,8 +2678,7 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("shift-base")))
 #endif
-void
-StartPlayerKill(Player &player, DeathReason deathReason)
+void StartPlayerKill(Player &player, DeathReason deathReason)
 {
 	if (player.hasNoLife() && player._pmode == PM_DEATH) {
 		return;
@@ -2896,8 +2893,7 @@ void RemovePlrMissiles(const Player &player)
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("shift-base")))
 #endif
-void
-StartNewLvl(Player &player, interface_mode fom, int lvl)
+void StartNewLvl(Player &player, interface_mode fom, int lvl)
 {
 	InitLevelChange(player);
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2678,7 +2678,8 @@ void StartPlrHit(Player &player, int dam, bool forcehit)
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("shift-base")))
 #endif
-void StartPlayerKill(Player &player, DeathReason deathReason)
+void
+StartPlayerKill(Player &player, DeathReason deathReason)
 {
 	if (player.hasNoLife() && player._pmode == PM_DEATH) {
 		return;
@@ -2893,7 +2894,8 @@ void RemovePlrMissiles(const Player &player)
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("shift-base")))
 #endif
-void StartNewLvl(Player &player, interface_mode fom, int lvl)
+void
+StartNewLvl(Player &player, interface_mode fom, int lvl)
 {
 	InitLevelChange(player);
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -244,7 +244,8 @@ struct Player {
 	int _pIMinDam;
 	int _pIMaxDam;
 	int _pIAC;
-	int _pIBonusDam;
+	int _pIBonusMinDam;
+	int _pIBonusMaxDam;
 	int _pIBonusToHit;
 	int _pIBonusAC;
 	int _pIBonusDamMod;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Features
+
+#### Gameplay
+
+- Apply +Damage% item power per item
+
 ## DevilutionX 1.5.2
 
 ### Bug Fixes

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -1193,7 +1193,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_iBonusMinDam)
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iPLDam++;
+	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iPLDam += 100;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }
@@ -1206,7 +1206,7 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_iBonusMaxDam)
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_TRUE(TestNetPackValidation());
 
-	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iPLDam++;
+	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iPLDam += 100;
 	CalcPlrItemVals(*MyPlayer, false);
 	ASSERT_FALSE(TestNetPackValidation());
 }

--- a/test/pack_test.cpp
+++ b/test/pack_test.cpp
@@ -1185,9 +1185,22 @@ TEST_F(NetPackTest, UnPackNetPlayer_invalid_iAC)
 	ASSERT_FALSE(TestNetPackValidation());
 }
 
-TEST_F(NetPackTest, UnPackNetPlayer_invalid_iBonusDam)
+TEST_F(NetPackTest, UnPackNetPlayer_invalid_iBonusMinDam)
 {
-	MyPlayer->_pIBonusDam++;
+	MyPlayer->_pIBonusMinDam++;
+	ASSERT_FALSE(TestNetPackValidation());
+
+	CalcPlrItemVals(*MyPlayer, false);
+	ASSERT_TRUE(TestNetPackValidation());
+
+	MyPlayer->InvBody[INVLOC_HAND_LEFT]._iPLDam++;
+	CalcPlrItemVals(*MyPlayer, false);
+	ASSERT_FALSE(TestNetPackValidation());
+}
+
+TEST_F(NetPackTest, UnPackNetPlayer_invalid_iBonusMaxDam)
+{
+	MyPlayer->_pIBonusMaxDam++;
 	ASSERT_FALSE(TestNetPackValidation());
 
 	CalcPlrItemVals(*MyPlayer, false);

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -172,7 +172,8 @@ static void AssertPlayer(devilution::Player &player)
 	ASSERT_EQ(player._pIMinDam, 1);
 	ASSERT_EQ(player._pIMaxDam, 4);
 	ASSERT_EQ(player._pIAC, 0);
-	ASSERT_EQ(player._pIBonusDam, 0);
+	ASSERT_EQ(player._pIBonusMinDam, 0);
+	ASSERT_EQ(player._pIBonusMaxDam, 0);
 	ASSERT_EQ(player._pIBonusToHit, 0);
 	ASSERT_EQ(player._pIBonusAC, 0);
 	ASSERT_EQ(player._pIBonusDamMod, 0);

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -346,7 +346,8 @@ void AssertPlayer(Player &player)
 	ASSERT_EQ(player._pIMinDam, 1);
 	ASSERT_EQ(player._pIMaxDam, 14);
 	ASSERT_EQ(player._pIAC, 115);
-	ASSERT_EQ(player._pIBonusDam, 0);
+	ASSERT_EQ(player._pIBonusMinDam, 0);
+	ASSERT_EQ(player._pIBonusMaxDam, 0);
 	ASSERT_EQ(player._pIBonusToHit, 0);
 	ASSERT_EQ(player._pIBonusAC, 0);
 	ASSERT_EQ(player._pIBonusDamMod, 0);


### PR DESCRIPTION
When calculating item bonuses, the game iterates through all the player's equipment, and additively combines the bonuses, which are all applied to the player as a whole at the end, except for Armor Class. Armor Class has special handling, because if the +AC% bonuses were combined together, those bonuses would apply to both the Helmet and Armor slots, boasting a massive boost if these bonuses were stacked on both slots. To address this, Blizzard North added special handling that calculated the +% for its respective item, and added the result to the character's bonus AC, rather than adding a percentage itself to the player and applying it later. Since +Damage% could only be applied to a single equipment slot at a time, there was absolutely no reason for Blizzard North to apply the same logic. Hellfire introduced dual wielding, which broke that previous rule and allows the player to equip 2 weapons at a time. As a result, we end up with +Damage% stacking from both weapons, resulting a massive damage boost, since the Hellfire developers did not take care to address side effects of introducing this new mechanic. To address this, I carefully added handling for +Damage% similar to how +AC% is handled. This results in graceful continuity between how items with percentage based modifiers that affect raw item stats are handled.