### PR TITLE
Restore option to switch to window mode at runtime

### DIFF
--- a/Source/utils/display.cpp
+++ b/Source/utils/display.cpp
@@ -830,7 +830,8 @@ void SetFullscreenMode()
 #if USE_SDL3
 	if (!SDL_SetWindowFullscreen(ghMainWnd, *GetOptions().Graphics.fullscreen)) ErrSdl();
 #else
-	if (SDL_SetWindowFullscreen(ghMainWnd, *GetOptions().Graphics.upscale ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_FULLSCREEN) != 0) ErrSdl();
+	const Uint32 flags = *GetOptions().Graphics.upscale ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_FULLSCREEN;
+	if (SDL_SetWindowFullscreen(ghMainWnd, *GetOptions().Graphics.fullscreen ? flags : 0) != 0) ErrSdl();
 #endif
 
 	if (!*GetOptions().Graphics.fullscreen) {


### PR DESCRIPTION
Here's another minor bug that slipped in with the support for SDL3. Looks like the logic allowed for three options for the value of `flags` in this case, and the refactor missed one of those options. I tried tweaking the logic compared to the original so that hopefully it would be more obvious what's going on.

For reference, here is the original logic.

https://github.com/diasurgical/DevilutionX/blob/febf576b3c421550ad3652bfa8502c72da771c80/Source/utils/display.cpp#L475-L481

Introduced in #8222
This resolves #8323