### PR TITLE
Don't show Debug Toggles unless one is active.

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1481,24 +1481,26 @@ void DrawAutomapText(const Surface &out)
 	drawStringAndAdvanceLine(description);
 
 #ifdef _DEBUG
-	const TextRenderOptions disabled {
-		.flags = UiFlags::ColorBlack,
-	};
-	const TextRenderOptions enabled {
-		.flags = UiFlags::ColorOrange,
-	};
+	if (DebugGodMode || DebugInvisible || DisableLighting || DebugVision || DebugPath || DebugGrid || DebugScrollViewEnabled) {
+		const TextRenderOptions disabled {
+			.flags = UiFlags::ColorBlack,
+		};
+		const TextRenderOptions enabled {
+			.flags = UiFlags::ColorOrange,
+		};
 
-	advanceLine();
-	drawStringAndAdvanceLine("Debug toggles:");
-	drawStringAndAdvanceLine("Player:");
-	drawStringAndAdvanceLine("God Mode", DebugGodMode ? enabled : disabled);
-	drawStringAndAdvanceLine("Invisible", DebugInvisible ? enabled : disabled);
-	drawStringAndAdvanceLine("Display:");
-	drawStringAndAdvanceLine("Fullbright", DisableLighting ? enabled : disabled);
-	drawStringAndAdvanceLine("Draw Vision", DebugVision ? enabled : disabled);
-	drawStringAndAdvanceLine("Draw Path", DebugPath ? enabled : disabled);
-	drawStringAndAdvanceLine("Draw Grid", DebugGrid ? enabled : disabled);
-	drawStringAndAdvanceLine("Scroll View", DebugScrollViewEnabled ? enabled : disabled);
+		advanceLine();
+		drawStringAndAdvanceLine("Debug toggles:");
+		drawStringAndAdvanceLine("Player:");
+		drawStringAndAdvanceLine("God Mode", DebugGodMode ? enabled : disabled);
+		drawStringAndAdvanceLine("Invisible", DebugInvisible ? enabled : disabled);
+		drawStringAndAdvanceLine("Display:");
+		drawStringAndAdvanceLine("Fullbright", DisableLighting ? enabled : disabled);
+		drawStringAndAdvanceLine("Draw Vision", DebugVision ? enabled : disabled);
+		drawStringAndAdvanceLine("Draw Path", DebugPath ? enabled : disabled);
+		drawStringAndAdvanceLine("Draw Grid", DebugGrid ? enabled : disabled);
+		drawStringAndAdvanceLine("Scroll View", DebugScrollViewEnabled ? enabled : disabled);
+	}
 #endif
 }
 


### PR DESCRIPTION
With the change in #8345 of always showing the debug toggles when the map is open, testing with debug builds is very cluttery, specifically if not using debug toggles. This change makes it so that the whole list will only show up if any of the debug toggles is enabled.