### PR TITLE
[Bugfix] Prevent item deletion when dropping items

### DIFF
--- a/Source/controls/plrctrls.cpp
+++ b/Source/controls/plrctrls.cpp
@@ -2060,42 +2060,6 @@ void UpdateSpellTarget(SpellID spell)
 	cursPosition = myPlayer.position.future + Displacement(myPlayer._pdir) * range;
 }
 
-/**
- * @brief Try dropping item in all 9 possible places
- */
-bool TryDropItem()
-{
-	Player &myPlayer = *MyPlayer;
-
-	if (myPlayer.HoldItem.isEmpty()) {
-		return false;
-	}
-
-	if (leveltype == DTYPE_TOWN) {
-		if (UseItemOpensHive(myPlayer.HoldItem, myPlayer.position.tile)) {
-			OpenHive();
-			NewCursor(CURSOR_HAND);
-			return true;
-		}
-		if (UseItemOpensGrave(myPlayer.HoldItem, myPlayer.position.tile)) {
-			OpenGrave();
-			NewCursor(CURSOR_HAND);
-			return true;
-		}
-	}
-
-	std::optional<Point> itemTile = FindAdjacentPositionForItem(myPlayer.position.future, myPlayer._pdir);
-	if (!itemTile) {
-		myPlayer.Say(HeroSpeech::WhereWouldIPutThis);
-		return false;
-	}
-
-	NetSendCmdPItem(true, CMD_PUTITEM, *itemTile, myPlayer.HoldItem);
-	myPlayer.HoldItem.clear();
-	NewCursor(CURSOR_HAND);
-	return true;
-}
-
 void PerformSpellAction()
 {
 	if (SpellSelectFlag) {

--- a/Source/controls/plrctrls.h
+++ b/Source/controls/plrctrls.h
@@ -58,7 +58,6 @@ void PerformPrimaryAction();
 // Open chests, doors, pickup items.
 void PerformSecondaryAction();
 void UpdateSpellTarget(SpellID spell);
-bool TryDropItem();
 void InvalidateInventorySlot();
 void FocusOnInventory();
 void PerformSpellAction();

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -162,30 +162,28 @@ extern void plrctrls_after_game_logic();
 
 bool TryOpenDungeon(bool useCursorPosition)
 {
-    if (leveltype != DTYPE_TOWN)
-        return false;
+	if (leveltype != DTYPE_TOWN)
+		return false;
 
-    Item &holdItem = MyPlayer->HoldItem;
-    WorldTilePosition &position = MyPlayer->position.tile;
+	Item &holdItem = MyPlayer->HoldItem;
+	WorldTilePosition &position = MyPlayer->position.tile;
 
-    // Common function to attempt opening based on input method.
-    auto attemptOpen = [&]() -> bool {
-        if ((useCursorPosition && holdItem.IDidx == IDI_RUNEBOMB && OpensHive(cursPosition)) || 
-            (!useCursorPosition && UseItemOpensHive(holdItem, position))) {
-            OpenHive();
-            NewCursor(CURSOR_HAND);
-            return true;
-        }
-        if ((useCursorPosition && holdItem.IDidx == IDI_MAPOFDOOM && OpensGrave(cursPosition)) || 
-            (!useCursorPosition && UseItemOpensGrave(holdItem, position))) {
-            OpenGrave();
-            NewCursor(CURSOR_HAND);
-            return true;
-        }
-        return false;
-    };
+	// Common function to attempt opening based on input method.
+	auto attemptOpen = [&]() -> bool {
+		if ((useCursorPosition && holdItem.IDidx == IDI_RUNEBOMB && OpensHive(cursPosition)) || (!useCursorPosition && UseItemOpensHive(holdItem, position))) {
+			OpenHive();
+			NewCursor(CURSOR_HAND);
+			return true;
+		}
+		if ((useCursorPosition && holdItem.IDidx == IDI_MAPOFDOOM && OpensGrave(cursPosition)) || (!useCursorPosition && UseItemOpensGrave(holdItem, position))) {
+			OpenGrave();
+			NewCursor(CURSOR_HAND);
+			return true;
+		}
+		return false;
+	};
 
-    return attemptOpen();
+	return attemptOpen();
 }
 
 /**

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -160,21 +160,32 @@ extern void plrctrls_after_check_curs_move();
 extern void plrctrls_every_frame();
 extern void plrctrls_after_game_logic();
 
-bool TryOpenDungeonWithMouse()
+bool TryOpenDungeon(bool useCursorPosition)
 {
-	if (leveltype != DTYPE_TOWN)
-		return false;
+    if (leveltype != DTYPE_TOWN)
+        return false;
 
-	Item &holdItem = MyPlayer->HoldItem;
-	if (holdItem.IDidx == IDI_RUNEBOMB && OpensHive(cursPosition))
-		OpenHive();
-	else if (holdItem.IDidx == IDI_MAPOFDOOM && OpensGrave(cursPosition))
-		OpenGrave();
-	else
-		return false;
+    Item &holdItem = MyPlayer->HoldItem;
+    WorldTilePosition &position = MyPlayer->position.tile;
 
-	NewCursor(CURSOR_HAND);
-	return true;
+    // Common function to attempt opening based on input method.
+    auto attemptOpen = [&]() -> bool {
+        if ((useCursorPosition && holdItem.IDidx == IDI_RUNEBOMB && OpensHive(cursPosition)) || 
+            (!useCursorPosition && UseItemOpensHive(holdItem, position))) {
+            OpenHive();
+            NewCursor(CURSOR_HAND);
+            return true;
+        }
+        if ((useCursorPosition && holdItem.IDidx == IDI_MAPOFDOOM && OpensGrave(cursPosition)) || 
+            (!useCursorPosition && UseItemOpensGrave(holdItem, position))) {
+            OpenGrave();
+            NewCursor(CURSOR_HAND);
+            return true;
+        }
+        return false;
+    };
+
+    return attemptOpen();
 }
 
 /**
@@ -188,23 +199,8 @@ bool TryDropItem(bool useCursorPosition /*= false*/)
 		return false;
 	}
 
