### PR TITLE
[feature] Check mods hash on join game

### DIFF
--- a/Source/DiabloUI/multi/selgame.cpp
+++ b/Source/DiabloUI/multi/selgame.cpp
@@ -94,12 +94,14 @@ bool IsGameCompatible(const GameData &data)
 	return (data.versionMajor == PROJECT_VERSION_MAJOR
 	    && data.versionMinor == PROJECT_VERSION_MINOR
 	    && data.versionPatch == PROJECT_VERSION_PATCH
-	    && data.programid == GAME_ID);
-	return false;
+	    && data.programid == GAME_ID
+	    && data.modHash == sgGameInitInfo.modHash);
 }
 
 static std::string GetErrorMessageIncompatibility(const GameData &data)
 {
+	if (data.modHash != sgGameInitInfo.modHash)
+		return std::string(_("The host is using a different set of mods."));
 	if (data.programid != GAME_ID) {
 		std::string_view gameMode;
 		switch (data.programid) {

--- a/Source/dvlnet/base_protocol.h
+++ b/Source/dvlnet/base_protocol.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <set>
 #include <string>
@@ -318,6 +319,12 @@ void base_protocol<P>::recv()
 template <class P>
 tl::expected<void, PacketError> base_protocol<P>::handle_join_request(packet &inPkt, endpoint_t sender)
 {
+	tl::expected<const buffer_t *, PacketError> pktInfo = inPkt.Info();
+	if (pktInfo.has_value() && (*pktInfo)->size() == sizeof(GameData) && game_init_info.size() == sizeof(GameData)) {
+		constexpr size_t ModHashOffset = offsetof(GameData, modHash);
+		if (LoadLE32((*pktInfo)->data() + ModHashOffset) != LoadLE32(game_init_info.data() + ModHashOffset))
+			return {};
+	}
 	plr_t i;
 	for (i = 0; i < Players.size(); ++i) {
 		Peer &peer = peers[i];

--- a/Source/dvlnet/packet.h
+++ b/Source/dvlnet/packet.h
@@ -67,7 +67,8 @@ public:
 	enum class ErrorCode : uint8_t {
 		None,
 		EncryptionFailed,
-		DecryptionFailed
+		DecryptionFailed,
+		ModMismatch
 	};
 
 	PacketError()

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -214,6 +214,8 @@ void tcp_client::HandleTcpErrorCode()
 	PacketError::ErrorCode code = static_cast<PacketError::ErrorCode>(pktData[0]);
 	if (code == PacketError::ErrorCode::DecryptionFailed)
 		RaiseIoHandlerError(_("Server failed to decrypt your packet. Check if you typed the password correctly."));
+	else if (code == PacketError::ErrorCode::ModMismatch)
+		RaiseIoHandlerError(_("The host is using a different set of mods."));
 	else
 		RaiseIoHandlerError(fmt::format("Unknown error code received from server: {:#04x}", pktData[0]));
 }

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -6,7 +6,9 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "dvlnet/leaveinfo.hpp"
@@ -39,6 +41,8 @@ struct GameData {
 	uint8_t fullQuests;
 	/** Used to initialise the seed table for dungeon levels so players in multiplayer games generate the same layout */
 	uint32_t gameSeed[4];
+	/** FNV-1a hash of active mod list for multiplayer compatibility check */
+	uint32_t modHash;
 
 	void swapLE();
 };
@@ -68,6 +72,7 @@ extern bool IsLoopback;
 
 DVL_API_FOR_TEST std::string DescribeLeaveReason(leaveinfo_t leaveReason);
 std::string FormatGameSeed(const uint32_t gameSeed[4]);
+uint32_t ComputeModListHash(std::span<const std::string_view> mods);
 
 void InitGameInfo();
 void NetSendLoPri(uint8_t playerId, const std::byte *data, size_t size);

--- a/test/multi_logging_test.cpp
+++ b/test/multi_logging_test.cpp
@@ -1,8 +1,52 @@
+#include <array>
+#include <cstdint>
+#include <string_view>
+
 #include <gtest/gtest.h>
 
 #include "multi.h"
 
 namespace devilution {
+
+TEST(ComputeModListHash, EmptyListProducesZero)
+{
+	// An empty mod list produces zero (XOR identity with no contributors).
+	EXPECT_EQ(ComputeModListHash({}), 0U);
+}
+
+TEST(ComputeModListHash, Deterministic)
+{
+	const std::array<std::string_view, 2> mods = { "mod-a", "mod-b" };
+	EXPECT_EQ(ComputeModListHash(mods), ComputeModListHash(mods));
+}
+
+TEST(ComputeModListHash, DifferentModsProduceDifferentHashes)
+{
+	const std::array<std::string_view, 1> modsA = { "mod-a" };
+	const std::array<std::string_view, 1> modsB = { "mod-b" };
+	EXPECT_NE(ComputeModListHash(modsA), ComputeModListHash(modsB));
+}
+
+TEST(ComputeModListHash, OrderDoesNotMatter)
+{
+	const std::array<std::string_view, 2> ab = { "mod-a", "mod-b" };
+	const std::array<std::string_view, 2> ba = { "mod-b", "mod-a" };
+	EXPECT_EQ(ComputeModListHash(ab), ComputeModListHash(ba));
+}
+
+TEST(ComputeModListHash, DifferentModNamesDifferentHashes)
+{
+	// ["ab", "c"] must not collide with ["a", "bc"].
+	const std::array<std::string_view, 2> splitFirst = { "ab", "c" };
+	const std::array<std::string_view, 2> splitSecond = { "a", "bc" };
+	EXPECT_NE(ComputeModListHash(splitFirst), ComputeModListHash(splitSecond));
+}
+
+TEST(ComputeModListHash, NoModsDifferFromSomeMods)
+{
+	const std::array<std::string_view, 1> oneMod = { "any-mod" };
+	EXPECT_NE(ComputeModListHash({}), ComputeModListHash(oneMod));
+}
 
 TEST(MultiplayerLogging, NormalExitReason)
 {


### PR DESCRIPTION
Add a simple and straightforward comparison of enabled mods based on hash. When a user tries to join a multiplayer game, they send the hash of enabled mods to the server, if the hash is different, the user cannot join and receives an error message.

Limitations:
- Order of mods do not matter
- Version of the mods is not checked (only names)

Needs extensive test