### PR TITLE
Remove unused CMD_ATTACKXY

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -380,7 +380,6 @@ bool WasPlayerCmdAlreadyRequested(_cmd_id bCmd, Point position = {}, uint16_t wP
 	case _cmd_id::CMD_RATTACKPID:
 	case _cmd_id::CMD_SPELLPID:
 	case _cmd_id::CMD_ATTACKPID:
-	case _cmd_id::CMD_ATTACKXY:
 	case _cmd_id::CMD_SATTACKXY:
 	case _cmd_id::CMD_RATTACKXY:
 	case _cmd_id::CMD_SPELLXY:
@@ -1648,20 +1647,6 @@ size_t OnSyncPutItem(const TCmdPItem &message, Player &player)
 			if (&player == MyPlayer)
 				pfile_update(true);
 		}
-	}
-
-	return sizeof(message);
-}
-
-size_t OnAttackTile(const TCmdLoc &message, Player &player)
-{
-	const Point position { message.x, message.y };
-
-	if (gbBufferMsgs != 1 && player.isOnActiveLevel() && leveltype != DTYPE_TOWN && InDungeonBounds(position)) {
-		MakePlrPath(player, position, false);
-		player.destAction = ACTION_ATTACK;
-		player.destParam1 = position.x;
-		player.destParam2 = position.y;
 	}
 
 	return sizeof(message);
@@ -3359,8 +3344,6 @@ size_t ParseCmd(uint8_t pnum, const TCmd *pCmd, size_t maxCmdSize)
 		return HandleCmd(OnSyncPutItem, player, pCmd, maxCmdSize);
 	case CMD_SPAWNITEM:
 		return HandleCmd(OnSpawnItem, player, pCmd, maxCmdSize);
-	case CMD_ATTACKXY:
-		return HandleCmd(OnAttackTile, player, pCmd, maxCmdSize);
 	case CMD_SATTACKXY:
 		return HandleCmd(OnStandingAttackTile, player, pCmd, maxCmdSize);
 	case CMD_RATTACKXY:

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -70,10 +70,6 @@ enum _cmd_id : uint8_t {
 	// attempted loot item when inventory is full).
 	// body (TCmdPItem)
 	CMD_SPAWNITEM,
-	// Attack target location.
-	//
-	// body (TCmdLoc)
-	CMD_ATTACKXY,
 	// Range attack target location.
 	//
 	// body (TCmdLoc)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1906,11 +1906,6 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 		graphic = player_graphic::Attack;
 		break;
 	}
-	case _cmd_id::CMD_ATTACKXY:
-		dir = GetDirection(position.tile, point);
-		graphic = player_graphic::Attack;
-		minimalWalkDistance = 2;
-		break;
 	case _cmd_id::CMD_RATTACKXY:
 	case _cmd_id::CMD_SATTACKXY:
 		dir = GetDirection(position.tile, point);


### PR DESCRIPTION
This command is never used. Its function would be to click on an empty tile, walk to it, and attack it. Not to be confused with `CMD_SATTACKXY`, which is what is used when the player attacks a tile while holding the Shift key.