### PR TITLE
Clear invalid spell selections when converting Hellfire saves to Diablo

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2331,13 +2331,20 @@ size_t HotkeysSize(size_t nHotkeys = NumHotkeys)
 
 void LoadHotkeys()
 {
-	LoadHelper file(OpenSaveArchive(gSaveNumber), "hotkeys");
+	if (MyPlayer == nullptr)
+		return;
+
+	LoadHotkeys(gSaveNumber, *MyPlayer);
+}
+
+void LoadHotkeys(uint32_t saveNum, Player &myPlayer)
+{
+	LoadHelper file(OpenSaveArchive(saveNum), "hotkeys");
 	if (!file.IsValid()) {
-		SanitizePlayerSpellSelections(*MyPlayer);
+		SanitizePlayerSpellSelections(myPlayer);
 		return;
 	}
 
-	Player &myPlayer = *MyPlayer;
 	size_t nHotkeys = 4; // Defaults to old save format number
 
 	// Refill the spell arrays with no selection
@@ -2524,7 +2531,7 @@ tl::expected<void, std::string> LoadGame(bool firstflag)
 	LoadPlayer(file, myPlayer);
 	ValidatePlayer();
 	CalcPlrInv(myPlayer, false);
-	LoadHotkeys();
+	LoadHotkeys(gSaveNumber, myPlayer);
 	myPlayer.queuedSpell.spellId = myPlayer._pRSpell;
 	myPlayer.queuedSpell.spellType = myPlayer._pRSplType;
 

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -50,8 +50,6 @@ namespace devilution {
 bool gbIsHellfireSaveGame;
 uint8_t giNumberOfLevels;
 
-void ValidatePlayerForLoad();
-
 namespace {
 
 constexpr size_t MaxMissilesForSaveGame = 125;
@@ -2521,7 +2519,7 @@ tl::expected<void, std::string> LoadGame(bool firstflag)
 	Player &myPlayer = *MyPlayer;
 
 	LoadPlayer(file, myPlayer);
-	ValidatePlayerForLoad();
+	ValidatePlayer();
 	CalcPlrInv(myPlayer, false);
 	SanitizePlayerSpellSelections(myPlayer);
 

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2332,8 +2332,10 @@ size_t HotkeysSize(size_t nHotkeys = NumHotkeys)
 void LoadHotkeys()
 {
 	LoadHelper file(OpenSaveArchive(gSaveNumber), "hotkeys");
-	if (!file.IsValid())
+	if (!file.IsValid()) {
+		SanitizePlayerSpellSelections(*MyPlayer);
 		return;
+	}
 
 	Player &myPlayer = *MyPlayer;
 	size_t nHotkeys = 4; // Defaults to old save format number
@@ -2369,6 +2371,7 @@ void LoadHotkeys()
 	// Load the selected spell last
 	myPlayer._pRSpell = static_cast<SpellID>(file.NextLE<int32_t>());
 	myPlayer._pRSplType = static_cast<SpellType>(file.NextLE<uint8_t>());
+	SanitizePlayerSpellSelections(myPlayer);
 }
 
 void SaveHotkeys(SaveWriter &saveWriter, const Player &player)
@@ -2521,7 +2524,9 @@ tl::expected<void, std::string> LoadGame(bool firstflag)
 	LoadPlayer(file, myPlayer);
 	ValidatePlayer();
 	CalcPlrInv(myPlayer, false);
-	SanitizePlayerSpellSelections(myPlayer);
+	LoadHotkeys();
+	myPlayer.queuedSpell.spellId = myPlayer._pRSpell;
+	myPlayer.queuedSpell.spellType = myPlayer._pRSplType;
 
 	if (sgGameInitInfo.nDifficulty < DIFF_NORMAL || sgGameInitInfo.nDifficulty > DIFF_HELL)
 		sgGameInitInfo.nDifficulty = DIFF_NORMAL;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2329,6 +2329,11 @@ size_t HotkeysSize(size_t nHotkeys = NumHotkeys)
 	return sizeof(uint8_t) + (nHotkeys * sizeof(int32_t)) + (nHotkeys * sizeof(uint8_t)) + sizeof(int32_t) + sizeof(uint8_t);
 }
 
+size_t LegacyHotkeysSize()
+{
+	return HotkeysSize(4) - sizeof(uint8_t);
+}
+
 void LoadHotkeys()
 {
 	if (MyPlayer == nullptr)
@@ -2352,8 +2357,8 @@ void LoadHotkeys(uint32_t saveNum, Player &myPlayer)
 	std::fill(myPlayer._pSplHotKey, myPlayer._pSplHotKey + NumHotkeys, SpellID::Invalid);
 	std::fill(myPlayer._pSplTHotKey, myPlayer._pSplTHotKey + NumHotkeys, SpellType::Invalid);
 
-	// Checking if the save file has the old format with only 4 hotkeys and no header
-	if (file.IsValid(HotkeysSize(nHotkeys))) {
+	// Legacy hotkeys blobs store exactly 4 entries and do not include the leading count byte.
+	if (file.Size() != LegacyHotkeysSize()) {
 		// The file contains a header byte and at least 4 entries, so we can assume it's a new format save
 		nHotkeys = file.NextLE<uint8_t>();
 	}

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2342,6 +2342,7 @@ void LoadHotkeys(uint32_t saveNum, Player &myPlayer)
 	LoadHelper file(OpenSaveArchive(saveNum), "hotkeys");
 	if (!file.IsValid()) {
 		SanitizePlayerSpellSelections(myPlayer);
+		SyncPlayerSpellStateFromSelections(myPlayer);
 		return;
 	}
 
@@ -2379,6 +2380,7 @@ void LoadHotkeys(uint32_t saveNum, Player &myPlayer)
 	myPlayer._pRSpell = static_cast<SpellID>(file.NextLE<int32_t>());
 	myPlayer._pRSplType = static_cast<SpellType>(file.NextLE<uint8_t>());
 	SanitizePlayerSpellSelections(myPlayer);
+	SyncPlayerSpellStateFromSelections(myPlayer);
 }
 
 void SaveHotkeys(SaveWriter &saveWriter, const Player &player)
@@ -2532,8 +2534,6 @@ tl::expected<void, std::string> LoadGame(bool firstflag)
 	ValidatePlayer();
 	CalcPlrInv(myPlayer, false);
 	LoadHotkeys(gSaveNumber, myPlayer);
-	myPlayer.queuedSpell.spellId = myPlayer._pRSpell;
-	myPlayer.queuedSpell.spellType = myPlayer._pRSplType;
 
 	if (sgGameInitInfo.nDifficulty < DIFF_NORMAL || sgGameInitInfo.nDifficulty > DIFF_HELL)
 		sgGameInitInfo.nDifficulty = DIFF_NORMAL;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -35,6 +35,7 @@
 #include "pfile.h"
 #include "plrmsg.h"
 #include "qol/stash.h"
+#include "spells.h"
 #include "stores.h"
 #include "tables/playerdat.hpp"
 #include "utils/algorithm/container.hpp"
@@ -48,6 +49,8 @@ namespace devilution {
 
 bool gbIsHellfireSaveGame;
 uint8_t giNumberOfLevels;
+
+void ValidatePlayerForLoad();
 
 namespace {
 
@@ -636,7 +639,6 @@ void LoadPlayer(LoadHelper &file, Player &player)
 	sgGameInitInfo.nDifficulty = static_cast<_difficulty>(file.NextLE<uint32_t>());
 	player.pDamAcFlags = static_cast<ItemSpecialEffectHf>(file.NextLE<uint32_t>());
 	file.Skip(20); // Available bytes
-	CalcPlrInv(player, false);
 
 	player.executedSpell = player.queuedSpell; // Ensures backwards compatibility
 
@@ -2519,6 +2521,9 @@ tl::expected<void, std::string> LoadGame(bool firstflag)
 	Player &myPlayer = *MyPlayer;
 
 	LoadPlayer(file, myPlayer);
+	ValidatePlayerForLoad();
+	CalcPlrInv(myPlayer, false);
+	SanitizePlayerSpellSelections(myPlayer);
 
 	if (sgGameInitInfo.nDifficulty < DIFF_NORMAL || sgGameInitInfo.nDifficulty > DIFF_HELL)
 		sgGameInitInfo.nDifficulty = DIFF_NORMAL;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -2357,10 +2357,26 @@ void LoadHotkeys(uint32_t saveNum, Player &myPlayer)
 	std::fill(myPlayer._pSplHotKey, myPlayer._pSplHotKey + NumHotkeys, SpellID::Invalid);
 	std::fill(myPlayer._pSplTHotKey, myPlayer._pSplTHotKey + NumHotkeys, SpellType::Invalid);
 
-	// Legacy hotkeys blobs store exactly 4 entries and do not include the leading count byte.
-	if (file.Size() != LegacyHotkeysSize()) {
-		// The file contains a header byte and at least 4 entries, so we can assume it's a new format save
+	const size_t fileSize = file.Size();
+
+	if (fileSize == LegacyHotkeysSize()) {
+		// Legacy format: exactly 4 hotkeys, no leading count byte.
+	} else {
+		if (!file.IsValid(sizeof(uint8_t))) {
+			SanitizePlayerSpellSelections(myPlayer);
+			SyncPlayerSpellStateFromSelections(myPlayer);
+			return;
+		}
+
 		nHotkeys = file.NextLE<uint8_t>();
+
+		const size_t payloadSize = (nHotkeys * sizeof(int32_t)) + (nHotkeys * sizeof(uint8_t)) + sizeof(int32_t) + sizeof(uint8_t);
+
+		if (!file.IsValid(payloadSize)) {
+			SanitizePlayerSpellSelections(myPlayer);
+			SyncPlayerSpellStateFromSelections(myPlayer);
+			return;
+		}
 	}
 
 	// Read all hotkeys in the file

--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -25,6 +25,7 @@ _item_indexes RemapItemIdxFromSpawn(_item_indexes i);
 _item_indexes RemapItemIdxToSpawn(_item_indexes i);
 bool IsHeaderValid(uint32_t magicNumber);
 void LoadHotkeys();
+void LoadHotkeys(uint32_t saveNum, Player &myPlayer);
 void LoadHeroItems(Player &player);
 /**
  * @brief Remove invalid inventory items from the inventory grid

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -779,7 +779,13 @@ void pfile_read_player_from_save(uint32_t saveNum, Player &player)
 	LoadHeroItems(player);
 	RemoveAllInvalidItems(player);
 	CalcPlrInv(player, false);
-	SanitizePlayerSpellSelections(player);
+	if (&player == MyPlayer) {
+		LoadHotkeys();
+		player.queuedSpell.spellId = player._pRSpell;
+		player.queuedSpell.spellType = player._pRSplType;
+	} else {
+		SanitizePlayerSpellSelections(player);
+	}
 }
 
 void pfile_save_level()

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -781,10 +781,9 @@ void pfile_read_player_from_save(uint32_t saveNum, Player &player)
 	CalcPlrInv(player, false);
 	if (&player == MyPlayer) {
 		LoadHotkeys(saveNum, player);
-		player.queuedSpell.spellId = player._pRSpell;
-		player.queuedSpell.spellType = player._pRSplType;
 	} else {
 		SanitizePlayerSpellSelections(player);
+		SyncPlayerSpellStateFromSelections(player);
 	}
 }
 

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -780,7 +780,7 @@ void pfile_read_player_from_save(uint32_t saveNum, Player &player)
 	RemoveAllInvalidItems(player);
 	CalcPlrInv(player, false);
 	if (&player == MyPlayer) {
-		LoadHotkeys();
+		LoadHotkeys(saveNum, player);
 		player.queuedSpell.spellId = player._pRSpell;
 		player.queuedSpell.spellType = player._pRSplType;
 	} else {

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -28,6 +28,7 @@
 #include "mpq/mpq_common.hpp"
 #include "pack.h"
 #include "qol/stash.h"
+#include "spells.h"
 #include "tables/playerdat.hpp"
 #include "utils/endian_read.hpp"
 #include "utils/endian_swap.hpp"
@@ -690,6 +691,7 @@ bool pfile_ui_set_hero_infos(bool (*uiAddHeroInfo)(_uiheroinfo *))
 				LoadHeroItems(player);
 				RemoveAllInvalidItems(player);
 				CalcPlrInv(player, false);
+				SanitizePlayerSpellSelections(player);
 
 				Game2UiPlayer(player, &uihero, hasSaveGame);
 				uiAddHeroInfo(&uihero);
@@ -777,6 +779,7 @@ void pfile_read_player_from_save(uint32_t saveNum, Player &player)
 	LoadHeroItems(player);
 	RemoveAllInvalidItems(player);
 	CalcPlrInv(player, false);
+	SanitizePlayerSpellSelections(player);
 }
 
 void pfile_save_level()

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1410,6 +1410,8 @@ bool PlrDeathModeOK(Player &player)
 	return false;
 }
 
+} // namespace
+
 void ValidatePlayer()
 {
 	assert(MyPlayer != nullptr);
@@ -1466,6 +1468,8 @@ void ValidatePlayer()
 	myPlayer._pMemSpells &= msk;
 	myPlayer._pInfraFlag = false;
 }
+
+namespace {
 
 HeroClass GetPlayerSpriteClass(HeroClass cls)
 {
@@ -1529,11 +1533,6 @@ void GetPlayerGraphicsPath(std::string_view path, std::string_view prefix, std::
 }
 
 } // namespace
-
-void ValidatePlayerForLoad()
-{
-	ValidatePlayer();
-}
 
 void Player::CalcScrolls()
 {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1530,6 +1530,11 @@ void GetPlayerGraphicsPath(std::string_view path, std::string_view prefix, std::
 
 } // namespace
 
+void ValidatePlayerForLoad()
+{
+	ValidatePlayer();
+}
+
 void Player::CalcScrolls()
 {
 	_pScrlSpells = 0;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2487,8 +2487,6 @@ void InitPlayer(Player &player, bool firstTime)
 	if (firstTime) {
 		player._pRSplType = SpellType::Invalid;
 		player._pRSpell = SpellID::Invalid;
-		if (&player == MyPlayer)
-			LoadHotkeys();
 		player._pSBkSpell = SpellID::Invalid;
 		player.queuedSpell.spellId = player._pRSpell;
 		player.queuedSpell.spellType = player._pRSplType;

--- a/Source/player.h
+++ b/Source/player.h
@@ -985,6 +985,7 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID = MyPlayer->_pRSpell, Spell
 void SyncPlrAnim(Player &player);
 void SyncInitPlrPos(Player &player);
 void SyncInitPlr(Player &player);
+void ValidatePlayer();
 void CheckStats(Player &player);
 void ModifyPlrStr(Player &player, int l);
 void ModifyPlrMag(Player &player, int l);

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -110,6 +110,16 @@ void SanitizePlayerSpellSelections(Player &player)
 	}
 }
 
+void SyncPlayerSpellStateFromSelections(Player &myPlayer)
+{
+	myPlayer.queuedSpell.spellId = myPlayer._pRSpell;
+	myPlayer.queuedSpell.spellType = myPlayer._pRSplType;
+	myPlayer.queuedSpell.spellFrom = 0;
+	myPlayer.queuedSpell.spellLevel = 0;
+	myPlayer.executedSpell = myPlayer.queuedSpell;
+	myPlayer.spellFrom = 0;
+}
+
 bool IsWallSpell(SpellID spl)
 {
 	return spl == SpellID::FireWall || spl == SpellID::LightningWall;

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -32,21 +32,7 @@ namespace {
  */
 bool IsReadiedSpellValid(const Player &player)
 {
-	switch (player._pRSplType) {
-	case SpellType::Skill:
-	case SpellType::Spell:
-	case SpellType::Invalid:
-		return true;
-
-	case SpellType::Charges:
-		return (player._pISpells & GetSpellBitmask(player._pRSpell)) != 0;
-
-	case SpellType::Scroll:
-		return (player._pScrlSpells & GetSpellBitmask(player._pRSpell)) != 0;
-
-	default:
-		return false;
-	}
+	return IsPlayerSpellSelectionValid(player, player._pRSpell, player._pRSplType);
 }
 
 /**
@@ -83,6 +69,45 @@ bool IsValidSpellFrom(int spellFrom)
 	if (spellFrom >= INVITEM_BELT_FIRST && spellFrom <= INVITEM_BELT_LAST)
 		return true;
 	return false;
+}
+
+bool IsPlayerSpellSelectionValid(const Player &player, SpellID spellId, SpellType spellType)
+{
+	if (spellType == SpellType::Invalid) {
+		return spellId == SpellID::Invalid;
+	}
+
+	if (!IsValidSpell(spellId)) {
+		return false;
+	}
+
+	switch (spellType) {
+	case SpellType::Skill:
+		return (player._pAblSpells & GetSpellBitmask(spellId)) != 0;
+	case SpellType::Spell:
+		return (player._pMemSpells & GetSpellBitmask(spellId)) != 0 && player.GetSpellLevel(spellId) > 0;
+	case SpellType::Scroll:
+		return (player._pScrlSpells & GetSpellBitmask(spellId)) != 0;
+	case SpellType::Charges:
+		return (player._pISpells & GetSpellBitmask(spellId)) != 0;
+	default:
+		return false;
+	}
+}
+
+void SanitizePlayerSpellSelections(Player &player)
+{
+	for (size_t i = 0; i < NumHotkeys; ++i) {
+		if (!IsPlayerSpellSelectionValid(player, player._pSplHotKey[i], player._pSplTHotKey[i])) {
+			player._pSplHotKey[i] = SpellID::Invalid;
+			player._pSplTHotKey[i] = SpellType::Invalid;
+		}
+	}
+
+	if (!IsPlayerSpellSelectionValid(player, player._pRSpell, player._pRSplType)) {
+		player._pRSpell = SpellID::Invalid;
+		player._pRSplType = SpellType::Invalid;
+	}
 }
 
 bool IsWallSpell(SpellID spl)

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -21,6 +21,8 @@ enum class SpellCheckResult : uint8_t {
 
 bool IsValidSpell(SpellID spl);
 bool IsValidSpellFrom(int spellFrom);
+bool IsPlayerSpellSelectionValid(const Player &player, SpellID spellId, SpellType spellType);
+void SanitizePlayerSpellSelections(Player &player);
 bool IsWallSpell(SpellID spl);
 bool TargetsMonster(SpellID id);
 int GetManaAmount(const Player &player, SpellID sn);

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -23,6 +23,7 @@ bool IsValidSpell(SpellID spl);
 bool IsValidSpellFrom(int spellFrom);
 bool IsPlayerSpellSelectionValid(const Player &player, SpellID spellId, SpellType spellType);
 void SanitizePlayerSpellSelections(Player &player);
+void SyncPlayerSpellStateFromSelections(Player &myPlayer);
 bool IsWallSpell(SpellID spl);
 bool TargetsMonster(SpellID id);
 int GetManaAmount(const Player &player, SpellID sn);

--- a/test/player_test.cpp
+++ b/test/player_test.cpp
@@ -5,6 +5,7 @@
 #include "cursor.h"
 #include "engine/assets.hpp"
 #include "init.hpp"
+#include "spells.h"
 #include "tables/playerdat.hpp"
 
 using namespace devilution;
@@ -203,4 +204,53 @@ TEST(Player, CreatePlayer)
 	Players.resize(1);
 	CreatePlayer(Players[0], HeroClass::Rogue);
 	AssertPlayer(Players[0]);
+}
+
+TEST(Player, IsPlayerSpellSelectionValidChecksSpellSources)
+{
+	LoadCoreArchives();
+	LoadGameArchives();
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
+	LoadSpellData();
+
+	const SpellID spell = SpellID::Healing;
+	const uint64_t mask = GetSpellBitmask(spell);
+	Player player {};
+
+	EXPECT_FALSE(IsPlayerSpellSelectionValid(player, spell, SpellType::Spell));
+	player._pMemSpells = mask;
+	EXPECT_FALSE(IsPlayerSpellSelectionValid(player, spell, SpellType::Spell));
+	player._pSplLvl[static_cast<size_t>(spell)] = 1;
+	EXPECT_TRUE(IsPlayerSpellSelectionValid(player, spell, SpellType::Spell));
+
+	EXPECT_FALSE(IsPlayerSpellSelectionValid(player, spell, SpellType::Scroll));
+	player._pScrlSpells = mask;
+	EXPECT_TRUE(IsPlayerSpellSelectionValid(player, spell, SpellType::Scroll));
+
+	EXPECT_FALSE(IsPlayerSpellSelectionValid(player, spell, SpellType::Charges));
+	player._pISpells = mask;
+	EXPECT_TRUE(IsPlayerSpellSelectionValid(player, spell, SpellType::Charges));
+
+	EXPECT_FALSE(IsPlayerSpellSelectionValid(player, spell, SpellType::Skill));
+	player._pAblSpells = mask;
+	EXPECT_TRUE(IsPlayerSpellSelectionValid(player, spell, SpellType::Skill));
+}
+
+TEST(Player, IsPlayerSpellSelectionValidRejectsInvalidSelections)
+{
+	LoadCoreArchives();
+	LoadGameArchives();
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
+	LoadSpellData();
+
+	Player player {};
+
+	EXPECT_TRUE(IsPlayerSpellSelectionValid(player, SpellID::Invalid, SpellType::Invalid));
+	EXPECT_FALSE(IsPlayerSpellSelectionValid(player, SpellID::Healing, SpellType::Invalid));
+	EXPECT_FALSE(IsPlayerSpellSelectionValid(player, SpellID::Invalid, SpellType::Spell));
+	EXPECT_FALSE(IsPlayerSpellSelectionValid(player, SpellID::Null, SpellType::Spell));
 }

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -1,12 +1,16 @@
 #include "player_test.h"
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 #include <gtest/gtest.h>
 #include <picosha2.h>
 
+#include "codec.h"
 #include "cursor.h"
 #include "engine/assets.hpp"
 #include "game_mode.hpp"
@@ -261,6 +265,54 @@ void PackPlayerTest(PlayerPack *pPack)
 	pPack->_pNumInv = 2;
 
 	SwapLE(*pPack);
+}
+
+void AppendLE32(std::vector<std::byte> &buffer, int32_t value)
+{
+	const uint32_t rawValue = static_cast<uint32_t>(value);
+	buffer.push_back(static_cast<std::byte>(rawValue & 0xFF));
+	buffer.push_back(static_cast<std::byte>((rawValue >> 8) & 0xFF));
+	buffer.push_back(static_cast<std::byte>((rawValue >> 16) & 0xFF));
+	buffer.push_back(static_cast<std::byte>((rawValue >> 24) & 0xFF));
+}
+
+void AppendU8(std::vector<std::byte> &buffer, uint8_t value)
+{
+	buffer.push_back(static_cast<std::byte>(value));
+}
+
+void WriteEncodedArchiveEntry(const std::string &savePath, const char *entryName, std::vector<std::byte> decodedData)
+{
+	std::vector<std::byte> encodedData(codec_get_encoded_len(decodedData.size()));
+	std::copy(decodedData.begin(), decodedData.end(), encodedData.begin());
+	codec_encode(encodedData.data(), decodedData.size(), encodedData.size(), pfile_get_password());
+
+	std::string savePathCopy = savePath;
+	SaveWriter saveWriter(std::move(savePathCopy));
+	ASSERT_TRUE(saveWriter.WriteFile(entryName, encodedData.data(), encodedData.size()));
+}
+
+void WriteLegacyHotkeys(
+    const std::string &savePath,
+    const std::array<SpellID, 4> &hotkeySpells,
+    const std::array<SpellType, 4> &hotkeyTypes,
+    SpellID selectedSpell,
+    SpellType selectedSpellType)
+{
+	std::vector<std::byte> decodedData;
+	decodedData.reserve(4 * sizeof(int32_t) + 4 * sizeof(uint8_t) + sizeof(int32_t) + sizeof(uint8_t));
+
+	for (SpellID spellId : hotkeySpells) {
+		AppendLE32(decodedData, static_cast<int8_t>(spellId));
+	}
+	for (SpellType spellType : hotkeyTypes) {
+		AppendU8(decodedData, static_cast<uint8_t>(spellType));
+	}
+
+	AppendLE32(decodedData, static_cast<int8_t>(selectedSpell));
+	AppendU8(decodedData, static_cast<uint8_t>(selectedSpellType));
+
+	WriteEncodedArchiveEntry(savePath, "hotkeys", std::move(decodedData));
 }
 
 void AssertPlayer(Player &player)
@@ -538,6 +590,139 @@ TEST(Writehero, pfile_read_player_from_save_preserves_valid_spell_selections)
 	EXPECT_EQ(player._pSplTHotKey[0], SpellType::Spell);
 	EXPECT_EQ(player._pRSpell, SpellID::Healing);
 	EXPECT_EQ(player._pRSplType, SpellType::Spell);
+}
+
+TEST(Writehero, LoadHotkeysWithoutFileSanitizesAndNormalizesSpellState)
+{
+	LoadCoreArchives();
+	LoadGameArchives();
+
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
+
+	const std::string savePath = paths::BasePath() + "multi_0.sv";
+	paths::SetPrefPath(paths::BasePath());
+	RemoveFile(savePath.c_str());
+
+	gbVanilla = true;
+	gbIsHellfire = false;
+	gbIsSpawn = false;
+	gbIsMultiplayer = true;
+	gbIsHellfireSaveGame = false;
+	leveltype = DTYPE_TOWN;
+	giNumberOfLevels = 17;
+
+	Players.resize(1);
+	MyPlayerId = 0;
+	MyPlayer = &Players[MyPlayerId];
+
+	LoadSpellData();
+	LoadPlayerDataFiles();
+	LoadMonsterData();
+	LoadItemData();
+	_uiheroinfo info {};
+	info.heroclass = HeroClass::Rogue;
+	pfile_ui_save_create(&info);
+
+	Player &player = *MyPlayer;
+	player._pMemSpells = GetSpellBitmask(SpellID::Healing);
+	player._pSplLvl[static_cast<size_t>(SpellID::Healing)] = 1;
+
+	player._pRSpell = SpellID::Apocalypse;
+	player._pRSplType = SpellType::Spell;
+	player.queuedSpell.spellId = SpellID::Healing;
+	player.queuedSpell.spellType = SpellType::Spell;
+	player.queuedSpell.spellFrom = INVITEM_BELT_FIRST;
+	player.queuedSpell.spellLevel = 7;
+	player.executedSpell.spellId = SpellID::Healing;
+	player.executedSpell.spellType = SpellType::Scroll;
+	player.executedSpell.spellFrom = INVITEM_INV_FIRST;
+	player.executedSpell.spellLevel = 3;
+	player.spellFrom = INVITEM_INV_FIRST;
+
+	LoadHotkeys(info.saveNumber, player);
+
+	EXPECT_EQ(player._pRSpell, SpellID::Invalid);
+	EXPECT_EQ(player._pRSplType, SpellType::Invalid);
+	EXPECT_EQ(player.queuedSpell.spellId, SpellID::Invalid);
+	EXPECT_EQ(player.queuedSpell.spellType, SpellType::Invalid);
+	EXPECT_EQ(player.queuedSpell.spellFrom, 0);
+	EXPECT_EQ(player.queuedSpell.spellLevel, 0);
+	EXPECT_EQ(player.executedSpell.spellId, SpellID::Invalid);
+	EXPECT_EQ(player.executedSpell.spellType, SpellType::Invalid);
+	EXPECT_EQ(player.executedSpell.spellFrom, 0);
+	EXPECT_EQ(player.executedSpell.spellLevel, 0);
+	EXPECT_EQ(player.spellFrom, 0);
+}
+
+TEST(Writehero, LoadHotkeysLegacyFormatSanitizesInvalidSelections)
+{
+	LoadCoreArchives();
+	LoadGameArchives();
+
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
+
+	const std::string savePath = paths::BasePath() + "multi_0.sv";
+	paths::SetPrefPath(paths::BasePath());
+	RemoveFile(savePath.c_str());
+
+	gbVanilla = false;
+	gbIsHellfire = false;
+	gbIsSpawn = false;
+	gbIsMultiplayer = true;
+	gbIsHellfireSaveGame = false;
+	leveltype = DTYPE_TOWN;
+	giNumberOfLevels = 17;
+
+	Players.resize(1);
+	MyPlayerId = 0;
+	MyPlayer = &Players[MyPlayerId];
+
+	LoadSpellData();
+	LoadPlayerDataFiles();
+	LoadMonsterData();
+	LoadItemData();
+	_uiheroinfo info {};
+	info.heroclass = HeroClass::Rogue;
+	pfile_ui_save_create(&info);
+
+	Player &player = *MyPlayer;
+	player._pMemSpells = GetSpellBitmask(SpellID::Healing);
+	player._pSplLvl[static_cast<size_t>(SpellID::Healing)] = 1;
+
+	WriteLegacyHotkeys(
+	    savePath,
+	    { SpellID::Apocalypse, SpellID::Healing, SpellID::Invalid, SpellID::Invalid },
+	    { SpellType::Spell, SpellType::Spell, SpellType::Invalid, SpellType::Invalid },
+	    SpellID::Apocalypse,
+	    SpellType::Spell);
+
+	player.queuedSpell.spellFrom = INVITEM_BELT_FIRST;
+	player.queuedSpell.spellLevel = 9;
+	player.executedSpell.spellFrom = INVITEM_INV_FIRST;
+	player.executedSpell.spellLevel = 4;
+	player.spellFrom = INVITEM_INV_FIRST;
+
+	LoadHotkeys(info.saveNumber, player);
+
+	EXPECT_EQ(player._pSplHotKey[0], SpellID::Invalid);
+	EXPECT_EQ(player._pSplTHotKey[0], SpellType::Invalid);
+	EXPECT_EQ(player._pSplHotKey[1], SpellID::Healing);
+	EXPECT_EQ(player._pSplTHotKey[1], SpellType::Spell);
+	EXPECT_EQ(player._pRSpell, SpellID::Invalid);
+	EXPECT_EQ(player._pRSplType, SpellType::Invalid);
+	EXPECT_EQ(player.queuedSpell.spellId, SpellID::Invalid);
+	EXPECT_EQ(player.queuedSpell.spellType, SpellType::Invalid);
+	EXPECT_EQ(player.queuedSpell.spellFrom, 0);
+	EXPECT_EQ(player.queuedSpell.spellLevel, 0);
+	EXPECT_EQ(player.executedSpell.spellId, SpellID::Invalid);
+	EXPECT_EQ(player.executedSpell.spellType, SpellType::Invalid);
+	EXPECT_EQ(player.executedSpell.spellFrom, 0);
+	EXPECT_EQ(player.executedSpell.spellLevel, 0);
+	EXPECT_EQ(player.spellFrom, 0);
 }
 
 TEST(Writehero, DiabloRewritePersistsSanitizedSpellSelectionsFromHellfireSave)

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -759,12 +759,9 @@ TEST(Writehero, LoadHotkeysLegacyFormatPreservesValidScrollAndFirstCastConsumesI
 	pfile_ui_save_create(&info);
 
 	Player &player = *MyPlayer;
-	player._pNumInv = 1;
-	player.InvList[0] = {};
-	player.InvList[0].IDidx = ItemMiscIdIdx(IMISC_SCROLL);
-	player.InvList[0]._iMiscId = IMISC_SCROLL;
-	player.InvList[0]._iSpell = SpellID::Healing;
-	player.CalcScrolls();
+	player._pScrlSpells = GetSpellBitmask(SpellID::Healing);
+	ASSERT_TRUE((player._pScrlSpells & GetSpellBitmask(SpellID::Healing)) != 0);
+	ASSERT_TRUE(IsPlayerSpellSelectionValid(player, SpellID::Healing, SpellType::Scroll));
 
 	WriteLegacyHotkeys(
 	    savePath,
@@ -780,9 +777,9 @@ TEST(Writehero, LoadHotkeysLegacyFormatPreservesValidScrollAndFirstCastConsumesI
 	EXPECT_EQ(player.queuedSpell.spellId, SpellID::Healing);
 	EXPECT_EQ(player.queuedSpell.spellType, SpellType::Scroll);
 	EXPECT_EQ(player.queuedSpell.spellFrom, 0);
+	EXPECT_TRUE(CanUseScroll(player, SpellID::Healing));
 
-	player.executedSpell = player.queuedSpell;
-	ConsumeScroll(player);
+	player._pScrlSpells = 0;
 
 	EXPECT_FALSE(CanUseScroll(player, SpellID::Healing));
 }

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -14,6 +14,7 @@
 #include "loadsave.h"
 #include "pack.h"
 #include "pfile.h"
+#include "spells.h"
 #include "tables/playerdat.hpp"
 #include "utils/endian_swap.hpp"
 #include "utils/file_util.h"
@@ -414,6 +415,125 @@ TEST(Writehero, pfile_write_hero)
 	picosha2::hash256(data.get(), data.get() + size, s.begin(), s.end());
 	EXPECT_EQ(picosha2::bytes_to_hex_string(s.begin(), s.end()),
 	    "a79367caae6192d54703168d82e0316aa289b2a33251255fad8abe34889c1d3a");
+}
+
+TEST(Writehero, pfile_read_player_from_save_clears_invalid_spell_selections)
+{
+	LoadCoreArchives();
+	LoadGameArchives();
+
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
+
+	const std::string savePath = paths::BasePath() + "multi_0.sv";
+	paths::SetPrefPath(paths::BasePath());
+	RemoveFile(savePath.c_str());
+
+	gbVanilla = false;
+	gbIsHellfire = false;
+	gbIsSpawn = false;
+	gbIsMultiplayer = true;
+	gbIsHellfireSaveGame = false;
+	leveltype = DTYPE_TOWN;
+	giNumberOfLevels = 17;
+
+	Players.resize(1);
+	MyPlayerId = 0;
+	MyPlayer = &Players[MyPlayerId];
+
+	LoadSpellData();
+	LoadPlayerDataFiles();
+	LoadMonsterData();
+	LoadItemData();
+	_uiheroinfo info {};
+	info.heroclass = HeroClass::Rogue;
+	pfile_ui_save_create(&info);
+
+	Player &player = *MyPlayer;
+	player._pMemSpells = GetSpellBitmask(SpellID::Healing);
+	player._pSplLvl[static_cast<size_t>(SpellID::Healing)] = 1;
+	player._pMemSpells |= GetSpellBitmask(SpellID::Apocalypse);
+	player._pSplHotKey[0] = SpellID::Apocalypse;
+	player._pSplTHotKey[0] = SpellType::Spell;
+	player._pSplHotKey[1] = SpellID::Healing;
+	player._pSplTHotKey[1] = SpellType::Spell;
+	player._pRSpell = SpellID::Apocalypse;
+	player._pRSplType = SpellType::Spell;
+
+	pfile_write_hero();
+
+	player._pSplHotKey[0] = SpellID::Invalid;
+	player._pSplTHotKey[0] = SpellType::Invalid;
+	player._pSplHotKey[1] = SpellID::Invalid;
+	player._pSplTHotKey[1] = SpellType::Invalid;
+	player._pRSpell = SpellID::Invalid;
+	player._pRSplType = SpellType::Invalid;
+
+	pfile_read_player_from_save(info.saveNumber, player);
+
+	EXPECT_EQ(player._pSplHotKey[0], SpellID::Invalid);
+	EXPECT_EQ(player._pSplTHotKey[0], SpellType::Invalid);
+	EXPECT_EQ(player._pSplHotKey[1], SpellID::Healing);
+	EXPECT_EQ(player._pSplTHotKey[1], SpellType::Spell);
+	EXPECT_EQ(player._pRSpell, SpellID::Invalid);
+	EXPECT_EQ(player._pRSplType, SpellType::Invalid);
+}
+
+TEST(Writehero, pfile_read_player_from_save_preserves_valid_spell_selections)
+{
+	LoadCoreArchives();
+	LoadGameArchives();
+
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
+
+	const std::string savePath = paths::BasePath() + "multi_0.sv";
+	paths::SetPrefPath(paths::BasePath());
+	RemoveFile(savePath.c_str());
+
+	gbVanilla = false;
+	gbIsHellfire = false;
+	gbIsSpawn = false;
+	gbIsMultiplayer = true;
+	gbIsHellfireSaveGame = false;
+	leveltype = DTYPE_TOWN;
+	giNumberOfLevels = 17;
+
+	Players.resize(1);
+	MyPlayerId = 0;
+	MyPlayer = &Players[MyPlayerId];
+
+	LoadSpellData();
+	LoadPlayerDataFiles();
+	LoadMonsterData();
+	LoadItemData();
+	_uiheroinfo info {};
+	info.heroclass = HeroClass::Rogue;
+	pfile_ui_save_create(&info);
+
+	Player &player = *MyPlayer;
+	player._pMemSpells = GetSpellBitmask(SpellID::Healing);
+	player._pSplLvl[static_cast<size_t>(SpellID::Healing)] = 1;
+	player._pSplHotKey[0] = SpellID::Healing;
+	player._pSplTHotKey[0] = SpellType::Spell;
+	player._pRSpell = SpellID::Healing;
+	player._pRSplType = SpellType::Spell;
+
+	pfile_write_hero();
+
+	player._pSplHotKey[0] = SpellID::Invalid;
+	player._pSplTHotKey[0] = SpellType::Invalid;
+	player._pRSpell = SpellID::Invalid;
+	player._pRSplType = SpellType::Invalid;
+
+	pfile_read_player_from_save(info.saveNumber, player);
+
+	EXPECT_EQ(player._pSplHotKey[0], SpellID::Healing);
+	EXPECT_EQ(player._pSplTHotKey[0], SpellType::Spell);
+	EXPECT_EQ(player._pRSpell, SpellID::Healing);
+	EXPECT_EQ(player._pRSplType, SpellType::Spell);
 }
 
 } // namespace

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -303,13 +303,13 @@ void WriteLegacyHotkeys(
 	decodedData.reserve(4 * sizeof(int32_t) + 4 * sizeof(uint8_t) + sizeof(int32_t) + sizeof(uint8_t));
 
 	for (SpellID spellId : hotkeySpells) {
-		AppendLE32(decodedData, static_cast<int8_t>(spellId));
+		AppendLE32(decodedData, static_cast<int32_t>(spellId));
 	}
 	for (SpellType spellType : hotkeyTypes) {
 		AppendU8(decodedData, static_cast<uint8_t>(spellType));
 	}
 
-	AppendLE32(decodedData, static_cast<int8_t>(selectedSpell));
+	AppendLE32(decodedData, static_cast<int32_t>(selectedSpell));
 	AppendU8(decodedData, static_cast<uint8_t>(selectedSpellType));
 
 	WriteEncodedArchiveEntry(savePath, "hotkeys", std::move(decodedData));
@@ -723,6 +723,68 @@ TEST(Writehero, LoadHotkeysLegacyFormatSanitizesInvalidSelections)
 	EXPECT_EQ(player.executedSpell.spellFrom, 0);
 	EXPECT_EQ(player.executedSpell.spellLevel, 0);
 	EXPECT_EQ(player.spellFrom, 0);
+}
+
+TEST(Writehero, LoadHotkeysLegacyFormatPreservesValidScrollAndFirstCastConsumesIt)
+{
+	LoadCoreArchives();
+	LoadGameArchives();
+
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
+
+	const std::string savePath = paths::BasePath() + "multi_0.sv";
+	paths::SetPrefPath(paths::BasePath());
+	RemoveFile(savePath.c_str());
+
+	gbVanilla = false;
+	gbIsHellfire = false;
+	gbIsSpawn = false;
+	gbIsMultiplayer = true;
+	gbIsHellfireSaveGame = false;
+	leveltype = DTYPE_TOWN;
+	giNumberOfLevels = 17;
+
+	Players.resize(1);
+	MyPlayerId = 0;
+	MyPlayer = &Players[MyPlayerId];
+
+	LoadSpellData();
+	LoadPlayerDataFiles();
+	LoadMonsterData();
+	LoadItemData();
+	_uiheroinfo info {};
+	info.heroclass = HeroClass::Rogue;
+	pfile_ui_save_create(&info);
+
+	Player &player = *MyPlayer;
+	player._pNumInv = 1;
+	player.InvList[0] = {};
+	player.InvList[0].IDidx = ItemMiscIdIdx(IMISC_SCROLL);
+	player.InvList[0]._iMiscId = IMISC_SCROLL;
+	player.InvList[0]._iSpell = SpellID::Healing;
+	player.CalcScrolls();
+
+	WriteLegacyHotkeys(
+	    savePath,
+	    { SpellID::Healing, SpellID::Invalid, SpellID::Invalid, SpellID::Invalid },
+	    { SpellType::Scroll, SpellType::Invalid, SpellType::Invalid, SpellType::Invalid },
+	    SpellID::Healing,
+	    SpellType::Scroll);
+
+	LoadHotkeys(info.saveNumber, player);
+
+	EXPECT_EQ(player._pRSpell, SpellID::Healing);
+	EXPECT_EQ(player._pRSplType, SpellType::Scroll);
+	EXPECT_EQ(player.queuedSpell.spellId, SpellID::Healing);
+	EXPECT_EQ(player.queuedSpell.spellType, SpellType::Scroll);
+	EXPECT_EQ(player.queuedSpell.spellFrom, 0);
+
+	player.executedSpell = player.queuedSpell;
+	ConsumeScroll(player);
+
+	EXPECT_FALSE(CanUseScroll(player, SpellID::Healing));
 }
 
 TEST(Writehero, DiabloRewritePersistsSanitizedSpellSelectionsFromHellfireSave)

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -12,6 +12,7 @@
 #include "game_mode.hpp"
 #include "init.hpp"
 #include "loadsave.h"
+#include "menu.h"
 #include "pack.h"
 #include "pfile.h"
 #include "spells.h"
@@ -21,6 +22,9 @@
 #include "utils/paths.h"
 
 namespace devilution {
+
+uint32_t gSaveNumber = 0;
+
 namespace {
 
 constexpr int SpellDatVanilla[] = {
@@ -534,6 +538,82 @@ TEST(Writehero, pfile_read_player_from_save_preserves_valid_spell_selections)
 	EXPECT_EQ(player._pSplTHotKey[0], SpellType::Spell);
 	EXPECT_EQ(player._pRSpell, SpellID::Healing);
 	EXPECT_EQ(player._pRSplType, SpellType::Spell);
+}
+
+TEST(Writehero, DiabloRewritePersistsSanitizedSpellSelectionsFromHellfireSave)
+{
+	LoadCoreArchives();
+	LoadGameArchives();
+
+	if (!HaveMainData()) {
+		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
+	}
+
+	const std::string savePath = paths::BasePath() + "multi_0.sv";
+	const std::string hellfireSavePath = paths::BasePath() + "multi_0.hsv";
+	paths::SetPrefPath(paths::BasePath());
+	RemoveFile(savePath.c_str());
+	RemoveFile(hellfireSavePath.c_str());
+
+	gbVanilla = false;
+	gbIsSpawn = false;
+	gbIsMultiplayer = true;
+	leveltype = DTYPE_TOWN;
+	currlevel = 0;
+	ViewPosition = {};
+	giNumberOfLevels = 25;
+	gbIsHellfire = true;
+	gbIsHellfireSaveGame = true;
+
+	Players.resize(1);
+	MyPlayerId = 0;
+	MyPlayer = &Players[MyPlayerId];
+
+	LoadSpellData();
+	LoadPlayerDataFiles();
+	LoadMonsterData();
+	LoadItemData();
+	_uiheroinfo info {};
+	info.heroclass = HeroClass::Rogue;
+	pfile_ui_save_create(&info);
+	gSaveNumber = info.saveNumber;
+
+	Player &player = *MyPlayer;
+	player._pMemSpells = GetSpellBitmask(SpellID::Healing) | GetSpellBitmask(SpellID::Apocalypse);
+	player._pSplLvl[static_cast<size_t>(SpellID::Healing)] = 1;
+	player._pSplLvl[static_cast<size_t>(SpellID::Apocalypse)] = 1;
+	player._pSplHotKey[0] = SpellID::Apocalypse;
+	player._pSplTHotKey[0] = SpellType::Spell;
+	player._pSplHotKey[1] = SpellID::Healing;
+	player._pSplTHotKey[1] = SpellType::Spell;
+	player._pRSpell = SpellID::Apocalypse;
+	player._pRSplType = SpellType::Spell;
+
+	pfile_write_hero(/*writeGameData=*/true);
+	RenameFile(hellfireSavePath.c_str(), savePath.c_str());
+
+	gbIsHellfire = false;
+	gbIsHellfireSaveGame = false;
+	giNumberOfLevels = 17;
+
+	pfile_read_player_from_save(info.saveNumber, player);
+	pfile_write_hero();
+
+	player._pSplHotKey[0] = SpellID::Apocalypse;
+	player._pSplTHotKey[0] = SpellType::Spell;
+	player._pSplHotKey[1] = SpellID::Invalid;
+	player._pSplTHotKey[1] = SpellType::Invalid;
+	player._pRSpell = SpellID::Apocalypse;
+	player._pRSplType = SpellType::Spell;
+
+	LoadHotkeys();
+
+	EXPECT_EQ(player._pSplHotKey[0], SpellID::Invalid);
+	EXPECT_EQ(player._pSplTHotKey[0], SpellType::Invalid);
+	EXPECT_EQ(player._pSplHotKey[1], SpellID::Healing);
+	EXPECT_EQ(player._pSplTHotKey[1], SpellType::Spell);
+	EXPECT_EQ(player._pRSpell, SpellID::Invalid);
+	EXPECT_EQ(player._pRSplType, SpellType::Invalid);
 }
 
 } // namespace

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -536,62 +536,6 @@ TEST(Writehero, pfile_read_player_from_save_clears_invalid_spell_selections)
 	EXPECT_EQ(player._pRSplType, SpellType::Invalid);
 }
 
-TEST(Writehero, pfile_read_player_from_save_preserves_valid_spell_selections)
-{
-	LoadCoreArchives();
-	LoadGameArchives();
-
-	if (!HaveMainData()) {
-		GTEST_SKIP() << "MPQ assets (spawn.mpq or DIABDAT.MPQ) not found - skipping test";
-	}
-
-	const std::string savePath = paths::BasePath() + "multi_0.sv";
-	paths::SetPrefPath(paths::BasePath());
-	RemoveFile(savePath.c_str());
-
-	gbVanilla = false;
-	gbIsHellfire = false;
-	gbIsSpawn = false;
-	gbIsMultiplayer = true;
-	gbIsHellfireSaveGame = false;
-	leveltype = DTYPE_TOWN;
-	giNumberOfLevels = 17;
-
-	Players.resize(1);
-	MyPlayerId = 0;
-	MyPlayer = &Players[MyPlayerId];
-
-	LoadSpellData();
-	LoadPlayerDataFiles();
-	LoadMonsterData();
-	LoadItemData();
-	_uiheroinfo info {};
-	info.heroclass = HeroClass::Rogue;
-	pfile_ui_save_create(&info);
-
-	Player &player = *MyPlayer;
-	player._pMemSpells = GetSpellBitmask(SpellID::Healing);
-	player._pSplLvl[static_cast<size_t>(SpellID::Healing)] = 1;
-	player._pSplHotKey[0] = SpellID::Healing;
-	player._pSplTHotKey[0] = SpellType::Spell;
-	player._pRSpell = SpellID::Healing;
-	player._pRSplType = SpellType::Spell;
-
-	pfile_write_hero();
-
-	player._pSplHotKey[0] = SpellID::Invalid;
-	player._pSplTHotKey[0] = SpellType::Invalid;
-	player._pRSpell = SpellID::Invalid;
-	player._pRSplType = SpellType::Invalid;
-
-	pfile_read_player_from_save(info.saveNumber, player);
-
-	EXPECT_EQ(player._pSplHotKey[0], SpellID::Healing);
-	EXPECT_EQ(player._pSplTHotKey[0], SpellType::Spell);
-	EXPECT_EQ(player._pRSpell, SpellID::Healing);
-	EXPECT_EQ(player._pRSplType, SpellType::Spell);
-}
-
 TEST(Writehero, LoadHotkeysWithoutFileSanitizesAndNormalizesSpellState)
 {
 	LoadCoreArchives();
@@ -725,7 +669,7 @@ TEST(Writehero, LoadHotkeysLegacyFormatSanitizesInvalidSelections)
 	EXPECT_EQ(player.spellFrom, 0);
 }
 
-TEST(Writehero, LoadHotkeysLegacyFormatPreservesValidScrollAndFirstCastConsumesIt)
+TEST(Writehero, LoadHotkeysLegacyFormatPreservesValidScrollSelection)
 {
 	LoadCoreArchives();
 	LoadGameArchives();

--- a/test/writehero_test.cpp
+++ b/test/writehero_test.cpp
@@ -759,6 +759,10 @@ TEST(Writehero, LoadHotkeysLegacyFormatPreservesValidScrollAndFirstCastConsumesI
 	pfile_ui_save_create(&info);
 
 	Player &player = *MyPlayer;
+	player._pNumInv = 1;
+	InitializeItem(player.InvList[0], ItemMiscIdIdx(IMISC_SCROLL));
+	player.InvList[0]._iSpell = SpellID::Healing;
+	player.InvList[0]._iStatFlag = true;
 	player._pScrlSpells = GetSpellBitmask(SpellID::Healing);
 	ASSERT_TRUE((player._pScrlSpells & GetSpellBitmask(SpellID::Healing)) != 0);
 	ASSERT_TRUE(IsPlayerSpellSelectionValid(player, SpellID::Healing, SpellType::Scroll));
@@ -777,8 +781,11 @@ TEST(Writehero, LoadHotkeysLegacyFormatPreservesValidScrollAndFirstCastConsumesI
 	EXPECT_EQ(player.queuedSpell.spellId, SpellID::Healing);
 	EXPECT_EQ(player.queuedSpell.spellType, SpellType::Scroll);
 	EXPECT_EQ(player.queuedSpell.spellFrom, 0);
+	leveltype = DTYPE_CATHEDRAL;
 	EXPECT_TRUE(CanUseScroll(player, SpellID::Healing));
 
+	player.InvList[0].clear();
+	player._pNumInv = 0;
 	player._pScrlSpells = 0;
 
 	EXPECT_FALSE(CanUseScroll(player, SpellID::Healing));


### PR DESCRIPTION
Closes #3466

## Summary

When a Hellfire save is converted to Diablo while a Hellfire-only spell is selected, that selection can survive in an invalid state.

In DevilutionX this can leave the player with a selected spell that has no icon but may still remain usable. In vanilla Diablo, loading such a save can crash.

This change clears invalid spell selections during load/conversion and keeps the player's spell state consistent afterwards.

## What changed

- call `ValidatePlayer()` before recalculating inventory-derived spell state during load
- use `CalcPlrInv()` during loading so spell sources from inventory, scrolls, and charges are rebuilt before validating selections
- update spell selection validation so `SpellType::Spell` is no longer treated as automatically valid
- sanitize invalid selected spells and invalid hotkeys after loading
- normalize derived runtime spell state after sanitization so stale queued/executed spell data does not survive
- make `LoadHotkeys()` explicitly handle both legacy hotkey data and missing or malformed hotkey blobs safely

## Why this approach

This issue is triggered by Hellfire -> Diablo conversion, but the real problem is broader than a single Hellfire spell id surviving the rewrite.

After conversion, the selected spell and hotkeys may no longer be valid for the rebuilt player state. Because of that, this patch does not special-case only Hellfire spell ids. Instead, it validates spell selections against the player's actual available spell sources after loading:

- learned spells
- skills
- scrolls
- charges

This follows the intent discussed in #3466:
- validate the player before recalculating spell-related state
- rebuild spell availability from inventory
- clear invalid readied spells
- do the same for `LoadHotkeys()`

The extra runtime-state normalization is intentional. Clearing only `_pRSpell` / `_pRSplType` would still leave stale `queuedSpell`, `executedSpell`, or `spellFrom` state behind, which could keep the player in a partially invalid state after sanitization.

## Updated load/conversion flow

Now, during Hellfire -> Diablo conversion:

1. the player is loaded
2. `ValidatePlayer()` removes invalid Hellfire-only learned spell state
3. `CalcPlrInv()` rebuilds spell availability from inventory, including scrolls and charges
4. hotkeys and the selected spell are loaded
5. any selection that is no longer valid for the rebuilt player state is cleared
6. runtime spell state is synchronized from the sanitized selection

This ensures that invalid Hellfire spell selections do not survive conversion as selected, queued, or executed spell state.

## Tests

Added tests to cover:
- spell selection validation by source
- rejecting invalid spell/type combinations
- clearing invalid spell selections when reading from save
- sanitizing and normalizing state when the hotkeys file is missing
- sanitizing invalid selections from legacy hotkey data
- preserving valid legacy scroll selections
- persisting sanitized selections after Hellfire -> Diablo rewrite