### PR TITLE
Fix memory stomp due to inconsistent inventory layout

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1565,29 +1565,39 @@ void inv_update_rem_item(Player &player, inv_body_loc iv)
 	CalcPlrInv(player, player._pmode != PM_DEATH);
 }
 
-void CheckInvSwap(Player &player, const Item &item, int invGridIndex)
+bool CheckInvSwap(Player &player, const Item &item, int invGridIndex)
 {
 	Size itemSize = GetInventorySize(item);
 
 	const int pitch = 10;
-	const int invListIndex = [&]() -> int {
-		for (int y = 0; y < itemSize.height; y++) {
-			const int rowGridIndex = invGridIndex + pitch * y;
-			for (int x = 0; x < itemSize.width; x++) {
-				const int gridIndex = rowGridIndex + x;
-				if (player.InvGrid[gridIndex] != 0)
-					return std::abs(player.InvGrid[gridIndex]);
+	if (invGridIndex + itemSize.width - 1 + pitch * (itemSize.height - 1) >= InventoryGridCells)
+		return false;
+
+	int invListIndex = 0;
+	for (int y = 0; y < itemSize.height; y++) {
+		int rowGridIndex = invGridIndex + pitch * y;
+		for (int x = 0; x < itemSize.width; x++) {
+			int gridIndex = rowGridIndex + x;
+			if (player.InvGrid[gridIndex] != 0) {
+				int existingItem = std::abs(player.InvGrid[gridIndex]);
+				if (!invListIndex) {
+					invListIndex = existingItem;
+				} else if (invListIndex != existingItem) {
+					// More than one item exists where we want to place the new item
+					return false;
+				}
 			}
 		}
-		player._pNumInv++;
-		return player._pNumInv;
-	}();
+	}
 
-	if (invListIndex < player._pNumInv) {
-		for (int8_t &itemIndex : player.InvGrid) {
-			if (itemIndex == invListIndex)
-				itemIndex = 0;
-			if (itemIndex == -invListIndex)
+	if (!invListIndex) {
+		// The inventory is empty where we want to place the new item.  Allocate a new spot.
+		player._pNumInv++;
+		invListIndex = player._pNumInv;
+	} else {
+		// Remove the old location of the existing item
+		for (int8_t& itemIndex : player.InvGrid) {
+			if (std::abs(itemIndex) == invListIndex)
 				itemIndex = 0;
 		}
 	}
@@ -1605,6 +1615,7 @@ void CheckInvSwap(Player &player, const Item &item, int invGridIndex)
 	}
 
 	CalcPlrInv(player, true);
+	return true;
 }
 
 void CheckInvRemove(Player &player, int invGridIndex)

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -188,7 +188,7 @@ int AddGoldToInventory(Player &player, int value);
 bool GoldAutoPlace(Player &player, Item &goldStack);
 void CheckInvSwap(Player &player, inv_body_loc bLoc);
 void inv_update_rem_item(Player &player, inv_body_loc iv);
-void CheckInvSwap(Player &player, const Item &item, int invGridIndex);
+bool CheckInvSwap(Player &player, const Item &item, int invGridIndex);
 void CheckInvRemove(Player &player, int invGridIndex);
 void TransferItemToStash(Player &player, int location);
 void CheckInvItem(bool isShiftHeld = false, bool isCtrlHeld = false);

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -2172,7 +2172,10 @@ size_t OnChangeInventoryItems(const TCmdChItem &message, Player &player)
 	} else if (&player != MyPlayer && IsItemAvailable(static_cast<_item_indexes>(Swap16LE(message.def.wIndx)))) {
 		Item item {};
 		RecreateItem(player, message, item);
-		CheckInvSwap(player, item, message.bLoc);
+		if (!CheckInvSwap(player, item, message.bLoc)) {
+			// item is larger than 1x1, and it occupies invalid inventory slots
+			return sizeof(message);
+		}
 	}
 
 	return sizeof(message);


### PR DESCRIPTION
Bug repro:  Create a multiplayer game with Player A joining Player B's game.  Both players enter cathedral.  Player A expends inferno staff charges until staff is empty before returning to town.  Player A moves staff from hand to inventory (important).  Then Player A recharges the staff at the witch.  Player A will now send command with invalid inventory slot to Player B, and Player B fails to detect the invalid data which causes data to be written to player.InvGrid[] beyond the length of the array.  Because of memory layout in the Player class, this memory stomp corrupts Player A's position.tile on Player B's computer, and Player B drops player A from the game.

I fixed the memory stomp by adding an error check in CheckInvSwap() but this is not sufficient to fix the problem because Player B still sends invalid data due to inconsistent assumptions about "bottom left" versus "top left" corner of items being the slot which defines the item location in the inventory.  I made the code consistent by changing everything to be rooted at the bottom left corner because this is what the sprite rendering code assumes.  However, I didn't add a conversion for save games so any existing save game will look weird until the inventory items are lifted to hand and replaced in the inventory.  Then everything works fine again.  The stash assumes items are rooted at the top left corner but this code works reliably as-is, and it's independent from the inventory code so it wasn't necessary to change it.