### PR TITLE
[Rebalance] Auto Pickup more frequently

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -65,6 +65,7 @@
 #include "levels/trigs.h"
 #include "lighting.h"
 #include "monster.h"
+#include "qol/autopickup.h"
 #include "utils/is_of.hpp"
 #include "utils/str_cat.hpp"
 
@@ -3697,6 +3698,7 @@ void ProcessTeleport(Missile &missile)
 	}
 	if (&player == MyPlayer) {
 		ViewPosition = player.position.tile;
+		AutoPickup(player);
 	}
 }
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -438,7 +438,6 @@ bool DoWalk(Player &player)
 		ChangeLightOffset(player.lightId, { 0, 0 });
 	}
 
-	AutoPickup(player);
 	return true;
 }
 
@@ -2596,6 +2595,7 @@ void StartStand(Player &player, Direction dir)
 	FixPlrWalkTags(player);
 	player.occupyTile(player.position.tile, false);
 	SetPlayerOld(player);
+	AutoPickup(player);
 }
 
 void StartPlrBlock(Player &player, Direction dir)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Gameplay
 
-- Completion of Teleport or Phasing triggers Auto Pickup, if enabled
+- Auto Pickup occurs more frequently
 
 ## DevilutionX 1.5.2
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Features
+
+#### Gameplay
+
+- Completion of Teleport or Phasing triggers Auto Pickup, if enabled
+
 ## DevilutionX 1.5.2
 
 ### Bug Fixes


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/DevilutionX/issues/8334

Triggers auto pickup on beginning the stand animation regardless of what action led to the player reaching the stand animation.