### PR TITLE
Update iOS build to run on macOS 14

### DIFF
--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -28,7 +28,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
iOS builds are being canceled because the `macos-13` runner was retired.

https://github.com/actions/runner-images/issues/13046

> The macOS 13 Ventura based runner images will begin deprecation on September 22nd and will be fully unsupported by December 4th for GitHub