### PR TITLE
Fix crash on ZWSP

### DIFF
--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -516,6 +516,7 @@ void DrawLine(
 		currentPos += cpLen;
 		lineCopy.remove_prefix(cpLen);
 	}
+	assert(currentPos == text.size());
 	maybeDrawCursor();
 }
 


### PR DESCRIPTION
fixes https://github.com/diasurgical/DevilutionX/issues/8422 (from https://github.com/diasurgical/DevilutionX/pull/8379)

I also have removed the assert for to avoid crashes on Utf8DecodeError
although such crash will only happen in Debug builds (assert seems to be stripped down on Release builds)