### PR TITLE
[Engine] ModifyPlrManaCapacity helper function

### DIFF
--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2524,10 +2524,12 @@ void OperateShrineCostOfWisdom(Player &player, SpellID spellId, diablo_message m
 		}
 	}
 
-	const int maxBase = std::max(0, player._pMaxManaBase);
-	const int penalty = maxBase / 10; // 10% of max base mana (>= 0)
+	if (player._pMaxManaBase < 0)
+		player._pMaxManaBase = 0;
 
-	ModifyPlrManaCapacity(player, -penalty);
+	const int penalty = player._pMaxManaBase / 10;
+
+	ModifyPlrManaCapacity(player, -penalty, true);
 	RedrawEverything();
 	InitDiabloMsg(message);
 }

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -2524,21 +2524,10 @@ void OperateShrineCostOfWisdom(Player &player, SpellID spellId, diablo_message m
 		}
 	}
 
-	int maxBase = player._pMaxManaBase;
-
-	if (maxBase < 0) {
-		// Fix bugged state; do not turn this into a "negative penalty" mana boost.
-		player._pMaxManaBase = 0;
-		maxBase = 0;
-	}
-
+	const int maxBase = std::max(0, player._pMaxManaBase);
 	const int penalty = maxBase / 10; // 10% of max base mana (>= 0)
 
-	player._pMaxManaBase -= penalty; // will remain >= 0
-	player._pManaBase -= penalty;    // may go negative, allowed
-	player._pMaxMana -= penalty;     // may go negative, allowed
-	player._pMana -= penalty;        // may go negative, allowed
-
+	ModifyPlrManaCapacity(player, -penalty);
 	RedrawEverything();
 	InitDiabloMsg(message);
 }

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3372,6 +3372,24 @@ void ModifyPlrVit(Player &player, int l)
 	}
 }
 
+void ModifyPlrManaCapacity(Player &player, int l)
+{
+	// Repair bugged base; do not propagate this "fix" to other fields.
+	if (player._pMaxManaBase < 0)
+		player._pMaxManaBase = 0;
+
+	// Clamp so base never goes below 0 after applying l.
+	const int newMaxBase = std::max(0, player._pMaxManaBase + l);
+	const int applied = newMaxBase - player._pMaxManaBase; // actual l after clamp
+
+	player._pMaxManaBase = newMaxBase;
+
+	// Apply the same actual l to the other mana fields (may go negative, allowed).
+	player._pManaBase += applied;
+	player._pMaxMana += applied;
+	player._pMana += applied;
+}
+
 void SetPlayerHitPoints(Player &player, int val)
 {
 	player._pHitPoints = val;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3389,9 +3389,6 @@ void ModifyPlrManaCapacity(Player &player, int delta, bool shiftCurrent)
 		player._pManaBase = std::min(player._pManaBase, player._pMaxManaBase);
 		player._pMana = std::min(player._pMana, player._pMaxMana);
 	}
-
-	if (&player == MyPlayer)
-		RedrawComponent(PanelDrawComponent::Mana);
 }
 
 void SetPlayerHitPoints(Player &player, int val)

--- a/Source/player.h
+++ b/Source/player.h
@@ -990,7 +990,7 @@ void ModifyPlrStr(Player &player, int l);
 void ModifyPlrMag(Player &player, int l);
 void ModifyPlrDex(Player &player, int l);
 void ModifyPlrVit(Player &player, int l);
-void ModifyPlrManaCapacity(Player &player, int l);
+void ModifyPlrManaCapacity(Player &player, int l, bool shiftCurrent);
 void SetPlayerHitPoints(Player &player, int val);
 void SetPlrStr(Player &player, int v);
 void SetPlrMag(Player &player, int v);

--- a/Source/player.h
+++ b/Source/player.h
@@ -990,6 +990,7 @@ void ModifyPlrStr(Player &player, int l);
 void ModifyPlrMag(Player &player, int l);
 void ModifyPlrDex(Player &player, int l);
 void ModifyPlrVit(Player &player, int l);
+void ModifyPlrManaCapacity(Player &player, int l);
 void SetPlayerHitPoints(Player &player, int val);
 void SetPlrStr(Player &player, int v);
 void SetPlrMag(Player &player, int v);

--- a/Source/player.h
+++ b/Source/player.h
@@ -990,7 +990,7 @@ void ModifyPlrStr(Player &player, int l);
 void ModifyPlrMag(Player &player, int l);
 void ModifyPlrDex(Player &player, int l);
 void ModifyPlrVit(Player &player, int l);
-void ModifyPlrManaCapacity(Player &player, int l, bool shiftCurrent);
+void ModifyPlrManaCapacity(Player &player, int delta, bool shiftCurrent);
 void SetPlayerHitPoints(Player &player, int val);
 void SetPlrStr(Player &player, int v);
 void SetPlrMag(Player &player, int v);


### PR DESCRIPTION
Used in `OperateShrineCostOfWisdom`. Helps prevent incorrect mutations of `Player` mana variables.

Includes a bool argument `shiftCurrent`. 

- If true, it moves the current mana variables proportionally. This is the existing default behavior for ShrineCostOfWisdom.
- If false, it keeps the current mana variables the same.