### PR TITLE
SDL3: Update deps

### DIFF
--- a/.github/workflows/Linux_x86_64_SDL3_test.yml
+++ b/.github/workflows/Linux_x86_64_SDL3_test.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y cmake curl g++ git libgtest-dev libgmock-dev libbenchmark-dev libfmt-dev libsodium-dev libpng-dev libbz2-dev wget
+        sudo apt-get install -y cmake curl g++ git libgtest-dev libgmock-dev libbenchmark-dev libfmt-dev libsodium-dev libpng-dev libbz2-dev libasound2-dev libxcursor-dev libxi-dev libxrandr-dev libxss-dev libxtst-dev libxkbcommon-dev wget
 
     - name: Cache CMake build folder
       uses: actions/cache@v5

--- a/3rdParty/SDL3/CMakeLists.txt
+++ b/3rdParty/SDL3/CMakeLists.txt
@@ -16,7 +16,7 @@ include(functions/FetchContent_ExcludeFromAll_backport)
 include(FetchContent)
 
 FetchContent_Declare(SDL3
-  URL https://github.com/libsdl-org/SDL/archive/02c4478f9364ac9ba8c0b157c01e47c2f059552c.tar.gz
-  URL_HASH SHA256=1c8e9369ef6c67b6ca4102cc957846966815de56924b24a8a28feeac344a506a
+  URL https://github.com/libsdl-org/SDL/archive/6665ebaa2e9ccad6bc426ab3694a4c067dda5d91.tar.gz
+  URL_HASH SHA256=ca8249a85555da575b108e0b233ff616c9e52b91b1934ae983f341b383a85d6f
 )
 FetchContent_MakeAvailable_ExcludeFromAll(SDL3)

--- a/3rdParty/SDL3_mixer/CMakeLists.txt
+++ b/3rdParty/SDL3_mixer/CMakeLists.txt
@@ -27,7 +27,7 @@ set(SDLMIXER_VORBIS_TREMOR OFF)
 set(SDLMIXER_WAVPACK OFF)
 
 FetchContent_Declare_ExcludeFromAll(SDL_mixer
-  URL https://github.com/libsdl-org/SDL_mixer/archive/4b4b05949208ad0a49832ed34f59beeae6d6c2da.tar.gz
-  URL_HASH SHA256=744bbe25e127121a87b070f9211794b38e71db7e6ea497757bf45ac85525a905
+  URL https://github.com/libsdl-org/SDL_mixer/archive/7d37755016f0952c32c9483c556d8608da7ee82f.tar.gz
+  URL_HASH SHA256=2fa63f1eb623e3acd0012a461771eb93332e2026205f9487da3a3a75bc790111
 )
 FetchContent_MakeAvailable_ExcludeFromAll(SDL_mixer)


### PR DESCRIPTION
Keep testing with the latest upstream, as we'll need the upcoming SDL 3.4.0 for audio support.