### PR TITLE
[QoL] Group Gameplay settings with section headers for readability

### DIFF
--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -107,6 +107,41 @@ bool NeedsTwoLinesToDisplayOption(std::vector<DrawStringFormatArg> &formatArgs)
 	return GetLineWidth("{}: {}", formatArgs.data(), formatArgs.size(), 0, GameFontTables::GameFont24, 1) >= (rectList.size.width - 90);
 }
 
+void AddSettingsSpacer()
+{
+	vecDialogItems.push_back(std::make_unique<UiListItem>(
+	    std::string_view {}, static_cast<int>(SpecialMenuEntry::None), UiFlags::ElementDisabled));
+}
+
+void AddSettingsSectionHeader(std::string_view text, bool addSpacer)
+{
+	if (addSpacer)
+		AddSettingsSpacer();
+	vecDialogItems.push_back(std::make_unique<UiListItem>(
+	    text, static_cast<int>(SpecialMenuEntry::None), UiFlags::ColorWhitegold | UiFlags::ElementDisabled));
+}
+
+void MaybeAddGameplaySectionHeader(OptionEntryBase *pEntry)
+{
+	if (selectedCategory != &GetOptions().Gameplay)
+		return;
+
+	const GameplayOptions &gameplay = GetOptions().Gameplay;
+
+	// Sections are intentionally lightweight: just labels/separators, no submenus and no changes to options model.
+	if (pEntry == &gameplay.friendlyFire) {
+		AddSettingsSectionHeader(_("Game Rules"), false);
+	} else if (pEntry == &gameplay.runInTown) {
+		AddSettingsSectionHeader(_("Controls"), true);
+	} else if (pEntry == &gameplay.experienceBar) {
+		AddSettingsSectionHeader(_("Interface"), true);
+	} else if (pEntry == &gameplay.autoRefillBelt) {
+		AddSettingsSectionHeader(_("Items & Auto Pickup"), true);
+	} else if (pEntry == &gameplay.disableCripplingShrines) {
+		AddSettingsSectionHeader(_("Safety & Focus"), true);
+	}
+}
+
 void CleanUpSettingsUI()
 {
 	UiInitList_clear();
@@ -419,11 +454,21 @@ void UiSettingsMenu()
 			}
 		} break;
 		case ShownMenuType::Settings: {
+			bool foundSelectedOption = false;
+			std::optional<size_t> firstSelectableItemIndex;
 			for (OptionEntryBase *pEntry : selectedCategory->GetEntries()) {
 				if (!IsValidEntry(pEntry))
 					continue;
-				if (selectedOption == pEntry)
+
+				MaybeAddGameplaySectionHeader(pEntry);
+
+				if (!firstSelectableItemIndex.has_value())
+					firstSelectableItemIndex = vecDialogItems.size();
+				if (selectedOption == pEntry) {
 					itemToSelect = vecDialogItems.size();
+					foundSelectedOption = true;
+				}
+
 				auto formatArgs = CreateDrawStringFormatArgForEntry(pEntry);
 				const int optionId = static_cast<int>(vecOptions.size());
 				if (NeedsTwoLinesToDisplayOption(formatArgs)) {
@@ -434,6 +479,10 @@ void UiSettingsMenu()
 				}
 				vecOptions.push_back(pEntry);
 			}
+			// If previously selected option doesn't exist (e.g., became invisible),
+			// set focus on first real option, not on header.
+			if (!foundSelectedOption && firstSelectableItemIndex.has_value())
+				itemToSelect = *firstSelectableItemIndex;
 		} break;
 		case ShownMenuType::ListOption: {
 			auto *pOptionList = static_cast<OptionEntryListBase *>(selectedOption);

--- a/Source/DiabloUI/settingsmenu.cpp
+++ b/Source/DiabloUI/settingsmenu.cpp
@@ -136,9 +136,7 @@ void MaybeAddGameplaySectionHeader(OptionEntryBase *pEntry)
 	} else if (pEntry == &gameplay.experienceBar) {
 		AddSettingsSectionHeader(_("Interface"), true);
 	} else if (pEntry == &gameplay.autoRefillBelt) {
-		AddSettingsSectionHeader(_("Items & Auto Pickup"), true);
-	} else if (pEntry == &gameplay.disableCripplingShrines) {
-		AddSettingsSectionHeader(_("Safety & Focus"), true);
+		AddSettingsSectionHeader(_("Inventory"), true);
 	}
 }
 

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -884,8 +884,11 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&randomizeQuests,
 		&theoQuest,
 		&cowQuest,
+		&disableCripplingShrines,
 		&runInTown,
 		&quickCast,
+		&grabInput,
+		&pauseOnFocusLoss,
 		&testBard,
 		&testBarbarian,
 		&experienceBar,
@@ -913,9 +916,6 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&numRejuPotionPickup,
 		&numFullRejuPotionPickup,
 		&autoPickupInTown,
-		&disableCripplingShrines,
-		&grabInput,
-		&pauseOnFocusLoss,
 		&skipLoadingScreenThresholdMs,
 	};
 }


### PR DESCRIPTION
closes #8508

## Summary

Group Gameplay settings with lightweight section headers to improve readability.

This is a UI-only change implemented in `settingsmenu.cpp` using disabled list items, with no changes to option behavior or the options model.

Also ensure the menu falls back to the first selectable option if the previous selection is no longer visible.

<img width="1920" height="1080" alt="devilutionx_Z9sUgHqrNh" src="https://github.com/user-attachments/assets/7a5bbb26-3d3f-41c8-8c22-49fd06a84b1e" />
<img width="1920" height="1080" alt="devilutionx_Gn9gLQUZbf" src="https://github.com/user-attachments/assets/2ac7116f-169b-4533-ae61-17a1ecf7d10b" />

