### PR TITLE
Lua Hooks to disable drops from players

### DIFF
--- a/Source/lua/lua_event.cpp
+++ b/Source/lua/lua_event.cpp
@@ -79,6 +79,18 @@ void OnMonsterTakeDamage(const Monster *monster, int damage, int damageType)
 	CallLuaEvent("OnMonsterTakeDamage", monster, damage, damageType);
 }
 
+bool OnPlayerDeathDropEar(const Player *player)
+{
+	return CallLuaEventReturn<bool>(true, "OnPlayerDeathDropEar", player);
+}
+bool OnPlayerDeathDropGold(const Player *player)
+{
+	return CallLuaEventReturn<bool>(true, "OnPlayerDeathDropGold", player);
+}
+bool OnPlayerDeathDropItem(const Player *player)
+{
+	return CallLuaEventReturn<bool>(true, "OnPlayerDeathDropItem", player);
+}
 void OnPlayerGainExperience(const Player *player, uint32_t exp)
 {
 	CallLuaEvent("OnPlayerGainExperience", player, exp);

--- a/Source/lua/lua_event.hpp
+++ b/Source/lua/lua_event.hpp
@@ -19,6 +19,9 @@ void StoreOpened(std::string_view name);
 
 void OnMonsterTakeDamage(const Monster *monster, int damage, int damageType);
 
+bool OnPlayerDeathDropEar(const Player *player);
+bool OnPlayerDeathDropGold(const Player *player);
+bool OnPlayerDeathDropItem(const Player *player);
 void OnPlayerGainExperience(const Player *player, uint32_t exp);
 void OnPlayerTakeDamage(const Player *player, int damage, int damageType);
 

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2689,9 +2689,19 @@ StartPlayerKill(Player &player, DeathReason deathReason)
 		gamemenu_off();
 	}
 
-	const bool dropGold = !gbIsMultiplayer || !(player.isOnLevel(16) || player.isOnArenaLevel());
-	const bool dropItems = dropGold && deathReason == DeathReason::MonsterOrTrap;
-	const bool dropEar = dropGold && deathReason == DeathReason::Player;
+	bool dropGold = !gbIsMultiplayer || !(player.isOnLevel(16) || player.isOnArenaLevel());
+	bool dropItems = dropGold && deathReason == DeathReason::MonsterOrTrap;
+	bool dropEar = dropGold && deathReason == DeathReason::Player;
+
+	if (dropGold && !lua::OnPlayerDeathDropGold(&player)) {
+		dropGold = false;
+	}
+	if (dropItems && !lua::OnPlayerDeathDropItem(&player)) {
+		dropItems = false;
+	}
+	if (dropEar && !lua::OnPlayerDeathDropEar(&player)) {
+		dropEar = false;
+	}
 
 	player.Say(HeroSpeech::AuughUh);
 

--- a/assets/lua/devilutionx/events.lua
+++ b/assets/lua/devilutionx/events.lua
@@ -80,6 +80,18 @@ local events = {
   ---Called when Player gains experience.
   OnPlayerGainExperience = CreateEvent(),
   __doc_OnPlayerGainExperience = "Called when Player gains experience.",
+
+  ---Called when Player dies to determine if gold is dropped. Return false to prevent gold drop.
+  OnPlayerDeathDropGold = CreateEvent(),
+  __doc_OnPlayerDeathDropGold = "Called when Player dies to determine if gold is dropped. Return false to prevent gold drop.",
+
+  ---Called when Player dies to determine if items are dropped. Return false to prevent item drop.
+  OnPlayerDeathDropItem = CreateEvent(),
+  __doc_OnPlayerDeathDropItem = "Called when Player dies to determine if items are dropped. Return false to prevent item drop.",
+
+  ---Called when Player dies to determine if an ear is dropped. Return false to prevent ear drop.
+  OnPlayerDeathDropEar = CreateEvent(),
+  __doc_OnPlayerDeathDropEar = "Called when Player dies to determine if an ear is dropped. Return false to prevent ear drop.",
 }
 
 ---Registers a custom event type with the given name.


### PR DESCRIPTION
Adds lua hooks for players to disable drops on death.

events.OnPlayerDeathDropEar
events.OnPlayerDeathDropGold
events.OnPlayerDeathDropItem

Example lua mod that disables dropping items on death.

```lua
local events = require("devilutionx.events")

events.OnPlayerDeathDropItem.add(function(player)
  return false
end)
```