### PR TITLE
Remove unused variable in CheckVisualStoreHLight()

### DIFF
--- a/Source/qol/visual_store.cpp
+++ b/Source/qol/visual_store.cpp
@@ -516,7 +516,6 @@ void DrawVisualStore(const Surface &out)
 int16_t CheckVisualStoreHLight(Point mousePosition)
 {
 	// Check buttons first
-	const Point panelPos = GetPanelPosition(UiPanels::Stash);
 	if (MyPlayer->HoldItem.isEmpty()) {
 		for (int i = 0; i < 4; i++) {
 			// Skip tab buttons if vendor doesn't have tabs


### PR DESCRIPTION
This PR eliminates the following compiler warning.

```
[ 77%] Building CXX object Source/CMakeFiles/libdevilutionx.dir/qol/visual_store.cpp.o
.../DevilutionX/Source/qol/visual_store.cpp: In function ‘int16_t devilution::CheckVisualStoreHLight(Point)’:
.../DevilutionX/Source/qol/visual_store.cpp:519:21: warning: variable ‘panelPos’ set but not used [-Wunused-but-set-variable]
  519 |         const Point panelPos = GetPanelPosition(UiPanels::Stash);
      |                     ^~~~~~~~
```