### PR TITLE
[Engine] Refactor Mana Shield damage handling

### DIFF
--- a/Source/player.h
+++ b/Source/player.h
@@ -624,12 +624,13 @@ public:
 		return blkper;
 	}
 
+	// 
 	/**
-	 * @brief Return reciprocal of the factor for calculating damage reduction due to Mana Shield.
-	 *
-	 * Valid only for players with Mana Shield spell level greater than zero.
+	 * @brief Applies fractional damage to Mana if Mana Shield is present
+	 * @param totalDamage - full fractional damage value from damage source before reductions
+	 * @return Remaining fractional damage to apply to Player Life
 	 */
-	int GetManaShieldDamageReduction();
+	int ApplyManaShieldToDamage(int totalDamage);
 
 	/**
 	 * @brief Gets the effective spell level for the player, considering item bonuses

--- a/Source/player.h
+++ b/Source/player.h
@@ -624,7 +624,6 @@ public:
 		return blkper;
 	}
 
-	// 
 	/**
 	 * @brief Applies fractional damage to Mana if Mana Shield is present
 	 * @param totalDamage - full fractional damage value from damage source before reductions


### PR DESCRIPTION
Moves reduction to Mana while Mana Shield is active into a `Player` member function `ApplyManaShieldToDamage()`, and removes `GetManaShieldDamageReduction()`.

`ApplyManaShieldToDamage()` takes `totalDamage` as an argument and reduces the Player's Mana (if applicable), and returns the remaining amount of damage to be dealt to the Player's Life.