### PR TITLE
Add hp_mana_units.hpp helper

### DIFF
--- a/Source/utils/hp_mana_units.hpp
+++ b/Source/utils/hp_mana_units.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace devilution {
+
+constexpr int HpManaFracBits = 6;
+constexpr int HpManaScale = 1 << HpManaFracBits;
+
+constexpr int HpManaToFrac(int whole)
+{
+	return whole * HpManaScale;
+}
+
+constexpr int HpManaToWhole(int frac)
+{
+	return frac / HpManaScale;
+}
+
+constexpr int HpManaFromParts(int whole, int frac)
+{
+	return HpManaToFrac(whole) + frac;
+}
+
+} // namespace devilution


### PR DESCRIPTION
Adds a header to be included in files that do `<< 6` and `>> 6` bitshifting.
- Unhardcodes values
- Makes working with life and mana less ambiguous
- Safer handling if the game accidentally bitshifts negative numbers