### PR TITLE
Support Android Termux

### DIFF
--- a/3rdParty/Lua/CMakeLists.txt
+++ b/3rdParty/Lua/CMakeLists.txt
@@ -11,6 +11,16 @@ else()
   set(LUA_ENABLE_SHARED ON)
 endif()
 
+if(ANDROID AND NOT CMAKE_CROSSCOMPILING)
+  # Compiling on an Android device itself, e.g. via Termux.
+  # Lua CMake does `find_library(LIBM m)` but it cannot find it there on Android.
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(LIBM /system/lib64/libm.so)
+  else()
+    set(LIBM /system/lib/libm.so)
+  endif()
+endif()
+
 include(FetchContent)
 FetchContent_Declare_ExcludeFromAll(Lua
     URL https://github.com/walterschell/Lua/archive/3ed55a56eaa05c9221f40b3c07d0e908eb1067b0.tar.gz

--- a/3rdParty/SDL_audiolib/.editorconfig
+++ b/3rdParty/SDL_audiolib/.editorconfig
@@ -1,0 +1,2 @@
+[*.patch]
+end_of_line = lf

--- a/3rdParty/SDL_audiolib/0001-aulib_log.h-Include-missing-fmt-format.h.patch
+++ b/3rdParty/SDL_audiolib/0001-aulib_log.h-Include-missing-fmt-format.h.patch
@@ -1,0 +1,25 @@
+From e89e20a71e824a182c1ba519a9f4004686ed2433 Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Sun, 28 Jun 2026 22:50:06 +0100
+Subject: [PATCH] aulib_log.h: Include missing <fmt/format.h>
+
+This include was missing and this started causing an error recently in our CI
+---
+ src/aulib_log.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/aulib_log.h b/src/aulib_log.h
+index b87ee7d..bfd8652 100644
+--- a/src/aulib_log.h
++++ b/src/aulib_log.h
+@@ -2,6 +2,7 @@
+ #pragma once
+ #include "aulib_config.h"
+ #include <fmt/core.h>
++#include <fmt/format.h>
+ 
+ namespace aulib {
+ namespace log {
+-- 
+2.53.0
+

--- a/3rdParty/SDL_audiolib/CMakeLists.txt
+++ b/3rdParty/SDL_audiolib/CMakeLists.txt
@@ -36,10 +36,14 @@ set(USE_DEC_WILDMIDI OFF)
 set(USE_DEC_ADLMIDI OFF)
 set(USE_DEC_DRMP3 ON)
 
+find_package(Patch REQUIRED)
+
 include(FetchContent)
 FetchContent_Declare_ExcludeFromAll(SDL_audiolib
   URL https://github.com/realnc/SDL_audiolib/archive/cc1bb6af8d4cf5e200259072bde1edd1c8c5137e.tar.gz
-  URL_HASH MD5=0e8174264ac9c6b314c6b2d9a5f72efd)
+  URL_HASH MD5=0e8174264ac9c6b314c6b2d9a5f72efd
+  PATCH_COMMAND "${Patch_EXECUTABLE}" -p1 -N < "${CMAKE_CURRENT_LIST_DIR}/0001-aulib_log.h-Include-missing-fmt-format.h.patch" || true
+)
 FetchContent_MakeAvailable_ExcludeFromAll(SDL_audiolib)
 
 add_library(SDL_audiolib::SDL_audiolib ALIAS SDL_audiolib)

--- a/CMake/Definitions.cmake
+++ b/CMake/Definitions.cmake
@@ -22,6 +22,7 @@ foreach(
   UNPACKED_MPQS
   UNPACKED_SAVES
   DEVILUTIONX_WINDOWS_NO_WCHAR
+  TERMUX
 )
   if(${def_name})
     list(APPEND DEVILUTIONX_DEFINITIONS ${def_name})
@@ -101,5 +102,15 @@ foreach(
 )
   if(DEFINED ${def_name} AND NOT ${def_name} STREQUAL "")
     list(APPEND DEVILUTIONX_DEFINITIONS ${def_name}=${${def_name}})
+  endif()
+endforeach(def_name)
+
+# Defines with string value
+foreach(
+  def_name
+  CMAKE_INSTALL_PREFIX
+)
+  if(DEFINED ${def_name} AND NOT ${def_name} STREQUAL "")
+    list(APPEND DEVILUTIONX_DEFINITIONS "${def_name}=\"${${def_name}}\"")
   endif()
 endforeach(def_name)

--- a/CMake/Platforms.cmake
+++ b/CMake/Platforms.cmake
@@ -61,7 +61,13 @@ if(PS4)
 endif()
 
 if(ANDROID)
-  include(platforms/android)
+  if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Android")
+    # Natively compiling on Android, e.g. Termux.
+    include(platforms/android_termux)
+  else()
+    # Cross-compiling for Android.
+    include(platforms/android)
+  endif()
 endif()
 
 if(IOS)

--- a/CMake/platforms/android.cmake
+++ b/CMake/platforms/android.cmake
@@ -1,3 +1,5 @@
+# Cross-compiling for Android.
+
 # General build options.
 set(BUILD_TESTING OFF)
 

--- a/CMake/platforms/android_termux.cmake
+++ b/CMake/platforms/android_termux.cmake
@@ -1,0 +1,5 @@
+# Compiling on an Android device itself, e.g. via Termux.
+#
+# In this scenario, Android is more like a regular Linux platform,
+# and the NDK is not available.
+set(TERMUX ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,7 +368,7 @@ elseif(TARGET_PLATFORM STREQUAL "dos")
   set(BIN_TARGET devx)
 endif()
 
-if(ANDROID)
+if(ANDROID AND NOT TERMUX)
   add_library(${BIN_TARGET} SHARED Source/main.cpp)
 elseif(UWP_LIB)
   set(BIN_TARGET libdevilutionx)
@@ -419,7 +419,7 @@ if(EMSCRIPTEN)
     -lidbfs.js
     --shell-file ${CMAKE_CURRENT_SOURCE_DIR}/Packaging/emscripten/index.html
   )
-  
+
   add_dependencies(${BIN_TARGET} hellfire_copied_assets)
   # Add JavaScript to load MPQ files from the server directory at runtime
   target_link_options(${BIN_TARGET} PRIVATE --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/Packaging/emscripten/emscripten_pre.js)

--- a/Source/DiabloUI/hero/selhero.cpp
+++ b/Source/DiabloUI/hero/selhero.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/dialogs.h"

--- a/Source/DiabloUI/multi/selconn.cpp
+++ b/Source/DiabloUI/multi/selconn.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/ui_flags.hpp"

--- a/Source/DiabloUI/multi/selgame.cpp
+++ b/Source/DiabloUI/multi/selgame.cpp
@@ -18,6 +18,7 @@
 #endif
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "DiabloUI/diabloui.h"
 #include "DiabloUI/hero/selhero.h"

--- a/Source/control/control_chat_commands.cpp
+++ b/Source/control/control_chat_commands.cpp
@@ -1,6 +1,8 @@
 #include "control_chat_commands.hpp"
 #include "control.hpp"
 
+#include <fmt/format.h>
+
 #include "diablo_msg.hpp"
 #include "engine/backbuffer_state.hpp"
 #include "inv.h"

--- a/Source/control/control_gold.cpp
+++ b/Source/control/control_gold.cpp
@@ -1,6 +1,8 @@
 #include "control.hpp"
 #include "control_chat.hpp"
 
+#include <fmt/format.h>
+
 #include "DiabloUI/text_input.hpp"
 #include "engine/render/clx_render.hpp"
 #include "inv.h"

--- a/Source/control/control_infobox.cpp
+++ b/Source/control/control_infobox.cpp
@@ -1,6 +1,8 @@
 #include "control.hpp"
 #include "control_panel.hpp"
 
+#include <fmt/format.h>
+
 #include "engine/render/primitive_render.hpp"
 #include "inv.h"
 #include "levels/trigs.h"

--- a/Source/control/control_panel.cpp
+++ b/Source/control/control_panel.cpp
@@ -3,6 +3,8 @@
 #include "control_chat.hpp"
 #include "control_flasks.hpp"
 
+#include <fmt/format.h>
+
 #include "automap.h"
 #include "controls/control_mode.hpp"
 #include "controls/modifier_hints.h"

--- a/Source/data/value_reader.cpp
+++ b/Source/data/value_reader.cpp
@@ -1,6 +1,7 @@
 #include "data/value_reader.hpp"
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "appfat.h"
 

--- a/Source/dvlnet/tcp_client.cpp
+++ b/Source/dvlnet/tcp_client.cpp
@@ -15,6 +15,7 @@
 
 #include <asio/connect.hpp>
 #include <expected.hpp>
+#include <fmt/format.h>
 
 #include "options.h"
 #include "utils/language.h"

--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <string_view>
 #include <vector>
 
 #ifdef USE_SDL3
@@ -167,7 +168,7 @@ AssetRef FindAsset(std::string_view filename)
 	if (result.directHandle != nullptr)
 		return result;
 
-#if defined(__ANDROID__) || defined(__APPLE__)
+#if (defined(__ANDROID__) && !defined(TERMUX)) || defined(__APPLE__)
 	// Fall back to the bundled assets on supported systems.
 	// This is handled by SDL when we pass a relative path.
 	if (!paths::AssetsPath().empty()) {
@@ -404,6 +405,12 @@ std::vector<std::string> GetMPQSearchPaths()
 		paths.emplace_back("/usr/local/share/diasurgical/devilutionx/");
 		paths.emplace_back("/usr/share/diasurgical/devilutionx/");
 	}
+#elif defined(TERMUX)
+#ifdef CMAKE_INSTALL_PREFIX
+	paths.emplace_back(CMAKE_INSTALL_PREFIX "/share/diasurgical/devilutionx/");
+#else
+	paths.emplace_back("/usr/share/diasurgical/devilutionx/");
+#endif
 #elif defined(NXDK)
 	paths.emplace_back("D:\\");
 #elif defined(_WIN32) && !defined(__UWP__) && !defined(DEVILUTIONX_WINDOWS_NO_WCHAR)
@@ -439,7 +446,7 @@ void LoadCoreArchives()
 {
 	auto paths = GetMPQSearchPaths();
 
-#if !defined(__ANDROID__) && !defined(__APPLE__) && !defined(__3DS__) && !defined(__SWITCH__)
+#if !(defined(__ANDROID__) && !defined(TERMUX)) && !defined(__APPLE__) && !defined(__3DS__) && !defined(__SWITCH__)
 	// Load devilutionx.mpq first to get the font file for error messages
 #ifdef __DJGPP__
 	LoadMPQ(paths, "devx", DevilutionXMpqPriority);

--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -14,6 +14,8 @@
 #include <SDL.h>
 #endif
 
+#include <fmt/format.h>
+
 #include "appfat.h"
 #include "game_mode.hpp"
 #include "utils/file_util.h"

--- a/Source/engine/render/text_render.cpp
+++ b/Source/engine/render/text_render.cpp
@@ -16,6 +16,7 @@
 
 #include <ankerl/unordered_dense.h>
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "DiabloUI/ui_flags.hpp"
 #include "engine/clx_sprite.hpp"

--- a/Source/engine/render/text_render.hpp
+++ b/Source/engine/render/text_render.hpp
@@ -14,6 +14,8 @@
 #include <variant>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include "DiabloUI/ui_flags.hpp"
 #include "engine/clx_sprite.hpp"
 #include "engine/palette.h"

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "DiabloUI/ui_flags.hpp"
 #include "control/control.hpp"

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -32,6 +32,7 @@
 
 #include <expected.hpp>
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "automap.h"
 #include "control/control.hpp"

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -13,6 +13,7 @@
 
 #include <expected.hpp>
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "DiabloUI/ui_flags.hpp"
 #include "automap.h"

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -118,7 +118,7 @@ void DiscoverMods()
 
 std::optional<Ini> ini;
 
-#if defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
+#if (defined(__ANDROID__) && !defined(TERMUX)) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
 constexpr OptionEntryFlags OnlyIfSupportsWindowed = OptionEntryFlags::Invisible;
 #else
 constexpr OptionEntryFlags OnlyIfSupportsWindowed = OptionEntryFlags::None;

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -7,6 +7,8 @@
 
 #include <cstdint>
 
+#include <fmt/format.h>
+
 #include "engine/random.hpp"
 #include "game_mode.hpp"
 #include "items/validation.h"

--- a/Source/platform/locale.cpp
+++ b/Source/platform/locale.cpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <string_view>
 
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && !defined(TERMUX)
 #include <SDL.h>
 #include <jni.h>
 #elif defined(__vita__)
@@ -61,7 +61,7 @@ std::string IetfToPosix(std::string_view langCode)
 std::vector<std::string> GetLocales()
 {
 	std::vector<std::string> locales {};
-#ifdef __ANDROID__
+#if defined(__ANDROID__) && !defined(TERMUX)
 	JNIEnv *env = (JNIEnv *)SDL_AndroidGetJNIEnv();
 	jobject activity = (jobject)SDL_AndroidGetActivity();
 	jclass clazz(env->GetObjectClass(activity));

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -15,6 +15,7 @@
 #endif
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "control/control.hpp"
 #include "controls/control_mode.hpp"

--- a/Source/qol/xpbar.cpp
+++ b/Source/qol/xpbar.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "control/control.hpp"
 #include "engine/clx_sprite.hpp"

--- a/Source/tables/monstdat.cpp
+++ b/Source/tables/monstdat.cpp
@@ -16,6 +16,7 @@
 #include <ankerl/unordered_dense.h>
 #include <expected.hpp>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <magic_enum/magic_enum.hpp>
 
 #include "appfat.h"

--- a/Source/tables/textdat.cpp
+++ b/Source/tables/textdat.cpp
@@ -7,6 +7,7 @@
 
 #include <ankerl/unordered_dense.h>
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <magic_enum/magic_enum.hpp>
 
 #include "data/file.hpp"

--- a/Source/utils/ini.cpp
+++ b/Source/utils/ini.cpp
@@ -17,6 +17,7 @@
 #include <ankerl/unordered_dense.h>
 #include <expected.hpp>
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "utils/algorithm/container.hpp"
 #include "utils/str_cat.hpp"

--- a/docs/building.md
+++ b/docs/building.md
@@ -329,6 +329,28 @@ In Android Studio, go to "Build -> Make Project" or use the shortcut Ctrl+F9
 You can find the compiled APK in `/android-project/app/build/outputs/apk/`
 </details>
 
+<details><summary>Android Termux</summary>
+
+### Installing dependencies on Debian and Ubuntu
+
+```
+pkg i which getconf cmake gettext libsodium sdl2 sdl2-image zlib bzip2 fmt
+```
+
+### If you want to build the devilutionX.mpq File (optional)
+
+```
+NOSUDO=1 tools/build_and_install_smpq.sh
+```
+
+### Compiling
+
+```bash
+cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$PREFIX" -DDEVILUTIONX_SYSTEM_BENCHMARK=OFF -DDISABLE_ZERO_TIER=ON
+cmake --build build -j $(nproc)
+```
+</details>
+
 <details><summary>Nintendo Switch</summary>
 
 ### Installing dependencies

--- a/tools/build_and_install_smpq.sh
+++ b/tools/build_and_install_smpq.sh
@@ -4,11 +4,17 @@
 #
 # Useful when developing on systems that do not have an SMPQ package.
 # Compatible with Linux, *BSD, and macOS.
-# Requires: cmake curl sed sudo zlib bzip2
+# Requires: cmake curl sed zlib bzip2
+#
+# Uses `sudo` by default but can be disabled by setting the environment variable `NOSUDO=1`.
+# Installs to the default system prefix unless the environment variable `PREFIX` is set to a different path.
 
 set -ex
-
-PARALLELISM="$(getconf _NPROCESSORS_ONLN)"
+if [ -f "${PREFIX}/bin/nproc" ]; then
+	PARALLELISM="$("${PREFIX}/bin/nproc")"
+else
+	PARALLELISM="$(getconf _NPROCESSORS_ONLN)"
+fi
 if [ "$PARALLELISM" = "undefined" ] && [ -f /usr/sbin/sysctl ]; then
 	# On older OSX, such as 10.4, _NPROCESSOR_ONLN is not defined.
 	if [ -z "$CC" ]; then
@@ -18,23 +24,24 @@ if [ "$PARALLELISM" = "undefined" ] && [ -f /usr/sbin/sysctl ]; then
 	PARALLELISM="$(/usr/sbin/sysctl -n hw.ncpu)"
 fi
 
+TMP_DIR="$(mktemp -d)"
 STORMLIB_VERSION=e01d93cc8ae743cfe2da5450854c5d2e3a939265
-STORMLIB_SRC="/tmp/StormLib-$STORMLIB_VERSION"
+STORMLIB_SRC="${TMP_DIR}/StormLib-$STORMLIB_VERSION"
 SMPQ_VERSION=1.7
-SMPQ_SRC="/tmp/smpq-$SMPQ_VERSION"
+SMPQ_SRC="${TMP_DIR}/smpq-$SMPQ_VERSION"
 
 # Download, build, and install the static version of StormLib, an SMPQ dependency, to the staging prefix.
 if ! [ -d "$STORMLIB_SRC" ]; then
-	curl -L -s "https://github.com/ladislav-zezula/StormLib/archive/${STORMLIB_VERSION}.tar.gz" | tar -C /tmp -xvzf -
+	curl -L -s "https://github.com/ladislav-zezula/StormLib/archive/${STORMLIB_VERSION}.tar.gz" | tar -C "$TMP_DIR" -xvzf -
 fi
 
-cmake -S"$STORMLIB_SRC" -B"$STORMLIB_SRC"/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/tmp/smpq-staging -DBUILD_SHARED_LIBS=OFF \
+cmake -S"$STORMLIB_SRC" -B"$STORMLIB_SRC"/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${TMP_DIR}/smpq-staging" -DBUILD_SHARED_LIBS=OFF \
 	-DWITH_STATIC=ON -DSTORM_BUILD_TESTS=OFF -DWITH_LIBTOMCRYPT=OFF
 cmake --build "$STORMLIB_SRC"/build --config Release --target install -j"$PARALLELISM"
 
 # Download, build, and install SMPQ.
 if ! [ -d "$SMPQ_SRC" ]; then
-	curl -L -s "https://launchpad.net/smpq/trunk/${SMPQ_VERSION}/+download/smpq_${SMPQ_VERSION}.orig.tar.gz" | tar -C /tmp -xvzf -
+	curl -L -s "https://launchpad.net/smpq/trunk/${SMPQ_VERSION}/+download/smpq_${SMPQ_VERSION}.orig.tar.gz" | tar -C "$TMP_DIR" -xvzf -
 
 	# StormLib.a is C++ and must be linked with a C++ linker (e.g. via g++ instead of gcc).
 	sed -i.bak -e '/^project/a\
@@ -57,6 +64,19 @@ SET_SOURCE_FILES_PROPERTIES(${CFILES} PROPERTIES LANGUAGE CXX)' "$SMPQ_SRC"/CMak
 fi
 
 # The StormLib version check in SMPQ CMake is broken. We bypass it by passing the paths to StormLib explicitly.
-cmake -S"$SMPQ_SRC" -B"$SMPQ_SRC"/build -DCMAKE_BUILD_TYPE=Release -DWITH_KDE=OFF -DCMAKE_PREFIX_PATH=/tmp/smpq-staging \
-	-DSTORMLIB_INCLUDE_DIR=/tmp/smpq-staging/include -DSTORMLIB_LIBRARY=/tmp/smpq-staging/lib/libstorm.a
-sudo cmake --build "$SMPQ_SRC"/build --config Release --target install -j"$PARALLELISM"
+cmake_configure_args=""
+if ! [ -z "$PREFIX" ]; then
+	cmake_configure_args="${cmake_args} -DCMAKE_INSTALL_PREFIX='${PREFIX}'"
+fi
+cmake -S"$SMPQ_SRC" -B"$SMPQ_SRC"/build -DCMAKE_BUILD_TYPE=Release -DWITH_KDE=OFF -DCMAKE_PREFIX_PATH="${TMP_DIR}/smpq-staging" \
+	-DSTORMLIB_INCLUDE_DIR="${TMP_DIR}/smpq-staging/include" -DSTORMLIB_LIBRARY="${TMP_DIR}/smpq-staging/lib/libstorm.a" \
+	${cmake_configure_args}
+
+if [ NOSUDO ]; then
+	SUDO=
+else
+	SUDO=sudo
+fi
+$SUDO cmake --build "$SMPQ_SRC"/build --config Release --target install -j"$PARALLELISM"
+
+rm -rf "$TMP_DIR"


### PR DESCRIPTION
Our CMake assumed that `ANDROID` meant we're compiling for Android from a non-Android machine.

However, these days it's entirely possible to use an Android device as a Linux desktop (e.g. via Termux).

Here it is on my Pixel 9 Fold, built on the device itself and running in Termux:X11 + XFCE:

<img width="1901" height="1970" alt="image" src="https://github.com/user-attachments/assets/3b4367e2-a223-4625-8577-6465be9dcdd0" />
