### PR TITLE
CI: Install gettext in the SDL1 Linux workflow

### DIFF
--- a/.github/workflows/Linux_x86_64_SDL1.yml
+++ b/.github/workflows/Linux_x86_64_SDL1.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Create Build Environment
       run: >
         sudo apt-get update &&
-        sudo apt-get install -y cmake file g++ git libfmt-dev libsdl1.2-dev libsodium-dev libpng-dev libbz2-dev rpm smpq
+        sudo apt-get install -y cmake file g++ gettext git libfmt-dev libsdl1.2-dev libsodium-dev libpng-dev libbz2-dev rpm smpq
 
     - name: Cache CMake build folder
       uses: actions/cache@v5


### PR DESCRIPTION
Adds gettext to the apt-get install step in Linux_x86_64_SDL1.yml so that translation files are compiled and included in test builds. The other Linux workflows already install gettext via their prep scripts.

Closes #3801