### PR TITLE
fix macos cache from libsodium update

### DIFF
--- a/.github/workflows/macOS_arm64.yml
+++ b/.github/workflows/macOS_arm64.yml
@@ -38,8 +38,8 @@ jobs:
       uses: actions/cache@v5
       with:
         path: build
-        key: ${{ github.workflow }}-v1-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v1-
+        key: ${{ github.workflow }}-v2-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v2-
 
     - name: Clean previous DMG
       working-directory: ${{github.workspace}}

--- a/.github/workflows/macOS_x86_64.yml
+++ b/.github/workflows/macOS_x86_64.yml
@@ -38,8 +38,8 @@ jobs:
       uses: actions/cache@v5
       with:
         path: build
-        key: ${{ github.workflow }}-v3-${{ github.sha }}
-        restore-keys: ${{ github.workflow }}-v3-
+        key: ${{ github.workflow }}-v4-${{ github.sha }}
+        restore-keys: ${{ github.workflow }}-v4-
 
     - name: Clean previous DMG
       working-directory: ${{github.workspace}}


### PR DESCRIPTION
MacOS CIs have been failing since homebrew updated libsodium to 1.21.0