### PR TITLE
Validate echo requests and replies

### DIFF
--- a/Source/dvlnet/base.cpp
+++ b/Source/dvlnet/base.cpp
@@ -155,6 +155,10 @@ tl::expected<void, PacketError> base::HandleDisconnect(packet &pkt)
 
 tl::expected<void, PacketError> base::HandleEchoRequest(packet &pkt)
 {
+	// If we have already left the game,
+	// there is no need to respond to echoes
+	if (plr_self == PLR_BROADCAST) return {};
+
 	return pkt.Time()
 	    .and_then([&](cookie_t &&pktTime) {
 		    return pktfty->make_packet<PT_ECHO_REPLY>(plr_self, pkt.Source(), pktTime);
@@ -168,6 +172,7 @@ tl::expected<void, PacketError> base::HandleEchoReply(packet &pkt)
 {
 	const uint32_t now = SDL_GetTicks();
 	plr_t src = pkt.Source();
+	if (src >= MAX_PLRS) return {};
 	return pkt.Time().transform([&](cookie_t &&pktTime) {
 		PlayerState &playerState = playerStateTable_[src];
 		playerState.roundTripLatency = now - pktTime;


### PR DESCRIPTION
Fixes a race condition where a player who already left a game may respond with an echo reply coming from `PLR_BROADCAST`. Attempting to look that player up in `playerStateTable_` naturally results in an OOB read. This violates an assertion in debug mode and causes a crash.