### PR TITLE
Optimize dun_render FullyDark and FullyLit paths

### DIFF
--- a/Source/engine/render/dun_render.cpp
+++ b/Source/engine/render/dun_render.cpp
@@ -18,6 +18,7 @@
 #include "appfat.h"
 #include "engine/point.hpp"
 #include "engine/render/blit_impl.hpp"
+#include "engine/render/overlapped_memset.hpp"
 #include "levels/dun_tile.hpp"
 #include "options.h"
 #include "utils/attributes.h"
@@ -121,14 +122,14 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque(uint8_t *DVL_RESTRICT 
 template <>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::FullyDark>(uint8_t *DVL_RESTRICT dst, [[maybe_unused]] const uint8_t *DVL_RESTRICT src, uint_fast8_t n, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
-	BlitFillDirect(dst, n, 0);
+	FillBytesUpTo32(dst, n, 0);
 }
 
 template <>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineOpaque<LightType::FullyLit>(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t n, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
 {
 #ifndef DEBUG_RENDER_COLOR
-	BlitPixelsDirect(dst, src, n);
+	CopyBytesUpTo32(dst, src, n);
 #else
 	BlitFillDirect(dst, n, DBGCOLOR);
 #endif
@@ -201,6 +202,20 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparentOrOpaque(uint8_t *
 	}
 }
 
+// Overload for statically-known pixel counts. For FullyDark+opaque, uses
+// BlitFillDirect with a compile-time constant instead of FillBytesUpTo32.
+template <LightType Light, bool Transparent, uint_fast8_t N>
+DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparentOrOpaqueN(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
+{
+	if constexpr (!Transparent && Light == LightType::FullyDark) {
+		BlitFillDirect(dst, N, 0);
+	} else if constexpr (!Transparent && Light == LightType::FullyLit) {
+		BlitPixelsDirect(dst, src, N);
+	} else {
+		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, N, tbl, lightmap);
+	}
+}
+
 template <LightType Light, bool OpaqueFirst>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderLineTransparentAndOpaque(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, uint_fast8_t prefixWidth, uint_fast8_t width, const uint8_t *DVL_RESTRICT tbl, const Lightmap &lightmap)
 {
@@ -261,7 +276,7 @@ template <LightType Light, bool Transparent>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderSquareFull(uint8_t *DVL_RESTRICT dst, uint16_t dstPitch, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap &lightmap)
 {
 	for (auto i = 0; i < Height; ++i, dst -= dstPitch) {
-		RenderLineTransparentOrOpaque<Light, Transparent>(dst, src, Width, tbl, &lightmap);
+		RenderLineTransparentOrOpaqueN<Light, Transparent, Width>(dst, src, tbl, &lightmap);
 		src += Width;
 	}
 }
@@ -442,67 +457,44 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT std::size_t CalculateTriangleSourceSkipUpper
 template <LightType Light, bool Transparent>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleLower(uint8_t *DVL_RESTRICT &dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT &src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (0 * dstLineOffset), src + 0, 2, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (1 * dstLineOffset), src + 2, 4, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (2 * dstLineOffset), src + 6, 6, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (3 * dstLineOffset), src + 12, 8, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (4 * dstLineOffset), src + 20, 10, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (5 * dstLineOffset), src + 30, 12, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (6 * dstLineOffset), src + 42, 14, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (7 * dstLineOffset), src + 56, 16, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (8 * dstLineOffset), src + 72, 18, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (9 * dstLineOffset), src + 90, 20, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (10 * dstLineOffset), src + 110, 22, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (11 * dstLineOffset), src + 132, 24, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (12 * dstLineOffset), src + 156, 26, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (13 * dstLineOffset), src + 182, 28, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (14 * dstLineOffset), src + 210, 30, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (15 * dstLineOffset), src + 240, 32, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 2>(dst - (0 * dstLineOffset), src + 0, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 4>(dst - (1 * dstLineOffset), src + 2, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 6>(dst - (2 * dstLineOffset), src + 6, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 8>(dst - (3 * dstLineOffset), src + 12, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 10>(dst - (4 * dstLineOffset), src + 20, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 12>(dst - (5 * dstLineOffset), src + 30, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 14>(dst - (6 * dstLineOffset), src + 42, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 16>(dst - (7 * dstLineOffset), src + 56, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 18>(dst - (8 * dstLineOffset), src + 72, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 20>(dst - (9 * dstLineOffset), src + 90, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 22>(dst - (10 * dstLineOffset), src + 110, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 24>(dst - (11 * dstLineOffset), src + 132, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 26>(dst - (12 * dstLineOffset), src + 156, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 28>(dst - (13 * dstLineOffset), src + 182, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 30>(dst - (14 * dstLineOffset), src + 210, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 32>(dst - (15 * dstLineOffset), src + 240, tbl, lightmap);
 	src += 272;
 	dst -= 16 * dstLineOffset;
-}
-
-template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleLower<LightType::FullyDark, /*Transparent=*/false>(uint8_t *DVL_RESTRICT &dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT &src, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
-{
-	unsigned width = XStep;
-	for (unsigned i = 0; i < LowerHeight; ++i) {
-		BlitFillDirect(dst, width, 0);
-		dst -= dstLineOffset;
-		width += XStep;
-	}
-	src += 272;
 }
 
 template <LightType Light, bool Transparent>
 DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper(uint8_t *DVL_RESTRICT dst, ptrdiff_t dstLineOffset, const uint8_t *DVL_RESTRICT src, const uint8_t *DVL_RESTRICT tbl, const Lightmap *lightmap)
 {
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (0 * dstLineOffset), src + 0, 30, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (1 * dstLineOffset), src + 30, 28, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (2 * dstLineOffset), src + 58, 26, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (3 * dstLineOffset), src + 84, 24, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (4 * dstLineOffset), src + 108, 22, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (5 * dstLineOffset), src + 130, 20, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (6 * dstLineOffset), src + 150, 18, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (7 * dstLineOffset), src + 168, 16, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (8 * dstLineOffset), src + 184, 14, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (9 * dstLineOffset), src + 198, 12, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (10 * dstLineOffset), src + 210, 10, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (11 * dstLineOffset), src + 220, 8, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (12 * dstLineOffset), src + 228, 6, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (13 * dstLineOffset), src + 234, 4, tbl, lightmap);
-	RenderLineTransparentOrOpaque<Light, Transparent>(dst - (14 * dstLineOffset), src + 238, 2, tbl, lightmap);
-}
-
-template <>
-DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTriangleUpper<LightType::FullyDark, /*Transparent=*/false>(uint8_t *DVL_RESTRICT dst, ptrdiff_t dstLineOffset, [[maybe_unused]] const uint8_t *DVL_RESTRICT src, [[maybe_unused]] const uint8_t *DVL_RESTRICT tbl, [[maybe_unused]] const Lightmap *lightmap)
-{
-	unsigned width = Width - XStep;
-	for (unsigned i = 0; i < TriangleUpperHeight; ++i) {
-		BlitFillDirect(dst, width, 0);
-		dst -= dstLineOffset;
-		width -= XStep;
-	}
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 30>(dst - (0 * dstLineOffset), src + 0, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 28>(dst - (1 * dstLineOffset), src + 30, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 26>(dst - (2 * dstLineOffset), src + 58, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 24>(dst - (3 * dstLineOffset), src + 84, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 22>(dst - (4 * dstLineOffset), src + 108, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 20>(dst - (5 * dstLineOffset), src + 130, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 18>(dst - (6 * dstLineOffset), src + 150, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 16>(dst - (7 * dstLineOffset), src + 168, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 14>(dst - (8 * dstLineOffset), src + 184, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 12>(dst - (9 * dstLineOffset), src + 198, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 10>(dst - (10 * dstLineOffset), src + 210, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 8>(dst - (11 * dstLineOffset), src + 220, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 6>(dst - (12 * dstLineOffset), src + 228, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 4>(dst - (13 * dstLineOffset), src + 234, tbl, lightmap);
+	RenderLineTransparentOrOpaqueN<Light, Transparent, 2>(dst - (14 * dstLineOffset), src + 238, tbl, lightmap);
 }
 
 template <LightType Light, bool Transparent>
@@ -752,7 +744,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalf(uint8_t *DVL_R
 		// The first line is always fully opaque.
 		// We handle it specially to avoid calling the blitter with width=0.
 		const uint8_t *srcEnd = src + (Width * TrapezoidUpperHeight);
-		RenderLineOpaque<Light>(dst, src, Width, tbl, &lightmap);
+		RenderLineTransparentOrOpaqueN<Light, false, Width>(dst, src, tbl, &lightmap);
 		src += Width;
 		dst -= dstPitch;
 		uint8_t prefixWidth = (PrefixIncrement<Mask> < 0 ? 32 : 0) + PrefixIncrement<Mask>;
@@ -765,7 +757,7 @@ DVL_ALWAYS_INLINE DVL_ATTRIBUTE_HOT void RenderTrapezoidUpperHalf(uint8_t *DVL_R
 	} else { // Mask == MaskType::Solid || Mask == MaskType::Transparent
 		const uint8_t *srcEnd = src + (Width * TrapezoidUpperHeight);
 		do {
-			RenderLineTransparentOrOpaque<Light, /*Transparent=*/Mask == MaskType::Transparent>(dst, src, Width, tbl, &lightmap);
+			RenderLineTransparentOrOpaqueN<Light, /*Transparent=*/Mask == MaskType::Transparent, Width>(dst, src, tbl, &lightmap);
 			src += Width;
 			dst -= dstPitch;
 		} while (src != srcEnd);

--- a/Source/engine/render/light_render.cpp
+++ b/Source/engine/render/light_render.cpp
@@ -1,16 +1,15 @@
 #include "engine/render/light_render.hpp"
 
 #include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <span>
 #include <vector>
 
 #include "engine/displacement.hpp"
 #include "engine/lighting_defs.hpp"
 #include "engine/point.hpp"
+#include "engine/render/overlapped_memset.hpp"
 #include "levels/dun_tile.hpp"
 #include "levels/gendung_defs.hpp"
 #include "utils/attributes.h"
@@ -20,110 +19,6 @@ namespace devilution {
 namespace {
 
 std::vector<uint8_t> LightmapBuffer;
-
-/**
- * @brief Fills a block of memory with a specified byte value without invoking memset.
- *
- * This function provides an ultra-fast, branch-optimized alternative to standard
- * memset for small buffers. By leveraging fixed-size, constant-expression memcpy
- * calls, it forces the compiler to emit inline, architectural store instructions
- * (e.g., movq, movl) directly, bypassing PLT/library overhead entirely.
- *
- * To minimize branching and completely eliminate loops, it utilizes an
- * "overlapping store" strategy (writing identical data from both ends of the buffer).
- *
- * @note CRITICAL: This function is strictly optimized and mathematically bounded
- * for buffers between 0 and 64 bytes. Passing a size greater than 64 will
- * leave an uninitialized memory gap in the middle of the destination buffer.
- *
- * @param dst   Pointer to the destination memory block.
- * @param n     The number of bytes to fill (Must be between 0 and 64 inclusive).
- * @param value The byte value to broadcast across the memory block.
- */
-DVL_ALWAYS_INLINE void FillBytesUpTo64(uint8_t *dst, int n, uint8_t value)
-{
-	assert(n > 0);
-	assert(n <= 64);
-	if constexpr (sizeof(void *) == 8) {
-		const uint64_t fill64 = static_cast<uint64_t>(value) * 0x0101010101010101ULL;
-		if (n >= 32) {
-			memcpy(dst, &fill64, 8);
-			memcpy(dst + 8, &fill64, 8);
-			memcpy(dst + 16, &fill64, 8);
-			memcpy(dst + 24, &fill64, 8);
-			memcpy(dst + n - 32, &fill64, 8);
-			memcpy(dst + n - 24, &fill64, 8);
-			memcpy(dst + n - 16, &fill64, 8);
-			memcpy(dst + n - 8, &fill64, 8);
-			return;
-		}
-		if (n >= 16) {
-			memcpy(dst, &fill64, 8);
-			memcpy(dst + 8, &fill64, 8);
-			memcpy(dst + n - 16, &fill64, 8);
-			memcpy(dst + n - 8, &fill64, 8);
-			return;
-		}
-		if (n >= 8) {
-			memcpy(dst, &fill64, 8);
-			memcpy(dst + n - 8, &fill64, 8);
-			return;
-		}
-	} else {
-		const uint32_t fill32 = static_cast<uint32_t>(value) * 0x01010101U;
-		if (n >= 32) {
-			memcpy(dst, &fill32, 4);
-			memcpy(dst + 4, &fill32, 4);
-			memcpy(dst + 8, &fill32, 4);
-			memcpy(dst + 12, &fill32, 4);
-			memcpy(dst + 16, &fill32, 4);
-			memcpy(dst + 20, &fill32, 4);
-			memcpy(dst + 24, &fill32, 4);
-			memcpy(dst + 28, &fill32, 4);
-			memcpy(dst + n - 32, &fill32, 4);
-			memcpy(dst + n - 28, &fill32, 4);
-			memcpy(dst + n - 24, &fill32, 4);
-			memcpy(dst + n - 20, &fill32, 4);
-			memcpy(dst + n - 16, &fill32, 4);
-			memcpy(dst + n - 12, &fill32, 4);
-			memcpy(dst + n - 8, &fill32, 4);
-			memcpy(dst + n - 4, &fill32, 4);
-			return;
-		}
-		if (n >= 16) {
-			memcpy(dst, &fill32, 4);
-			memcpy(dst + 4, &fill32, 4);
-			memcpy(dst + 8, &fill32, 4);
-			memcpy(dst + 12, &fill32, 4);
-			memcpy(dst + n - 16, &fill32, 4);
-			memcpy(dst + n - 12, &fill32, 4);
-			memcpy(dst + n - 8, &fill32, 4);
-			memcpy(dst + n - 4, &fill32, 4);
-			return;
-		}
-		if (n >= 8) {
-			memcpy(dst, &fill32, 4);
-			memcpy(dst + 4, &fill32, 4);
-			memcpy(dst + n - 8, &fill32, 4);
-			memcpy(dst + n - 4, &fill32, 4);
-			return;
-		}
-	}
-
-	const uint32_t fill32 = static_cast<uint32_t>(value) * 0x01010101U;
-
-	if (n >= 4) {
-		memcpy(dst, &fill32, 4);
-		memcpy(dst + n - 4, &fill32, 4);
-		return;
-	}
-
-	dst[0] = value;
-	if (n >= 2) {
-		const uint16_t fill16 = static_cast<uint16_t>(value) * 0x0101U;
-		memcpy(dst + n - 2, &fill16, 2);
-	}
-}
 
 void RenderFullTile(Point position, uint8_t lightLevel, uint8_t *lightmap, uint16_t pitch)
 {

--- a/Source/engine/render/overlapped_memset.hpp
+++ b/Source/engine/render/overlapped_memset.hpp
@@ -1,0 +1,271 @@
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+
+#include "utils/attributes.h"
+
+namespace devilution {
+
+/**
+ * @brief Copies up to 32 bytes without invoking memcpy.
+ *
+ * Uses overlapping loads and stores to cover the buffer with two fixed-size
+ * operations per size tier, reading all source bytes into temporaries before
+ * any write so the overlap is safe.
+ *
+ * @note n > 32 leaves a gap in the middle uninitialized.
+ */
+DVL_ALWAYS_INLINE void CopyBytesUpTo32(uint8_t *DVL_RESTRICT dst, const uint8_t *DVL_RESTRICT src, int n)
+{
+	assert(n > 0);
+	assert(n <= 32);
+	if constexpr (sizeof(void *) == 8) {
+		if (n >= 16) {
+			uint64_t a, b, c, d;
+			memcpy(&a, src, 8);
+			memcpy(&b, src + 8, 8);
+			memcpy(&c, src + n - 16, 8);
+			memcpy(&d, src + n - 8, 8);
+			memcpy(dst, &a, 8);
+			memcpy(dst + 8, &b, 8);
+			memcpy(dst + n - 16, &c, 8);
+			memcpy(dst + n - 8, &d, 8);
+			return;
+		}
+		if (n >= 8) {
+			uint64_t a, b;
+			memcpy(&a, src, 8);
+			memcpy(&b, src + n - 8, 8);
+			memcpy(dst, &a, 8);
+			memcpy(dst + n - 8, &b, 8);
+			return;
+		}
+	} else {
+		if (n >= 16) {
+			uint32_t a, b, c, d, e, f, g, h;
+			memcpy(&a, src, 4);
+			memcpy(&b, src + 4, 4);
+			memcpy(&c, src + 8, 4);
+			memcpy(&d, src + 12, 4);
+			memcpy(&e, src + n - 16, 4);
+			memcpy(&f, src + n - 12, 4);
+			memcpy(&g, src + n - 8, 4);
+			memcpy(&h, src + n - 4, 4);
+			memcpy(dst, &a, 4);
+			memcpy(dst + 4, &b, 4);
+			memcpy(dst + 8, &c, 4);
+			memcpy(dst + 12, &d, 4);
+			memcpy(dst + n - 16, &e, 4);
+			memcpy(dst + n - 12, &f, 4);
+			memcpy(dst + n - 8, &g, 4);
+			memcpy(dst + n - 4, &h, 4);
+			return;
+		}
+		if (n >= 8) {
+			uint32_t a, b, c, d;
+			memcpy(&a, src, 4);
+			memcpy(&b, src + 4, 4);
+			memcpy(&c, src + n - 8, 4);
+			memcpy(&d, src + n - 4, 4);
+			memcpy(dst, &a, 4);
+			memcpy(dst + 4, &b, 4);
+			memcpy(dst + n - 8, &c, 4);
+			memcpy(dst + n - 4, &d, 4);
+			return;
+		}
+	}
+	if (n >= 4) {
+		uint32_t a, b;
+		memcpy(&a, src, 4);
+		memcpy(&b, src + n - 4, 4);
+		memcpy(dst, &a, 4);
+		memcpy(dst + n - 4, &b, 4);
+		return;
+	}
+	dst[0] = src[0];
+	if (n >= 2) {
+		uint16_t a;
+		memcpy(&a, src + n - 2, 2);
+		memcpy(dst + n - 2, &a, 2);
+	}
+}
+
+/**
+ * @brief Fills a block of memory with a specified byte value without invoking memset.
+ *
+ * This function provides an ultra-fast, branch-optimized alternative to standard
+ * memset for small buffers. By leveraging fixed-size, constant-expression memcpy
+ * calls, it forces the compiler to emit inline, architectural store instructions
+ * (e.g., movq, movl) directly, bypassing PLT/library overhead entirely.
+ *
+ * To minimize branching and completely eliminate loops, it utilizes an
+ * "overlapping store" strategy (writing identical data from both ends of the buffer).
+ *
+ * @note CRITICAL: This function is strictly optimized and mathematically bounded
+ * for buffers between 0 and 32 bytes. Passing a size greater than 32 will
+ * leave an uninitialized memory gap in the middle of the destination buffer.
+ *
+ * @param dst   Pointer to the destination memory block.
+ * @param n     The number of bytes to fill (Must be between 0 and 32 inclusive).
+ * @param value The byte value to broadcast across the memory block.
+ */
+DVL_ALWAYS_INLINE void FillBytesUpTo32(uint8_t *dst, int n, uint8_t value)
+{
+	assert(n > 0);
+	assert(n <= 32);
+	if constexpr (sizeof(void *) == 8) {
+		const uint64_t fill64 = static_cast<uint64_t>(value) * 0x0101010101010101ULL;
+		if (n >= 16) {
+			memcpy(dst, &fill64, 8);
+			memcpy(dst + 8, &fill64, 8);
+			memcpy(dst + n - 16, &fill64, 8);
+			memcpy(dst + n - 8, &fill64, 8);
+			return;
+		}
+		if (n >= 8) {
+			memcpy(dst, &fill64, 8);
+			memcpy(dst + n - 8, &fill64, 8);
+			return;
+		}
+	} else {
+		const uint32_t fill32 = static_cast<uint32_t>(value) * 0x01010101U;
+		if (n >= 16) {
+			memcpy(dst, &fill32, 4);
+			memcpy(dst + 4, &fill32, 4);
+			memcpy(dst + 8, &fill32, 4);
+			memcpy(dst + 12, &fill32, 4);
+			memcpy(dst + n - 16, &fill32, 4);
+			memcpy(dst + n - 12, &fill32, 4);
+			memcpy(dst + n - 8, &fill32, 4);
+			memcpy(dst + n - 4, &fill32, 4);
+			return;
+		}
+		if (n >= 8) {
+			memcpy(dst, &fill32, 4);
+			memcpy(dst + 4, &fill32, 4);
+			memcpy(dst + n - 8, &fill32, 4);
+			memcpy(dst + n - 4, &fill32, 4);
+			return;
+		}
+	}
+
+	const uint32_t fill32 = static_cast<uint32_t>(value) * 0x01010101U;
+	if (n >= 4) {
+		memcpy(dst, &fill32, 4);
+		memcpy(dst + n - 4, &fill32, 4);
+		return;
+	}
+	dst[0] = value;
+	if (n >= 2) {
+		const uint16_t fill16 = static_cast<uint16_t>(value) * 0x0101U;
+		memcpy(dst + n - 2, &fill16, 2);
+	}
+}
+
+/**
+ * @brief Fills a block of memory with a specified byte value without invoking memset.
+ *
+ * This function provides an ultra-fast, branch-optimized alternative to standard
+ * memset for small buffers. By leveraging fixed-size, constant-expression memcpy
+ * calls, it forces the compiler to emit inline, architectural store instructions
+ * (e.g., movq, movl) directly, bypassing PLT/library overhead entirely.
+ *
+ * To minimize branching and completely eliminate loops, it utilizes an
+ * "overlapping store" strategy (writing identical data from both ends of the buffer).
+ *
+ * @note CRITICAL: This function is strictly optimized and mathematically bounded
+ * for buffers between 0 and 64 bytes. Passing a size greater than 64 will
+ * leave an uninitialized memory gap in the middle of the destination buffer.
+ *
+ * @param dst   Pointer to the destination memory block.
+ * @param n     The number of bytes to fill (Must be between 0 and 64 inclusive).
+ * @param value The byte value to broadcast across the memory block.
+ */
+DVL_ALWAYS_INLINE void FillBytesUpTo64(uint8_t *dst, int n, uint8_t value)
+{
+	assert(n > 0);
+	assert(n <= 64);
+	if constexpr (sizeof(void *) == 8) {
+		const uint64_t fill64 = static_cast<uint64_t>(value) * 0x0101010101010101ULL;
+		if (n >= 32) {
+			memcpy(dst, &fill64, 8);
+			memcpy(dst + 8, &fill64, 8);
+			memcpy(dst + 16, &fill64, 8);
+			memcpy(dst + 24, &fill64, 8);
+			memcpy(dst + n - 32, &fill64, 8);
+			memcpy(dst + n - 24, &fill64, 8);
+			memcpy(dst + n - 16, &fill64, 8);
+			memcpy(dst + n - 8, &fill64, 8);
+			return;
+		}
+		if (n >= 16) {
+			memcpy(dst, &fill64, 8);
+			memcpy(dst + 8, &fill64, 8);
+			memcpy(dst + n - 16, &fill64, 8);
+			memcpy(dst + n - 8, &fill64, 8);
+			return;
+		}
+		if (n >= 8) {
+			memcpy(dst, &fill64, 8);
+			memcpy(dst + n - 8, &fill64, 8);
+			return;
+		}
+	} else {
+		const uint32_t fill32 = static_cast<uint32_t>(value) * 0x01010101U;
+		if (n >= 32) {
+			memcpy(dst, &fill32, 4);
+			memcpy(dst + 4, &fill32, 4);
+			memcpy(dst + 8, &fill32, 4);
+			memcpy(dst + 12, &fill32, 4);
+			memcpy(dst + 16, &fill32, 4);
+			memcpy(dst + 20, &fill32, 4);
+			memcpy(dst + 24, &fill32, 4);
+			memcpy(dst + 28, &fill32, 4);
+			memcpy(dst + n - 32, &fill32, 4);
+			memcpy(dst + n - 28, &fill32, 4);
+			memcpy(dst + n - 24, &fill32, 4);
+			memcpy(dst + n - 20, &fill32, 4);
+			memcpy(dst + n - 16, &fill32, 4);
+			memcpy(dst + n - 12, &fill32, 4);
+			memcpy(dst + n - 8, &fill32, 4);
+			memcpy(dst + n - 4, &fill32, 4);
+			return;
+		}
+		if (n >= 16) {
+			memcpy(dst, &fill32, 4);
+			memcpy(dst + 4, &fill32, 4);
+			memcpy(dst + 8, &fill32, 4);
+			memcpy(dst + 12, &fill32, 4);
+			memcpy(dst + n - 16, &fill32, 4);
+			memcpy(dst + n - 12, &fill32, 4);
+			memcpy(dst + n - 8, &fill32, 4);
+			memcpy(dst + n - 4, &fill32, 4);
+			return;
+		}
+		if (n >= 8) {
+			memcpy(dst, &fill32, 4);
+			memcpy(dst + 4, &fill32, 4);
+			memcpy(dst + n - 8, &fill32, 4);
+			memcpy(dst + n - 4, &fill32, 4);
+			return;
+		}
+	}
+
+	const uint32_t fill32 = static_cast<uint32_t>(value) * 0x01010101U;
+
+	if (n >= 4) {
+		memcpy(dst, &fill32, 4);
+		memcpy(dst + n - 4, &fill32, 4);
+		return;
+	}
+
+	dst[0] = value;
+	if (n >= 2) {
+		const uint16_t fill16 = static_cast<uint16_t>(value) * 0x0101U;
+		memcpy(dst + n - 2, &fill16, 2);
+	}
+}
+
+} // namespace devilution


### PR DESCRIPTION
Add overlapped_memset.hpp with FillBytesUpTo32, FillBytesUpTo64 (moved
from light_render.cpp), and CopyBytesUpTo32. All three avoid PLT/IFUNC
dispatch overhead for small variable-length memset/memcpy calls on Linux
by using fixed-size inline memcpy calls with overlapping stores/loads.

- RenderLineOpaque<FullyDark>: use FillBytesUpTo32 instead of memset.
    Fixes ~3x slowdown vs PartiallyLit on the TransparentSquare RLE path.
- RenderLineOpaque<FullyLit>: use CopyBytesUpTo32 instead of memcpy.
    TransparentSquare FullyLit was 6x slower than FullyDark despite doing
    less work per pixel; now on par with FullyDark (~5.8x improvement).
- Remove RenderTriangleLower/Upper<FullyDark, false> loop specializations.
    Falling back to the unrolled N-template lets the compiler see each blit
    width as a compile-time constant: FullyDark triangles ~5x faster,
    trapezoids ~2x faster, RenderBlackTile ~4x faster.
- RenderLineTransparentOrOpaqueN: for static N, bypass the fill/copy
    helpers and call BlitFillDirect (FullyDark) or BlitPixelsDirect (FullyLit)
    directly, guaranteeing a single vector instruction from the compiler.

Benchmarks (ns, RelWithDebInfo, single core, CPU scaling warnings apply):

Benchmark              | Baseline | +FillUpTo32 | -LoopSpecs | +CopyUpTo32
-----------------------|----------|-------------|------------|-----------
LTri  So/FL            |  7266 ns |     8377 ns |    7745 ns |    8427 ns
LTri  So/FD            | 21506 ns |    18274 ns |    4151 ns |    5758 ns
LTri  So/PL            | 69289 ns |    61874 ns |   60053 ns |   67337 ns
LTri  Tr/FL            | 83602 ns |    77991 ns |   79224 ns |   86274 ns
LTri  Tr/FD            | 70809 ns |    68356 ns |   62336 ns |   86026 ns
LTri  Tr/PL            |109707 ns |    95830 ns |   95321 ns |  103802 ns
RTri  So/FL            |  6220 ns |     5953 ns |    6052 ns |    7392 ns
RTri  So/FD            | 17101 ns |    17778 ns |    4145 ns |    4878 ns
RTri  So/PL            | 62913 ns |    63671 ns |   64209 ns |   70015 ns
RTri  Tr/FL            | 81890 ns |    81554 ns |   79492 ns |   82832 ns
RTri  Tr/FD            | 76801 ns |    66247 ns |   63267 ns |   77821 ns
RTri  Tr/PL            | 99755 ns |   102136 ns |  100410 ns |  104500 ns
TrSq  So/FL            |322304 ns |   340121 ns |  330975 ns |   56543 ns
TrSq  So/FD            |178437 ns |    63454 ns |   54919 ns |   57429 ns
TrSq  So/PL            |127834 ns |   141316 ns |  131048 ns |  147341 ns
TrSq  Tr/FL            |141366 ns |   142851 ns |  143384 ns |  153830 ns
TrSq  Tr/FD            |125299 ns |   121498 ns |  130854 ns |  133110 ns
TrSq  Tr/PL            |183519 ns |   177058 ns |  179739 ns |  177087 ns
Sq    So/FL            |  9618 ns |     8923 ns |    8291 ns |   10151 ns
Sq    So/FD            |  4885 ns |     5449 ns |    5426 ns |    9530 ns
Sq    So/PL            |118292 ns |   122309 ns |  118639 ns |  118512 ns
Sq    Tr/FL            |166114 ns |   165816 ns |  165845 ns |  167127 ns
Sq    Tr/FD            |113779 ns |   116176 ns |  113845 ns |  118415 ns
Sq    Tr/PL            |208899 ns |   210274 ns |  207931 ns |  208100 ns
LTrap So/FL            |  2386 ns |     2663 ns |    2389 ns |    2825 ns
LTrap So/FD            |  4159 ns |     3879 ns |    1723 ns |    1924 ns
LTrap So/PL            | 31172 ns |    30478 ns |   30913 ns |   31173 ns
LTrap Tr/FL            | 41760 ns |    46841 ns |   41622 ns |   42224 ns
LTrap Tr/FD            | 31138 ns |    31824 ns |   32467 ns |   33399 ns
LTrap Tr/PL            | 54863 ns |    52467 ns |   52177 ns |   53973 ns
RTrap So/FL            |  2387 ns |     2369 ns |    2280 ns |    3046 ns
RTrap So/FD            |  3901 ns |     3772 ns |    1522 ns |    1914 ns
RTrap So/PL            | 29838 ns |    30107 ns |   30544 ns |   34756 ns
RTrap Tr/FL            | 43348 ns |    41696 ns |   40635 ns |   43537 ns
RTrap Tr/FD            | 32092 ns |    31350 ns |   31687 ns |   31598 ns
RTrap Tr/PL            | 52474 ns |    51980 ns |   51348 ns |   51540 ns
RenderBlackTile        |   98.7 ns |      107 ns |    21.2 ns |    23.8 ns