### PR TITLE
[Bugfix/Engine] Fix DamageWeapon

### DIFF
--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -462,6 +462,7 @@ bool DamageWeapon(Player &player, unsigned damageFrequency, int numDurLost)
 		const int otherSlot = (slot == minHandSlot) ? maxHandSlot : minHandSlot;
 		const Item &otherItem = player.InvBody[otherSlot];
 
+		// Do not damage shields when a weapon is equipped
 		if (item._itype == ItemType::Shield && !otherItem.isEmpty())
 			continue;
 


### PR DESCRIPTION
`DamageWeapon()` is very repetitive and has some bugs:
- Dual wielding can result in the right hand item not losing damage %/durability on attacks
- Indestructible items with a current durability < 255 can lose durability and be destroyed
- Inconsistent durability conditions (<= 0 VS == 0)

`DecayWeapon()` isn't really needed and just adds additional complexity. It can safely be nested in `DamageWeapon()`'s for loop in the refactored function, preventing the need for an additional for loop for the purpose of checking all hand items while dual wielding.