-	if (useCursorPosition) {
-		if (TryOpenDungeonWithMouse())
-			return true;
-	} else {
-		if (leveltype == DTYPE_TOWN) {
-			if (UseItemOpensHive(myPlayer.HoldItem, myPlayer.position.tile)) {
-				OpenHive();
-				NewCursor(CURSOR_HAND);
-				return true;
-			}
-			if (UseItemOpensGrave(myPlayer.HoldItem, myPlayer.position.tile)) {
-				OpenGrave();
-				NewCursor(CURSOR_HAND);
-				return true;
-			}
-		}
-	}
+	if (TryOpenDungeon(useCursorPosition))
+		return true;
 
 	Direction dir = useCursorPosition ? GetDirection(myPlayer.position.tile, cursPosition) : myPlayer._pdir;
 	std::optional<Point> itemTile = FindAdjacentPositionForItem(myPlayer.position.tile, dir);

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2233,31 +2233,31 @@ void InitPadmapActions()
 	    N_("Move up"),
 	    N_("Moves the player character up."),
 	    ControllerButton_BUTTON_DPAD_UP,
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "MoveDown",
 	    N_("Move down"),
 	    N_("Moves the player character down."),
 	    ControllerButton_BUTTON_DPAD_DOWN,
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "MoveLeft",
 	    N_("Move left"),
 	    N_("Moves the player character left."),
 	    ControllerButton_BUTTON_DPAD_LEFT,
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "MoveRight",
 	    N_("Move right"),
 	    N_("Moves the player character right."),
 	    ControllerButton_BUTTON_DPAD_RIGHT,
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "StandGround",
 	    N_("Stand ground"),
 	    N_("Hold to prevent the player from moving."),
 	    ControllerButton_NONE,
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "ToggleStandGround",
 	    N_("Toggle stand ground"),
