### PR TITLE
Fix pathfinding burn bug

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1202,8 +1202,9 @@ size_t OnWalk(const TCmdLoc &message, Player &player)
 
 	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && InDungeonBounds(position)) {
 		ClrPlrPath(player);
-		MakePlrPath(player, position, true);
-		player.destAction = ACTION_NONE;
+		player.destAction = ACTION_WALK;
+		player.destParam1 = position.x;
+		player.destParam2 = position.y;
 	}
 
 	return sizeof(message);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1102,6 +1102,9 @@ void CheckNewPath(Player &player, bool pmWillBeCalled)
 	const int targetId = player.destParam1;
 
 	switch (player.destAction) {
+	case ACTION_WALK:
+		MakePlrPath(player, { player.destParam1, player.destParam2 }, true);
+		break;
 	case ACTION_ATTACKMON:
 	case ACTION_RATTACKMON:
 	case ACTION_SPELLMON:


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/DevilutionX/issues/6103

Credit: @pionere

Instead of creating the path at input time, we create it on demand. Path gets calculated for each call of `CheckNewPath` while the destination action is `ACTION_WALK`, so we always end up walking to the correct tile. This also fixes a bug not reported in the linked issue report, where if a monster or player enters the path when the pathing player reaches it, path is consumed unnecessarily when redirecting the player.