### PR TITLE
C++ RAII for SheenBidi + `Utf8CodePoints` bidirectional iterator

### DIFF
--- a/CMake/Tests.cmake
+++ b/CMake/Tests.cmake
@@ -60,6 +60,7 @@ set(standalone_tests
   vision_test
   random_test
   rectangle_test
+  sheen_bidi_test
   static_vector_test
   str_cat_test
   utf8_test
@@ -204,6 +205,7 @@ if(DEVILUTIONX_SCREENSHOT_FORMAT STREQUAL DEVILUTIONX_SCREENSHOT_FORMAT_PNG AND 
   )
   add_dependencies(text_render_integration_test text_render_integration_test_resources)
 endif()
+target_link_dependencies(sheen_bidi_test PRIVATE libdevilutionx_sheen_bidi)
 target_link_dependencies(utf8_test PRIVATE libdevilutionx_utf8)
 
 target_include_directories(writehero_test PRIVATE 3rdParty/PicoSHA2)

--- a/Packaging/xbox-one/build.bat
+++ b/Packaging/xbox-one/build.bat
@@ -5,11 +5,10 @@ cd ..\..\build
 
 git clone --branch SDL2 https://github.com/libsdl-org/SDL.git
 git -C SDL reset --hard 10135b2d7bbed6ea0cba24410ebc12887d92968d
-msbuild /p:PlatformToolset=v143;TargetPlatformVersion=10.0.26100.0;TargetPlatformMinVersion=10.0.14393.0;ConfigurationType=StaticLibrary;Configuration=Release;Platform=x64 SDL\VisualC-WinRT\SDL-UWP.vcxproj
+msbuild /p:PlatformToolset=v145;TargetPlatformVersion=10.0.26100.0;TargetPlatformMinVersion=10.0.14393.0;ConfigurationType=StaticLibrary;Configuration=Release;Platform=x64 SDL\VisualC-WinRT\SDL-UWP.vcxproj
 
-cmake -DUWP_LIB=1 -DUWP_SDL2_DIR="%CD%/SDL" -DCMAKE_BUILD_TYPE=x64-Release ..
-
-msbuild /p:Configuration=Release;Platform=x64 /m DevilutionX.sln
+cmake -DUWP_LIB=1 -DUWP_SDL2_DIR="%CD%/SDL" -A x64 ..
+cmake --build . --config Release -j
 
 powershell "Get-Content ..\uwp-project\Package.appxmanifest.template | %% {$_ -replace '__PROJECT_VERSION__',$(Select-String -Path ..\VERSION -Pattern \d+\.\d+\.\d+).Matches[0].Value} | Out-File -FilePath ..\uwp-project\Package.appxmanifest -encoding ASCII"
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -34,13 +34,6 @@ set(libdevilutionx_SRCS
   towners.cpp
   track.cpp
 
-  control/control_chat.cpp
-  control/control_chat_commands.cpp
-  control/control_flasks.cpp
-  control/control_gold.cpp
-  control/control_infobox.cpp
-  control/control_panel.cpp
-
   controls/axis_direction.cpp
   controls/controller_motion.cpp
   controls/controller.cpp
@@ -69,7 +62,6 @@ set(libdevilutionx_SRCS
   DiabloUI/settingsmenu.cpp
   DiabloUI/support_lines.cpp
   DiabloUI/title.cpp
-  DiabloUI/text_input.cpp
 
   dvlnet/abstract_net.cpp
   dvlnet/base.cpp
@@ -243,6 +235,33 @@ add_devilutionx_object_library(libdevilutionx_codec
 target_link_dependencies(libdevilutionx_codec PRIVATE
   DevilutionX::SDL
   libdevilutionx_log
+)
+
+add_devilutionx_object_library(libdevilutionx_control
+  control/control_chat.cpp
+  control/control_chat_commands.cpp
+  control/control_flasks.cpp
+  control/control_gold.cpp
+  control/control_infobox.cpp
+  control/control_panel.cpp
+)
+target_link_dependencies(libdevilutionx_control
+  PUBLIC
+  DevilutionX::SDL
+  tl
+  libdevilutionx_text_input
+  PRIVATE
+  fmt::fmt
+  libdevilutionx_clx_render
+  libdevilutionx_control_mode
+  libdevilutionx_format_int
+  libdevilutionx_load_cel
+  libdevilutionx_log
+  libdevilutionx_options
+  libdevilutionx_parse_int
+  libdevilutionx_primitive_render
+  libdevilutionx_quick_messages
+  libdevilutionx_strings
 )
 
 add_devilutionx_object_library(libdevilutionx_controller_buttons
@@ -497,7 +516,8 @@ add_devilutionx_object_library(libdevilutionx_items
   tables/itemdat.cpp
   items.cpp
 )
-target_link_dependencies(libdevilutionx_items PUBLIC
+target_link_dependencies(libdevilutionx_items
+  PUBLIC
   DevilutionX::SDL
   sol2::sol2
   tl
@@ -506,6 +526,8 @@ target_link_dependencies(libdevilutionx_items PUBLIC
   libdevilutionx_spells
   libdevilutionx_stores
   libdevilutionx_strings
+  PRIVATE
+  libdevilutionx_control
 )
 
 add_library(libdevilutionx_sheen_bidi INTERFACE)
@@ -571,6 +593,7 @@ target_link_dependencies(libdevilutionx_monster
   libdevilutionx_txtdata
   PRIVATE
   libdevilutionx_cl2_to_clx
+  libdevilutionx_control
 )
 
 add_devilutionx_object_library(libdevilutionx_palette_blending
@@ -667,6 +690,7 @@ target_link_dependencies(libdevilutionx_player
   unordered_dense::unordered_dense
   libdevilutionx_game_mode
   PRIVATE
+  libdevilutionx_control
   libdevilutionx_load_cl2
   libdevilutionx_strings
 )
@@ -674,9 +698,12 @@ target_link_dependencies(libdevilutionx_player
 add_devilutionx_object_library(libdevilutionx_quests
   quests.cpp
 )
-target_link_dependencies(libdevilutionx_quests PUBLIC
+target_link_dependencies(libdevilutionx_quests
+  PUBLIC
   libdevilutionx_surface
   libdevilutionx_gendung
+  PRIVATE
+  libdevilutionx_control
 )
 
 add_devilutionx_object_library(libdevilutionx_random
@@ -691,10 +718,27 @@ add_devilutionx_object_library(libdevilutionx_spells
   tables/spelldat.cpp
   spells.cpp
 )
-target_link_dependencies(libdevilutionx_spells PUBLIC
+target_link_dependencies(libdevilutionx_spells
+  PUBLIC
   tl
   libdevilutionx_player
   libdevilutionx_txtdata
+  PRIVATE
+  libdevilutionx_control
+)
+
+add_devilutionx_object_library(libdevilutionx_text_input
+  DiabloUI/text_input.cpp
+)
+target_link_dependencies(libdevilutionx_text_input
+  PUBLIC
+  DevilutionX::SDL
+  libdevilutionx_utf8
+  PRIVATE
+  tl
+  libdevilutionx_log
+  libdevilutionx_parse_int
+  libdevilutionx_strings
 )
 
 add_devilutionx_object_library(libdevilutionx_text_render
@@ -741,7 +785,7 @@ target_link_dependencies(libdevilutionx_txtdata PUBLIC
 add_devilutionx_object_library(libdevilutionx_utf8
   utils/utf8.cpp
 )
-target_link_dependencies(libdevilutionx_utf8 PRIVATE
+target_link_dependencies(libdevilutionx_utf8 PUBLIC
   libdevilutionx_sheen_bidi
 )
 
@@ -797,6 +841,7 @@ target_link_dependencies(libdevilutionx_stores PUBLIC
   fmt::fmt
   tl
   libdevilutionx_clx_render
+  libdevilutionx_control
   libdevilutionx_options
   libdevilutionx_sound
   libdevilutionx_strings
@@ -923,6 +968,7 @@ target_link_dependencies(libdevilutionx PUBLIC
   libdevilutionx_clx_render
   libdevilutionx_codec
   libdevilutionx_config
+  libdevilutionx_control
   libdevilutionx_controller_buttons
   libdevilutionx_control_mode
   libdevilutionx_crawl
@@ -958,6 +1004,7 @@ target_link_dependencies(libdevilutionx PUBLIC
   libdevilutionx_spells
   libdevilutionx_stores
   libdevilutionx_strings
+  libdevilutionx_text_input
   libdevilutionx_text_render
   libdevilutionx_txtdata
   libdevilutionx_ticks

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -508,6 +508,13 @@ target_link_dependencies(libdevilutionx_items PUBLIC
   libdevilutionx_strings
 )
 
+add_library(libdevilutionx_sheen_bidi INTERFACE)
+target_include_directories(libdevilutionx_sheen_bidi INTERFACE
+  ${PROJECT_SOURCE_DIR}/Source)
+target_link_dependencies(libdevilutionx_sheen_bidi INTERFACE
+  SheenBidi::SheenBidi
+)
+
 add_devilutionx_object_library(libdevilutionx_ini
   utils/ini.cpp
 )
@@ -735,7 +742,7 @@ add_devilutionx_object_library(libdevilutionx_utf8
   utils/utf8.cpp
 )
 target_link_dependencies(libdevilutionx_utf8 PRIVATE
-  SheenBidi::SheenBidi
+  libdevilutionx_sheen_bidi
 )
 
 if(NOSOUND)

--- a/Source/DiabloUI/text_input.hpp
+++ b/Source/DiabloUI/text_input.hpp
@@ -311,46 +311,53 @@ public:
 	}
 
 private:
-	[[nodiscard]] static bool isWordSeparator(unsigned char c)
+	[[nodiscard]] static bool isWordSeparator(char32_t c)
 	{
-		const bool isAsciiWordChar = (c >= '0' && c <= '9')
-		    || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
-		return c <= '\x7E' && !isAsciiWordChar;
+		const bool isAsciiWordChar = (c >= U'0' && c <= U'9')
+		    || (c >= U'A' && c <= U'Z') || (c >= U'a' && c <= U'z') || c == U'_';
+		return c <= U'\x7E' && !isAsciiWordChar;
 	}
 
 	[[nodiscard]] size_t prevPosition(bool word) const
 	{
 		const std::string_view str = beforeCursor();
-		size_t pos = FindLastUtf8Symbols(str);
+		if (str.empty()) return 0;
+
+		auto it = Utf8CodePoints(str).rbegin();
+		const auto end = Utf8CodePoints(str).rend();
 		if (!word)
-			return pos;
-		while (pos > 0 && isWordSeparator(str[pos])) {
-			pos = FindLastUtf8Symbols({ str.data(), pos });
+			return static_cast<size_t>(std::prev(it.base()).data() - str.data());
+
+		while (it != end && isWordSeparator(*it)) {
+			++it;
 		}
-		while (pos > 0) {
-			const size_t prevPos = FindLastUtf8Symbols({ str.data(), pos });
-			if (isWordSeparator(str[prevPos]))
-				break;
-			pos = prevPos;
+		while (it != end && !isWordSeparator(*it)) {
+			++it;
 		}
-		return pos;
+		if (it == end) return 0;
+
+		return static_cast<size_t>(it.base().data() - str.data());
 	}
 
 	[[nodiscard]] size_t nextPosition(bool word) const
 	{
 		const std::string_view str = afterCursor();
-		size_t pos = Utf8CodePointLen(str.data());
-		if (!word)
-			return cursor_->position + pos;
-		while (pos < str.size() && isWordSeparator(str[pos])) {
-			pos += Utf8CodePointLen(str.data() + pos);
+		if (str.empty()) return cursor_->position;
+
+		auto it = Utf8CodePoints(str).begin();
+		const auto end = Utf8CodePoints(str).end();
+		if (!word) return cursor_->position + it.size();
+
+		++it;
+		while (it != end && isWordSeparator(*it)) {
+			++it;
 		}
-		while (pos < str.size()) {
-			pos += Utf8CodePointLen(str.data() + pos);
-			if (isWordSeparator(str[pos]))
-				break;
+		while (it != end && !isWordSeparator(*it)) {
+			++it;
 		}
-		return cursor_->position + pos;
+		if (it == end) return cursor_->position + str.size();
+
+		return cursor_->position + static_cast<size_t>(it.data() - str.data());
 	}
 
 	[[nodiscard]] std::string_view beforeCursor() const

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -363,8 +363,7 @@ private:
 
 bool ContainsSmallFontTallCodepoints(std::string_view text)
 {
-	while (!text.empty()) {
-		const char32_t next = ConsumeFirstUtf8CodePoint(&text);
+	for (char32_t next : Utf8CodePoints(text)) {
 		if (next == Utf8DecodeError)
 			break;
 		if (next == ZWSP)
@@ -453,11 +452,7 @@ void DrawLine(
 {
 	CurrentFont currentFont;
 
-	std::string_view lineCopy = text;
-
 	size_t currentPos = 0;
-
-	size_t cpLen;
 
 	const auto maybeDrawCursor = [&]() {
 		const auto byteIndex = static_cast<int>(lineStartPos + currentPos);
@@ -478,12 +473,13 @@ void DrawLine(
 	// Start from the beginning of the line
 	characterPosition.x = GetLineStartX(flags, rect, totalWidth);
 
-	while (!lineCopy.empty()) {
-		char32_t c = DecodeFirstUtf8CodePoint(lineCopy, &cpLen);
+	for (auto it = Utf8CodePoints(text).begin(), itEnd = Utf8CodePoints(text).end();
+	     it != itEnd; ++it) {
+		char32_t c = *it;
 		if (c == Utf8DecodeError) break;
+		const auto cpLen = it.size();
 		if (c == ZWSP) {
 			currentPos += cpLen;
-			lineCopy.remove_prefix(cpLen);
 			continue;
 		}
 
@@ -514,7 +510,6 @@ void DrawLine(
 		// Move to the next position
 		characterPosition.x += charWidth + curSpacing;
 		currentPos += cpLen;
-		lineCopy.remove_prefix(cpLen);
 	}
 	assert(currentPos == text.size());
 	maybeDrawCursor();
@@ -638,9 +633,7 @@ int GetLineWidth(std::string_view text, GameFontTables size, int spacing, int *c
 	int lineWidth = 0;
 	CurrentFont currentFont;
 	uint32_t codepoints = 0;
-	char32_t next;
-	while (!text.empty()) {
-		next = ConsumeFirstUtf8CodePoint(&text);
+	for (char32_t next : Utf8CodePoints(text)) {
 		if (next == Utf8DecodeError)
 			break;
 		if (next == ZWSP)

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -1460,16 +1460,10 @@ void PadmapperOptions::Action::UpdateValueDescription() const
 
 std::string_view PadmapperOptions::Action::Shorten(std::string_view buttonName) const
 {
-	size_t index = 0;
-	size_t chars = 0;
-	while (index < buttonName.size()) {
-		if (!IsTrailUtf8CodeUnit(buttonName[index]))
-			chars++;
-		if (chars == 3)
-			break;
-		index++;
-	}
-	return std::string_view(buttonName.data(), index);
+	auto it = Utf8CodePoints(buttonName).begin();
+	const auto end = Utf8CodePoints(buttonName).end();
+	for (int i = 0; i < 3 && it != end; ++i, ++it) { }
+	return { buttonName.data(), static_cast<size_t>(it.data() - buttonName.data()) };
 }
 
 std::string_view PadmapperOptions::Action::GetValueDescription() const

--- a/Source/platform/ctr/CMakeLists.txt
+++ b/Source/platform/ctr/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(functions/devilutionx_library)
+include(functions/object_libraries)
 
 add_devilutionx_object_library(libdevilutionx_ctr
   system.cpp
@@ -14,17 +15,21 @@ add_devilutionx_object_library(libdevilutionx_ctr
 
 if(NOT NONET)
   if(NOT DISABLE_TCP)
-    target_link_libraries(libdevilutionx_ctr PUBLIC asio)
+    target_link_dependencies(libdevilutionx_ctr PUBLIC asio)
   endif()
   if(PACKET_ENCRYPTION)
     target_sources(libdevilutionx_ctr PRIVATE random.cpp)
-    target_link_libraries(libdevilutionx_ctr PUBLIC sodium)
+    target_link_dependencies(libdevilutionx_ctr PUBLIC sodium)
   endif()
 endif()
 
-target_link_libraries(libdevilutionx_ctr PUBLIC
+target_link_dependencies(libdevilutionx_ctr
+  PUBLIC
   DevilutionX::SDL
   fmt::fmt
   3ds::citro3d
   3ds::ctrulib
+  PRIVATE
+  libdevilutionx_utf8
+  libdevilutionx_strings
 )

--- a/Source/platform/switch/CMakeLists.txt
+++ b/Source/platform/switch/CMakeLists.txt
@@ -23,4 +23,5 @@ endif()
 target_link_libraries(libdevilutionx_switch PUBLIC
   DevilutionX::SDL
   libdevilutionx_log
+  libdevilutionx_text_input
 )

--- a/Source/platform/vita/CMakeLists.txt
+++ b/Source/platform/vita/CMakeLists.txt
@@ -23,4 +23,5 @@ target_link_libraries(libdevilutionx_vita PUBLIC
   SceNet_stub
   SceNetCtl_stub
   libdevilutionx_options
+  libdevilutionx_text_input
 )

--- a/Source/utils/sheen_bidi.hpp
+++ b/Source/utils/sheen_bidi.hpp
@@ -1,0 +1,268 @@
+#pragma once
+
+#include <cstddef>
+#include <span>
+#include <string_view>
+#include <type_traits>
+
+#include <SheenBidi/SheenBidi.h>
+
+namespace devilution::sb {
+
+template <typename T>
+using SheenBidiRetainFn = T (*)(T);
+template <typename T>
+using SheenBidiReleaseFn = void (*)(T);
+
+template <typename T, SheenBidiRetainFn<T> Retain, SheenBidiReleaseFn<T> Release>
+class SheenBidiPtr {
+public:
+	SheenBidiPtr()
+	    : ptr_(nullptr)
+	{
+	}
+	explicit SheenBidiPtr(T ptr)
+	    : ptr_(ptr)
+	{
+	}
+
+	SheenBidiPtr(const SheenBidiPtr &other)
+	    : ptr_(other.ptr_)
+	{
+		if (ptr_ != nullptr) Retain(ptr_);
+	}
+
+	SheenBidiPtr(SheenBidiPtr &&other) noexcept
+	    : ptr_(other.ptr_)
+	{
+		other.ptr_ = nullptr;
+	}
+
+	SheenBidiPtr &operator=(const SheenBidiPtr &other)
+	{
+		if (this != &other) {
+			if (ptr_ != nullptr) Release(ptr_);
+			ptr_ = other.ptr_;
+			if (ptr_ != nullptr) Retain(ptr_);
+		}
+		return *this;
+	}
+
+	SheenBidiPtr &operator=(SheenBidiPtr &&other) noexcept
+	{
+		if (this != &other) {
+			if (ptr_ != nullptr) Release(ptr_);
+			ptr_ = other.ptr_;
+			other.ptr_ = nullptr;
+		}
+		return *this;
+	}
+
+	~SheenBidiPtr()
+	{
+		if (ptr_ != nullptr) Release(ptr_);
+	}
+
+	[[nodiscard]] T get() const { return ptr_; }
+	T operator->() const { return ptr_; }
+	[[nodiscard]] std::remove_pointer_t<T> &operator*() const { return *ptr_; }
+
+	[[nodiscard]] bool operator==(std::nullptr_t) const { return ptr_ == nullptr; }
+	[[nodiscard]] bool operator!=(std::nullptr_t) const { return ptr_ != nullptr; }
+
+	[[nodiscard]] friend bool operator==(std::nullptr_t, const SheenBidiPtr &p) { return p.ptr_ == nullptr; }
+	[[nodiscard]] friend bool operator!=(std::nullptr_t, const SheenBidiPtr &p) { return p.ptr_ != nullptr; }
+
+	[[nodiscard]] explicit operator bool() const { return ptr_ != nullptr; }
+
+private:
+	T ptr_;
+};
+
+/**
+ * @brief Creates a codepoint sequence from a UTF-8 encoded string view.
+ *
+ * @param text The UTF-8 encoded string.
+ * @return A SBCodepointSequence structure.
+ */
+[[nodiscard]] inline SBCodepointSequence CreateCodepointSequence(std::string_view text)
+{
+	return SBCodepointSequence { SBStringEncodingUTF8, text.data(), text.size() };
+}
+
+class Paragraph;
+
+/**
+ * @brief An algorithm object that applies the bidirectional algorithm to a code point sequence.
+ */
+class Algorithm : public SheenBidiPtr<SBAlgorithmRef, SBAlgorithmRetain, SBAlgorithmRelease> {
+public:
+	using SheenBidiPtr::SheenBidiPtr;
+
+	/**
+	 * @brief Creates an algorithm object for the specified code point sequence.
+	 *
+	 * The source string inside the code point sequence should not be freed until the algorithm object is in use.
+	 *
+	 * @param sequence The code point sequence to apply bidirectional algorithm on.
+	 * @return A reference to an algorithm object.
+	 */
+	[[nodiscard]] static Algorithm create(const SBCodepointSequence &sequence)
+	{
+		return Algorithm(SBAlgorithmCreate(&sequence));
+	}
+
+	/**
+	 * @brief Creates an algorithm object for the specified text.
+	 *
+	 * The source string should not be freed until the algorithm object is in use.
+	 *
+	 * @param text The text to apply bidirectional algorithm on.
+	 * @return A reference to an algorithm object.
+	 */
+	[[nodiscard]] static Algorithm create(std::string_view text)
+	{
+		return create(CreateCodepointSequence(text));
+	}
+
+	/**
+	 * @brief Creates a paragraph object processed with Unicode Bidirectional Algorithm.
+	 *
+	 * This function processes only first paragraph starting at start with length less than or
+	 * equal to length, in accordance with Rule P1 of Unicode Bidirectional Algorithm.
+	 *
+	 * The paragraph level is determined by applying Rules P2-P3 and embedding levels are resolved by
+	 * applying Rules X1-I2.
+	 *
+	 * @param start The index to the first code unit of the paragraph in source string.
+	 * @param length The number of code units covering the suggested length of the paragraph.
+	 * @param level The desired base level of the paragraph. Rules P2-P3 would be ignored if it is neither
+	 *      SBLevelDefaultLTR nor SBLevelDefaultRTL.
+	 * @return A reference to a paragraph object.
+	 */
+	[[nodiscard]] Paragraph createParagraph(SBUInteger start, SBUInteger length, SBUInteger level) const;
+};
+
+class Line;
+
+/**
+ * @brief A paragraph object processed with Unicode Bidirectional Algorithm.
+ */
+class Paragraph : public SheenBidiPtr<SBParagraphRef, SBParagraphRetain, SBParagraphRelease> {
+public:
+	using SheenBidiPtr::SheenBidiPtr;
+
+	/**
+	 * @brief Creates a paragraph object processed with Unicode Bidirectional Algorithm.
+	 *
+	 * @param algorithm The algorithm object to use for creating the desired paragraph.
+	 * @param start The index to the first code unit of the paragraph in source string.
+	 * @param length The number of code units covering the suggested length of the paragraph.
+	 * @param level The desired base level of the paragraph.
+	 * @return A reference to a paragraph object.
+	 */
+	[[nodiscard]] static Paragraph create(SBAlgorithmRef algorithm, SBUInteger start, SBUInteger length, SBLevel level)
+	{
+		return Paragraph(SBAlgorithmCreateParagraph(algorithm, start, length, level));
+	}
+
+	/**
+	 * @brief Creates a line object of specified range by applying rules L1-L2 of Unicode Bidirectional Algorithm.
+	 *
+	 * @param start The index to the first code unit of the line in source string. It should occur within the range of paragraph.
+	 * @param length The number of code units covering the length of the line.
+	 * @return A reference to a line object.
+	 */
+	[[nodiscard]] Line createLine(SBUInteger start, SBUInteger length) const;
+};
+
+inline Paragraph Algorithm::createParagraph(SBUInteger start, SBUInteger length, SBUInteger level) const
+{
+	return Paragraph::create(get(), start, length, level);
+}
+
+/**
+ * @brief A line object that contains visual runs.
+ */
+class Line : public SheenBidiPtr<SBLineRef, SBLineRetain, SBLineRelease> {
+public:
+	using SheenBidiPtr::SheenBidiPtr;
+
+	/**
+	 * @brief Creates a line object of specified range by applying rules L1-L2 of Unicode Bidirectional Algorithm.
+	 *
+	 * @param paragraph The paragraph that creates the line.
+	 * @param start The index to the first code unit of the line in source string.
+	 * @param length The number of code units covering the length of the line.
+	 * @return A reference to a line object.
+	 */
+	[[nodiscard]] static Line create(SBParagraphRef paragraph, SBUInteger start, SBUInteger length)
+	{
+		return Line(SBParagraphCreateLine(paragraph, start, length));
+	}
+
+	/**
+	 * @brief Returns the runs in the line.
+	 *
+	 * @return A span of SBRun structures.
+	 */
+	[[nodiscard]] std::span<const SBRun> runs() const
+	{
+		return std::span<const SBRun>(runsPtr(), runCount());
+	}
+
+	/**
+	 * @brief Returns the number of runs in the line.
+	 *
+	 * @return The number of runs in the line.
+	 */
+	[[nodiscard]] size_t runCount() const { return static_cast<size_t>(SBLineGetRunCount(get())); }
+
+	/**
+	 * @brief Returns a direct pointer to the run array, stored in the line.
+	 *
+	 * @return A valid pointer to an array of SBRun structures.
+	 */
+	[[nodiscard]] const SBRun *runsPtr() const { return SBLineGetRunsPtr(get()); }
+};
+
+inline Line Paragraph::createLine(SBUInteger start, SBUInteger length) const
+{
+	return Line::create(get(), start, length);
+}
+
+/**
+ * @brief Checks if a run is right-to-left.
+ *
+ * @param run The run to check.
+ * @return True if the run is right-to-left, false otherwise.
+ */
+[[nodiscard]] inline bool IsRTL(const SBRun &run) { return (run.level & 1) == 1; }
+
+/**
+ * @brief Decodes the next Unicode code point from a UTF-8 encoded string.
+ *
+ * @param input The string containing UTF-8 encoded code units.
+ * @param index The index at which decoding starts. On output, it is updated to the start of the next code point.
+ * @return The decoded code point, or SBCodepointInvalid if index is out of bounds.
+ */
+[[nodiscard]] inline SBCodepoint CodepointDecodeNext(std::string_view input, SBUInteger &index)
+{
+	return SBCodepointDecodeNextFromUTF8(
+	    reinterpret_cast<const SBUInt8 *>(input.data()), static_cast<SBUInteger>(input.size()), &index);
+}
+
+/**
+ * @brief Decodes the previous Unicode code point from a UTF-8 encoded string.
+ *
+ * @param input The string containing UTF-8 encoded code units.
+ * @param index The index before which decoding occurs. On output, it is updated to the start of the decoded code point.
+ * @return The decoded code point, or SBCodepointInvalid if index is zero or out of bounds.
+ */
+[[nodiscard]] inline SBCodepoint CodepointDecodePrevious(std::string_view input, SBUInteger &index)
+{
+	return SBCodepointDecodePreviousFromUTF8(
+	    reinterpret_cast<const SBUInt8 *>(input.data()), static_cast<SBUInteger>(input.size()), &index);
+}
+
+} // namespace devilution::sb

--- a/Source/utils/utf8.cpp
+++ b/Source/utils/utf8.cpp
@@ -5,15 +5,14 @@
 #include <cstring>
 #include <string_view>
 
-#include <SheenBidi/SheenBidi.h>
+#include "utils/sheen_bidi.hpp"
 
 namespace devilution {
 
 char32_t DecodeFirstUtf8CodePoint(std::string_view input, std::size_t *len)
 {
 	SBUInteger index = 0;
-	const SBCodepoint result = SBCodepointDecodeNextFromUTF8(
-	    reinterpret_cast<const SBUInt8 *>(input.data()), static_cast<SBUInteger>(input.size()), &index);
+	const SBCodepoint result = sb::CodepointDecodeNext(input, index);
 	*len = index;
 	return result;
 }

--- a/Source/utils/utf8.hpp
+++ b/Source/utils/utf8.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <cstddef>
+#include <iterator>
 #include <string>
 #include <string_view>
+
+#include "utils/sheen_bidi.hpp"
 
 namespace devilution {
 
@@ -14,7 +17,7 @@ constexpr char32_t Utf8DecodeError = 0xFFFD;
  * Sets `len` to the length of the code point in bytes.
  * Returns `Utf8DecodeError` on error.
  */
-char32_t DecodeFirstUtf8CodePoint(std::string_view input, std::size_t *len);
+[[nodiscard]] char32_t DecodeFirstUtf8CodePoint(std::string_view input, std::size_t *len);
 
 /**
  * Decodes and removes the first code point from UTF8-encoded input.
@@ -32,7 +35,7 @@ inline char32_t ConsumeFirstUtf8CodePoint(std::string_view *input)
  *
  * This includes ASCII punctuation, symbols, math operators, digits, and both uppercase/lowercase latin alphabets
  */
-constexpr bool IsBasicLatin(char x)
+[[nodiscard]] constexpr bool IsBasicLatin(char x)
 {
 	return x >= '\x20' && x <= '\x7E';
 }
@@ -44,7 +47,7 @@ constexpr bool IsBasicLatin(char x)
  * 0xBF. Please note that certain 3 and 4 byte sequences use a narrower range for the second byte, this function is
  * not intended to guarantee the character is valid within the sequence (or that the sequence is well-formed).
  */
-inline bool IsTrailUtf8CodeUnit(char x)
+[[nodiscard]] inline bool IsTrailUtf8CodeUnit(char x)
 {
 	// The following is equivalent to a bitmask test (x & 0xC0) == 0x80
 	// On x86_64 architectures it ends up being one instruction shorter
@@ -57,7 +60,7 @@ inline bool IsTrailUtf8CodeUnit(char x)
  * `src` must not be empty.
  * If `src` does not begin with a UTF-8 code point start byte, returns 1.
  */
-inline size_t Utf8CodePointLen(const char *src)
+[[nodiscard]] inline size_t Utf8CodePointLen(const char *src)
 {
 	// This constant is effectively a lookup table for 2-bit keys, where
 	// values represent code point length - 1.
@@ -71,7 +74,7 @@ inline size_t Utf8CodePointLen(const char *src)
 /**
  * Returns the start byte index of the last code point in a UTF-8 string.
  */
-inline std::size_t FindLastUtf8Symbols(std::string_view input)
+[[nodiscard]] inline std::size_t FindLastUtf8Symbols(std::string_view input)
 {
 	if (input.empty())
 		return 0;
@@ -93,6 +96,151 @@ void CopyUtf8(char *dest, std::string_view source, std::size_t bytes);
 void AppendUtf8(char32_t codepoint, std::string &out);
 
 /** @brief Truncates `str` to at most `len` at a code point boundary. */
-std::string_view TruncateUtf8(std::string_view str, std::size_t len);
+[[nodiscard]] std::string_view TruncateUtf8(std::string_view str, std::size_t len);
+
+/**
+ * @brief Bidirectional iterator for UTF-8 encoded code points.
+ *
+ * This iterator yields Unicode code points (`char32_t`) from a UTF-8 string.
+ * It uses the SheenBidi library for decoding.
+ */
+class Utf8CodePointIterator {
+public:
+	using iterator_category = std::bidirectional_iterator_tag;
+	using value_type = char32_t;
+	using difference_type = std::ptrdiff_t;
+	using pointer = void;
+	using reference = char32_t;
+
+	Utf8CodePointIterator() = default;
+
+	/**
+	 * @brief Constructs the iterator at the specified byte index.
+	 */
+	explicit Utf8CodePointIterator(std::string_view str, std::size_t index)
+	    : end_(str.data() + str.size())
+	    , current_ptr_(str.data() + index)
+	{
+	}
+
+	[[nodiscard]] char32_t operator*() const
+	{
+		SBUInteger index = 0;
+		return sb::CodepointDecodeNext(
+		    { current_ptr_, static_cast<std::size_t>(end_ - current_ptr_) }, index);
+	}
+
+	Utf8CodePointIterator &operator++()
+	{
+		current_ptr_ += Utf8CodePointLen(current_ptr_);
+		return *this;
+	}
+
+	Utf8CodePointIterator operator++(int)
+	{
+		Utf8CodePointIterator copy = *this;
+		++*this;
+		return copy;
+	}
+
+	Utf8CodePointIterator &operator--()
+	{
+		// UTF-8 has at most 3 trail bytes per code point; scan back to find the lead byte.
+		const char *p = current_ptr_ - 1;
+		for (int i = 0; i < 3 && IsTrailUtf8CodeUnit(*p); ++i, --p) { }
+		current_ptr_ = p;
+		return *this;
+	}
+
+	Utf8CodePointIterator operator--(int)
+	{
+		Utf8CodePointIterator copy = *this;
+		--*this;
+		return copy;
+	}
+
+	[[nodiscard]] bool operator==(const Utf8CodePointIterator &other) const
+	{
+		return current_ptr_ == other.current_ptr_;
+	}
+
+	[[nodiscard]] bool operator!=(const Utf8CodePointIterator &other) const
+	{
+		return !(*this == other);
+	}
+
+	/**
+	 * @brief Returns the substring corresponding to the current code point.
+	 */
+	[[nodiscard]] std::string_view str() const
+	{
+		return { current_ptr_, Utf8CodePointLen(current_ptr_) };
+	}
+
+	/**
+	 * @brief Returns the length in bytes of the current code point in the UTF-8 sequence.
+	 */
+	[[nodiscard]] std::size_t size() const
+	{
+		return Utf8CodePointLen(current_ptr_);
+	}
+
+	/**
+	 * @brief Returns a pointer to the first byte of the current code point.
+	 */
+	[[nodiscard]] const char *data() const
+	{
+		return current_ptr_;
+	}
+
+private:
+	const char *end_ = nullptr;
+	const char *current_ptr_ = nullptr;
+};
+
+using Utf8CodePointReverseIterator = std::reverse_iterator<Utf8CodePointIterator>;
+
+/**
+ * @brief A range wrapper for iterating over UTF-8 encoded code points.
+ *
+ * Provides `begin()`, `end()`, `rbegin()`, and `rend()` methods to yield
+ * UTF-8 code point iterators.
+ */
+class Utf8CodePoints {
+public:
+	explicit Utf8CodePoints(std::string_view str)
+	    : str_(str)
+	{
+	}
+
+	[[nodiscard]] Utf8CodePointIterator begin() const { return Utf8CodePointIterator(str_, 0); }
+	[[nodiscard]] Utf8CodePointIterator end() const { return Utf8CodePointIterator(str_, str_.size()); }
+	[[nodiscard]] Utf8CodePointReverseIterator rbegin() const { return Utf8CodePointReverseIterator(end()); }
+	[[nodiscard]] Utf8CodePointReverseIterator rend() const { return Utf8CodePointReverseIterator(begin()); }
+
+private:
+	std::string_view str_;
+};
+
+/**
+ * @brief A range wrapper for reverse iterating over UTF-8 encoded code points.
+ *
+ * Provides `begin()` and `end()` methods that yield reverse UTF-8 code point iterators.
+ */
+class Utf8ReverseCodePoints {
+public:
+	explicit Utf8ReverseCodePoints(std::string_view str)
+	    : str_(str)
+	{
+	}
+
+	[[nodiscard]] Utf8CodePointReverseIterator begin() const { return Utf8CodePointReverseIterator(rend()); }
+	[[nodiscard]] Utf8CodePointReverseIterator end() const { return Utf8CodePointReverseIterator(rbegin()); }
+	[[nodiscard]] Utf8CodePointIterator rbegin() const { return Utf8CodePointIterator(str_, 0); }
+	[[nodiscard]] Utf8CodePointIterator rend() const { return Utf8CodePointIterator(str_, str_.size()); }
+
+private:
+	std::string_view str_;
+};
 
 } // namespace devilution

--- a/docs/building.md
+++ b/docs/building.md
@@ -546,13 +546,13 @@ emrun index.html
 
 ### Dependencies
 
-* Windows 10
+* Windows 10+
 * CMake
 * Git
-* Visual Studio 2022 with the following packages installed:
-    * C++ (v143) Universal Windows Platform tools
+* Visual Studio 2026 with the following packages installed:
+    * C++ (v145) Universal Windows Platform tools
     * Windows 11 SDK (10.0.26100.0)
-    * MSVC v143 - VS 2022 C++ x64/x86 build tools
+    * MSVC v145 - VS 2026 C++ x64/x86 build tools
 
 _Note: Visual Studio Community Edition can be used._
 

--- a/test/sheen_bidi_test.cpp
+++ b/test/sheen_bidi_test.cpp
@@ -1,0 +1,204 @@
+
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+#include "utils/sheen_bidi.hpp"
+
+namespace devilution {
+namespace {
+
+TEST(SheenBidiTest, AlgorithmCreated)
+{
+	sb::Algorithm algorithm = sb::Algorithm::create("Hello");
+	EXPECT_TRUE(algorithm);
+	EXPECT_NE(algorithm.get(), nullptr);
+}
+
+TEST(SheenBidiTest, CreateParagraphEnglish)
+{
+	std::string_view text = "Hello, World!";
+	sb::Algorithm algorithm = sb::Algorithm::create(text);
+
+	sb::Paragraph paragraph = algorithm.createParagraph(0, text.size(), SBLevelDefaultLTR);
+	EXPECT_TRUE(paragraph);
+}
+
+TEST(SheenBidiTest, CreateParagraphHebrew)
+{
+	std::string_view text = "שלום עולם";
+	sb::Algorithm algorithm = sb::Algorithm::create(text);
+
+	sb::Paragraph paragraph = algorithm.createParagraph(0, text.size(), SBLevelDefaultRTL);
+	EXPECT_TRUE(paragraph);
+}
+
+TEST(SheenBidiTest, CreateParagraphMixed)
+{
+	std::string_view text = "Hello שלום World";
+	sb::Algorithm algorithm = sb::Algorithm::create(text);
+
+	sb::Paragraph paragraph = algorithm.createParagraph(0, text.size(), SBLevelDefaultLTR);
+	EXPECT_TRUE(paragraph);
+}
+
+TEST(SheenBidiTest, CreateLineFromParagraph)
+{
+	std::string_view text = "Hello, World!";
+	sb::Algorithm algorithm = sb::Algorithm::create(text);
+
+	sb::Paragraph paragraph = algorithm.createParagraph(0, text.size(), SBLevelDefaultLTR);
+	EXPECT_TRUE(paragraph);
+
+	sb::Line line = paragraph.createLine(0, text.size());
+	EXPECT_TRUE(line);
+}
+
+TEST(SheenBidiTest, GetRunsFromLine)
+{
+	std::string_view text = "Hello, World!";
+	sb::Algorithm algorithm = sb::Algorithm::create(text);
+
+	sb::Paragraph paragraph = algorithm.createParagraph(0, text.size(), SBLevelDefaultLTR);
+	sb::Line line = paragraph.createLine(0, text.size());
+
+	SBUInteger runCount = line.runCount();
+	EXPECT_GT(runCount, 0);
+
+	const SBRun *runs = line.runsPtr();
+	EXPECT_NE(runs, nullptr);
+}
+
+TEST(SheenBidiTest, IsRTLDetectsLTRRun)
+{
+	SBRun run;
+	run.level = 0; // LTR (even level)
+
+	EXPECT_FALSE(sb::IsRTL(run));
+}
+
+TEST(SheenBidiTest, IsRTLDetectsRTLRun)
+{
+	SBRun run;
+	run.level = 1; // RTL (odd level)
+
+	EXPECT_TRUE(sb::IsRTL(run));
+}
+
+TEST(SheenBidiTest, MixedLanguageAnalysis)
+{
+	std::string_view text = "Hello שלום World";
+	sb::Algorithm algorithm = sb::Algorithm::create(text);
+
+	sb::Paragraph paragraph = algorithm.createParagraph(0, text.size(), SBLevelDefaultLTR);
+	EXPECT_TRUE(paragraph);
+
+	sb::Line line = paragraph.createLine(0, text.size());
+	EXPECT_TRUE(line);
+
+	SBUInteger runCount = line.runCount();
+	EXPECT_GT(runCount, 0);
+
+	// We expect multiple runs due to the directional changes
+	// (English -> Hebrew -> English)
+	const SBRun *runs = line.runsPtr();
+	EXPECT_NE(runs, nullptr);
+
+	// Verify each run has valid level
+	for (const SBRun &run : line.runs()) {
+		EXPECT_GE(run.level, 0);
+		EXPECT_LE(run.level, 125); // Max bidi level according to Unicode spec
+	}
+}
+
+TEST(SheenBidiTest, ParagraphCopySemantics)
+{
+	std::string_view text = "Test";
+	sb::Algorithm algorithm = sb::Algorithm::create(text);
+
+	sb::Paragraph para1(algorithm.createParagraph(0, text.size(), SBLevelDefaultLTR));
+	EXPECT_TRUE(para1);
+
+	// Copy constructor
+	sb::Paragraph para2 = para1;
+	EXPECT_TRUE(para2);
+	EXPECT_EQ(para1.get(), para2.get());
+}
+
+TEST(SheenBidiTest, ParagraphMoveSemantics)
+{
+	std::string_view text = "Test";
+	sb::Algorithm algorithm = sb::Algorithm::create(text);
+
+	sb::Paragraph para1(algorithm.createParagraph(0, text.size(), SBLevelDefaultLTR));
+	EXPECT_TRUE(para1);
+
+	// Move constructor
+	sb::Paragraph para2 = std::move(para1);
+	EXPECT_TRUE(para2);
+	EXPECT_FALSE(para1);
+	EXPECT_EQ(para1.get(), nullptr);
+}
+
+TEST(SheenBidiTest, LineCopySemantics)
+{
+	std::string_view text = "Test";
+	sb::Algorithm algorithm = sb::Algorithm::create(text);
+
+	sb::Paragraph paragraph = algorithm.createParagraph(0, text.size(), SBLevelDefaultLTR);
+	sb::Line line1(SBParagraphCreateLine(paragraph.get(), 0, text.size()));
+	EXPECT_TRUE(line1);
+
+	// Copy constructor
+	sb::Line line2 = line1;
+	EXPECT_TRUE(line2);
+	EXPECT_EQ(line1.get(), line2.get());
+}
+
+TEST(SheenBidiTest, LineMoveSemantics)
+{
+	std::string_view text = "Test";
+	sb::Algorithm algorithm = sb::Algorithm::create(text);
+
+	sb::Paragraph paragraph = algorithm.createParagraph(0, text.size(), SBLevelDefaultLTR);
+	sb::Line line1(SBParagraphCreateLine(paragraph.get(), 0, text.size()));
+	EXPECT_TRUE(line1);
+
+	// Move constructor
+	sb::Line line2 = std::move(line1);
+	EXPECT_TRUE(line2);
+	EXPECT_FALSE(line1);
+	EXPECT_EQ(line1.get(), nullptr);
+}
+
+TEST(SheenBidiTest, AlgorithmPointerOperations)
+{
+	sb::Algorithm algorithm = sb::Algorithm::create("Hello");
+	EXPECT_TRUE(algorithm);
+	EXPECT_NE(algorithm.get(), nullptr);
+
+	// Test nullptr comparison
+	EXPECT_FALSE(algorithm == nullptr);
+	EXPECT_TRUE(algorithm != nullptr);
+	EXPECT_FALSE(nullptr == algorithm);
+	EXPECT_TRUE(nullptr != algorithm);
+}
+
+TEST(SheenBidiTest, ParagraphPointerNullptr)
+{
+	sb::Paragraph paragraph;
+	EXPECT_FALSE(paragraph);
+	EXPECT_EQ(paragraph.get(), nullptr);
+	EXPECT_TRUE(paragraph == nullptr);
+}
+
+TEST(SheenBidiTest, LinePointerNullptr)
+{
+	sb::Line line;
+	EXPECT_FALSE(line);
+	EXPECT_EQ(line.get(), nullptr);
+	EXPECT_TRUE(line == nullptr);
+}
+
+} // namespace
+} // namespace devilution

--- a/test/utf8_test.cpp
+++ b/test/utf8_test.cpp
@@ -121,5 +121,116 @@ TEST(Utf8CodeUnits, BasicLatin)
 	EXPECT_FALSE(IsBasicLatin('\xFF')) << "Multibyte Utf8 code units are not Basic Latin symbols";
 }
 
+TEST(Utf8CodePointIteratorTest, ForwardIteration)
+{
+	std::string_view s = "aж€💡";
+	Utf8CodePoints codepoints(s);
+	auto it = codepoints.begin();
+
+	EXPECT_NE(it, codepoints.end());
+	EXPECT_EQ(*it, U'a');
+	EXPECT_EQ(it.str(), "a");
+	EXPECT_EQ(it.size(), 1);
+
+	++it;
+	EXPECT_NE(it, codepoints.end());
+	EXPECT_EQ(*it, U'ж');
+	EXPECT_EQ(it.str(), "ж");
+	EXPECT_EQ(it.size(), 2);
+
+	++it;
+	EXPECT_NE(it, codepoints.end());
+	EXPECT_EQ(*it, U'€');
+	EXPECT_EQ(it.str(), "€");
+	EXPECT_EQ(it.size(), 3);
+
+	++it;
+	EXPECT_NE(it, codepoints.end());
+	EXPECT_EQ(*it, U'💡');
+	EXPECT_EQ(it.str(), "💡");
+	EXPECT_EQ(it.size(), 4);
+
+	++it;
+	EXPECT_EQ(it, codepoints.end());
+}
+
+TEST(Utf8CodePointIteratorTest, ReverseIteration)
+{
+	std::string_view s = "aж€💡";
+	Utf8CodePoints codepoints(s);
+	auto it = codepoints.rbegin();
+
+	EXPECT_NE(it, codepoints.rend());
+	EXPECT_EQ(*it, U'💡');
+	EXPECT_EQ(std::prev(it.base()).str(), "💡");
+	EXPECT_EQ(std::prev(it.base()).size(), 4);
+
+	++it;
+	EXPECT_NE(it, codepoints.rend());
+	EXPECT_EQ(*it, U'€');
+	EXPECT_EQ(std::prev(it.base()).str(), "€");
+	EXPECT_EQ(std::prev(it.base()).size(), 3);
+
+	++it;
+	EXPECT_NE(it, codepoints.rend());
+	EXPECT_EQ(*it, U'ж');
+	EXPECT_EQ(std::prev(it.base()).str(), "ж");
+	EXPECT_EQ(std::prev(it.base()).size(), 2);
+
+	++it;
+	EXPECT_NE(it, codepoints.rend());
+	EXPECT_EQ(*it, U'a');
+	EXPECT_EQ(std::prev(it.base()).str(), "a");
+	EXPECT_EQ(std::prev(it.base()).size(), 1);
+
+	++it;
+	EXPECT_EQ(it, codepoints.rend());
+}
+
+TEST(Utf8CodePointIteratorTest, BidirectionalDecrement)
+{
+	std::string_view s = "aж€💡";
+	Utf8CodePoints codepoints(s);
+	auto it = codepoints.end();
+
+	--it;
+	EXPECT_EQ(*it, U'💡');
+	EXPECT_EQ(it.str(), "💡");
+
+	--it;
+	EXPECT_EQ(*it, U'€');
+	EXPECT_EQ(it.str(), "€");
+
+	--it;
+	EXPECT_EQ(*it, U'ж');
+	EXPECT_EQ(it.str(), "ж");
+
+	--it;
+	EXPECT_EQ(*it, U'a');
+	EXPECT_EQ(it.str(), "a");
+
+	EXPECT_EQ(it, codepoints.begin());
+}
+
+TEST(Utf8CodePointIteratorTest, RangeBasedFor)
+{
+	std::string_view s = "aж€💡";
+	std::string result;
+	for (char32_t cp : Utf8CodePoints(s)) {
+		AppendUtf8(cp, result);
+	}
+	EXPECT_EQ(result, s);
+}
+
+TEST(Utf8CodePointIteratorTest, ReverseRangeBasedFor)
+{
+	std::string_view s = "aж€💡";
+	std::string result;
+	for (char32_t cp : Utf8ReverseCodePoints(s)) {
+		AppendUtf8(cp, result);
+	}
+	EXPECT_EQ(result, "💡€жa");
+}
+
 } // namespace
 } // namespace devilution

--- a/uwp-project/devilutionx.vcxproj
+++ b/uwp-project/devilutionx.vcxproj
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
1. Adds C++ wrappers for SheenBidi to avoid manual memory management.
2. Add a bidirectional UTF-8 iterator.

These are intended to help with BiDi support that @BLooperZ is working on.