### PR TITLE
Switch to GitLab mirror of bzip2

### DIFF
--- a/3rdParty/bzip2/CMakeLists.txt
+++ b/3rdParty/bzip2/CMakeLists.txt
@@ -3,7 +3,7 @@ include(functions/FetchContent_ExcludeFromAll_backport)
 include(FetchContent)
 
 FetchContent_Declare_ExcludeFromAll(bzip2
-    GIT_REPOSITORY https://sourceware.org/git/bzip2
+    GIT_REPOSITORY https://gitlab.com/bzip2/bzip2
     GIT_TAG bzip2-1.0.8
 )
 FetchContent_MakeAvailable_ExcludeFromAll(bzip2)


### PR DESCRIPTION
I'm starting to think the periodic outages for bzip are not related to rate-limiting as much as they are related to Anubis. If so, switching to the GitLab mirror ought to resolve it entirely.

<img width="1320" height="953" alt="image" src="https://github.com/user-attachments/assets/9d49b40d-165b-4bb1-bf06-912039a7e98f" />

> You are seeing this because the administrator of this website has set up Anubis to protect the server against the scourge of AI companies aggressively scraping websites. This can and does cause downtime for the websites, which makes their resources inaccessible for everyone.
> 
> Anubis is a compromise. Anubis uses a Proof-of-Work scheme in the vein of Hashcash, a proposed proof-of-work scheme for reducing email spam. The idea is that at individual scales the additional load is ignorable, but at mass scraper levels it adds up and makes scraping much more expensive.
> 
> Ultimately, this is a placeholder solution so that more time can be spent on fingerprinting and identifying headless browsers (EG: via how they do font rendering) so that the challenge proof of work page doesn't need to be presented to users that are much more likely to be legitimate.
> 
> Please note that Anubis requires the use of modern JavaScript features that plugins like JShelter will disable. Please disable JShelter or other such plugins for this domain.
