### PR TITLE
Update effects_cleanup_sfx stub

### DIFF
--- a/Source/effects_stubs.cpp
+++ b/Source/effects_stubs.cpp
@@ -44,7 +44,7 @@ void PlaySfxLoc(SfxID psfx, Point position, bool randomizeByCategory)
 }
 void sound_stop() { }
 void sound_update() { }
-void effects_cleanup_sfx() { }
+void effects_cleanup_sfx(bool fullUnload) { }
 void sound_init() { }
 void ui_sound_init() { }
 void effects_play_sound(SfxID id) { }


### PR DESCRIPTION
Add missing stub from commit: https://github.com/diasurgical/DevilutionX/commit/c55e7a4107ccb341c8eb7a92e892fa11dbb8e62b

Fix builds with `NOSOUND ON`

Closes #8433 