### PR TITLE
Fix bug: remote player on different level writes to dPlayer[][] on the host

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -726,17 +726,16 @@ void ProcessGameMessagePackets()
 			player._pBaseMag = pkt->bmag;
 			player._pBaseDex = pkt->bdex;
 
-			const uint8_t rawDir = pkt->pdir;
-			if (rawDir <= static_cast<uint8_t>(Direction::SouthEast)) {
-				const Direction newDir = static_cast<Direction>(rawDir);
-				if (player._pdir != newDir && player._pmode == PM_STAND) {
-					player._pdir = newDir;
-					StartStand(player, newDir);
-				}
-			}
-
 			if (!cond && player.plractive && !player.hasNoLife()) {
 				if (player.isOnActiveLevel() && !player._pLvlChanging) {
+					const uint8_t rawDir = pkt->pdir;
+					if (rawDir <= static_cast<uint8_t>(Direction::SouthEast)) {
+						const Direction newDir = static_cast<Direction>(rawDir);
+						if (player._pdir != newDir && player._pmode == PM_STAND) {
+							player._pdir = newDir;
+							StartStand(player, newDir);
+						}
+					}
 					if (player.position.tile.WalkingDistance(syncPosition) > 3 && PosOkPlayer(player, syncPosition)) {
 						// got out of sync, clear the tiles around where we last thought the player was located
 						FixPlrWalkTags(player);


### PR DESCRIPTION
Bug repro:  Player A creates multiplayer game and goes to dungeon level 1.  Player B joins and goes to dungeon level 1.  Player B moves a few tiles and then exits the game.  Player B rejoins the game.  Player A can now see player B's cursor selection in dungeon level one despite the fact player B has rejoined in town.

Cause: On Player A's computer, StartStand() is called for Player B when Player B is not valid ("" for player name, 0 health, etc), and StartStand() writes to dPlayer[][] for Player A's dungeon level 1 despite the fact Player B is not on dungeon level 1.  Bug was introduced in recent commit 5a08031 "[Bugfix] Update players directions on joining"

See debugger screenshot:
<img width="992" height="1114" alt="image" src="https://github.com/user-attachments/assets/0cbfc4d1-210a-4d5f-ba3c-34b8d8304cfc" />
