### PR TITLE
Adjust clock width so it doesn't wrap

### DIFF
--- a/assets/lua/mods/clock/init.lua
+++ b/assets/lua/mods/clock/init.lua
@@ -2,5 +2,5 @@ local events = require("devilutionx.events")
 local render = require("devilutionx.render")
 
 events.GameDrawComplete.add(function()
-  render.string(os.date('%H:%M:%S', os.time()), render.screen_width() - 69, 6)
+  render.string(os.date('%H:%M:%S', os.time()), render.screen_width() - 76, 6)
 end)


### PR DESCRIPTION
`0` is the widest digit, coming in at 10 pixels. `:` is 4 pixels, and there is 1-pixel spacing between each character.

6 zeros, 2 colons, and 7 spaces will add up to:
`6 * 10 + 2 * 4 + 7 = 75`

Seems like maybe 69 was chosen by adding 1 pixel of spacing to the right of the clock without considering the 1-pixel spacing between each character:
`6 * 10 + 2 * 4 + 1 = 69`

So I went with the same 1 pixel of spacing to the right of the clock and bumped it up to 76.

Before:
<img width="778" height="514" alt="image" src="https://github.com/user-attachments/assets/d3bd50dd-5ae3-44e9-bb77-826ec0b7b476" />

After:
<img width="778" height="514" alt="image" src="https://github.com/user-attachments/assets/a1bcb054-927e-4940-8a55-0bb409a592ca" />
