### PR TITLE
CLX rendering: Add some DVL_ASSUME hints

### DIFF
--- a/CMake/Tests.cmake
+++ b/CMake/Tests.cmake
@@ -111,6 +111,13 @@ add_library(language_for_testing OBJECT test/language_for_testing.cpp)
 target_sources(language_for_testing INTERFACE $<TARGET_OBJECTS:language_for_testing>)
 
 target_link_dependencies(codec_test PRIVATE libdevilutionx_codec app_fatal_for_testing)
+
+add_custom_target(clx_render_benchmark_resources
+  DEPENDS
+  "${DEVILUTIONX_ASSETS_OUTPUT_DIRECTORY}/data/resistance.clx"
+  "${DEVILUTIONX_ASSETS_OUTPUT_DIRECTORY}/ui_art/dvl_lrpopup.clx"
+)
+add_dependencies(clx_render_benchmark clx_render_benchmark_resources)
 target_link_dependencies(clx_render_benchmark
   PRIVATE
   DevilutionX::SDL

--- a/Source/engine/render/clx_render.cpp
+++ b/Source/engine/render/clx_render.cpp
@@ -126,6 +126,7 @@ void DoRenderBackwardsClipY(
 					src.begin += v;
 				}
 			}
+			DVL_ASSUME(v >= 1); // All runs (transparent, fill, pixel) are at least 1px wide
 			dst += v;
 			remainingWidth -= v;
 		}

--- a/Source/utils/clx_decode.hpp
+++ b/Source/utils/clx_decode.hpp
@@ -15,7 +15,9 @@ namespace devilution {
 
 [[nodiscard]] constexpr uint8_t GetClxOpaquePixelsWidth(uint8_t control)
 {
-	return -static_cast<int8_t>(control);
+	const uint8_t width = -static_cast<int8_t>(control);
+	DVL_ASSUME(width >= 1 && width <= 65);
+	return width;
 }
 
 [[nodiscard]] constexpr bool IsClxOpaqueFill(uint8_t control)
@@ -27,7 +29,9 @@ namespace devilution {
 [[nodiscard]] constexpr uint8_t GetClxOpaqueFillWidth(uint8_t control)
 {
 	constexpr uint8_t ClxFillEnd = 0xBF;
-	return ClxFillEnd - control;
+	const uint8_t width = ClxFillEnd - control;
+	DVL_ASSUME(width >= 1 && width <= 63);
+	return width;
 }
 
 struct SkipSize {


### PR DESCRIPTION
These don't currently seem to affect performance (GCC-15). Still, they serve as documentation and perhaps future smarter compilers can't take more advantage of it.