### PR TITLE
[QOL] Borderless Minimap and Automap type save

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1815,12 +1815,6 @@ void DrawAutomap(const Surface &out)
 			SearchAutomapItem(out, myPlayerOffset, 8, [](Point position) {
 				return dItem[position.x][position.y] != 0;
 			});
-	} else if (GetAutomapType() == AutomapType::MinimapBorderless) {
-
-		if (AutoMapShowItems)
-			SearchAutomapItem(out, myPlayerOffset, 8, [](Point position) {
-				return dItem[position.x][position.y] != 0;
-			});
 	}
 
 	Point screen = {};

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1547,7 +1547,6 @@ std::unique_ptr<AutomapTile[]> LoadAutomapData(size_t &tileCount)
 } // namespace
 
 bool AutomapActive;
-AutomapType CurrentAutomapType = AutomapType::Opaque;
 uint8_t AutomapView[DMAXX][DMAXY];
 int AutoMapScale;
 int MinimapScale;
@@ -1576,6 +1575,16 @@ void InitAutomapOnce()
 	} else {
 		MinimapScale = scale * factor;
 	}
+}
+
+void SetAutomapType(AutomapType type)
+{
+	GetOptions().Gameplay.automapType.SetValue(type);
+}
+
+AutomapType GetAutomapType()
+{
+	return *GetOptions().Gameplay.automapType;
 }
 
 void InitAutomap()

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1557,6 +1557,7 @@ Rectangle MinimapRect {};
 void InitAutomapOnce()
 {
 	AutomapActive = false;
+	SetAutomapType(*GetOptions().Gameplay.automapType);
 	AutoMapScale = 50;
 
 	// Set the dimensions and screen position of the minimap relative to the screen dimensions

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1257,7 +1257,7 @@ Displacement GetAutomapScreen()
 {
 	Displacement screen = {};
 
-	if (GetAutomapType() == AutomapType::Minimap) {
+	if (IsMinimapAutomapType()) {
 		screen = {
 			MinimapRect.position.x + MinimapRect.size.width / 2,
 			MinimapRect.position.y + MinimapRect.size.height / 2
@@ -1291,7 +1291,7 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset, i
 	const int endY = std::clamp(tile.y + searchRadius, 0, MAXDUNY);
 
 	const AutomapType mapType = GetAutomapType();
-	const int scale = (mapType == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+	const int scale = IsMinimapAutomapType(mapType) ? MinimapScale : AutoMapScale;
 
 	for (int i = startX; i < endX; i++) {
 		for (int j = startY; j < endY; j++) {
@@ -1308,7 +1308,7 @@ void SearchAutomapItem(const Surface &out, const Displacement &myPlayerOffset, i
 
 			screen += GetAutomapScreen();
 
-			if (mapType != AutomapType::Minimap && CanPanelsCoverView()) {
+			if (!IsMinimapAutomapType(mapType) && CanPanelsCoverView()) {
 				if (IsRightPanelOpen())
 					screen.x -= gnScreenWidth / 4;
 				if (IsLeftPanelOpen())
@@ -1352,7 +1352,7 @@ void DrawAutomapPlr(const Surface &out, const Displacement &myPlayerOffset, cons
 	if (player.isWalking())
 		playerOffset = GetOffsetForWalking(player.AnimInfo, player._pdir);
 
-	const int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+	const int scale = IsMinimapAutomapType() ? MinimapScale : AutoMapScale;
 
 	Point base = {
 		((playerOffset.deltaX + myPlayerOffset.deltaX) * scale / 100 / 2) + (px - py) * AmLine(AmLineLength::DoubleTile),
@@ -1732,7 +1732,7 @@ void AutomapRight()
 
 void AutomapZoomIn()
 {
-	int &scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+	int &scale = IsMinimapAutomapType() ? MinimapScale : AutoMapScale;
 
 	if (scale >= 200)
 		return;
@@ -1742,7 +1742,7 @@ void AutomapZoomIn()
 
 void AutomapZoomOut()
 {
-	int &scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+	int &scale = IsMinimapAutomapType() ? MinimapScale : AutoMapScale;
 
 	if (scale <= 25)
 		return;
@@ -1773,7 +1773,7 @@ void DrawAutomap(const Surface &out)
 	if (myPlayer.isWalking())
 		myPlayerOffset = GetOffsetForWalking(myPlayer.AnimInfo, myPlayer._pdir, true);
 
-	const int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+	const int scale = IsMinimapAutomapType() ? MinimapScale : AutoMapScale;
 	const int d = (scale * 64) / 100;
 	int cells = 2 * (gnScreenWidth / 2 / d) + 1;
 	if (((gnScreenWidth / 2) % d) != 0)
@@ -1800,6 +1800,12 @@ void DrawAutomap(const Surface &out)
 		DrawHorizontalLine(out, MinimapRect.position + Displacement { -2, MinimapRect.size.height }, MinimapRect.size.width + 3, MapColorsDim);
 		DrawVerticalLine(out, MinimapRect.position + Displacement { -2, -1 }, MinimapRect.size.height + 1, MapColorsDim);
 		DrawVerticalLine(out, MinimapRect.position + Displacement { MinimapRect.size.width, -1 }, MinimapRect.size.height + 1, MapColorsDim);
+
+		if (AutoMapShowItems)
+			SearchAutomapItem(out, myPlayerOffset, 8, [](Point position) {
+				return dItem[position.x][position.y] != 0;
+			});
+	} else if (GetAutomapType() == AutomapType::MinimapBorderless) {
 
 		if (AutoMapShowItems)
 			SearchAutomapItem(out, myPlayerOffset, 8, [](Point position) {

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -12,6 +12,7 @@
 #include "engine/surface.hpp"
 #include "levels/gendung.h"
 #include "utils/attributes.h"
+#include "utils/is_of.hpp"
 
 namespace devilution {
 
@@ -89,27 +90,11 @@ enum class AutomapType : uint8_t {
 	LAST = MinimapBorderless
 };
 
-extern DVL_API_FOR_TEST AutomapType CurrentAutomapType;
-
-/**
- * @brief Sets the map type. Does not change `AutomapActive`.
- */
-inline void SetAutomapType(AutomapType type)
-{
-	CurrentAutomapType = type;
-}
-
-/**
- * @brief Sets the map type. Does not change `AutomapActive`.
- */
-inline AutomapType GetAutomapType()
-{
-	return CurrentAutomapType;
-}
+AutomapType GetAutomapType();
 
 inline bool IsMinimapAutomapType(AutomapType type)
 {
-	return type == AutomapType::Minimap || type == AutomapType::MinimapBorderless;
+	return IsAnyOf(type, AutomapType::Minimap, AutomapType::MinimapBorderless);
 }
 
 inline bool IsMinimapAutomapType()

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -85,7 +85,8 @@ enum class AutomapType : uint8_t {
 	FIRST = Opaque,
 	Transparent,
 	Minimap,
-	LAST = Minimap
+	MinimapBorderless,
+	LAST = MinimapBorderless
 };
 
 extern DVL_API_FOR_TEST AutomapType CurrentAutomapType;
@@ -106,16 +107,26 @@ inline AutomapType GetAutomapType()
 	return CurrentAutomapType;
 }
 
+inline bool IsMinimapAutomapType(AutomapType type)
+{
+	return type == AutomapType::Minimap || type == AutomapType::MinimapBorderless;
+}
+
+inline bool IsMinimapAutomapType()
+{
+	return IsMinimapAutomapType(GetAutomapType());
+}
+
 inline Displacement AmOffset(AmWidthOffset x, AmHeightOffset y)
 {
-	int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+	int scale = IsMinimapAutomapType() ? MinimapScale : AutoMapScale;
 
 	return { scale * static_cast<int>(x) / 100, scale * static_cast<int>(y) / 100 };
 }
 
 inline int AmLine(AmLineLength l)
 {
-	int scale = (GetAutomapType() == AutomapType::Minimap) ? MinimapScale : AutoMapScale;
+	int scale = IsMinimapAutomapType() ? MinimapScale : AutoMapScale;
 
 	return scale * static_cast<int>(l) / 100;
 }

--- a/Source/control/control_panel.cpp
+++ b/Source/control/control_panel.cpp
@@ -532,7 +532,7 @@ void CycleAutomapType()
 	}
 	const AutomapType newType { static_cast<std::underlying_type_t<AutomapType>>(
 		(static_cast<unsigned>(GetAutomapType()) + 1) % enum_size<AutomapType>::value) };
-	SetAutomapType(newType);
+	GetOptions().Gameplay.automapType.SetValue(newType);
 	if (newType == AutomapType::FIRST) {
 		AutomapActive = false;
 	}

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1937,7 +1937,7 @@ void InitKeymapActions()
 	options.Keymapper.AddAction(
 	    "CycleAutomapType",
 	    N_("Cycle map type"),
-	    N_("Opaque -> Transparent -> Minimap -> None"),
+	    N_("Opaque -> Transparent -> Minimap -> Borderless Minimap -> None"),
 	    SDLK_M,
 	    CycleAutomapType,
 	    nullptr,

--- a/Source/engine/render/automap_render.cpp
+++ b/Source/engine/render/automap_render.cpp
@@ -165,7 +165,7 @@ void DrawMapFreeLine(const Surface &out, Point from, Point to, uint8_t colorInde
 
 void SetMapPixel(const Surface &out, Point position, uint8_t color)
 {
-	if (GetAutomapType() == AutomapType::Minimap && !MinimapRect.contains(position))
+	if (IsMinimapAutomapType() && !MinimapRect.contains(position))
 		return;
 
 	if (GetAutomapType() == AutomapType::Transparent) {

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -32,7 +32,6 @@
 #include "monster.h"
 #include "monsters/validation.hpp"
 #include "mpq/mpq_common.hpp"
-#include "options.h"
 #include "pfile.h"
 #include "plrmsg.h"
 #include "qol/stash.h"
@@ -2659,7 +2658,6 @@ tl::expected<void, std::string> LoadGame(bool firstflag)
 
 	AutomapActive = file.NextBool8();
 	AutoMapScale = file.NextBE<int32_t>();
-	SetAutomapType(*GetOptions().Gameplay.automapType);
 	AutomapZoomReset();
 	ResyncQuests();
 

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2658,6 +2658,16 @@ tl::expected<void, std::string> LoadGame(bool firstflag)
 
 	AutomapActive = file.NextBool8();
 	AutoMapScale = file.NextBE<int32_t>();
+	if (file.IsValid(sizeof(uint8_t))) {
+		const auto automapType = file.NextLE<uint8_t>();
+		if (automapType <= static_cast<uint8_t>(AutomapType::LAST)) {
+			SetAutomapType(static_cast<AutomapType>(automapType));
+		} else {
+			SetAutomapType(AutomapType::Opaque);
+		}
+	} else {
+		SetAutomapType(AutomapType::Opaque);
+	}
 	AutomapZoomReset();
 	ResyncQuests();
 
@@ -2921,6 +2931,7 @@ void SaveGameData(SaveWriter &saveWriter)
 
 	file.WriteLE<uint8_t>(AutomapActive ? 1 : 0);
 	file.WriteBE<int32_t>(AutoMapScale);
+	file.WriteLE<uint8_t>(static_cast<uint8_t>(GetAutomapType()));
 
 	SaveAdditionalMissiles(saveWriter);
 	SaveLevelSeeds(saveWriter);

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2930,8 +2930,6 @@ void SaveGameData(SaveWriter &saveWriter)
 
 void SaveGame()
 {
-	GetOptions().Gameplay.automapType.SetValue(GetAutomapType());
-	SaveOptions();
 	gbValidSaveFile = true;
 	pfile_write_hero(/*writeGameData=*/true);
 	sfile_write_stash();

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -865,6 +865,13 @@ GameplayOptions::GameplayOptions()
     , autoRefillBelt("Auto Refill Belt", OptionEntryFlags::None, N_("Auto Refill Belt"), N_("Refill belt from inventory when belt item is consumed."), false)
     , disableCripplingShrines("Disable Crippling Shrines", OptionEntryFlags::None, N_("Disable Crippling Shrines"), N_("When enabled Cauldrons, Fascinating Shrines, Goat Shrines, Ornate Shrines, Sacred Shrines and Murphy's Shrines are not able to be clicked on and labeled as disabled."), false)
     , quickCast("Quick Cast", OptionEntryFlags::None, N_("Quick Cast"), N_("Spell hotkeys instantly cast the spell, rather than switching the readied spell."), false)
+	, automapType("Automap Type", OptionEntryFlags::None, N_("Automap Type"), N_("Default automap type used when loading a game."), AutomapType::Opaque,
+		  {
+			  { AutomapType::Opaque, N_("Opaque") },
+			  { AutomapType::Transparent, N_("Transparent") },
+			  { AutomapType::Minimap, N_("Minimap") },
+			  { AutomapType::MinimapBorderless, N_("Minimap Borderless") },
+		  })
     , numHealPotionPickup("Heal Potion Pickup", OptionEntryFlags::None, N_("Heal Potion Pickup"), N_("Number of Healing potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
     , numFullHealPotionPickup("Full Heal Potion Pickup", OptionEntryFlags::None, N_("Full Heal Potion Pickup"), N_("Number of Full Healing potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
     , numManaPotionPickup("Mana Potion Pickup", OptionEntryFlags::None, N_("Mana Potion Pickup"), N_("Number of Mana potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
@@ -916,6 +923,7 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&disableCripplingShrines,
 		&grabInput,
 		&pauseOnFocusLoss,
+		&automapType,
 		&skipLoadingScreenThresholdMs,
 	};
 }

--- a/Source/options.h
+++ b/Source/options.h
@@ -25,6 +25,7 @@
 #include <ankerl/unordered_dense.h>
 #include <function_ref.hpp>
 
+#include "automap.h"
 #include "appfat.h"
 #include "controls/controller_buttons.h"
 #include "engine/size.hpp"
@@ -623,6 +624,8 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryBoolean disableCripplingShrines;
 	/** @brief Spell hotkeys instantly cast the spell. */
 	OptionEntryBoolean quickCast;
+	/** @brief Default automap type to use when loading a game. */
+	OptionEntryEnum<AutomapType> automapType;
 	/** @brief Number of Healing potions to pick up automatically */
 	OptionEntryInt<int> numHealPotionPickup;
 	/** @brief Number of Full Healing potions to pick up automatically */


### PR DESCRIPTION
Adds a new automap type similar to the existing minimap, but less intrusive on the screen.
Also fixes the issue of not having the current automap type being saved and the game defaulting to the regular fullscreen automap on load. It does so by appending 1 byte of extra data to store the current automap type in the savefile, if that extra byte isn't found on load or is invalid, it falls back to the regular map ensuring backwards compatibility.

Preview of the new automap type and behavior:
![minimap](https://github.com/user-attachments/assets/ad1febac-f71e-46db-8dd3-02b3baf0e6e2)
