### PR TITLE
[feature] Add Lua mod infrastructure (OnMonsterDeath, OnItemUse hooks)

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -118,6 +118,7 @@ set(libdevilutionx_SRCS
   lua/modules/dev/search.cpp
   lua/modules/dev/towners.cpp
   lua/modules/floatingnumbers.cpp
+  lua/modules/game.cpp
   lua/modules/i18n.cpp
   lua/modules/items.cpp
   lua/modules/log.cpp

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -33,6 +33,7 @@
 #include "inv_iterators.hpp"
 #include "levels/tile_properties.hpp"
 #include "levels/town.h"
+#include "lua/lua_global.hpp"
 #include "minitext.h"
 #include "options.h"
 #include "panels/ui_panels.hpp"
@@ -2175,6 +2176,10 @@ bool UseInvItem(int cii)
 
 	if (item->_iMiscId == IMISC_ARENAPOT && !player.isOnArenaLevel()) {
 		player.Say(HeroSpeech::ThatWontWorkHere);
+		return true;
+	}
+
+	if (LuaEventCancellable("OnItemUse", &player, item)) {
 		return true;
 	}
 

--- a/Source/lua/lua_global.hpp
+++ b/Source/lua/lua_global.hpp
@@ -8,6 +8,7 @@
 
 namespace devilution {
 
+struct Item;
 struct Player;
 struct Monster;
 
@@ -18,7 +19,14 @@ void LuaEvent(std::string_view name);
 void LuaEvent(std::string_view name, std::string_view arg);
 void LuaEvent(std::string_view name, const Player *player, int arg1, int arg2);
 void LuaEvent(std::string_view name, const Monster *monster, int arg1, int arg2);
+void LuaEvent(std::string_view name, const Monster *monster, int arg1);
 void LuaEvent(std::string_view name, const Player *player, uint32_t arg1);
+
+/**
+ * @brief Fires a cancellable Lua event.
+ * @return true if any handler returned true (i.e. default behaviour should be cancelled).
+ */
+bool LuaEventCancellable(std::string_view name, const Player *player, const Item *item);
 sol::state &GetLuaState();
 sol::environment CreateLuaSandbox();
 sol::object SafeCallResult(sol::protected_function_result result, bool optional);

--- a/Source/lua/modules/game.cpp
+++ b/Source/lua/modules/game.cpp
@@ -1,0 +1,34 @@
+#include "lua/modules/game.hpp"
+
+#include <sol/sol.hpp>
+
+#include "lua/metadoc.hpp"
+#include "monster.h"
+#include "multi.h"
+#include "quests.h"
+#include "tables/objdat.h"
+
+namespace devilution {
+
+sol::table LuaGameModule(sol::state_view &lua)
+{
+	sol::table table = lua.create_table();
+
+	LuaSetDocFn(table, "prepDoEnding", "()",
+	    "Triggers the game-ending sequence (win condition). Safe to call in multiplayer.",
+	    PrepDoEnding);
+
+	LuaSetDocFn(table, "isQuestDone", "(questId: integer) -> boolean",
+	    "Returns true if the quest with the given ID has been completed.",
+	    [](int questId) {
+		    return Quests[questId]._qactive == QUEST_DONE;
+	    });
+
+	LuaSetDocFn(table, "isMultiplayer", "() -> boolean",
+	    "Returns true when running in a multiplayer session.",
+	    []() { return gbIsMultiplayer; });
+
+	return table;
+}
+
+} // namespace devilution

--- a/Source/lua/modules/game.hpp
+++ b/Source/lua/modules/game.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <sol/sol.hpp>
+
+namespace devilution {
+
+sol::table LuaGameModule(sol::state_view &lua);
+
+} // namespace devilution

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -5,7 +5,9 @@
 #include <fmt/format.h>
 #include <sol/sol.hpp>
 
+#include "cursor.h"
 #include "data/file.hpp"
+#include "engine/point.hpp"
 #include "items.h"
 #include "lua/metadoc.hpp"
 #include "player.h"
@@ -465,6 +467,11 @@ void AddUniqueItemDataFromTsv(const std::string_view path, const int32_t baseMap
 	LoadUniqueItemDatFromFile(dataFile, path, baseMappingId);
 }
 
+void LuaSpawnQuestItem(int itemIdx, int x, int y, bool sendmsg)
+{
+	SpawnQuestItem(static_cast<_item_indexes>(itemIdx), Point { x, y }, 0, SelectionRegion::Bottom, sendmsg);
+}
+
 } // namespace
 
 sol::table LuaItemModule(sol::state_view &lua)
@@ -484,6 +491,10 @@ sol::table LuaItemModule(sol::state_view &lua)
 
 	LuaSetDocFn(table, "addItemDataFromTsv", "(path: string, baseMappingId: number)", AddItemDataFromTsv);
 	LuaSetDocFn(table, "addUniqueItemDataFromTsv", "(path: string, baseMappingId: number)", AddUniqueItemDataFromTsv);
+	LuaSetDocFn(table, "spawnQuestItem",
+	    "(itemIdx: ItemIndex, x: integer, y: integer, sendmsg: boolean = true)",
+	    "Spawns a quest item at the given world coordinates. Pass sendmsg=true to sync with other clients.",
+	    LuaSpawnQuestItem);
 
 	// Expose enums through the module table
 	table["ItemIndex"] = lua["ItemIndex"];

--- a/Source/lua/modules/monsters.cpp
+++ b/Source/lua/modules/monsters.cpp
@@ -42,6 +42,16 @@ void InitMonsterUserType(sol::state_view &lua)
 	    [](const Monster &monster) {
 		    return static_cast<int>(reinterpret_cast<uintptr_t>(&monster));
 	    });
