### PR TITLE
Ensure that buffered player info gets processed

### DIFF
--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -453,9 +453,11 @@ void PrePacket()
 				return;
 			}
 
-			if (!IsNetPlayerValid(playerId)) {
-				Log("Source of network message is no longer valid");
-				return;
+			if (IsNoneOf(cmdId, CMD_SEND_PLRINFO, CMD_ACK_PLRINFO)) {
+				if (!IsNetPlayerValid(playerId)) {
+					Log("Source of network message is no longer valid");
+					return;
+				}
 			}
 
 			const size_t size = ParseCmd(playerId, reinterpret_cast<TCmd *>(data), remainingBytes);


### PR DESCRIPTION
This fixes an issue where players 2 and 3 cannot communicate because player 2 sent their player info to player 3 while player 3 was still receiving deltas from the host. Since player info is what's used to validate messages, we need to accept `CMD_SEND_PLRINFO` and `CMD_ACK_PLRINFO` packets even when we do not trust the remote player just yet.