### PR TITLE
Cleanup DrawAutomapText

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1488,7 +1488,7 @@ void DrawAutomapText(const Surface &out)
 		.flags = UiFlags::ColorOrange,
 	};
 
-	advanceLine(1);
+	advanceLine();
 	drawStringAndAdvanceLine("Debug toggles:");
 	drawStringAndAdvanceLine("Player:");
 	drawStringAndAdvanceLine("God Mode", DebugGodMode ? enabled : disabled);


### PR DESCRIPTION


- Deduplicates repeated lines
- Restructures debug lines
- Fixes bug that causes remaining automap text to not display if the player is on a set level (Credit: https://github.com/diasurgical/DevilutionX/pull/7893)