### PR TITLE
[Bugfix/Engine] Refactor OperateShrineHidden

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2287,13 +2287,13 @@ void OperateShrineHidden(DiabloGenerator &rng, Player &player)
 	constexpr int DurMin = 1;
 	constexpr int DurMax = 255;
 
-	auto isEligible = [](const Item &it) {
+	auto isEligible = [DurMin, DurMax](const Item &it) {
 		return !it.isEmpty()
 		    && it._iMaxDur != DurMax
 		    && it._iMaxDur >= DurMin;
 	};
 
-	auto clampForSave = [](Item &it) {
+	auto clampForSave = [DurMin, DurMax](Item &it) {
 		it._iMaxDur = std::clamp(it._iMaxDur, DurMin, DurMax);
 		it._iDurability = std::clamp(it._iDurability, DurMin, it._iMaxDur);
 	};

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2314,7 +2314,7 @@ void OperateShrineHidden(DiabloGenerator &rng, Player &player)
 	for (int k = 0; k < eligibleCount; k++) {
 		Item &it = player.InvBody[eligible[k]];
 
-		const int delta = (eligible[k] == cursedSlot) ? -10 : +10;
+		const int delta = (eligible[k] == cursedSlot) ? -10 : 10;
 
 		it._iMaxDur += delta;
 		it._iDurability += delta;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2284,15 +2284,18 @@ void OperateShrineHidden(DiabloGenerator &rng, Player &player)
 	if (&player != MyPlayer)
 		return;
 
+	constexpr int DurMin = 1;
+	constexpr int DurMax = 255;
+
 	auto isEligible = [](const Item &it) {
 		return !it.isEmpty()
-		    && it._iMaxDur != DUR_INDESTRUCTIBLE
-		    && it._iMaxDur > 0;
+		    && it._iMaxDur != DurMax
+		    && it._iMaxDur >= DurMin;
 	};
 
 	auto clampForSave = [](Item &it) {
-		it._iMaxDur = std::clamp(it._iMaxDur, 1, DUR_INDESTRUCTIBLE);
-		it._iDurability = std::clamp(it._iDurability, 1, it._iMaxDur);
+		it._iMaxDur = std::clamp(it._iMaxDur, DurMin, DurMax);
+		it._iDurability = std::clamp(it._iDurability, DurMin, it._iMaxDur);
 	};
 
 	std::array<int, NUM_INVLOC> eligible {};

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2294,7 +2294,7 @@ void OperateShrineHidden(DiabloGenerator &rng, Player &player)
 
 	for (int i = 0; i < NUM_INVLOC; i++) {
 		const Item &it = player.InvBody[i];
-		if (!it.isEmpty() && it._iMaxDur > 0 && it._iMaxDur < 255)
+		if (!it.isEmpty() && it._iMaxDur != 0)
 			eligible[eligibleCount++] = i;
 	}
 
@@ -2310,7 +2310,11 @@ void OperateShrineHidden(DiabloGenerator &rng, Player &player)
 		Item &it = player.InvBody[eligible[k]];
 		const int delta = (eligible[k] == cursedSlot) ? -10 : 10;
 		it._iMaxDur = ClampU8(it._iMaxDur + delta);
+		if (it._iMaxDur == 0)
+			it._iMaxDur = 1;
 		it._iDurability = ClampU8(it._iDurability + delta);
+		if (it._iDurability == 0)
+			it._iDurability = 1;
 	}
 
 	InitDiabloMsg(EMSG_SHRINE_HIDDEN);

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2294,7 +2294,7 @@ void OperateShrineHidden(DiabloGenerator &rng, Player &player)
 
 	for (int i = 0; i < NUM_INVLOC; i++) {
 		const Item &it = player.InvBody[i];
-		if (!it.isEmpty() && it._iMaxDur != 0)
+		if (!it.isEmpty() && IsNoneOf(it._iMaxDur, 0, DUR_INDESTRUCTIBLE))
 			eligible[eligibleCount++] = i;
 	}
 


### PR DESCRIPTION
Refactors for clarity and to avoid the overflow that occurs with saving durability as 8-bit in the save file and over the network.