### PR TITLE
Add option to hide sensitive multiplayer info on automap

### DIFF
--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1444,9 +1444,13 @@ void DrawAutomapText(const Surface &out)
 
 	if (gbIsMultiplayer) {
 		if (GameName != "0.0.0.0" && !IsLoopback) {
-			std::string description = std::string(_("Game: "));
-			description.append(GameName);
-			drawStringAndAdvanceLine(description);
+			if (*GetOptions().Network.hideSensitiveInfo) {
+				drawStringAndAdvanceLine(_("(game name hidden)"));
+			} else {
+				std::string description = std::string(_("Game: "));
+				description.append(GameName);
+				drawStringAndAdvanceLine(description);
+			}
 		}
 
 		std::string description;
@@ -1454,6 +1458,8 @@ void DrawAutomapText(const Surface &out)
 			description = std::string(_("Offline Game"));
 		} else if (PublicGame) {
 			description = std::string(_("Public Game"));
+		} else if (*GetOptions().Network.hideSensitiveInfo) {
+			description = std::string(_("(password hidden)"));
 		} else {
 			description = std::string(_("Password: "));
 			description.append(GamePassword);

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -582,10 +582,10 @@ void OptionEntryResolution::SetActiveListIndex(size_t index)
 
 OptionEntryResampler::OptionEntryResampler()
     : OptionEntryListBase("Resampler", OptionEntryFlags::CantChangeInGame
-              // When there are exactly 2 options there is no submenu, so we need to recreate the UI
-              // to reflect the change in the "Resampling quality" setting visibility.
-              | (NumResamplers == 2 ? OptionEntryFlags::RecreateUI : OptionEntryFlags::None),
-          N_("Resampler"), N_("Audio resampler"))
+            // When there are exactly 2 options there is no submenu, so we need to recreate the UI
+            // to reflect the change in the "Resampling quality" setting visibility.
+            | (NumResamplers == 2 ? OptionEntryFlags::RecreateUI : OptionEntryFlags::None),
+        N_("Resampler"), N_("Audio resampler"))
 {
 }
 void OptionEntryResampler::LoadFromIni(std::string_view category)
@@ -941,12 +941,16 @@ std::vector<OptionEntryBase *> ControllerOptions::GetEntries()
 NetworkOptions::NetworkOptions()
     : OptionCategoryBase("Network", N_("Network"), N_("Network Settings"))
     , port("Port", OptionEntryFlags::Invisible, "Port", "What network port to use.", 6112)
+    , hideSensitiveInfo("Hide Sensitive Info", OptionEntryFlags::None,
+          N_("Hide sensitive info on automap"),
+          N_("Hides the game name, password, and any IP-derived text on the automap."),
+          false)
 {
 }
 std::vector<OptionEntryBase *> NetworkOptions::GetEntries()
 {
 	return {
-		&port,
+		&port, &hideSensitiveInfo
 	};
 }
 

--- a/Source/options.h
+++ b/Source/options.h
@@ -672,6 +672,8 @@ struct NetworkOptions : OptionCategoryBase {
 	char szPreviousHost[129];
 	/** @brief What network port to use. */
 	OptionEntryInt<uint16_t> port;
+	/** @brief Hide game name, password, and IP-derived text on the automap overlay. */
+	OptionEntryBoolean hideSensitiveInfo;
 };
 
 struct ChatOptions : OptionCategoryBase {


### PR DESCRIPTION
Streamers and screen-sharers were exposed because DrawAutomapText() always printed the game name (which for TCP direct connections is the host IP address) and the plain-text password for private games.

Adds GetOptions().Network.hideSensitiveInfo (Options > Network > Hide sensitive info on automap, default off). When enabled, the game name and password lines are replaced with placeholder text, while non-sensitive info (Offline Game, Public Game, level, difficulty) remains visible.

Fixes #8543.

Supersedes #7752.