### PR TITLE
[Engine] ModifyPlrLifeCapacity helper function

### DIFF
--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1205,16 +1205,8 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 		}
 		return;
 	}
-	if (monster.type().type == MT_YZOMBIE && &player == MyPlayer) {
-		if (player._pMaxHP > 64) {
-			if (player._pMaxHPBase > 64) {
-				player._pMaxHP -= 64;
-				player._pHitPoints = std::min(player._pHitPoints, player._pMaxHP);
-				player._pMaxHPBase -= 64;
-				player._pHPBase = std::min(player._pHPBase, player._pMaxHPBase);
-			}
-		}
-	}
+	if (monster.type().type == MT_YZOMBIE && &player == MyPlayer)
+		ModifyPlrLifeCapacity(player, -(1 << 6), false);
 	// New method fixes a bug which caused the maximum possible damage value to be 63/64ths too low.
 	int dam = RandomIntBetween(minDam << 6, maxDam << 6);
 	dam = std::max(dam + (player._pIGetHit << 6), 64);

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1205,7 +1205,7 @@ void MonsterAttackPlayer(Monster &monster, Player &player, int hit, int minDam, 
 		}
 		return;
 	}
-	if (monster.type().type == MT_YZOMBIE && &player == MyPlayer)
+	if (monster.type().type == MT_YZOMBIE && &player == MyPlayer && player._pMaxHP > (1 << 6))
 		ModifyPlrLifeCapacity(player, -(1 << 6), false);
 	// New method fixes a bug which caused the maximum possible damage value to be 63/64ths too low.
 	int dam = RandomIntBetween(minDam << 6, maxDam << 6);

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3372,6 +3372,33 @@ void ModifyPlrVit(Player &player, int l)
 	}
 }
 
+void ModifyPlrLifeCapacity(Player &player, int l, bool shiftCurrent)
+{
+	constexpr int MinHPBase = 1 << 6;
+
+	// Clamp so base never goes below minimum after applying l.
+	const int newMaxBase = std::max(MinHPBase, player._pMaxHPBase + l);
+	const int applied = newMaxBase - player._pMaxHPBase; // actual l after clamp
+
+	player._pMaxHPBase = newMaxBase;
+	player._pMaxHP += applied;
+
+	if (shiftCurrent) {
+		// Shift current values proportionally
+		player._pHPBase += applied;
+		player._pHitPoints += applied;
+	} else {
+		// Clamp current values
+		player._pHPBase = std::min(player._pHPBase, player._pMaxHPBase);
+		player._pHitPoints = std::min(player._pHitPoints, player._pMaxHP);
+	}
+
+	if (&player == MyPlayer) {
+		RedrawComponent(PanelDrawComponent::Health);
+	}
+}
+
+
 void SetPlayerHitPoints(Player &player, int val)
 {
 	player._pHitPoints = val;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3372,32 +3372,27 @@ void ModifyPlrVit(Player &player, int l)
 	}
 }
 
-void ModifyPlrLifeCapacity(Player &player, int l, bool shiftCurrent)
+void ModifyPlrLifeCapacity(Player &player, int delta, bool shiftCurrent)
 {
 	constexpr int MinHPBase = 1 << 6;
 
-	// Clamp so base never goes below minimum after applying l.
-	const int newMaxBase = std::max(MinHPBase, player._pMaxHPBase + l);
-	const int applied = newMaxBase - player._pMaxHPBase; // actual l after clamp
+	const int newMaxBase = std::max(MinHPBase, player._pMaxHPBase + delta);
+	const int applied = newMaxBase - player._pMaxHPBase;
 
 	player._pMaxHPBase = newMaxBase;
 	player._pMaxHP += applied;
 
 	if (shiftCurrent) {
-		// Shift current values proportionally
 		player._pHPBase += applied;
 		player._pHitPoints += applied;
 	} else {
-		// Clamp current values
 		player._pHPBase = std::min(player._pHPBase, player._pMaxHPBase);
 		player._pHitPoints = std::min(player._pHitPoints, player._pMaxHP);
 	}
 
-	if (&player == MyPlayer) {
+	if (&player == MyPlayer)
 		RedrawComponent(PanelDrawComponent::Health);
-	}
 }
-
 
 void SetPlayerHitPoints(Player &player, int val)
 {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3389,9 +3389,6 @@ void ModifyPlrLifeCapacity(Player &player, int delta, bool shiftCurrent)
 		player._pHPBase = std::min(player._pHPBase, player._pMaxHPBase);
 		player._pHitPoints = std::min(player._pHitPoints, player._pMaxHP);
 	}
-
-	if (&player == MyPlayer)
-		RedrawComponent(PanelDrawComponent::Health);
 }
 
 void SetPlayerHitPoints(Player &player, int val)

--- a/Source/player.h
+++ b/Source/player.h
@@ -990,6 +990,7 @@ void ModifyPlrStr(Player &player, int l);
 void ModifyPlrMag(Player &player, int l);
 void ModifyPlrDex(Player &player, int l);
 void ModifyPlrVit(Player &player, int l);
+void ModifyPlrLifeCapacity(Player &player, int l, bool shiftCurrent);
 void SetPlayerHitPoints(Player &player, int val);
 void SetPlrStr(Player &player, int v);
 void SetPlrMag(Player &player, int v);

--- a/Source/player.h
+++ b/Source/player.h
@@ -990,7 +990,7 @@ void ModifyPlrStr(Player &player, int l);
 void ModifyPlrMag(Player &player, int l);
 void ModifyPlrDex(Player &player, int l);
 void ModifyPlrVit(Player &player, int l);
-void ModifyPlrLifeCapacity(Player &player, int l, bool shiftCurrent);
+void ModifyPlrLifeCapacity(Player &player, int delta, bool shiftCurrent);
 void SetPlayerHitPoints(Player &player, int val);
 void SetPlrStr(Player &player, int v);
 void SetPlrMag(Player &player, int v);


### PR DESCRIPTION
Used in `MonsterAttackPlayer`. Helps prevent incorrect mutations of `Player` life variables.

Includes a bool argument `shiftCurrent`. 

- If true, it moves the current life variables proportionally.
- If false, it keeps the current life variables the same. This is the existing default behavior for Black Death.