@@ -2343,49 +2343,49 @@ void InitPadmapActions()
 	    N_("Automap Move Up"),
 	    N_("Moves the automap up when active."),
 	    ControllerButton_NONE,
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "AutomapMoveDown",
 	    N_("Automap Move Down"),
 	    N_("Moves the automap down when active."),
 	    ControllerButton_NONE,
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "AutomapMoveLeft",
 	    N_("Automap Move Left"),
 	    N_("Moves the automap left when active."),
 	    ControllerButton_NONE,
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "AutomapMoveRight",
 	    N_("Automap Move Right"),
 	    N_("Moves the automap right when active."),
 	    ControllerButton_NONE,
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "MouseUp",
 	    N_("Move mouse up"),
 	    N_("Simulates upward mouse movement."),
 	    { ControllerButton_BUTTON_BACK, ControllerButton_BUTTON_DPAD_UP },
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "MouseDown",
 	    N_("Move mouse down"),
 	    N_("Simulates downward mouse movement."),
 	    { ControllerButton_BUTTON_BACK, ControllerButton_BUTTON_DPAD_DOWN },
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "MouseLeft",
 	    N_("Move mouse left"),
 	    N_("Simulates leftward mouse movement."),
 	    { ControllerButton_BUTTON_BACK, ControllerButton_BUTTON_DPAD_LEFT },
-	    [] { });
+	    [] {});
 	options.Padmapper.AddAction(
 	    "MouseRight",
 	    N_("Move mouse right"),
 	    N_("Simulates rightward mouse movement."),
 	    { ControllerButton_BUTTON_BACK, ControllerButton_BUTTON_DPAD_RIGHT },
-	    [] { });
+	    [] {});
 	auto leftMouseDown = [] {
 		const ControllerButtonCombo standGroundCombo = GetOptions().Padmapper.ButtonComboForAction("StandGround");
 		const bool standGround = StandToggle || IsControllerButtonComboPressed(standGroundCombo);

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -102,7 +102,6 @@ void DisableInputEventHandler(const SDL_Event &event, uint16_t modState);
 tl::expected<void, std::string> LoadGameLevel(bool firstflag, lvl_entry lvldir);
 bool IsDiabloAlive(bool playSFX);
 void PrintScreen(SDL_Keycode vkey);
-bool TryDropItem(bool useCursorPosition = false);
 
 /**
  * @param bStartup Process additional ticks before returning
@@ -124,5 +123,7 @@ extern GameLogicStep gGameLogicStep;
 #ifdef __UWP__
 void setOnInitialized(void (*)());
 #endif
+
+bool TryDropItem(bool useCursorPosition = false);
 
 } // namespace devilution

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -102,6 +102,7 @@ void DisableInputEventHandler(const SDL_Event &event, uint16_t modState);
 tl::expected<void, std::string> LoadGameLevel(bool firstflag, lvl_entry lvldir);
 bool IsDiabloAlive(bool playSFX);
 void PrintScreen(SDL_Keycode vkey);
+bool TryDropItem(bool useCursorPosition = false);
 
 /**
  * @param bStartup Process additional ticks before returning

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1614,12 +1614,12 @@ size_t OnPutItem(const TCmdPItem &message, Player &player)
 				if (isSelf)
 					pfile_update(true);
 			}
-		} else {
-			PutItemRecord(dwSeed, wCI, wIndx);
-			DeltaPutItem(message, position, player);
-			if (isSelf)
-				pfile_update(true);
+			return sizeof(message);
 		}
+		PutItemRecord(dwSeed, wCI, wIndx);
+		DeltaPutItem(message, position, player);
+		if (isSelf)
+			pfile_update(true);
 	}
 
 	return sizeof(message);


### PR DESCRIPTION
Fixes: https://github.com/diasurgical/devilutionX/issues/6937

`TryDropItem()` attempted to use the future position of the player to validate the drop position of an item, which would be invalidated in certain cases in `OnPutItem()` which uses the player's current position. This mismatch would result in the item being removed from the player's hand, but failing to be dropped.

I deduplicated and unified the logic used for handling using the mouse to drop items and other methods (Ctrl + click or non-mouse controls), and set the player's position to current position universally instead of future position. Additionally, I've given the same treatment to the logic for opening dungeons.