+	LuaSetDocReadonlyProperty(monsterType, "typeId", "integer",
+	    "Monster type ID matching monsters.MonsterID constants (readonly)",
+	    [](const Monster &monster) {
+		    return static_cast<int>(monster.type().type);
+	    });
+	LuaSetDocReadonlyProperty(monsterType, "name", "string",
+	    "Monster's display name (readonly)",
+	    [](const Monster &monster) -> std::string_view {
+		    return monster.name();
+	    });
 }
 
 } // namespace

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1499,6 +1499,7 @@ void ShrinkLeaderPacksize(const Monster &monster)
 void MonsterDeath(Monster &monster)
 {
 	monster.var1++;
+	LuaEvent("OnMonsterDeath", &monster, monster.var1);
 	if (monster.type().type == MT_DIABLO) {
 		if (monster.position.tile.x < ViewPosition.x) {
 			ViewPosition.x--;

--- a/assets/lua/devilutionx/events.lua
+++ b/assets/lua/devilutionx/events.lua
@@ -40,6 +40,42 @@ local function CreateEvent()
   }
 end
 
+---Creates a cancellable event. If any handler returns true the trigger returns true.
+local function CreateCancellableEvent()
+  local functions = {}
+  return {
+    ---@param func function
+    add = function(func)
+      table.insert(functions, func)
+    end,
+
+    ---@param func function
+    remove = function(func)
+      for i, f in ipairs(functions) do
+        if f == func then
+          table.remove(functions, i)
+          break
+        end
+      end
+    end,
+
+    ---Triggers the event. Returns true if any handler cancelled the default behaviour.
+    ---@param ... any
+    ---@return boolean
+    trigger = function(...)
+      local cancelled = false
+      local args = {...}
+      for _, func in ipairs(functions) do
+        if func(table.unpack(args)) == true then
+          cancelled = true
+        end
+      end
+      return cancelled
+    end,
+    __sig_trigger = "(...) -> boolean",
+  }
+end
+
 local events = {
   ---Called after all mods have been loaded.
   LoadModsComplete = CreateEvent(),
@@ -84,6 +120,15 @@ local events = {
   ---Called when Player gains experience.
   OnPlayerGainExperience = CreateEvent(),
   __doc_OnPlayerGainExperience = "Called when Player gains experience.",
+
+  ---Called each frame of a monster's death animation. Arguments: monster, deathFrame (integer).
+  OnMonsterDeath = CreateEvent(),
+  __doc_OnMonsterDeath = "Called each frame of a monster's death animation. Arguments: monster, deathFrame.",
+
+  ---Called when a player is about to use an item. Arguments: player, item.
+  ---If any handler returns true the default item-use behaviour is cancelled.
+  OnItemUse = CreateCancellableEvent(),
+  __doc_OnItemUse = "Called when a player uses an item. Return true to cancel default behaviour.",
 }
 
 ---Registers a custom event type with the given name.


### PR DESCRIPTION
Provides the C++ bindings and Lua events needed to implement the soulstone mod

New events (assets/lua/devilutionx/events.lua):
- OnMonsterDeath(monster, deathFrame) - fires every death-animation frame
- OnItemUse(player, item) -> bool     - cancellable item-use event
- CreateCancellableEvent() helper

New devilutionx.game module:
- game.prepDoEnding()        - trigger the win-screen sequence
- game.isQuestDone(questId)  - check quest completion state
- game.isMultiplayer()       - multiplayer detection

Extended devilutionx.monsters:
- monster.typeId   - integer type ID
- monster.name     - display name

Extended devilutionx.player:
- player:isOnLevel(n)  - dungeon-level check
- player:say(speech)   - hero speech
- player.isMyPlayer    - local-player flag
- player.level         - current dungeon level
- player.HeroSpeech    - enum

Extended devilutionx.items:
- items.spawnQuestItem(itemIdx, x, y, sendmsg) - spawn with network sync

C++ hooks (no-ops when no Lua mod is registered):
- LuaEvent("OnMonsterDeath", ...) in MonsterDeath(), before the vanilla Diablo death sequence.
- LuaEventCancellable("OnItemUse", ...) in UseInventoryItem(), after all existing guards and before the default item-processing path.