### PR TITLE
Fix Emscripten build, with support for mods and Hellfire

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,9 +419,8 @@ if(EMSCRIPTEN)
     -lidbfs.js
     --shell-file ${CMAKE_CURRENT_SOURCE_DIR}/Packaging/emscripten/index.html
   )
-  if(TARGET hellfire_copied_assets)
-    add_dependencies(${BIN_TARGET} hellfire_copied_assets)
-  endif()
+  
+  add_dependencies(${BIN_TARGET} hellfire_copied_assets)
   # Add JavaScript to load MPQ files from the server directory at runtime
   target_link_options(${BIN_TARGET} PRIVATE --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/Packaging/emscripten/emscripten_pre.js)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,13 +411,17 @@ include(Mods)
 
 if(EMSCRIPTEN)
   target_link_options(${BIN_TARGET} PRIVATE
-    --preload-file assets
+    "SHELL:--preload-file assets"
+    "SHELL:--preload-file mods"
     -sFORCE_FILESYSTEM=1
     -sALLOW_MEMORY_GROWTH=1
     -sASYNCIFY
     -lidbfs.js
     --shell-file ${CMAKE_CURRENT_SOURCE_DIR}/Packaging/emscripten/index.html
   )
+  if(TARGET hellfire_copied_assets)
+    add_dependencies(${BIN_TARGET} hellfire_copied_assets)
+  endif()
   # Add JavaScript to load MPQ files from the server directory at runtime
   target_link_options(${BIN_TARGET} PRIVATE --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/Packaging/emscripten/emscripten_pre.js)
 endif()

--- a/Source/utils/sdl_thread.cpp
+++ b/Source/utils/sdl_thread.cpp
@@ -2,7 +2,7 @@
 
 namespace devilution {
 
-#ifndef __DJGPP__
+#if !defined(__DJGPP__) && !defined(__EMSCRIPTEN__)
 int SDLCALL SdlThread::ThreadTranslate(void *ptr)
 {
 	auto handler = (void (*)())ptr;


### PR DESCRIPTION
These changes are what I had to do to get Emscripten to compile/build, as well as get Hellfire working on it, as before it didn't account for mods so it wouldn't do anything with the Hellfire .mpq files