### PR TITLE
Check asset integrity in main loop to catch lazy-loaded assets

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -902,6 +902,10 @@ void RunGameLoop(interface_mode uMsg)
 			}
 			DebugCmdsFromCommandLine.clear();
 		}
+#else
+		if (gbIsMultiplayer && IsAssetIntegrityViolated) {
+			app_fatal(_("Cannot play Multiplayer with overridden *.lua, *.tsv, or *.sol assets."));
+		}
 #endif
 
 		SDL_Event event;


### PR DESCRIPTION
Since Lua mods can invoke `require()` at any time (such as inside a Lua event handler) to load an overridden Lua script from the filesystem, the safest way to catch lazy-loaded assets is to check for it in the main loop.

<img width="778" height="514" alt="image" src="https://github.com/user-attachments/assets/f5d1d4ae-8c5a-4322-9b11-315b85424095" />