### PR TITLE
Fix NaKrul book sequence not clearing

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -3356,6 +3356,7 @@ tl::expected<void, std::string> LoadGameLevel(bool firstflag, lvl_entry lvldir)
 	LoadGameLevelStopMusic(neededTrack);
 	LoadGameLevelResetCursor();
 	SetRndSeedForDungeonLevel();
+	NaKrulTomeSequence = 0;
 
 	IncProgress();
 

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -58,6 +58,7 @@ int AvailableObjects[MAXOBJECTS];
 int ActiveObjects[MAXOBJECTS];
 int ActiveObjectCount;
 bool LoadingMapObjects;
+int NaKrulTomeSequence;
 
 namespace {
 
@@ -114,9 +115,6 @@ object_graphic_id ObjFileList[40];
 /** Specifies the number of active objects. */
 int leverid;
 int numobjfiles;
-
-/** Tracks progress through the tome sequence that spawns Na-Krul (see OperateNakrulBook()) */
-int NaKrulTomeSequence;
 
 /** Specifies the X-coordinate delta between barrels. */
 int bxadd[8] = { -1, 0, 1, -1, 1, -1, 0, 1 };

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -287,6 +287,8 @@ extern int ActiveObjects[MAXOBJECTS];
 extern int ActiveObjectCount;
 /** @brief Indicates that objects are being loaded during gameplay and pre calculated data should be updated. */
 extern bool LoadingMapObjects;
+/** Tracks progress through the tome sequence that spawns Na-Krul (see OperateNakrulBook()) */
+extern int NaKrulTomeSequence;
 
 /**
  * @brief Find an object given a point in map coordinates


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/DevilutionX/issues/3807

This PR clears the global variable for the tome sequence on level load, so that it doesn't persist from game to game. Now requires the player to read the books in sequence without leaving the level/reloading the game/creating a new game, otherwise they have to restart the sequence.