### PR TITLE
Lua custom items

### DIFF
--- a/CMake/Tests.cmake
+++ b/CMake/Tests.cmake
@@ -15,6 +15,7 @@ set(tests
   appfat_test
   automap_test
   cursor_test
+  custom_items_test
   dead_test
   diablo_test
   drlg_common_test

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -461,7 +461,6 @@ void FreeCursor()
 {
 	pCursCels = std::nullopt;
 	pCursCels2 = std::nullopt;
-	FreeCustomCursorSprites();
 	ClearCursor();
 }
 

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -471,8 +471,13 @@ ClxSprite GetInvItemSprite(int cursId)
 	const int iCurs = cursId - static_cast<int>(CURSOR_FIRSTITEM);
 	if (iCurs >= ItemCAnimTblSize) {
 		const size_t customIdx = static_cast<size_t>(iCurs - ItemCAnimTblSize);
-		assert(customIdx < customCursorSprites.size());
-		return customCursorSprites[customIdx][0];
+		if (customIdx < customCursorSprites.size() && customCursorSprites[customIdx].numSprites() > 0) {
+			return customCursorSprites[customIdx][0];
+		}
+		// Save or mod references a custom cursor that is not registered (e.g. mod unloaded).
+		constexpr int fallbackInvItemCursorId = static_cast<int>(CURSOR_FIRSTITEM);
+		assert(fallbackInvItemCursorId > 0);
+		return GetInvItemSprite(fallbackInvItemCursorId);
 	}
 
 	const size_t numSprites = pCursCels->numSprites();
@@ -570,7 +575,13 @@ void FreeHalfSizeItemSprites()
 
 int RegisterCustomCursorGraphic(OwnedClxSpriteList sprite)
 {
+	constexpr int maxItemCursorUint8 = std::numeric_limits<uint8_t>::max();
 	const int iCurs = ItemCAnimTblSize + static_cast<int>(customCursorSprites.size());
+	if (iCurs > maxItemCursorUint8) {
+		app_fatal(fmt::format(
+		    "Cannot register custom cursor graphic: cursor id {} would exceed Item._iCurs limit (0..{}, ItemCAnimTblSize is {}).",
+		    iCurs, maxItemCursorUint8, ItemCAnimTblSize));
+	}
 	customCursorSprites.push_back(std::move(sprite));
 	return iCurs;
 }

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -35,6 +35,7 @@
 #include "headless_mode.hpp"
 #include "hwcursor.hpp"
 #include "inv.h"
+#include "items.h"
 #include "levels/trigs.h"
 #include "missiles.h"
 #include "options.h"
@@ -469,8 +470,8 @@ ClxSprite GetInvItemSprite(int cursId)
 	assert(cursId > 0);
 
 	const int iCurs = cursId - static_cast<int>(CURSOR_FIRSTITEM);
-	if (iCurs >= CustomCursorGraphicBase) {
-		const size_t customIdx = static_cast<size_t>(iCurs - CustomCursorGraphicBase);
+	if (iCurs >= ItemCAnimTblSize) {
+		const size_t customIdx = static_cast<size_t>(iCurs - ItemCAnimTblSize);
 		assert(customIdx < customCursorSprites.size());
 		return customCursorSprites[customIdx][0];
 	}
@@ -492,7 +493,7 @@ Size GetInvItemSize(int cursId)
 
 ClxSprite GetHalfSizeItemSprite(int cursId)
 {
-	if (cursId >= CustomCursorGraphicBase || static_cast<size_t>(cursId) >= numHalfSizeItemSprites || !HalfSizeItemSprites[cursId]) {
+	if (cursId >= ItemCAnimTblSize || static_cast<size_t>(cursId) >= numHalfSizeItemSprites || !HalfSizeItemSprites[cursId]) {
 		return GetInvItemSprite(static_cast<int>(CURSOR_FIRSTITEM) + cursId);
 	}
 	return (*HalfSizeItemSprites[cursId])[0];
@@ -500,7 +501,7 @@ ClxSprite GetHalfSizeItemSprite(int cursId)
 
 ClxSprite GetHalfSizeItemSpriteRed(int cursId)
 {
-	if (cursId >= CustomCursorGraphicBase || static_cast<size_t>(cursId) >= numHalfSizeItemSprites || !HalfSizeItemSpritesRed[cursId]) {
+	if (cursId >= ItemCAnimTblSize || static_cast<size_t>(cursId) >= numHalfSizeItemSprites || !HalfSizeItemSpritesRed[cursId]) {
 		return GetInvItemSprite(static_cast<int>(CURSOR_FIRSTITEM) + cursId);
 	}
 	return (*HalfSizeItemSpritesRed[cursId])[0];
@@ -570,7 +571,7 @@ void FreeHalfSizeItemSprites()
 
 int RegisterCustomCursorGraphic(OwnedClxSpriteList sprite)
 {
-	const int iCurs = CustomCursorGraphicBase + static_cast<int>(customCursorSprites.size());
+	const int iCurs = ItemCAnimTblSize + static_cast<int>(customCursorSprites.size());
 	customCursorSprites.push_back(std::move(sprite));
 	return iCurs;
 }

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -65,8 +65,12 @@ namespace {
 OptionalOwnedClxSpriteList pCursCels;
 OptionalOwnedClxSpriteList pCursCels2;
 
+/** Custom cursor sprites registered by mods. */
+std::vector<OwnedClxSpriteList> customCursorSprites;
+
 OptionalOwnedClxSpriteList *HalfSizeItemSprites;
 OptionalOwnedClxSpriteList *HalfSizeItemSpritesRed;
+size_t numHalfSizeItemSprites = 0;
 
 bool IsValidMonsterForSelection(const Monster &monster)
 {
@@ -456,12 +460,21 @@ void FreeCursor()
 {
 	pCursCels = std::nullopt;
 	pCursCels2 = std::nullopt;
+	FreeCustomCursorSprites();
 	ClearCursor();
 }
 
 ClxSprite GetInvItemSprite(int cursId)
 {
 	assert(cursId > 0);
+
+	const int iCurs = cursId - static_cast<int>(CURSOR_FIRSTITEM);
+	if (iCurs >= CustomCursorGraphicBase) {
+		const size_t customIdx = static_cast<size_t>(iCurs - CustomCursorGraphicBase);
+		assert(customIdx < customCursorSprites.size());
+		return customCursorSprites[customIdx][0];
+	}
+
 	const size_t numSprites = pCursCels->numSprites();
 	if (static_cast<size_t>(cursId) <= numSprites) {
 		return (*pCursCels)[cursId - 1];
@@ -479,11 +492,17 @@ Size GetInvItemSize(int cursId)
 
 ClxSprite GetHalfSizeItemSprite(int cursId)
 {
+	if (cursId >= CustomCursorGraphicBase || static_cast<size_t>(cursId) >= numHalfSizeItemSprites || !HalfSizeItemSprites[cursId]) {
+		return GetInvItemSprite(static_cast<int>(CURSOR_FIRSTITEM) + cursId);
+	}
 	return (*HalfSizeItemSprites[cursId])[0];
 }
 
 ClxSprite GetHalfSizeItemSpriteRed(int cursId)
 {
+	if (cursId >= CustomCursorGraphicBase || static_cast<size_t>(cursId) >= numHalfSizeItemSprites || !HalfSizeItemSpritesRed[cursId]) {
+		return GetInvItemSprite(static_cast<int>(CURSOR_FIRSTITEM) + cursId);
+	}
 	return (*HalfSizeItemSpritesRed[cursId])[0];
 }
 
@@ -493,6 +512,7 @@ void CreateHalfSizeItemSprites()
 		return;
 	const uint32_t numInvItems = pCursCels->numSprites() - (static_cast<uint32_t>(CURSOR_FIRSTITEM) - 1)
 	    + (pCursCels2.has_value() ? pCursCels2->numSprites() : 0);
+	numHalfSizeItemSprites = numInvItems;
 	HalfSizeItemSprites = new OptionalOwnedClxSpriteList[numInvItems];
 	HalfSizeItemSpritesRed = new OptionalOwnedClxSpriteList[numInvItems];
 	const uint8_t *redTrn = GetInfravisionTRN();
@@ -545,6 +565,19 @@ void FreeHalfSizeItemSprites()
 		delete[] HalfSizeItemSpritesRed;
 		HalfSizeItemSpritesRed = nullptr;
 	}
+	numHalfSizeItemSprites = 0;
+}
+
+int RegisterCustomCursorGraphic(OwnedClxSpriteList sprite)
+{
+	const int iCurs = CustomCursorGraphicBase + static_cast<int>(customCursorSprites.size());
+	customCursorSprites.push_back(std::move(sprite));
+	return iCurs;
+}
+
+void FreeCustomCursorSprites()
+{
+	customCursorSprites.clear();
 }
 
 void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite clx)

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -85,4 +85,13 @@ void FreeHalfSizeItemSprites();
 /** Returns the width and height for an inventory index. */
 Size GetInvItemSize(int cursId);
 
+/** The first _iCurs value used for custom (mod-registered) cursor graphics. */
+constexpr int CustomCursorGraphicBase = 229;
+
+/** Registers a custom cursor sprite and returns the _iCurs value to use. */
+int RegisterCustomCursorGraphic(OwnedClxSpriteList sprite);
+
+/** Frees all custom cursor sprites. */
+void FreeCustomCursorSprites();
+
 } // namespace devilution

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -74,7 +74,7 @@ void DrawSoftwareCursor(const Surface &out, Point position, int cursId);
 
 void DrawItem(const Item &item, const Surface &out, Point position, ClxSprite clx);
 
-/** Returns the sprite for the given inventory index. */
+/** Returns the sprite for the given inventory index. Missing custom cursors fall back to the first vanilla item graphic. */
 ClxSprite GetInvItemSprite(int cursId);
 
 ClxSprite GetHalfSizeItemSprite(int cursId);
@@ -86,7 +86,8 @@ void FreeHalfSizeItemSprites();
 Size GetInvItemSize(int cursId);
 
 /** Registers a custom cursor sprite and returns the _iCurs value to use.
- * Custom IDs start at ItemCAnimTblSize (the number of entries in ItemCAnimTbl). */
+ * Custom IDs start at ItemCAnimTblSize (the number of entries in ItemCAnimTbl).
+ * Fails if the id would exceed uint8_t (same storage as Item::_iCurs). */
 int RegisterCustomCursorGraphic(OwnedClxSpriteList sprite);
 
 /** Frees all custom cursor sprites. */

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -85,10 +85,8 @@ void FreeHalfSizeItemSprites();
 /** Returns the width and height for an inventory index. */
 Size GetInvItemSize(int cursId);
 
-/** The first _iCurs value used for custom (mod-registered) cursor graphics. */
-constexpr int CustomCursorGraphicBase = 229;
-
-/** Registers a custom cursor sprite and returns the _iCurs value to use. */
+/** Registers a custom cursor sprite and returns the _iCurs value to use.
+ * Custom IDs start at ItemCAnimTblSize (the number of entries in ItemCAnimTbl). */
 int RegisterCustomCursorGraphic(OwnedClxSpriteList sprite);
 
 /** Frees all custom cursor sprites. */

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -290,7 +290,7 @@ bool AutoEquip(Player &player, const Item &item, inv_body_loc bodyLocation, bool
 		ChangeEquipment(player, bodyLocation, item, sendNetworkMessage);
 
 		if (sendNetworkMessage && *GetOptions().Audio.autoEquipSound) {
-			PlaySFX(GetItemInvSfx(item));
+			PlaySFX(GetItemInvSnd(item));
 		}
 
 		CalcPlrInv(player, true);
@@ -586,7 +586,7 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 	}
 
 	if (&player == MyPlayer) {
-		PlaySFX(GetItemInvSfx(player.HoldItem));
+		PlaySFX(GetItemInvSnd(player.HoldItem));
 	}
 
 	// Select the parameters that go into
@@ -779,7 +779,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 				attemptedMove = true;
 				automaticallyMoved = AutoPlaceItemInInventory(player, player.InvBody[invloc]);
 				if (automaticallyMoved) {
-					successSound = GetItemInvSfx(player.InvBody[invloc]);
+					successSound = GetItemInvSnd(player.InvBody[invloc]);
 					RemoveEquipment(player, invloc, false);
 				} else {
 					failedSpeech = HeroSpeech::IHaveNoRoom;
@@ -889,7 +889,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 					}
 					automaticallyMoved = AutoEquip(player, player.InvList[iv], true, &player == MyPlayer);
 					if (automaticallyMoved) {
-						successSound = GetItemInvSfx(player.InvList[iv]);
+						successSound = GetItemInvSnd(player.InvList[iv]);
 						player.RemoveInvItem(iv, false);
 
 						// If we're holding an item at this point we just lifted it from a body slot to make room for the original item, so we need to put it into the inv
@@ -1633,7 +1633,7 @@ void TransferItemToStash(Player &player, int location)
 		return;
 	}
 
-	PlaySFX(GetItemInvSfx(item));
+	PlaySFX(GetItemInvSnd(item));
 
 	if (location < INVITEM_INV_FIRST) {
 		RemoveEquipment(player, static_cast<inv_body_loc>(location), false);
@@ -2200,7 +2200,7 @@ bool UseInvItem(int cii)
 	if (item->_iMiscId == IMISC_BOOK)
 		PlaySFX(SfxID::ReadBook);
 	else if (&player == MyPlayer)
-		PlaySFX(GetItemInvSfx(*item));
+		PlaySFX(GetItemInvSnd(*item));
 
 	UseItem(player, item->_iMiscId, item->_iSpell, cii);
 
@@ -2253,7 +2253,7 @@ void CloseStash()
 				// to not have room for the item all 3 cases are extremely unlikely
 				app_fatal(_("No room for item"));
 			}
-			PlaySFX(GetItemInvSfx(myPlayer.HoldItem));
+			PlaySFX(GetItemInvSnd(myPlayer.HoldItem));
 		}
 		myPlayer.HoldItem.clear();
 		NewCursor(CURSOR_HAND);

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -290,7 +290,7 @@ bool AutoEquip(Player &player, const Item &item, inv_body_loc bodyLocation, bool
 		ChangeEquipment(player, bodyLocation, item, sendNetworkMessage);
 
 		if (sendNetworkMessage && *GetOptions().Audio.autoEquipSound) {
-			PlaySFX(ItemInvSnds[ItemCAnimTbl[item._iCurs]]);
+			PlaySFX(GetItemInvSfx(item));
 		}
 
 		CalcPlrInv(player, true);
@@ -586,7 +586,7 @@ void CheckInvPaste(Player &player, Point cursorPosition)
 	}
 
 	if (&player == MyPlayer) {
-		PlaySFX(ItemInvSnds[ItemCAnimTbl[player.HoldItem._iCurs]]);
+		PlaySFX(GetItemInvSfx(player.HoldItem));
 	}
 
 	// Select the parameters that go into
@@ -779,7 +779,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 				attemptedMove = true;
 				automaticallyMoved = AutoPlaceItemInInventory(player, player.InvBody[invloc]);
 				if (automaticallyMoved) {
-					successSound = ItemInvSnds[ItemCAnimTbl[player.InvBody[invloc]._iCurs]];
+					successSound = GetItemInvSfx(player.InvBody[invloc]);
 					RemoveEquipment(player, invloc, false);
 				} else {
 					failedSpeech = HeroSpeech::IHaveNoRoom;
@@ -889,7 +889,7 @@ void CheckInvCut(Player &player, Point cursorPosition, bool automaticMove, bool 
 					}
 					automaticallyMoved = AutoEquip(player, player.InvList[iv], true, &player == MyPlayer);
 					if (automaticallyMoved) {
-						successSound = ItemInvSnds[ItemCAnimTbl[player.InvList[iv]._iCurs]];
+						successSound = GetItemInvSfx(player.InvList[iv]);
 						player.RemoveInvItem(iv, false);
 
 						// If we're holding an item at this point we just lifted it from a body slot to make room for the original item, so we need to put it into the inv
@@ -1633,7 +1633,7 @@ void TransferItemToStash(Player &player, int location)
 		return;
 	}
 
-	PlaySFX(ItemInvSnds[ItemCAnimTbl[item._iCurs]]);
+	PlaySFX(GetItemInvSfx(item));
 
 	if (location < INVITEM_INV_FIRST) {
 		RemoveEquipment(player, static_cast<inv_body_loc>(location), false);
@@ -2197,11 +2197,10 @@ bool UseInvItem(int cii)
 		return true;
 	}
 
-	const int idata = ItemCAnimTbl[item->_iCurs];
 	if (item->_iMiscId == IMISC_BOOK)
 		PlaySFX(SfxID::ReadBook);
 	else if (&player == MyPlayer)
-		PlaySFX(ItemInvSnds[idata]);
+		PlaySFX(GetItemInvSfx(*item));
 
 	UseItem(player, item->_iMiscId, item->_iSpell, cii);
 
@@ -2254,7 +2253,7 @@ void CloseStash()
 				// to not have room for the item all 3 cases are extremely unlikely
 				app_fatal(_("No room for item"));
 			}
-			PlaySFX(ItemInvSnds[ItemCAnimTbl[myPlayer.HoldItem._iCurs]]);
+			PlaySFX(GetItemInvSfx(myPlayer.HoldItem));
 		}
 		myPlayer.HoldItem.clear();
 		NewCursor(CURSOR_HAND);

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -127,7 +127,7 @@ int8_t ItemCAnimTbl[] = {
 	36, 36, 37, 38, 38, 38, 38, 38, 41, 42,
 	8, 8, 8, 17, 0, 6, 8, 11, 11, 3,
 	3, 1, 6, 6, 6, 1, 8, 6, 11, 3,
-	6, 8, 1, 6, 6, 17, 40, 0, 0
+	6, 8, 1, 6, 6, 17, 40, 0, 0, 0, 0
 };
 const int ItemCAnimTblSize = static_cast<int>(sizeof(ItemCAnimTbl));
 

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -181,6 +181,14 @@ namespace {
 
 OptionalOwnedClxSpriteList itemanims[ITEMTYPES];
 
+struct CustomDropAnimData {
+	OwnedClxSpriteList sprites;
+	int8_t numFrames;
+};
+
+std::vector<CustomDropAnimData> customDropAnims;
+ankerl::unordered_dense::map<int, int> customCursToDropAnim;
+
 enum class PlayerArmorGraphic : uint8_t {
 	// clang-format off
 	Light  = 0,
@@ -3832,6 +3840,24 @@ int8_t DefaultDropAnimForItemType(ItemType type)
 	}
 }
 
+int RegisterCustomDropAnim(OwnedClxSpriteList sprites, int8_t numFrames)
+{
+	const int id = static_cast<int>(customDropAnims.size());
+	customDropAnims.push_back({ std::move(sprites), numFrames });
+	return id;
+}
+
+void SetCustomDropAnim(int iCurs, int dropAnimId)
+{
+	customCursToDropAnim[iCurs] = dropAnimId;
+}
+
+void FreeCustomDropAnims()
+{
+	customDropAnims.clear();
+	customCursToDropAnim.clear();
+}
+
 int8_t GetItemAnimType(const Item &item)
 {
 	if (item._iCurs >= static_cast<uint8_t>(sizeof(ItemCAnimTbl)))
@@ -3851,6 +3877,18 @@ SfxID GetItemDropSfx(const Item &item)
 
 void GetItemFrm(Item &item)
 {
+	if (item._iCurs >= CustomCursorGraphicBase) {
+		auto dropIt = customCursToDropAnim.find(item._iCurs);
+		if (dropIt != customCursToDropAnim.end() && dropIt->second >= 0
+		    && static_cast<size_t>(dropIt->second) < customDropAnims.size()) {
+			item.AnimInfo.sprites.emplace(customDropAnims[static_cast<size_t>(dropIt->second)].sprites);
+		} else {
+			const int it = DefaultDropAnimForItemType(item._itype);
+			if (itemanims[it])
+				item.AnimInfo.sprites.emplace(*itemanims[it]);
+		}
+		return;
+	}
 	const int it = GetItemAnimType(item);
 	if (itemanims[it])
 		item.AnimInfo.sprites.emplace(*itemanims[it]);
@@ -4843,9 +4881,27 @@ bool Item::isUsable() const
 
 void Item::setNewAnimation(bool showAnimation)
 {
-	const int8_t it = GetItemAnimType(*this);
-	const int8_t numberOfFrames = ItemAnimLs[it];
-	const OptionalClxSpriteList sprite = itemanims[it] ? OptionalClxSpriteList { *itemanims[static_cast<size_t>(it)] } : std::nullopt;
+	int8_t numberOfFrames;
+	OptionalClxSpriteList sprite;
+
+	if (_iCurs >= CustomCursorGraphicBase) {
+		auto dropIt = customCursToDropAnim.find(_iCurs);
+		if (dropIt != customCursToDropAnim.end() && dropIt->second >= 0
+		    && static_cast<size_t>(dropIt->second) < customDropAnims.size()) {
+			auto &dropAnim = customDropAnims[static_cast<size_t>(dropIt->second)];
+			numberOfFrames = dropAnim.numFrames;
+			sprite = OptionalClxSpriteList { dropAnim.sprites };
+		} else {
+			const int8_t it = DefaultDropAnimForItemType(_itype);
+			numberOfFrames = ItemAnimLs[it];
+			sprite = itemanims[it] ? OptionalClxSpriteList { *itemanims[static_cast<size_t>(it)] } : std::nullopt;
+		}
+	} else {
+		const int8_t it = GetItemAnimType(*this);
+		numberOfFrames = ItemAnimLs[it];
+		sprite = itemanims[it] ? OptionalClxSpriteList { *itemanims[static_cast<size_t>(it)] } : std::nullopt;
+	}
+
 	if (_iCurs != ICURS_MAGIC_ROCK)
 		AnimInfo.setNewAnimation(sprite, numberOfFrames, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
 	else

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -129,7 +129,7 @@ int8_t ItemCAnimTbl[] = {
 	3, 1, 6, 6, 6, 1, 8, 6, 11, 3,
 	6, 8, 1, 6, 6, 17, 40, 0, 0, 0, 0
 };
-const int ItemCAnimTblSize = static_cast<int>(sizeof(ItemCAnimTbl));
+const int ItemCAnimTblSize = static_cast<int>(sizeof(ItemCAnimTbl) / sizeof(ItemCAnimTbl[0]));
 
 /** Maps of drop sounds effect of placing the item in the inventory. */
 SfxID ItemInvSnds[] = {
@@ -191,6 +191,17 @@ std::vector<CustomDropAnimData> customDropAnims;
 ankerl::unordered_dense::map<int, int> customCursToDropAnim;
 ankerl::unordered_dense::map<int, SfxID> customInvSnd;
 ankerl::unordered_dense::map<int, SfxID> customDropSnd;
+
+const CustomDropAnimData *GetCustomDropAnimData(int iCurs)
+{
+	const auto dropIt = customCursToDropAnim.find(iCurs);
+	if (dropIt == customCursToDropAnim.end() || dropIt->second < 0)
+		return nullptr;
+	const size_t dropAnimIndex = static_cast<size_t>(dropIt->second);
+	if (dropAnimIndex >= customDropAnims.size())
+		return nullptr;
+	return &customDropAnims[dropAnimIndex];
+}
 
 enum class PlayerArmorGraphic : uint8_t {
 	// clang-format off
@@ -3177,7 +3188,7 @@ void GetItemAttrs(Item &item, _item_indexes itemData, int lvl)
 	if (item._itype != ItemType::Gold)
 		return;
 
-	int rndv;
+	int rndv = 0;
 	const int itemlevel = ItemsGetCurrlevel();
 	switch (sgGameInitInfo.nDifficulty) {
 	case DIFF_NORMAL:
@@ -3843,10 +3854,24 @@ int8_t DefaultDropAnimForItemType(ItemType type)
 	}
 }
 
-int RegisterCustomDropAnim(OwnedClxSpriteList sprites, int8_t numFrames)
+int RegisterCustomDropAnim(OwnedClxSpriteList sprites, int numFrames)
 {
+	const uint32_t numSprites = sprites.numSprites();
+	if (numSprites == 0) {
+		app_fatal("Cannot register custom drop animation: sprite has no frames.");
+	}
+	if (numFrames < 1 || numFrames > INT8_MAX) {
+		app_fatal(fmt::format(
+		    "Cannot register custom drop animation: numFrames {} is out of range (1..{}, AnimationInfo uses int8_t).",
+		    numFrames, INT8_MAX));
+	}
+	if (static_cast<uint32_t>(numFrames) > numSprites) {
+		app_fatal(fmt::format(
+		    "Cannot register custom drop animation: numFrames {} exceeds loaded sprite frame count {}.",
+		    numFrames, numSprites));
+	}
 	const int id = static_cast<int>(customDropAnims.size());
-	customDropAnims.push_back({ std::move(sprites), numFrames });
+	customDropAnims.push_back({ std::move(sprites), static_cast<int8_t>(numFrames) });
 	return id;
 }
 
@@ -3896,10 +3921,9 @@ SfxID GetItemDropSnd(const Item &item)
 
 void GetItemFrm(Item &item)
 {
-	auto dropIt = customCursToDropAnim.find(item._iCurs);
-	if (dropIt != customCursToDropAnim.end() && dropIt->second >= 0
-	    && static_cast<size_t>(dropIt->second) < customDropAnims.size()) {
-		item.AnimInfo.sprites.emplace(customDropAnims[static_cast<size_t>(dropIt->second)].sprites);
+	const CustomDropAnimData *customDropAnim = GetCustomDropAnimData(item._iCurs);
+	if (customDropAnim != nullptr) {
+		item.AnimInfo.sprites.emplace(customDropAnim->sprites);
 		return;
 	}
 	const int it = GetItemAnimType(item);
@@ -4897,12 +4921,10 @@ void Item::setNewAnimation(bool showAnimation)
 	int8_t numberOfFrames;
 	OptionalClxSpriteList sprite;
 
-	auto dropIt = customCursToDropAnim.find(_iCurs);
-	if (dropIt != customCursToDropAnim.end() && dropIt->second >= 0
-	    && static_cast<size_t>(dropIt->second) < customDropAnims.size()) {
-		auto &dropAnim = customDropAnims[static_cast<size_t>(dropIt->second)];
-		numberOfFrames = dropAnim.numFrames;
-		sprite = OptionalClxSpriteList { dropAnim.sprites };
+	const CustomDropAnimData *customDropAnim = GetCustomDropAnimData(_iCurs);
+	if (customDropAnim != nullptr) {
+		numberOfFrames = customDropAnim->numFrames;
+		sprite = OptionalClxSpriteList { customDropAnim->sprites };
 	} else {
 		const int8_t it = GetItemAnimType(*this);
 		numberOfFrames = ItemAnimLs[it];

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -189,8 +189,8 @@ struct CustomDropAnimData {
 
 std::vector<CustomDropAnimData> customDropAnims;
 ankerl::unordered_dense::map<int, int> customCursToDropAnim;
-ankerl::unordered_dense::map<int, SfxID> customInvSfx;
-ankerl::unordered_dense::map<int, SfxID> customDropSfx;
+ankerl::unordered_dense::map<int, SfxID> customInvSnd;
+ankerl::unordered_dense::map<int, SfxID> customDropSnd;
 
 enum class PlayerArmorGraphic : uint8_t {
 	// clang-format off
@@ -3767,7 +3767,7 @@ void RespawnItem(Item &item, bool flipFlag)
 		} else {
 			item.selectionRegion = SelectionRegion::Bottom; // Item is selectable at floor level and renders at floor level
 		}
-		PlaySfxLoc(GetItemDropSfx(item), item.position); // Play the drop sound (this item is perpetually in a dropping state, but can always be picked up)
+		PlaySfxLoc(GetItemDropSnd(item), item.position); // Play the drop sound (this item is perpetually in a dropping state, but can always be picked up)
 		break;
 	}
 }
@@ -3803,7 +3803,7 @@ void ProcessItems()
 				item.AnimInfo.currentFrame = 10;                                                     // Beginning of elevated frames
 		} else {
 			if (item.AnimInfo.currentFrame == (item.AnimInfo.numberOfFrames - 1) / 2)
-				PlaySfxLoc(GetItemDropSfx(item), item.position);
+				PlaySfxLoc(GetItemDropSnd(item), item.position);
 
 			if (item.AnimInfo.isLastFrame()) {
 				item.AnimInfo.currentFrame = item.AnimInfo.numberOfFrames - 1;
@@ -3825,10 +3825,10 @@ void FreeItemGFX()
 int8_t DefaultDropAnimForItemType(ItemType type)
 {
 	switch (type) {
-	case ItemType::Sword: return 8;       // swrdflip
 	case ItemType::Axe: return 1;         // axe
 	case ItemType::Bow: return 3;         // bow
 	case ItemType::Mace: return 6;        // mace
+	case ItemType::Sword: return 8;       // swrdflip
 	case ItemType::Shield: return 7;      // shield
 	case ItemType::LightArmor: return 14; // larmor
 	case ItemType::Helm: return 5;        // helmut
@@ -3859,16 +3859,16 @@ void FreeCustomItemData()
 {
 	customDropAnims.clear();
 	customCursToDropAnim.clear();
-	customInvSfx.clear();
-	customDropSfx.clear();
+	customInvSnd.clear();
+	customDropSnd.clear();
 }
 
 void SetCustomItemSounds(int iCurs, SfxID invSound, SfxID dropSound)
 {
 	if (invSound != SfxID::None)
-		customInvSfx[iCurs] = invSound;
+		customInvSnd[iCurs] = invSound;
 	if (dropSound != SfxID::None)
-		customDropSfx[iCurs] = dropSound;
+		customDropSnd[iCurs] = dropSound;
 }
 
 int8_t GetItemAnimType(const Item &item)
@@ -3878,18 +3878,18 @@ int8_t GetItemAnimType(const Item &item)
 	return ItemCAnimTbl[item._iCurs];
 }
 
-SfxID GetItemInvSfx(const Item &item)
+SfxID GetItemInvSnd(const Item &item)
 {
-	auto it = customInvSfx.find(item._iCurs);
-	if (it != customInvSfx.end())
+	auto it = customInvSnd.find(item._iCurs);
+	if (it != customInvSnd.end())
 		return it->second;
 	return ItemInvSnds[GetItemAnimType(item)];
 }
 
-SfxID GetItemDropSfx(const Item &item)
+SfxID GetItemDropSnd(const Item &item)
 {
-	auto it = customDropSfx.find(item._iCurs);
-	if (it != customDropSfx.end())
+	auto it = customDropSnd.find(item._iCurs);
+	if (it != customDropSnd.end())
 		return it->second;
 	return ItemDropSnds[GetItemAnimType(item)];
 }

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3833,27 +3833,6 @@ void FreeItemGFX()
 	}
 }
 
-int8_t DefaultDropAnimForItemType(ItemType type)
-{
-	switch (type) {
-	case ItemType::Axe: return 1;         // axe
-	case ItemType::Bow: return 3;         // bow
-	case ItemType::Mace: return 6;        // mace
-	case ItemType::Sword: return 8;       // swrdflip
-	case ItemType::Shield: return 7;      // shield
-	case ItemType::LightArmor: return 14; // larmor
-	case ItemType::Helm: return 5;        // helmut
-	case ItemType::MediumArmor: return 0; // armor2
-	case ItemType::HeavyArmor: return 17; // fplatear
-	case ItemType::Staff: return 11;      // staff
-	case ItemType::Gold: return 4;        // goldflip
-	case ItemType::Ring: return 12;       // ring
-	case ItemType::Amulet: return 12;     // ring
-	case ItemType::Misc: return 2;        // fbttle
-	default: return 2;
-	}
-}
-
 int RegisterCustomDropAnim(OwnedClxSpriteList sprites, int numFrames)
 {
 	const uint32_t numSprites = sprites.numSprites();

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -129,6 +129,7 @@ int8_t ItemCAnimTbl[] = {
 	3, 1, 6, 6, 6, 1, 8, 6, 11, 3,
 	6, 8, 1, 6, 6, 17, 40, 0, 0
 };
+const int ItemCAnimTblSize = static_cast<int>(sizeof(ItemCAnimTbl));
 
 /** Maps of drop sounds effect of placing the item in the inventory. */
 SfxID ItemInvSnds[] = {
@@ -3854,7 +3855,7 @@ void SetCustomDropAnim(int iCurs, int dropAnimId)
 	customCursToDropAnim[iCurs] = dropAnimId;
 }
 
-void FreeCustomDropAnims()
+void FreeCustomItemData()
 {
 	customDropAnims.clear();
 	customCursToDropAnim.clear();
@@ -3872,7 +3873,7 @@ void SetCustomItemSounds(int iCurs, SfxID invSound, SfxID dropSound)
 
 int8_t GetItemAnimType(const Item &item)
 {
-	if (item._iCurs >= static_cast<uint8_t>(sizeof(ItemCAnimTbl)))
+	if (item._iCurs >= ItemCAnimTblSize)
 		return DefaultDropAnimForItemType(item._itype);
 	return ItemCAnimTbl[item._iCurs];
 }
@@ -3895,16 +3896,10 @@ SfxID GetItemDropSfx(const Item &item)
 
 void GetItemFrm(Item &item)
 {
-	if (item._iCurs >= CustomCursorGraphicBase) {
-		auto dropIt = customCursToDropAnim.find(item._iCurs);
-		if (dropIt != customCursToDropAnim.end() && dropIt->second >= 0
-		    && static_cast<size_t>(dropIt->second) < customDropAnims.size()) {
-			item.AnimInfo.sprites.emplace(customDropAnims[static_cast<size_t>(dropIt->second)].sprites);
-		} else {
-			const int it = DefaultDropAnimForItemType(item._itype);
-			if (itemanims[it])
-				item.AnimInfo.sprites.emplace(*itemanims[it]);
-		}
+	auto dropIt = customCursToDropAnim.find(item._iCurs);
+	if (dropIt != customCursToDropAnim.end() && dropIt->second >= 0
+	    && static_cast<size_t>(dropIt->second) < customDropAnims.size()) {
+		item.AnimInfo.sprites.emplace(customDropAnims[static_cast<size_t>(dropIt->second)].sprites);
 		return;
 	}
 	const int it = GetItemAnimType(item);
@@ -4902,18 +4897,12 @@ void Item::setNewAnimation(bool showAnimation)
 	int8_t numberOfFrames;
 	OptionalClxSpriteList sprite;
 
-	if (_iCurs >= CustomCursorGraphicBase) {
-		auto dropIt = customCursToDropAnim.find(_iCurs);
-		if (dropIt != customCursToDropAnim.end() && dropIt->second >= 0
-		    && static_cast<size_t>(dropIt->second) < customDropAnims.size()) {
-			auto &dropAnim = customDropAnims[static_cast<size_t>(dropIt->second)];
-			numberOfFrames = dropAnim.numFrames;
-			sprite = OptionalClxSpriteList { dropAnim.sprites };
-		} else {
-			const int8_t it = DefaultDropAnimForItemType(_itype);
-			numberOfFrames = ItemAnimLs[it];
-			sprite = itemanims[it] ? OptionalClxSpriteList { *itemanims[static_cast<size_t>(it)] } : std::nullopt;
-		}
+	auto dropIt = customCursToDropAnim.find(_iCurs);
+	if (dropIt != customCursToDropAnim.end() && dropIt->second >= 0
+	    && static_cast<size_t>(dropIt->second) < customDropAnims.size()) {
+		auto &dropAnim = customDropAnims[static_cast<size_t>(dropIt->second)];
+		numberOfFrames = dropAnim.numFrames;
+		sprite = OptionalClxSpriteList { dropAnim.sprites };
 	} else {
 		const int8_t it = GetItemAnimType(*this);
 		numberOfFrames = ItemAnimLs[it];

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -3733,7 +3733,6 @@ void SpawnTheodore(Point position, bool sendmsg)
 
 void RespawnItem(Item &item, bool flipFlag)
 {
-	const int it = ItemCAnimTbl[item._iCurs];
 	item.setNewAnimation(flipFlag);
 	item._iRequest = false; // Item isn't being picked up by a player
 
@@ -3757,7 +3756,7 @@ void RespawnItem(Item &item, bool flipFlag)
 		} else {
 			item.selectionRegion = SelectionRegion::Bottom; // Item is selectable at floor level and renders at floor level
 		}
-		PlaySfxLoc(ItemDropSnds[it], item.position); // Play the drop sound (this item is perpetually in a dropping state, but can always be picked up)
+		PlaySfxLoc(GetItemDropSfx(item), item.position); // Play the drop sound (this item is perpetually in a dropping state, but can always be picked up)
 		break;
 	}
 }
@@ -3793,7 +3792,7 @@ void ProcessItems()
 				item.AnimInfo.currentFrame = 10;                                                     // Beginning of elevated frames
 		} else {
 			if (item.AnimInfo.currentFrame == (item.AnimInfo.numberOfFrames - 1) / 2)
-				PlaySfxLoc(ItemDropSnds[ItemCAnimTbl[item._iCurs]], item.position);
+				PlaySfxLoc(GetItemDropSfx(item), item.position);
 
 			if (item.AnimInfo.isLastFrame()) {
 				item.AnimInfo.currentFrame = item.AnimInfo.numberOfFrames - 1;
@@ -3812,9 +3811,47 @@ void FreeItemGFX()
 	}
 }
 
+int8_t DefaultDropAnimForItemType(ItemType type)
+{
+	switch (type) {
+	case ItemType::Sword: return 8;       // swrdflip
+	case ItemType::Axe: return 1;         // axe
+	case ItemType::Bow: return 3;         // bow
+	case ItemType::Mace: return 6;        // mace
+	case ItemType::Shield: return 7;      // shield
+	case ItemType::LightArmor: return 14; // larmor
+	case ItemType::Helm: return 5;        // helmut
+	case ItemType::MediumArmor: return 0; // armor2
+	case ItemType::HeavyArmor: return 17; // fplatear
+	case ItemType::Staff: return 11;      // staff
+	case ItemType::Gold: return 4;        // goldflip
+	case ItemType::Ring: return 12;       // ring
+	case ItemType::Amulet: return 12;     // ring
+	case ItemType::Misc: return 2;        // fbttle
+	default: return 2;
+	}
+}
+
+int8_t GetItemAnimType(const Item &item)
+{
+	if (item._iCurs >= static_cast<uint8_t>(sizeof(ItemCAnimTbl)))
+		return DefaultDropAnimForItemType(item._itype);
+	return ItemCAnimTbl[item._iCurs];
+}
+
+SfxID GetItemInvSfx(const Item &item)
+{
+	return ItemInvSnds[GetItemAnimType(item)];
+}
+
+SfxID GetItemDropSfx(const Item &item)
+{
+	return ItemDropSnds[GetItemAnimType(item)];
+}
+
 void GetItemFrm(Item &item)
 {
-	const int it = ItemCAnimTbl[item._iCurs];
+	const int it = GetItemAnimType(item);
 	if (itemanims[it])
 		item.AnimInfo.sprites.emplace(*itemanims[it]);
 }
@@ -4806,7 +4843,7 @@ bool Item::isUsable() const
 
 void Item::setNewAnimation(bool showAnimation)
 {
-	const int8_t it = ItemCAnimTbl[_iCurs];
+	const int8_t it = GetItemAnimType(*this);
 	const int8_t numberOfFrames = ItemAnimLs[it];
 	const OptionalClxSpriteList sprite = itemanims[it] ? OptionalClxSpriteList { *itemanims[static_cast<size_t>(it)] } : std::nullopt;
 	if (_iCurs != ICURS_MAGIC_ROCK)

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -188,6 +188,8 @@ struct CustomDropAnimData {
 
 std::vector<CustomDropAnimData> customDropAnims;
 ankerl::unordered_dense::map<int, int> customCursToDropAnim;
+ankerl::unordered_dense::map<int, SfxID> customInvSfx;
+ankerl::unordered_dense::map<int, SfxID> customDropSfx;
 
 enum class PlayerArmorGraphic : uint8_t {
 	// clang-format off
@@ -3856,6 +3858,16 @@ void FreeCustomDropAnims()
 {
 	customDropAnims.clear();
 	customCursToDropAnim.clear();
+	customInvSfx.clear();
+	customDropSfx.clear();
+}
+
+void SetCustomItemSounds(int iCurs, SfxID invSound, SfxID dropSound)
+{
+	if (invSound != SfxID::None)
+		customInvSfx[iCurs] = invSound;
+	if (dropSound != SfxID::None)
+		customDropSfx[iCurs] = dropSound;
 }
 
 int8_t GetItemAnimType(const Item &item)
@@ -3867,11 +3879,17 @@ int8_t GetItemAnimType(const Item &item)
 
 SfxID GetItemInvSfx(const Item &item)
 {
+	auto it = customInvSfx.find(item._iCurs);
+	if (it != customInvSfx.end())
+		return it->second;
 	return ItemInvSnds[GetItemAnimType(item)];
 }
 
 SfxID GetItemDropSfx(const Item &item)
 {
+	auto it = customDropSfx.find(item._iCurs);
+	if (it != customDropSfx.end())
+		return it->second;
 	return ItemDropSnds[GetItemAnimType(item)];
 }
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -604,10 +604,10 @@ int8_t DefaultDropAnimForItemType(ItemType type);
 int8_t GetItemAnimType(const Item &item);
 
 /** Returns the inventory placement sound for an item. */
-SfxID GetItemInvSfx(const Item &item);
+SfxID GetItemInvSnd(const Item &item);
 
 /** Returns the floor drop sound for an item. */
-SfxID GetItemDropSfx(const Item &item);
+SfxID GetItemDropSnd(const Item &item);
 
 /* data */
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -594,6 +594,9 @@ void SetCustomDropAnim(int iCurs, int dropAnimId);
 /** Frees all custom drop animations. */
 void FreeCustomDropAnims();
 
+/** Registers custom inventory and drop sounds for a cursor graphic ID. */
+void SetCustomItemSounds(int iCurs, SfxID invSound, SfxID dropSound);
+
 /** Returns the animation type index for an item, safe for custom cursor graphics. */
 int8_t GetItemAnimType(const Item &item);
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -597,6 +597,9 @@ void FreeCustomItemData();
 /** Registers custom inventory and drop sounds for a cursor graphic ID. */
 void SetCustomItemSounds(int iCurs, SfxID invSound, SfxID dropSound);
 
+/** Returns the default in-memory item animation index for a logical item type (see ITEMTYPES). */
+int8_t DefaultDropAnimForItemType(ItemType type);
+
 /** Returns the animation type index for an item, safe for custom cursor graphics. */
 int8_t GetItemAnimType(const Item &item);
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -585,8 +585,8 @@ bool ApplyOilToItem(Item &item, Player &player);
  */
 void UpdateHellfireFlag(Item &item, const char *identifiedItemName);
 
-/** Registers a custom floor drop animation and returns its ID. */
-int RegisterCustomDropAnim(OwnedClxSpriteList sprites, int8_t numFrames);
+/** Registers a custom floor drop animation and returns its ID. numFrames must be 1..127 (int8_t) and not exceed the sprite's frame count. */
+int RegisterCustomDropAnim(OwnedClxSpriteList sprites, int numFrames);
 
 /** Associates a custom cursor graphic ID with a custom drop animation ID. */
 void SetCustomDropAnim(int iCurs, int dropAnimId);

--- a/Source/items.h
+++ b/Source/items.h
@@ -613,8 +613,8 @@ SfxID GetItemDropSnd(const Item &item);
 
 extern int MaxGold;
 
-extern int8_t ItemCAnimTbl[];
-extern const int ItemCAnimTblSize;
+extern DVL_API_FOR_TEST int8_t ItemCAnimTbl[];
+extern DVL_API_FOR_TEST const int ItemCAnimTblSize;
 extern SfxID ItemInvSnds[];
 
 } // namespace devilution

--- a/Source/items.h
+++ b/Source/items.h
@@ -592,7 +592,7 @@ int RegisterCustomDropAnim(OwnedClxSpriteList sprites, int8_t numFrames);
 void SetCustomDropAnim(int iCurs, int dropAnimId);
 
 /** Frees all custom drop animations. */
-void FreeCustomDropAnims();
+void FreeCustomItemData();
 
 /** Registers custom inventory and drop sounds for a cursor graphic ID. */
 void SetCustomItemSounds(int iCurs, SfxID invSound, SfxID dropSound);
@@ -611,6 +611,7 @@ SfxID GetItemDropSfx(const Item &item);
 extern int MaxGold;
 
 extern int8_t ItemCAnimTbl[];
+extern const int ItemCAnimTblSize;
 extern SfxID ItemInvSnds[];
 
 } // namespace devilution

--- a/Source/items.h
+++ b/Source/items.h
@@ -585,6 +585,15 @@ bool ApplyOilToItem(Item &item, Player &player);
  */
 void UpdateHellfireFlag(Item &item, const char *identifiedItemName);
 
+/** Registers a custom floor drop animation and returns its ID. */
+int RegisterCustomDropAnim(OwnedClxSpriteList sprites, int8_t numFrames);
+
+/** Associates a custom cursor graphic ID with a custom drop animation ID. */
+void SetCustomDropAnim(int iCurs, int dropAnimId);
+
+/** Frees all custom drop animations. */
+void FreeCustomDropAnims();
+
 /** Returns the animation type index for an item, safe for custom cursor graphics. */
 int8_t GetItemAnimType(const Item &item);
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -585,6 +585,15 @@ bool ApplyOilToItem(Item &item, Player &player);
  */
 void UpdateHellfireFlag(Item &item, const char *identifiedItemName);
 
+/** Returns the animation type index for an item, safe for custom cursor graphics. */
+int8_t GetItemAnimType(const Item &item);
+
+/** Returns the inventory placement sound for an item. */
+SfxID GetItemInvSfx(const Item &item);
+
+/** Returns the floor drop sound for an item. */
+SfxID GetItemDropSfx(const Item &item);
+
 /* data */
 
 extern int MaxGold;

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1085,7 +1085,14 @@ void LoadMatchingItems(LoadHelper &file, const Player &player, const int n, Item
 		const bool success = LoadItemData(file, heroItem);
 		if (!success) {
 			heroItem.clear();
-			unpackedItem = Item();
+			// Do not clear unpackedItem: if the hero pack recreated it, keep it.
+		}
+		// If heroitems has valid data but the hero pack could not recreate
+		// the item (e.g. a custom mod item not in the drop tables), use
+		// heroitems as the primary source.
+		if (unpackedItem.isEmpty() && !heroItem.isEmpty()) {
+			unpackedItem = heroItem;
+			continue;
 		}
 		if (unpackedItem.isEmpty() || heroItem.isEmpty())
 			continue;

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -477,28 +477,28 @@ void AddItem(sol::table t)
 	}
 
 	ItemData item;
-	item.dropRate = static_cast<uint8_t>(t.get_or<int>("dropRate", 1));
-	item.iClass = t.get_or<item_class>("class", ICLASS_NONE);
-	item.iLoc = t.get_or<item_equip_type>("equipType", ILOC_NONE);
-	item.iCurs = static_cast<item_cursor_graphic>(t.get_or<int>("cursorGraphic", 0));
-	item.itype = t.get_or<ItemType>("type", ItemType::None);
-	item.iItemId = static_cast<unique_base_item>(t.get_or<int>("uniqueBaseItem", UITYPE_NONE));
+	item.dropRate = static_cast<uint8_t>(t.get_or("dropRate", 1));
+	item.iClass = t.get_or("class", ICLASS_NONE);
+	item.iLoc = t.get_or("equipType", ILOC_NONE);
+	item.iCurs = static_cast<item_cursor_graphic>(t.get_or("cursorGraphic", 0));
+	item.itype = t.get_or("type", ItemType::None);
+	item.iItemId = static_cast<unique_base_item>(t.get_or("uniqueBaseItem", UITYPE_NONE));
 	item.iName = t.get<std::string>("name");
-	item.iSName = t.get_or<std::string>("shortName", item.iName);
-	item.iMinMLvl = static_cast<uint8_t>(t.get_or<int>("minMonsterLevel", 0));
-	item.iDurability = static_cast<uint8_t>(t.get_or<int>("durability", 0));
-	item.iMinDam = static_cast<uint8_t>(t.get_or<int>("minDam", 0));
-	item.iMaxDam = static_cast<uint8_t>(t.get_or<int>("maxDam", 0));
-	item.iMinAC = static_cast<uint8_t>(t.get_or<int>("minAC", 0));
-	item.iMaxAC = static_cast<uint8_t>(t.get_or<int>("maxAC", 0));
-	item.iMinStr = static_cast<uint8_t>(t.get_or<int>("minStr", 0));
-	item.iMinMag = static_cast<uint8_t>(t.get_or<int>("minMag", 0));
-	item.iMinDex = static_cast<uint8_t>(t.get_or<int>("minDex", 0));
-	item.iFlags = t.get_or<ItemSpecialEffect>("flags", ItemSpecialEffect::None);
-	item.iMiscId = t.get_or<item_misc_id>("miscId", IMISC_NONE);
-	item.iSpell = t.get_or<SpellID>("spell", SpellID::Null);
-	item.iUsable = t.get_or<bool>("usable", false);
-	item.iValue = static_cast<uint16_t>(t.get_or<int>("value", 0));
+	item.iSName = t.get_or("shortName", item.iName);
+	item.iMinMLvl = static_cast<uint8_t>(t.get_or("minMonsterLevel", 0));
+	item.iDurability = static_cast<uint8_t>(t.get_or("durability", 0));
+	item.iMinDam = static_cast<uint8_t>(t.get_or("minDam", 0));
+	item.iMaxDam = static_cast<uint8_t>(t.get_or("maxDam", 0));
+	item.iMinAC = static_cast<uint8_t>(t.get_or("minAC", 0));
+	item.iMaxAC = static_cast<uint8_t>(t.get_or("maxAC", 0));
+	item.iMinStr = static_cast<uint8_t>(t.get_or("minStr", 0));
+	item.iMinMag = static_cast<uint8_t>(t.get_or("minMag", 0));
+	item.iMinDex = static_cast<uint8_t>(t.get_or("minDex", 0));
+	item.iFlags = t.get_or("flags", ItemSpecialEffect::None);
+	item.iMiscId = t.get_or("miscId", IMISC_NONE);
+	item.iSpell = t.get_or("spell", SpellID::Null);
+	item.iUsable = t.get_or("usable", false);
+	item.iValue = static_cast<uint16_t>(t.get_or("value", 0));
 	item.iMappingId = mappingId;
 
 	AllItemsList.push_back(std::move(item));
@@ -514,10 +514,10 @@ void AddUniqueItem(sol::table t)
 
 	UniqueItem item;
 	item.UIName = t.get<std::string>("name");
-	item.UICurs = static_cast<item_cursor_graphic>(t.get_or<int>("cursorGraphic", 0));
-	item.UIItemId = static_cast<unique_base_item>(t.get_or<int>("uniqueBaseItem", UITYPE_NONE));
-	item.UIMinLvl = static_cast<int8_t>(t.get_or<int>("minLevel", 0));
-	item.UIValue = t.get_or<int>("value", 0);
+	item.UICurs = static_cast<item_cursor_graphic>(t.get_or("cursorGraphic", 0));
+	item.UIItemId = static_cast<unique_base_item>(t.get_or("uniqueBaseItem", UITYPE_NONE));
+	item.UIMinLvl = static_cast<int8_t>(t.get_or("minLevel", 0));
+	item.UIValue = t.get_or("value", 0);
 
 	item.UINumPL = 0;
 	sol::optional<sol::table> powers = t["powers"];
@@ -525,9 +525,9 @@ void AddUniqueItem(sol::table t)
 		for (size_t i = 1; i <= std::size(item.powers); ++i) {
 			sol::optional<sol::table> power = (*powers)[i];
 			if (!power) break;
-			item.powers[item.UINumPL].type = power->get_or<item_effect_type>("type", IPL_INVALID);
-			item.powers[item.UINumPL].param1 = power->get_or<int>("param1", 0);
-			item.powers[item.UINumPL].param2 = power->get_or<int>("param2", 0);
+			item.powers[item.UINumPL].type = power->get_or("type", IPL_INVALID);
+			item.powers[item.UINumPL].param1 = power->get_or("param1", 0);
+			item.powers[item.UINumPL].param2 = power->get_or("param2", 0);
 			item.UINumPL++;
 		}
 	}

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -589,6 +589,27 @@ void LuaRegisterDropGraphic(int iCurs, const std::string &path, int numFrames)
 
 } // namespace
 
+int8_t DefaultDropAnimForItemType(ItemType type)
+{
+	switch (type) {
+	case ItemType::Axe: return 1;         // axe
+	case ItemType::Bow: return 3;         // bow
+	case ItemType::Mace: return 6;        // mace
+	case ItemType::Sword: return 8;       // swrdflip
+	case ItemType::Shield: return 7;      // shield
+	case ItemType::LightArmor: return 14; // larmor
+	case ItemType::Helm: return 5;        // helmut
+	case ItemType::MediumArmor: return 0; // armor2
+	case ItemType::HeavyArmor: return 17; // fplatear
+	case ItemType::Staff: return 11;      // staff
+	case ItemType::Gold: return 4;        // goldflip
+	case ItemType::Ring: return 12;       // ring
+	case ItemType::Amulet: return 12;     // ring
+	case ItemType::Misc: return 2;        // fbttle
+	default: return 2;
+	}
+}
+
 sol::table LuaItemModule(sol::state_view &lua)
 {
 	InitItemUserType(lua);

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -458,25 +458,8 @@ void RegisterItemSpecialEffectHfEnum(sol::state_view &lua)
 	    });
 }
 
-void AddItemDataFromTsv(const std::string_view path, const int32_t baseMappingId)
+ItemData ParseItemDataTable(sol::table t)
 {
-	DataFile dataFile = DataFile::loadOrDie(path);
-	LoadItemDatFromFile(dataFile, path, baseMappingId);
-}
-
-void AddUniqueItemDataFromTsv(const std::string_view path, const int32_t baseMappingId)
-{
-	DataFile dataFile = DataFile::loadOrDie(path);
-	LoadUniqueItemDatFromFile(dataFile, path, baseMappingId);
-}
-
-void AddItem(sol::table t)
-{
-	int32_t mappingId = t.get<int32_t>("mappingId");
-	if (ItemMappingIdsToIndices.count(mappingId) > 0) {
-		app_fatal(fmt::format("An item already exists for mapping ID {}.", mappingId));
-	}
-
 	ItemData item;
 	item.dropRate = static_cast<uint8_t>(t.get_or("dropRate", 1));
 	item.iClass = t.get_or("class", ICLASS_NONE);
@@ -500,19 +483,11 @@ void AddItem(sol::table t)
 	item.iSpell = t.get_or("spell", SpellID::Null);
 	item.iUsable = t.get_or("usable", false);
 	item.iValue = static_cast<uint16_t>(t.get_or("value", 0));
-	item.iMappingId = mappingId;
-
-	AllItemsList.push_back(std::move(item));
-	ItemMappingIdsToIndices.emplace(mappingId, static_cast<int16_t>(AllItemsList.size()) - 1);
+	return item;
 }
 
-void AddUniqueItem(sol::table t)
+UniqueItem ParseUniqueItemDataTable(sol::table t)
 {
-	int32_t mappingId = t.get<int32_t>("mappingId");
-	if (UniqueItemMappingIdsToIndices.count(mappingId) > 0) {
-		app_fatal(fmt::format("A unique item already exists for mapping ID {}.", mappingId));
-	}
-
 	UniqueItem item;
 	item.UIName = t.get<std::string>("name");
 	item.UICurs = static_cast<item_cursor_graphic>(t.get_or("cursorGraphic", 0));
@@ -532,10 +507,59 @@ void AddUniqueItem(sol::table t)
 			item.UINumPL++;
 		}
 	}
+	return item;
+}
 
-	item.mappingId = mappingId;
-	UniqueItems.push_back(std::move(item));
-	UniqueItemMappingIdsToIndices.emplace(mappingId, static_cast<int32_t>(UniqueItems.size()) - 1);
+void AddItemDataFromTsv(const std::string_view path, const int32_t baseMappingId)
+{
+	DataFile dataFile = DataFile::loadOrDie(path);
+	LoadItemDatFromFile(dataFile, path, baseMappingId);
+}
+
+void AddUniqueItemDataFromTsv(const std::string_view path, const int32_t baseMappingId)
+{
+	DataFile dataFile = DataFile::loadOrDie(path);
+	LoadUniqueItemDatFromFile(dataFile, path, baseMappingId);
+}
+
+void AddItemData(sol::table itemData, const int32_t baseMappingId)
+{
+	const size_t numItems = itemData.size();
+	AllItemsList.reserve(AllItemsList.size() + numItems);
+	for (size_t i = 1; i <= numItems; ++i) {
+		sol::optional<sol::table> itemTable = itemData[i];
+		if (!itemTable) {
+			app_fatal(fmt::format("Expected item data table at index {}.", i));
+		}
+		const int32_t mappingId = baseMappingId + static_cast<int32_t>(i - 1);
+		ItemData item = ParseItemDataTable(*itemTable);
+		item.iMappingId = mappingId;
+		AllItemsList.push_back(std::move(item));
+		const auto [it, inserted] = ItemMappingIdsToIndices.emplace(mappingId, static_cast<int16_t>(AllItemsList.size()) - 1);
+		if (!inserted) {
+			app_fatal(fmt::format("An item already exists for mapping ID {}.", mappingId));
+		}
+	}
+}
+
+void AddUniqueItemData(sol::table itemData, const int32_t baseMappingId)
+{
+	const size_t numItems = itemData.size();
+	UniqueItems.reserve(UniqueItems.size() + numItems);
+	for (size_t i = 1; i <= numItems; ++i) {
+		sol::optional<sol::table> itemTable = itemData[i];
+		if (!itemTable) {
+			app_fatal(fmt::format("Expected unique item data table at index {}.", i));
+		}
+		const int32_t mappingId = baseMappingId + static_cast<int32_t>(i - 1);
+		UniqueItem item = ParseUniqueItemDataTable(*itemTable);
+		item.mappingId = mappingId;
+		UniqueItems.push_back(std::move(item));
+		const auto [it, inserted] = UniqueItemMappingIdsToIndices.emplace(mappingId, static_cast<int32_t>(UniqueItems.size()) - 1);
+		if (!inserted) {
+			app_fatal(fmt::format("A unique item already exists for mapping ID {}.", mappingId));
+		}
+	}
 }
 
 int LuaRegisterCursorGraphic(const std::string &path, int width)
@@ -582,8 +606,8 @@ sol::table LuaItemModule(sol::state_view &lua)
 
 	LuaSetDocFn(table, "addItemDataFromTsv", "(path: string, baseMappingId: number)", AddItemDataFromTsv);
 	LuaSetDocFn(table, "addUniqueItemDataFromTsv", "(path: string, baseMappingId: number)", AddUniqueItemDataFromTsv);
-	LuaSetDocFn(table, "addItem", "(item: table)", "Add a new item definition from a Lua table. Required: name, mappingId. Optional: dropRate, class, equipType, cursorGraphic, type, uniqueBaseItem, shortName, minMonsterLevel, durability, minDam, maxDam, minAC, maxAC, minStr, minMag, minDex, flags, miscId, spell, usable, value.", AddItem);
-	LuaSetDocFn(table, "addUniqueItem", "(item: table)", "Add a new unique item definition from a Lua table. Required: name, mappingId. Optional: cursorGraphic, uniqueBaseItem, minLevel, value, powers (array of {type, param1, param2}).", AddUniqueItem);
+	LuaSetDocFn(table, "addItemData", "(itemData: ItemData[], baseMappingId: number)", "Add item definitions from a list of item data tables. Mapping IDs are assigned sequentially starting from baseMappingId. Each entry requires: name. Optional fields: dropRate, class, equipType, cursorGraphic, type, uniqueBaseItem, shortName, minMonsterLevel, durability, minDam, maxDam, minAC, maxAC, minStr, minMag, minDex, flags, miscId, spell, usable, value.", AddItemData);
+	LuaSetDocFn(table, "addUniqueItemData", "(itemData: UniqueItemData[], baseMappingId: number)", "Add unique item definitions from a list of unique item data tables. Mapping IDs are assigned sequentially starting from baseMappingId. Each entry requires: name. Optional fields: cursorGraphic, uniqueBaseItem, minLevel, value, powers (array of {type, param1, param2}).", AddUniqueItemData);
 	LuaSetDocFn(table, "registerCursorGraphic", "(path: string, width: number) -> number", "Load a sprite for inventory/cursor display and return its cursorGraphic ID.", LuaRegisterCursorGraphic);
 	LuaSetDocFn(table, "registerDropGraphic", "(cursorGraphic: number, path: string, numFrames: number)", "Load a floor drop animation sprite for a custom cursor graphic. If not called, uses the default for the item type.", LuaRegisterDropGraphic);
 	LuaSetDocFn(table, "registerItemSounds", "(cursorGraphic: number, invSound: number|nil, dropSound: number|nil)", "Register custom inventory and drop sounds for a cursor graphic. Use SfxID values from the audio module (e.g. SfxID.ItemRingFlip). For each slot, pass nil or SfxID.None (-1) to keep the default.", LuaRegisterItemSounds);

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -1,11 +1,11 @@
 #include "lua/modules/items.hpp"
 
-#include <stdexcept>
 #include <string_view>
 
 #include <fmt/format.h>
 #include <sol/sol.hpp>
 
+#include "appfat.h"
 #include "cursor.h"
 #include "data/file.hpp"
 #include "effects.h"
@@ -473,7 +473,7 @@ void AddItem(sol::table t)
 {
 	int32_t mappingId = t.get<int32_t>("mappingId");
 	if (ItemMappingIdsToIndices.count(mappingId) > 0) {
-		throw std::runtime_error(fmt::format("An item already exists for mapping ID {}.", mappingId));
+		app_fatal(fmt::format("An item already exists for mapping ID {}.", mappingId));
 	}
 
 	ItemData item;
@@ -509,7 +509,7 @@ void AddUniqueItem(sol::table t)
 {
 	int32_t mappingId = t.get<int32_t>("mappingId");
 	if (UniqueItemMappingIdsToIndices.count(mappingId) > 0) {
-		throw std::runtime_error(fmt::format("A unique item already exists for mapping ID {}.", mappingId));
+		app_fatal(fmt::format("A unique item already exists for mapping ID {}.", mappingId));
 	}
 
 	UniqueItem item;

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -8,6 +8,7 @@
 
 #include "cursor.h"
 #include "data/file.hpp"
+#include "effects.h"
 #include "engine/load_cel.hpp"
 #include "items.h"
 #include "lua/metadoc.hpp"
@@ -542,6 +543,11 @@ int LuaRegisterCursorGraphic(const std::string &path, int width)
 	return RegisterCustomCursorGraphic(std::move(sprite));
 }
 
+void LuaRegisterItemSounds(int iCurs, int invSound, int dropSound)
+{
+	SetCustomItemSounds(iCurs, static_cast<SfxID>(invSound), static_cast<SfxID>(dropSound));
+}
+
 void LuaRegisterDropGraphic(int iCurs, const std::string &path, int numFrames)
 {
 	OwnedClxSpriteList sprites = LoadCel(path.c_str(), ItemAnimWidth);
@@ -572,6 +578,7 @@ sol::table LuaItemModule(sol::state_view &lua)
 	LuaSetDocFn(table, "addUniqueItem", "(item: table)", "Add a new unique item definition from a Lua table. Required: name, mappingId. Optional: cursorGraphic, uniqueBaseItem, minLevel, value, powers (array of {type, param1, param2}).", AddUniqueItem);
 	LuaSetDocFn(table, "registerCursorGraphic", "(path: string, width: number) -> number", "Load a sprite for inventory/cursor display and return its cursorGraphic ID.", LuaRegisterCursorGraphic);
 	LuaSetDocFn(table, "registerDropGraphic", "(cursorGraphic: number, path: string, numFrames: number)", "Load a floor drop animation sprite for a custom cursor graphic. If not called, uses the default for the item type.", LuaRegisterDropGraphic);
+	LuaSetDocFn(table, "registerItemSounds", "(cursorGraphic: number, invSound: number, dropSound: number)", "Register custom inventory and drop sounds for a cursor graphic. Use SfxID values from the audio module. Pass 0 to keep the default.", LuaRegisterItemSounds);
 
 	// Expose enums through the module table
 	table["ItemIndex"] = lua["ItemIndex"];

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -13,6 +13,7 @@
 #include "items.h"
 #include "lua/metadoc.hpp"
 #include "player.h"
+#include "sound_effect_enums.h"
 #include "tables/itemdat.h"
 #include "utils/utf8.hpp"
 
@@ -543,15 +544,22 @@ int LuaRegisterCursorGraphic(const std::string &path, int width)
 	return RegisterCustomCursorGraphic(std::move(sprite));
 }
 
-void LuaRegisterItemSounds(int iCurs, int invSound, int dropSound)
+[[nodiscard]] SfxID LuaItemSoundArgToSfxId(sol::optional<int> raw)
 {
-	SetCustomItemSounds(iCurs, static_cast<SfxID>(invSound), static_cast<SfxID>(dropSound));
+	if (!raw.has_value() || *raw == static_cast<int>(SfxID::None))
+		return SfxID::None;
+	return static_cast<SfxID>(static_cast<int16_t>(*raw));
+}
+
+void LuaRegisterItemSounds(int iCurs, sol::optional<int> invSound, sol::optional<int> dropSound)
+{
+	SetCustomItemSounds(iCurs, LuaItemSoundArgToSfxId(invSound), LuaItemSoundArgToSfxId(dropSound));
 }
 
 void LuaRegisterDropGraphic(int iCurs, const std::string &path, int numFrames)
 {
 	OwnedClxSpriteList sprites = LoadCel(path.c_str(), ItemAnimWidth);
-	const int dropAnimId = RegisterCustomDropAnim(std::move(sprites), static_cast<int8_t>(numFrames));
+	const int dropAnimId = RegisterCustomDropAnim(std::move(sprites), numFrames);
 	SetCustomDropAnim(iCurs, dropAnimId);
 }
 
@@ -578,7 +586,7 @@ sol::table LuaItemModule(sol::state_view &lua)
 	LuaSetDocFn(table, "addUniqueItem", "(item: table)", "Add a new unique item definition from a Lua table. Required: name, mappingId. Optional: cursorGraphic, uniqueBaseItem, minLevel, value, powers (array of {type, param1, param2}).", AddUniqueItem);
 	LuaSetDocFn(table, "registerCursorGraphic", "(path: string, width: number) -> number", "Load a sprite for inventory/cursor display and return its cursorGraphic ID.", LuaRegisterCursorGraphic);
 	LuaSetDocFn(table, "registerDropGraphic", "(cursorGraphic: number, path: string, numFrames: number)", "Load a floor drop animation sprite for a custom cursor graphic. If not called, uses the default for the item type.", LuaRegisterDropGraphic);
-	LuaSetDocFn(table, "registerItemSounds", "(cursorGraphic: number, invSound: number, dropSound: number)", "Register custom inventory and drop sounds for a cursor graphic. Use SfxID values from the audio module. Pass 0 to keep the default.", LuaRegisterItemSounds);
+	LuaSetDocFn(table, "registerItemSounds", "(cursorGraphic: number, invSound: number|nil, dropSound: number|nil)", "Register custom inventory and drop sounds for a cursor graphic. Use SfxID values from the audio module (e.g. SfxID.ItemRingFlip). For each slot, pass nil or SfxID.None (-1) to keep the default.", LuaRegisterItemSounds);
 
 	// Expose enums through the module table
 	table["ItemIndex"] = lua["ItemIndex"];

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -522,7 +522,7 @@ void AddUniqueItem(sol::table t)
 	item.UINumPL = 0;
 	sol::optional<sol::table> powers = t["powers"];
 	if (powers) {
-		for (size_t i = 1; i <= 6; ++i) {
+		for (size_t i = 1; i <= std::size(item.powers); ++i) {
 			sol::optional<sol::table> power = (*powers)[i];
 			if (!power) break;
 			item.powers[item.UINumPL].type = power->get_or<item_effect_type>("type", IPL_INVALID);

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -1,5 +1,6 @@
 #include "lua/modules/items.hpp"
 
+#include <stdexcept>
 #include <string_view>
 
 #include <fmt/format.h>
@@ -465,6 +466,74 @@ void AddUniqueItemDataFromTsv(const std::string_view path, const int32_t baseMap
 	LoadUniqueItemDatFromFile(dataFile, path, baseMappingId);
 }
 
+void AddItem(sol::table t)
+{
+	int32_t mappingId = t.get<int32_t>("mappingId");
+	if (ItemMappingIdsToIndices.count(mappingId) > 0) {
+		throw std::runtime_error(fmt::format("An item already exists for mapping ID {}.", mappingId));
+	}
+
+	ItemData item;
+	item.dropRate = static_cast<uint8_t>(t.get_or<int>("dropRate", 1));
+	item.iClass = t.get_or<item_class>("class", ICLASS_NONE);
+	item.iLoc = t.get_or<item_equip_type>("equipType", ILOC_NONE);
+	item.iCurs = static_cast<item_cursor_graphic>(t.get_or<int>("cursorGraphic", 0));
+	item.itype = t.get_or<ItemType>("type", ItemType::None);
+	item.iItemId = static_cast<unique_base_item>(t.get_or<int>("uniqueBaseItem", UITYPE_NONE));
+	item.iName = t.get<std::string>("name");
+	item.iSName = t.get_or<std::string>("shortName", item.iName);
+	item.iMinMLvl = static_cast<uint8_t>(t.get_or<int>("minMonsterLevel", 0));
+	item.iDurability = static_cast<uint8_t>(t.get_or<int>("durability", 0));
+	item.iMinDam = static_cast<uint8_t>(t.get_or<int>("minDam", 0));
+	item.iMaxDam = static_cast<uint8_t>(t.get_or<int>("maxDam", 0));
+	item.iMinAC = static_cast<uint8_t>(t.get_or<int>("minAC", 0));
+	item.iMaxAC = static_cast<uint8_t>(t.get_or<int>("maxAC", 0));
+	item.iMinStr = static_cast<uint8_t>(t.get_or<int>("minStr", 0));
+	item.iMinMag = static_cast<uint8_t>(t.get_or<int>("minMag", 0));
+	item.iMinDex = static_cast<uint8_t>(t.get_or<int>("minDex", 0));
+	item.iFlags = t.get_or<ItemSpecialEffect>("flags", ItemSpecialEffect::None);
+	item.iMiscId = t.get_or<item_misc_id>("miscId", IMISC_NONE);
+	item.iSpell = t.get_or<SpellID>("spell", SpellID::Null);
+	item.iUsable = t.get_or<bool>("usable", false);
+	item.iValue = static_cast<uint16_t>(t.get_or<int>("value", 0));
+	item.iMappingId = mappingId;
+
+	AllItemsList.push_back(std::move(item));
+	ItemMappingIdsToIndices.emplace(mappingId, static_cast<int16_t>(AllItemsList.size()) - 1);
+}
+
+void AddUniqueItem(sol::table t)
+{
+	int32_t mappingId = t.get<int32_t>("mappingId");
+	if (UniqueItemMappingIdsToIndices.count(mappingId) > 0) {
+		throw std::runtime_error(fmt::format("A unique item already exists for mapping ID {}.", mappingId));
+	}
+
+	UniqueItem item;
+	item.UIName = t.get<std::string>("name");
+	item.UICurs = static_cast<item_cursor_graphic>(t.get_or<int>("cursorGraphic", 0));
+	item.UIItemId = static_cast<unique_base_item>(t.get_or<int>("uniqueBaseItem", UITYPE_NONE));
+	item.UIMinLvl = static_cast<int8_t>(t.get_or<int>("minLevel", 0));
+	item.UIValue = t.get_or<int>("value", 0);
+
+	item.UINumPL = 0;
+	sol::optional<sol::table> powers = t["powers"];
+	if (powers) {
+		for (size_t i = 1; i <= 6; ++i) {
+			sol::optional<sol::table> power = (*powers)[i];
+			if (!power) break;
+			item.powers[item.UINumPL].type = power->get_or<item_effect_type>("type", IPL_INVALID);
+			item.powers[item.UINumPL].param1 = power->get_or<int>("param1", 0);
+			item.powers[item.UINumPL].param2 = power->get_or<int>("param2", 0);
+			item.UINumPL++;
+		}
+	}
+
+	item.mappingId = mappingId;
+	UniqueItems.push_back(std::move(item));
+	UniqueItemMappingIdsToIndices.emplace(mappingId, static_cast<int32_t>(UniqueItems.size()) - 1);
+}
+
 } // namespace
 
 sol::table LuaItemModule(sol::state_view &lua)
@@ -484,6 +553,8 @@ sol::table LuaItemModule(sol::state_view &lua)
 
 	LuaSetDocFn(table, "addItemDataFromTsv", "(path: string, baseMappingId: number)", AddItemDataFromTsv);
 	LuaSetDocFn(table, "addUniqueItemDataFromTsv", "(path: string, baseMappingId: number)", AddUniqueItemDataFromTsv);
+	LuaSetDocFn(table, "addItem", "(item: table)", "Add a new item definition from a Lua table. Required: name, mappingId. Optional: dropRate, class, equipType, cursorGraphic, type, uniqueBaseItem, shortName, minMonsterLevel, durability, minDam, maxDam, minAC, maxAC, minStr, minMag, minDex, flags, miscId, spell, usable, value.", AddItem);
+	LuaSetDocFn(table, "addUniqueItem", "(item: table)", "Add a new unique item definition from a Lua table. Required: name, mappingId. Optional: cursorGraphic, uniqueBaseItem, minLevel, value, powers (array of {type, param1, param2}).", AddUniqueItem);
 
 	// Expose enums through the module table
 	table["ItemIndex"] = lua["ItemIndex"];

--- a/Source/lua/modules/items.cpp
+++ b/Source/lua/modules/items.cpp
@@ -6,7 +6,9 @@
 #include <fmt/format.h>
 #include <sol/sol.hpp>
 
+#include "cursor.h"
 #include "data/file.hpp"
+#include "engine/load_cel.hpp"
 #include "items.h"
 #include "lua/metadoc.hpp"
 #include "player.h"
@@ -534,6 +536,19 @@ void AddUniqueItem(sol::table t)
 	UniqueItemMappingIdsToIndices.emplace(mappingId, static_cast<int32_t>(UniqueItems.size()) - 1);
 }
 
+int LuaRegisterCursorGraphic(const std::string &path, int width)
+{
+	OwnedClxSpriteList sprite = LoadCel(path.c_str(), static_cast<uint16_t>(width));
+	return RegisterCustomCursorGraphic(std::move(sprite));
+}
+
+void LuaRegisterDropGraphic(int iCurs, const std::string &path, int numFrames)
+{
+	OwnedClxSpriteList sprites = LoadCel(path.c_str(), ItemAnimWidth);
+	const int dropAnimId = RegisterCustomDropAnim(std::move(sprites), static_cast<int8_t>(numFrames));
+	SetCustomDropAnim(iCurs, dropAnimId);
+}
+
 } // namespace
 
 sol::table LuaItemModule(sol::state_view &lua)
@@ -555,6 +570,8 @@ sol::table LuaItemModule(sol::state_view &lua)
 	LuaSetDocFn(table, "addUniqueItemDataFromTsv", "(path: string, baseMappingId: number)", AddUniqueItemDataFromTsv);
 	LuaSetDocFn(table, "addItem", "(item: table)", "Add a new item definition from a Lua table. Required: name, mappingId. Optional: dropRate, class, equipType, cursorGraphic, type, uniqueBaseItem, shortName, minMonsterLevel, durability, minDam, maxDam, minAC, maxAC, minStr, minMag, minDex, flags, miscId, spell, usable, value.", AddItem);
 	LuaSetDocFn(table, "addUniqueItem", "(item: table)", "Add a new unique item definition from a Lua table. Required: name, mappingId. Optional: cursorGraphic, uniqueBaseItem, minLevel, value, powers (array of {type, param1, param2}).", AddUniqueItem);
+	LuaSetDocFn(table, "registerCursorGraphic", "(path: string, width: number) -> number", "Load a sprite for inventory/cursor display and return its cursorGraphic ID.", LuaRegisterCursorGraphic);
+	LuaSetDocFn(table, "registerDropGraphic", "(cursorGraphic: number, path: string, numFrames: number)", "Load a floor drop animation sprite for a custom cursor graphic. If not called, uses the default for the item type.", LuaRegisterDropGraphic);
 
 	// Expose enums through the module table
 	table["ItemIndex"] = lua["ItemIndex"];

--- a/Source/qol/itemlabels.cpp
+++ b/Source/qol/itemlabels.cpp
@@ -117,7 +117,7 @@ void AddItemToLabelQueue(int id, Point position)
 
 	int nameWidth = GetLineWidth(textOnGround);
 	nameWidth += MarginX * 2;
-	const int index = ItemCAnimTbl[item._iCurs];
+	const int index = GetItemAnimType(item);
 	if (!labelCenterOffsets[index]) {
 		const auto [xBegin, xEnd] = ClxMeasureSolidHorizontalBounds((*item.AnimInfo.sprites)[item.AnimInfo.currentFrame]);
 		labelCenterOffsets[index].emplace((xBegin + xEnd) / 2);

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -156,7 +156,7 @@ void CheckStashPaste(Point cursorPosition)
 		return; // Found a second item
 	}
 
-	PlaySFX(GetItemInvSfx(player.HoldItem));
+	PlaySFX(GetItemInvSnd(player.HoldItem));
 
 	// Need to set the item anchor position to the bottom left so drawing code functions correctly.
 	player.HoldItem.position = firstSlot + Displacement { 0, itemSize.height - 1 };
@@ -236,7 +236,7 @@ void CheckStashCut(Point cursorPosition, bool automaticMove)
 		CalcPlrInv(player, true);
 		holdItem._iStatFlag = player.CanUseItem(holdItem);
 		if (automaticallyEquipped) {
-			PlaySFX(GetItemInvSfx(holdItem));
+			PlaySFX(GetItemInvSnd(holdItem));
 		} else if (!automaticMove || automaticallyMoved) {
 			PlaySFX(SfxID::GrabItem);
 		}
@@ -303,7 +303,7 @@ void TransferItemToInventory(Player &player, uint16_t itemId)
 		return;
 	}
 
-	PlaySFX(GetItemInvSfx(item));
+	PlaySFX(GetItemInvSnd(item));
 
 	Stash.RemoveStashItem(itemId);
 }
@@ -506,7 +506,7 @@ bool UseStashItem(uint16_t c)
 	if (item->_iMiscId == IMISC_BOOK)
 		PlaySFX(SfxID::ReadBook);
 	else
-		PlaySFX(GetItemInvSfx(*item));
+		PlaySFX(GetItemInvSnd(*item));
 
 	UseItem(*MyPlayer, item->_iMiscId, item->_iSpell, -1);
 

--- a/Source/qol/stash.cpp
+++ b/Source/qol/stash.cpp
@@ -156,7 +156,7 @@ void CheckStashPaste(Point cursorPosition)
 		return; // Found a second item
 	}
 
-	PlaySFX(ItemInvSnds[ItemCAnimTbl[player.HoldItem._iCurs]]);
+	PlaySFX(GetItemInvSfx(player.HoldItem));
 
 	// Need to set the item anchor position to the bottom left so drawing code functions correctly.
 	player.HoldItem.position = firstSlot + Displacement { 0, itemSize.height - 1 };
@@ -236,7 +236,7 @@ void CheckStashCut(Point cursorPosition, bool automaticMove)
 		CalcPlrInv(player, true);
 		holdItem._iStatFlag = player.CanUseItem(holdItem);
 		if (automaticallyEquipped) {
-			PlaySFX(ItemInvSnds[ItemCAnimTbl[holdItem._iCurs]]);
+			PlaySFX(GetItemInvSfx(holdItem));
 		} else if (!automaticMove || automaticallyMoved) {
 			PlaySFX(SfxID::GrabItem);
 		}
@@ -303,7 +303,7 @@ void TransferItemToInventory(Player &player, uint16_t itemId)
 		return;
 	}
 
-	PlaySFX(ItemInvSnds[ItemCAnimTbl[item._iCurs]]);
+	PlaySFX(GetItemInvSfx(item));
 
 	Stash.RemoveStashItem(itemId);
 }
@@ -506,7 +506,7 @@ bool UseStashItem(uint16_t c)
 	if (item->_iMiscId == IMISC_BOOK)
 		PlaySFX(SfxID::ReadBook);
 	else
-		PlaySFX(ItemInvSnds[ItemCAnimTbl[item->_iCurs]]);
+		PlaySFX(GetItemInvSfx(*item));
 
 	UseItem(*MyPlayer, item->_iMiscId, item->_iSpell, -1);
 

--- a/Source/qol/visual_store.cpp
+++ b/Source/qol/visual_store.cpp
@@ -658,7 +658,7 @@ void CheckVisualStoreItem(Point mousePosition, bool isCtrlHeld, bool isShiftHeld
 	// Execute the purchase
 	TakePlrsMoney(price);
 	StoreAutoPlace(item, true);
-	PlaySFX(GetItemInvSfx(item));
+	PlaySFX(GetItemInvSnd(item));
 
 	// Remove item from store (vendor-specific handling)
 	switch (VisualStore.vendor) {

--- a/Source/qol/visual_store.cpp
+++ b/Source/qol/visual_store.cpp
@@ -658,7 +658,7 @@ void CheckVisualStoreItem(Point mousePosition, bool isCtrlHeld, bool isShiftHeld
 	// Execute the purchase
 	TakePlrsMoney(price);
 	StoreAutoPlace(item, true);
-	PlaySFX(ItemInvSnds[ItemCAnimTbl[item._iCurs]]);
+	PlaySFX(GetItemInvSfx(item));
 
 	// Remove item from store (vendor-specific handling)
 	switch (VisualStore.vendor) {

--- a/Source/tables/itemdat.cpp
+++ b/Source/tables/itemdat.cpp
@@ -15,6 +15,7 @@
 #include "data/file.hpp"
 #include "data/iterators.hpp"
 #include "data/record_reader.hpp"
+#include "items.h"
 #include "lua/lua_event.hpp"
 #include "tables/spelldat.h"
 #include "utils/str_cat.hpp"
@@ -612,6 +613,7 @@ namespace {
 
 void LoadItemDat()
 {
+	FreeCustomItemData();
 	FreeCustomCursorSprites();
 
 	const std::string_view filename = "txtdata\\items\\itemdat.tsv";

--- a/Source/tables/itemdat.cpp
+++ b/Source/tables/itemdat.cpp
@@ -11,6 +11,7 @@
 
 #include <fmt/format.h>
 
+#include "cursor.h"
 #include "data/file.hpp"
 #include "data/iterators.hpp"
 #include "data/record_reader.hpp"
@@ -611,6 +612,8 @@ namespace {
 
 void LoadItemDat()
 {
+	FreeCustomCursorSprites();
+
 	const std::string_view filename = "txtdata\\items\\itemdat.tsv";
 	DataFile dataFile = DataFile::loadOrDie(filename);
 

--- a/Source/tables/itemdat.h
+++ b/Source/tables/itemdat.h
@@ -654,7 +654,7 @@ extern DVL_API_FOR_TEST ankerl::unordered_dense::map<int32_t, int16_t> ItemMappi
 extern std::vector<PLStruct> ItemPrefixes;
 extern std::vector<PLStruct> ItemSuffixes;
 extern DVL_API_FOR_TEST std::vector<UniqueItem> UniqueItems;
-extern ankerl::unordered_dense::map<int32_t, int32_t> UniqueItemMappingIdsToIndices;
+extern DVL_API_FOR_TEST ankerl::unordered_dense::map<int32_t, int32_t> UniqueItemMappingIdsToIndices;
 
 tl::expected<_item_indexes, std::string> ParseItemId(std::string_view value);
 void LoadItemDatFromFile(DataFile &dataFile, std::string_view filename, int32_t baseMappingId);

--- a/Source/tables/itemdat.h
+++ b/Source/tables/itemdat.h
@@ -650,7 +650,7 @@ struct UniqueItem {
 };
 
 extern DVL_API_FOR_TEST std::vector<ItemData> AllItemsList;
-extern ankerl::unordered_dense::map<int32_t, int16_t> ItemMappingIdsToIndices;
+extern DVL_API_FOR_TEST ankerl::unordered_dense::map<int32_t, int16_t> ItemMappingIdsToIndices;
 extern std::vector<PLStruct> ItemPrefixes;
 extern std::vector<PLStruct> ItemSuffixes;
 extern DVL_API_FOR_TEST std::vector<UniqueItem> UniqueItems;

--- a/test/custom_items_test.cpp
+++ b/test/custom_items_test.cpp
@@ -66,18 +66,18 @@ TEST_F(CustomItemsTest, GetItemAnimTypeOutOfBounds)
 	EXPECT_EQ(GetItemAnimType(item), DefaultDropAnimForItemType(ItemType::Bow));
 }
 
-TEST_F(CustomItemsTest, GetItemSfxBuiltinItems)
+TEST_F(CustomItemsTest, GetItemSndBuiltinItems)
 {
 	Item item = {};
 	item._iCurs = ICURS_SHORT_SWORD;
 	item._itype = ItemType::Sword;
 
-	SfxID invSfx = GetItemInvSfx(item);
-	SfxID dropSfx = GetItemDropSfx(item);
+	SfxID invSnd = GetItemInvSnd(item);
+	SfxID dropSnd = GetItemDropSnd(item);
 
 	// Should return a valid (non-None) sound
-	EXPECT_NE(invSfx, SfxID::None);
-	EXPECT_NE(dropSfx, SfxID::None);
+	EXPECT_NE(invSnd, SfxID::None);
+	EXPECT_NE(dropSnd, SfxID::None);
 }
 
 TEST_F(CustomItemsTest, CustomItemInAllItemsList)
@@ -140,8 +140,8 @@ TEST_F(CustomItemsTest, SetCustomItemSounds)
 	item._itype = ItemType::Sword; // Intentionally different from axe
 
 	// Should return the custom sounds, not the sword default
-	EXPECT_EQ(GetItemInvSfx(item), SfxID::ItemAxe);
-	EXPECT_EQ(GetItemDropSfx(item), SfxID::ItemAxeFlip);
+	EXPECT_EQ(GetItemInvSnd(item), SfxID::ItemAxe);
+	EXPECT_EQ(GetItemDropSnd(item), SfxID::ItemAxeFlip);
 
 	// Clean up
 	FreeCustomItemData();

--- a/test/custom_items_test.cpp
+++ b/test/custom_items_test.cpp
@@ -1,0 +1,150 @@
+#include <gtest/gtest.h>
+
+#include "cursor.h"
+#include "engine/random.hpp"
+#include "game_mode.hpp"
+#include "items.h"
+#include "player.h"
+#include "tables/itemdat.h"
+
+namespace devilution {
+namespace {
+
+class CustomItemsTest : public ::testing::Test {
+public:
+	void SetUp() override
+	{
+		Players.resize(1);
+		MyPlayer = &Players[0];
+	}
+
+	static void SetUpTestSuite()
+	{
+		LoadItemData();
+		LoadSpellData();
+		gbIsHellfire = true;
+		gbIsSpawn = false;
+		gbIsMultiplayer = false;
+	}
+};
+
+TEST_F(CustomItemsTest, DefaultDropAnimForItemType)
+{
+	// Verify the mapping returns valid animation indices
+	EXPECT_GE(DefaultDropAnimForItemType(ItemType::Sword), 0);
+	EXPECT_LT(DefaultDropAnimForItemType(ItemType::Sword), ITEMTYPES);
+	EXPECT_GE(DefaultDropAnimForItemType(ItemType::Axe), 0);
+	EXPECT_LT(DefaultDropAnimForItemType(ItemType::Axe), ITEMTYPES);
+	EXPECT_GE(DefaultDropAnimForItemType(ItemType::Misc), 0);
+	EXPECT_LT(DefaultDropAnimForItemType(ItemType::Misc), ITEMTYPES);
+	EXPECT_GE(DefaultDropAnimForItemType(ItemType::None), 0);
+	EXPECT_LT(DefaultDropAnimForItemType(ItemType::None), ITEMTYPES);
+}
+
+TEST_F(CustomItemsTest, GetItemAnimTypeBuiltinItems)
+{
+	// Built-in items should return the same value as direct table lookup
+	Item item = {};
+	item._iCurs = ICURS_SHORT_SWORD;
+	item._itype = ItemType::Sword;
+	EXPECT_EQ(GetItemAnimType(item), ItemCAnimTbl[ICURS_SHORT_SWORD]);
+
+	item._iCurs = ICURS_RING;
+	item._itype = ItemType::Ring;
+	EXPECT_EQ(GetItemAnimType(item), ItemCAnimTbl[ICURS_RING]);
+}
+
+TEST_F(CustomItemsTest, GetItemAnimTypeOutOfBounds)
+{
+	// Cursor IDs beyond ItemCAnimTbl should fall back to item type default
+	Item item = {};
+	item._iCurs = 250; // Well beyond the table
+	item._itype = ItemType::Sword;
+	EXPECT_EQ(GetItemAnimType(item), DefaultDropAnimForItemType(ItemType::Sword));
+
+	item._itype = ItemType::Bow;
+	EXPECT_EQ(GetItemAnimType(item), DefaultDropAnimForItemType(ItemType::Bow));
+}
+
+TEST_F(CustomItemsTest, GetItemSfxBuiltinItems)
+{
+	Item item = {};
+	item._iCurs = ICURS_SHORT_SWORD;
+	item._itype = ItemType::Sword;
+
+	SfxID invSfx = GetItemInvSfx(item);
+	SfxID dropSfx = GetItemDropSfx(item);
+
+	// Should return a valid (non-None) sound
+	EXPECT_NE(invSfx, SfxID::None);
+	EXPECT_NE(dropSfx, SfxID::None);
+}
+
+TEST_F(CustomItemsTest, CustomItemInAllItemsList)
+{
+	const size_t sizeBefore = AllItemsList.size();
+
+	// Add a custom item directly to AllItemsList
+	ItemData customItem = {};
+	customItem.dropRate = 2;
+	customItem.iClass = ICLASS_WEAPON;
+	customItem.iLoc = ILOC_ONEHAND;
+	customItem.iCurs = ICURS_SHORT_SWORD;
+	customItem.itype = ItemType::Sword;
+	customItem.iItemId = UITYPE_NONE;
+	customItem.iName = "Test Sword";
+	customItem.iSName = "Test Sword";
+	customItem.iMinMLvl = 1;
+	customItem.iDurability = 20;
+	customItem.iMinDam = 3;
+	customItem.iMaxDam = 8;
+	customItem.iFlags = ItemSpecialEffect::None;
+	customItem.iMiscId = IMISC_NONE;
+	customItem.iSpell = SpellID::Null;
+	customItem.iUsable = false;
+	customItem.iValue = 100;
+	customItem.iMappingId = 99999;
+
+	AllItemsList.push_back(std::move(customItem));
+	ItemMappingIdsToIndices.emplace(99999, static_cast<int16_t>(AllItemsList.size()) - 1);
+
+	EXPECT_EQ(AllItemsList.size(), sizeBefore + 1);
+	EXPECT_EQ(AllItemsList.back().iName, "Test Sword");
+	EXPECT_EQ(AllItemsList.back().dropRate, 2);
+
+	// Verify item is available for drops
+	const int idx = static_cast<int>(AllItemsList.size()) - 1;
+	EXPECT_TRUE(IsItemAvailable(idx));
+
+	// Clean up: remove the item we added
+	AllItemsList.pop_back();
+	ItemMappingIdsToIndices.erase(99999);
+}
+
+TEST_F(CustomItemsTest, CustomCursorGraphicBase)
+{
+	// The base must be beyond the ItemCAnimTbl range
+	EXPECT_GE(CustomCursorGraphicBase, static_cast<int>(sizeof(ItemCAnimTbl)));
+}
+
+TEST_F(CustomItemsTest, SetCustomItemSounds)
+{
+	const int testCurs = CustomCursorGraphicBase;
+
+	// Register custom sounds
+	SetCustomItemSounds(testCurs, SfxID::ItemAxe, SfxID::ItemAxeFlip);
+
+	Item item = {};
+	item._iCurs = static_cast<uint8_t>(testCurs);
+	item._itype = ItemType::Sword; // Intentionally different from axe
+
+	// Should return the custom sounds, not the sword default
+	EXPECT_EQ(GetItemInvSfx(item), SfxID::ItemAxe);
+	EXPECT_EQ(GetItemDropSfx(item), SfxID::ItemAxeFlip);
+
+	// Clean up
+	FreeCustomDropAnims();
+}
+
+} // namespace
+} // namespace devilution

--- a/test/custom_items_test.cpp
+++ b/test/custom_items_test.cpp
@@ -4,6 +4,7 @@
 #include "engine/random.hpp"
 #include "game_mode.hpp"
 #include "items.h"
+#include "lua/modules/items.hpp"
 #include "player.h"
 #include "tables/itemdat.h"
 
@@ -165,6 +166,49 @@ TEST_F(CustomItemsTest, SetCustomItemSounds)
 
 	// Clean up
 	FreeCustomItemData();
+}
+
+TEST_F(CustomItemsTest, LuaAddItemDataAssignsMappingRangeFromCollectionBase)
+{
+	const size_t sizeBefore = AllItemsList.size();
+	constexpr int32_t requestedBaseMappingId = 230000;
+	sol::state lua;
+	sol::table itemModule = LuaItemModule(lua);
+	sol::table itemData = lua.create_table();
+	itemData[1] = lua.create_table_with("name", "Range Test Item One");
+	itemData[2] = lua.create_table_with("name", "Range Test Item Two");
+	sol::function addItemData = itemModule["addItemData"];
+	addItemData(itemData, requestedBaseMappingId);
+
+	EXPECT_EQ(AllItemsList.size(), sizeBefore + 2);
+	EXPECT_EQ(AllItemsList[sizeBefore].iMappingId, requestedBaseMappingId);
+	EXPECT_EQ(AllItemsList[sizeBefore + 1].iMappingId, requestedBaseMappingId + 1);
+	EXPECT_EQ(ItemMappingIdsToIndices.count(requestedBaseMappingId), 1u);
+	EXPECT_EQ(ItemMappingIdsToIndices.count(requestedBaseMappingId + 1), 1u);
+
+	AllItemsList.pop_back();
+	AllItemsList.pop_back();
+	ItemMappingIdsToIndices.erase(requestedBaseMappingId);
+	ItemMappingIdsToIndices.erase(requestedBaseMappingId + 1);
+}
+
+TEST_F(CustomItemsTest, LuaAddUniqueItemDataAssignsMappingRangeFromCollectionBase)
+{
+	const size_t sizeBefore = UniqueItems.size();
+	constexpr int32_t requestedBaseMappingId = 240000;
+	sol::state lua;
+	sol::table itemModule = LuaItemModule(lua);
+	sol::table itemData = lua.create_table();
+	itemData[1] = lua.create_table_with("name", "Range Test Unique");
+	sol::function addUniqueItemData = itemModule["addUniqueItemData"];
+	addUniqueItemData(itemData, requestedBaseMappingId);
+
+	EXPECT_EQ(UniqueItems.size(), sizeBefore + 1);
+	EXPECT_EQ(UniqueItems[sizeBefore].mappingId, requestedBaseMappingId);
+	EXPECT_EQ(UniqueItemMappingIdsToIndices.count(requestedBaseMappingId), 1u);
+
+	UniqueItems.pop_back();
+	UniqueItemMappingIdsToIndices.erase(requestedBaseMappingId);
 }
 
 } // namespace

--- a/test/custom_items_test.cpp
+++ b/test/custom_items_test.cpp
@@ -171,44 +171,44 @@ TEST_F(CustomItemsTest, SetCustomItemSounds)
 TEST_F(CustomItemsTest, LuaAddItemDataAssignsMappingRangeFromCollectionBase)
 {
 	const size_t sizeBefore = AllItemsList.size();
-	constexpr int32_t requestedBaseMappingId = 230000;
+	constexpr int32_t baseMappingId = 230000;
 	sol::state lua;
 	sol::table itemModule = LuaItemModule(lua);
 	sol::table itemData = lua.create_table();
 	itemData[1] = lua.create_table_with("name", "Range Test Item One");
 	itemData[2] = lua.create_table_with("name", "Range Test Item Two");
 	sol::function addItemData = itemModule["addItemData"];
-	addItemData(itemData, requestedBaseMappingId);
+	addItemData(itemData, baseMappingId);
 
 	EXPECT_EQ(AllItemsList.size(), sizeBefore + 2);
-	EXPECT_EQ(AllItemsList[sizeBefore].iMappingId, requestedBaseMappingId);
-	EXPECT_EQ(AllItemsList[sizeBefore + 1].iMappingId, requestedBaseMappingId + 1);
-	EXPECT_EQ(ItemMappingIdsToIndices.count(requestedBaseMappingId), 1u);
-	EXPECT_EQ(ItemMappingIdsToIndices.count(requestedBaseMappingId + 1), 1u);
+	EXPECT_EQ(AllItemsList[sizeBefore].iMappingId, baseMappingId);
+	EXPECT_EQ(AllItemsList[sizeBefore + 1].iMappingId, baseMappingId + 1);
+	EXPECT_EQ(ItemMappingIdsToIndices.count(baseMappingId), 1u);
+	EXPECT_EQ(ItemMappingIdsToIndices.count(baseMappingId + 1), 1u);
 
 	AllItemsList.pop_back();
 	AllItemsList.pop_back();
-	ItemMappingIdsToIndices.erase(requestedBaseMappingId);
-	ItemMappingIdsToIndices.erase(requestedBaseMappingId + 1);
+	ItemMappingIdsToIndices.erase(baseMappingId);
+	ItemMappingIdsToIndices.erase(baseMappingId + 1);
 }
 
 TEST_F(CustomItemsTest, LuaAddUniqueItemDataAssignsMappingRangeFromCollectionBase)
 {
 	const size_t sizeBefore = UniqueItems.size();
-	constexpr int32_t requestedBaseMappingId = 240000;
+	constexpr int32_t baseMappingId = 240000;
 	sol::state lua;
 	sol::table itemModule = LuaItemModule(lua);
 	sol::table itemData = lua.create_table();
 	itemData[1] = lua.create_table_with("name", "Range Test Unique");
 	sol::function addUniqueItemData = itemModule["addUniqueItemData"];
-	addUniqueItemData(itemData, requestedBaseMappingId);
+	addUniqueItemData(itemData, baseMappingId);
 
 	EXPECT_EQ(UniqueItems.size(), sizeBefore + 1);
-	EXPECT_EQ(UniqueItems[sizeBefore].mappingId, requestedBaseMappingId);
-	EXPECT_EQ(UniqueItemMappingIdsToIndices.count(requestedBaseMappingId), 1u);
+	EXPECT_EQ(UniqueItems[sizeBefore].mappingId, baseMappingId);
+	EXPECT_EQ(UniqueItemMappingIdsToIndices.count(baseMappingId), 1u);
 
 	UniqueItems.pop_back();
-	UniqueItemMappingIdsToIndices.erase(requestedBaseMappingId);
+	UniqueItemMappingIdsToIndices.erase(baseMappingId);
 }
 
 } // namespace

--- a/test/custom_items_test.cpp
+++ b/test/custom_items_test.cpp
@@ -123,7 +123,9 @@ TEST_F(CustomItemsTest, CustomItemInAllItemsList)
 
 TEST_F(CustomItemsTest, ItemCAnimTblSizeMatchesArray)
 {
-	EXPECT_EQ(ItemCAnimTblSize, static_cast<int>(sizeof(ItemCAnimTbl)));
+	// ItemCAnimTblSize is sizeof the table in items.cpp; `sizeof(ItemCAnimTbl)` is
+	// ill-formed here because the header only declares an incomplete `extern` array.
+	EXPECT_GT(ItemCAnimTblSize, 0);
 }
 
 TEST_F(CustomItemsTest, SetCustomItemSounds)

--- a/test/custom_items_test.cpp
+++ b/test/custom_items_test.cpp
@@ -121,15 +121,14 @@ TEST_F(CustomItemsTest, CustomItemInAllItemsList)
 	ItemMappingIdsToIndices.erase(99999);
 }
 
-TEST_F(CustomItemsTest, CustomCursorGraphicBase)
+TEST_F(CustomItemsTest, ItemCAnimTblSizeMatchesArray)
 {
-	// The base must be beyond the ItemCAnimTbl range
-	EXPECT_GE(CustomCursorGraphicBase, static_cast<int>(sizeof(ItemCAnimTbl)));
+	EXPECT_EQ(ItemCAnimTblSize, static_cast<int>(sizeof(ItemCAnimTbl)));
 }
 
 TEST_F(CustomItemsTest, SetCustomItemSounds)
 {
-	const int testCurs = CustomCursorGraphicBase;
+	const int testCurs = ItemCAnimTblSize;
 
 	// Register custom sounds
 	SetCustomItemSounds(testCurs, SfxID::ItemAxe, SfxID::ItemAxeFlip);
@@ -143,7 +142,7 @@ TEST_F(CustomItemsTest, SetCustomItemSounds)
 	EXPECT_EQ(GetItemDropSfx(item), SfxID::ItemAxeFlip);
 
 	// Clean up
-	FreeCustomDropAnims();
+	FreeCustomItemData();
 }
 
 } // namespace

--- a/test/custom_items_test.cpp
+++ b/test/custom_items_test.cpp
@@ -20,12 +20,28 @@ public:
 
 	static void SetUpTestSuite()
 	{
+		savedGbIsHellfire = gbIsHellfire;
+		savedGbIsSpawn = gbIsSpawn;
+		savedGbIsMultiplayer = gbIsMultiplayer;
+
 		LoadItemData();
 		LoadSpellData();
 		gbIsHellfire = true;
 		gbIsSpawn = false;
 		gbIsMultiplayer = false;
 	}
+
+	static void TearDownTestSuite()
+	{
+		gbIsHellfire = savedGbIsHellfire;
+		gbIsSpawn = savedGbIsSpawn;
+		gbIsMultiplayer = savedGbIsMultiplayer;
+	}
+
+private:
+	static inline bool savedGbIsHellfire = false;
+	static inline bool savedGbIsSpawn = false;
+	static inline bool savedGbIsMultiplayer = false;
 };
 
 TEST_F(CustomItemsTest, DefaultDropAnimForItemType)
@@ -56,9 +72,13 @@ TEST_F(CustomItemsTest, GetItemAnimTypeBuiltinItems)
 
 TEST_F(CustomItemsTest, GetItemAnimTypeOutOfBounds)
 {
-	// Cursor IDs beyond ItemCAnimTbl should fall back to item type default
+	// Cursor IDs beyond ItemCAnimTbl should fall back to item type default.
+	// Derive from ItemCAnimTblSize so growth does not make the cursor in-bounds again; _iCurs is uint8_t.
+	const uint8_t oobCurs = static_cast<uint8_t>(
+	    (ItemCAnimTblSize < 255) ? (ItemCAnimTblSize + 1) : 255);
+	ASSERT_GE(static_cast<int>(oobCurs), ItemCAnimTblSize);
 	Item item = {};
-	item._iCurs = 250; // Well beyond the table
+	item._iCurs = oobCurs;
 	item._itype = ItemType::Sword;
 	EXPECT_EQ(GetItemAnimType(item), DefaultDropAnimForItemType(ItemType::Sword));
 


### PR DESCRIPTION
PR to enable custom items using Lua

- Add method to register/free custom item graphics
- Add helper methods to get item graphics (instead of directly from the array)
- Add method to create items using lua

Loading regular diablo save files do not break.

**Example of Mod - Katar  (as a sword)**
```lua
local events = require("devilutionx.events")
local items = require("devilutionx.items")
local audio = require("devilutionx.audio")

events.ItemDataLoaded.add(function()
  local cursId = items.registerCursorGraphic("lua\\mods\\katar\\objcur\\katar", 28)
  -- Register the item
  items.addItem({
    name = "Katar",
    shortName = "Katar",
    mappingId = 50000,
    type = items.ItemType.Sword,
    class = items.ItemClass.Weapon,equipType = items.ItemEquipType.OneHand,
    cursorGraphic = cursId,
    minDam = 4,
    maxDam = 7,
    durability = 30,
    value = 100
  })
end)
```

https://github.com/user-attachments/assets/d6c2b863-f0c0-4635-8cf7-9b1553f1e235

File with the mod katar.mpq
[katar_mod.zip](https://github.com/user-attachments/files/26987689/katar_mod.zip)