### PR TITLE
Update mpqfs

### DIFF
--- a/3rdParty/mpqfs/CMakeLists.txt
+++ b/3rdParty/mpqfs/CMakeLists.txt
@@ -3,11 +3,16 @@ include(functions/FetchContent_ExcludeFromAll_backport)
 include(FetchContent)
 
 FetchContent_Declare_ExcludeFromAll(mpqfs
-    GIT_REPOSITORY https://github.com/diasurgical/mpqfs.git
-    GIT_TAG c4e1327feb4620d42f183fed6e8aab9133719192
+    URL https://github.com/diasurgical/mpqfs/archive/ee29f596bd01822ae0edf01bcf3564cb9e6ea781.tar.gz
+    URL_HASH MD5=bb5503213e0f22f00fdd8c350fe40b19
 )
 FetchContent_MakeAvailable_ExcludeFromAll(mpqfs)
 
 if(MPQFS_FILE_BUFFER_SIZE)
-  target_compile_definitions(mpqfs PRIVATE "MPQFS_FILE_BUFFER_SIZE=${MPQFS_FILE_BUFFER_SIZE}")
+  target_compile_definitions(mpqfs_obj PRIVATE "MPQFS_FILE_BUFFER_SIZE=${MPQFS_FILE_BUFFER_SIZE}")
+endif()
+
+
+if(DEVILUTIONX_WINDOWS_NO_WCHAR)
+  target_compile_definitions(mpqfs_obj PRIVATE MPQFS_WINDOWS_NO_WCHAR)
 endif()

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -623,6 +623,7 @@ if(SUPPORTS_MPQ)
     DevilutionX::SDL
     fmt::fmt
     mpqfs::mpqfs
+    tl
     libdevilutionx_file_util
   )
 else()

--- a/Source/engine/assets.cpp
+++ b/Source/engine/assets.cpp
@@ -354,25 +354,26 @@ bool FindMPQ(std::span<const std::string> paths, std::string_view mpqName)
 
 bool LoadMPQ(std::span<const std::string> paths, std::string_view mpqName, int priority, std::string_view ext = ".mpq")
 {
-	std::optional<MpqArchive> archive;
 	std::string mpqAbsPath;
-	std::int32_t error = 0;
+	bool foundButFailed = false;
 	for (const auto &path : paths) {
 		mpqAbsPath = StrCat(path, mpqName, ext);
-		archive = MpqArchive::Open(mpqAbsPath.c_str(), error);
-		if (archive.has_value()) {
-			LogVerbose("  Found: {} in {}", mpqName, path);
-			auto [it, inserted] = MpqArchives.emplace(priority, *std::move(archive));
-			if (!inserted) {
-				LogError("MPQ with priority {} is already registered, skipping {}", priority, mpqName);
-			}
-			return true;
+		if (!FileExists(mpqAbsPath))
+			continue;
+		tl::expected<MpqArchive, std::string> archive = MpqArchive::Open(mpqAbsPath.c_str());
+		if (!archive.has_value()) {
+			foundButFailed = true;
+			LogError("Error {}: {}", archive.error(), mpqAbsPath);
+			continue;
 		}
-		if (error != 0) {
-			LogError("Error {}: {}", MpqArchive::ErrorMessage(), mpqAbsPath);
+		LogVerbose("  Found: {} in {}", mpqName, path);
+		auto [it, inserted] = MpqArchives.emplace(priority, *std::move(archive));
+		if (!inserted) {
+			LogError("MPQ with priority {} is already registered, skipping {}", priority, mpqName);
 		}
+		return true;
 	}
-	if (error == 0) {
+	if (!foundButFailed) {
 		LogVerbose("Missing: {}", mpqName);
 	}
 

--- a/Source/mpq/mpq_reader.cpp
+++ b/Source/mpq/mpq_reader.cpp
@@ -1,23 +1,42 @@
 #include "mpq/mpq_reader.hpp"
 
+#include <cerrno>
 #include <cstring>
+#include <limits>
+#include <string>
+#include <string_view>
 #include <utility>
 
 #include <mpqfs/mpqfs.h>
 
-#include "utils/file_util.h"
+#include "utils/str_cat.hpp"
 
 namespace devilution {
 
+namespace {
+
 // Helper: NUL-terminate a string_view into a stack buffer.
 // Returns false if the name doesn't fit.
-static bool CopyToPathBuf(std::string_view sv, char *buf, size_t bufSize)
+bool CopyToPathBuf(std::string_view sv, char *buf, size_t bufSize)
 {
 	if (sv.size() >= bufSize) return false;
 	std::memcpy(buf, sv.data(), sv.size());
 	buf[sv.size()] = '\0';
 	return true;
 }
+
+// mpqfs_error_message() only describes the general category of failure; for
+// I/O errors the specific OS error is only available via errno immediately
+// after the failing call, so it's folded in here for diagnostics.
+std::string FormatMpqfsError(mpqfs_error_code code)
+{
+	if (code == MPQFS_ERR_IO) {
+		return StrCat(mpqfs_error_message(code), ": ", std::strerror(errno));
+	}
+	return mpqfs_error_message(code);
+}
+
+} // namespace
 
 MpqArchive::MpqArchive(std::string path, mpqfs_archive_t *archive)
     : path_(std::move(path))
@@ -48,36 +67,24 @@ MpqArchive::~MpqArchive()
 	mpqfs_close(archive_);
 }
 
-std::optional<MpqArchive> MpqArchive::Open(const char *path, int32_t &error)
+tl::expected<MpqArchive, std::string> MpqArchive::Open(const char *path)
 {
-	if (!FileExists(path)) {
-		error = 0;
-		return std::nullopt;
+	mpqfs_archive_t *handle = nullptr;
+	const mpqfs_error_code code = mpqfs_open(path, &handle);
+	if (code != MPQFS_OK) {
+		return tl::make_unexpected(FormatMpqfsError(code));
 	}
-	mpqfs_archive_t *handle = mpqfs_open(path);
-	if (!handle) {
-		error = -1;
-		return std::nullopt;
-	}
-	error = 0;
 	return MpqArchive(path, handle);
 }
 
-std::optional<MpqArchive> MpqArchive::Clone(int32_t &error)
+tl::expected<MpqArchive, std::string> MpqArchive::Clone()
 {
-	mpqfs_archive_t *clone = mpqfs_clone(archive_);
-	if (!clone) {
-		error = -1;
-		return std::nullopt;
+	mpqfs_archive_t *clone = nullptr;
+	const mpqfs_error_code code = mpqfs_clone(archive_, &clone);
+	if (code != MPQFS_OK) {
+		return tl::make_unexpected(FormatMpqfsError(code));
 	}
-	error = 0;
 	return MpqArchive(path_, clone);
-}
-
-const char *MpqArchive::ErrorMessage()
-{
-	const char *msg = mpqfs_last_error();
-	return msg ? msg : "Unknown error";
 }
 
 bool MpqArchive::HasFile(std::string_view filename) const
@@ -93,14 +100,18 @@ size_t MpqArchive::GetFileSize(std::string_view filename) const
 	char buf[256];
 	if (!CopyToPathBuf(filename, buf, sizeof(buf)))
 		return 0;
-	return mpqfs_file_size(archive_, buf);
+	size_t size = 0;
+	if (mpqfs_file_size(archive_, buf, &size) != MPQFS_OK)
+		return 0;
+	return size;
 }
 
 uint32_t MpqArchive::FindHash(std::string_view filename) const
 {
 	char buf[256];
-	if (!CopyToPathBuf(filename, buf, sizeof(buf)))
-		return UINT32_MAX;
+	if (!CopyToPathBuf(filename, buf, sizeof(buf))) {
+		return std::numeric_limits<uint32_t>::max();
+	}
 	return mpqfs_find_hash(archive_, buf);
 }
 
@@ -111,7 +122,10 @@ bool MpqArchive::HasFileHash(uint32_t hash) const
 
 size_t MpqArchive::GetFileSizeFromHash(uint32_t hash) const
 {
-	return mpqfs_file_size_from_hash(archive_, hash);
+	size_t size = 0;
+	if (mpqfs_file_size_from_hash(archive_, hash, &size) != MPQFS_OK)
+		return 0;
+	return size;
 }
 
 std::unique_ptr<std::byte[]> MpqArchive::ReadFile(
@@ -123,22 +137,23 @@ std::unique_ptr<std::byte[]> MpqArchive::ReadFile(
 		return nullptr;
 	}
 
-	const size_t size = mpqfs_file_size(archive_, buf);
-	if (size == 0) {
-		error = -1;
+	size_t size = 0;
+	mpqfs_error_code code = mpqfs_file_size(archive_, buf, &size);
+	if (code != MPQFS_OK) {
+		error = static_cast<int32_t>(code);
 		return nullptr;
 	}
 
 	auto result = std::make_unique<std::byte[]>(size);
-	const size_t read = mpqfs_read_file_into(archive_, buf,
-	    result.get(), size);
-	if (read == 0) {
-		error = -1;
+	size_t bytesRead = 0;
+	code = mpqfs_read_file_into(archive_, buf, result.get(), size, &bytesRead);
+	if (code != MPQFS_OK) {
+		error = static_cast<int32_t>(code);
 		return nullptr;
 	}
 
 	error = 0;
-	fileSize = read;
+	fileSize = bytesRead;
 	return result;
 }
 

--- a/Source/mpq/mpq_reader.hpp
+++ b/Source/mpq/mpq_reader.hpp
@@ -3,9 +3,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <string>
 #include <string_view>
+
+#include <expected.hpp>
 
 // Forward-declare so that we can avoid exposing mpqfs.h to all consumers.
 struct mpqfs_archive;
@@ -15,9 +16,8 @@ namespace devilution {
 
 class MpqArchive {
 public:
-	static std::optional<MpqArchive> Open(const char *path, int32_t &error);
-	std::optional<MpqArchive> Clone(int32_t &error);
-	static const char *ErrorMessage();
+	static tl::expected<MpqArchive, std::string> Open(const char *path);
+	tl::expected<MpqArchive, std::string> Clone();
 
 	MpqArchive(MpqArchive &&other) noexcept;
 	MpqArchive &operator=(MpqArchive &&other) noexcept;

--- a/Source/mpq/mpq_sdl_rwops.cpp
+++ b/Source/mpq/mpq_sdl_rwops.cpp
@@ -59,8 +59,7 @@ static MpqStreamCtx *CreateCtx(mpqfs_archive_t *archive,
 	mpqfs_archive_t *clone = nullptr;
 
 	if (threadsafe) {
-		clone = mpqfs_clone(archive);
-		if (clone == nullptr)
+		if (mpqfs_clone(archive, &clone) != MPQFS_OK)
 			return nullptr;
 		target = clone;
 	}
@@ -69,12 +68,12 @@ static MpqStreamCtx *CreateCtx(mpqfs_archive_t *archive,
 
 	/* Try the fast hash-based path first (avoids re-hashing). */
 	if (hashIndex != UINT32_MAX)
-		stream = mpqfs_stream_open_from_hash(target, hashIndex);
+		(void)mpqfs_stream_open_from_hash(target, hashIndex, &stream);
 
 	/* Fall back to filename-based open (needed for encrypted files and
 	 * when hashIndex is not available). */
 	if (stream == nullptr)
-		stream = mpqfs_stream_open(target, filename);
+		(void)mpqfs_stream_open(target, filename, &stream);
 
 	if (stream == nullptr) {
 		if (clone != nullptr)
@@ -102,7 +101,13 @@ static MpqStreamCtx *CreateCtx(mpqfs_archive_t *archive,
 static Sint64 SDLCALL MpqStream_Size(void *userdata)
 {
 	auto *ctx = static_cast<MpqStreamCtx *>(userdata);
-	return static_cast<Sint64>(mpqfs_stream_size(ctx->stream));
+	size_t size = 0;
+	const mpqfs_error_code code = mpqfs_stream_size(ctx->stream, &size);
+	if (code != MPQFS_OK) {
+		SDL_SetError("%s", mpqfs_error_message(code));
+		return -1;
+	}
+	return static_cast<Sint64>(size);
 }
 
 static Sint64 SDLCALL MpqStream_Seek(void *userdata, Sint64 offset, SDL_IOWhence whence)
@@ -117,9 +122,10 @@ static Sint64 SDLCALL MpqStream_Seek(void *userdata, Sint64 offset, SDL_IOWhence
 		SDL_SetError("MpqStream_Seek: unknown whence");
 		return -1;
 	}
-	int64_t pos = mpqfs_stream_seek(ctx->stream, offset, w);
-	if (pos < 0) {
-		SDL_SetError("MpqStream_Seek: seek failed");
+	int64_t pos = 0;
+	const mpqfs_error_code code = mpqfs_stream_seek(ctx->stream, offset, w, &pos);
+	if (code != MPQFS_OK) {
+		SDL_SetError("%s", mpqfs_error_message(code));
 		return -1;
 	}
 	return static_cast<Sint64>(pos);
@@ -128,11 +134,12 @@ static Sint64 SDLCALL MpqStream_Seek(void *userdata, Sint64 offset, SDL_IOWhence
 static size_t SDLCALL MpqStream_Read(void *userdata, void *ptr, size_t size, SDL_IOStatus *status)
 {
 	auto *ctx = static_cast<MpqStreamCtx *>(userdata);
-	size_t n = mpqfs_stream_read(ctx->stream, ptr, size);
-	if (n == static_cast<size_t>(-1)) {
+	size_t n = 0;
+	const mpqfs_error_code code = mpqfs_stream_read(ctx->stream, ptr, size, &n);
+	if (code != MPQFS_OK) {
 		if (status != nullptr)
 			*status = SDL_IO_STATUS_ERROR;
-		SDL_SetError("MpqStream_Read: read failed");
+		SDL_SetError("%s", mpqfs_error_message(code));
 		return 0;
 	}
 	if (n == 0 && size > 0) {
@@ -149,7 +156,7 @@ static size_t SDLCALL MpqStream_Write(void * /*userdata*/, const void * /*ptr*/,
     size_t /*size*/, SDL_IOStatus *status)
 {
 	if (status != nullptr)
-		*status = SDL_IO_STATUS_ERROR;
+		*status = SDL_IO_STATUS_READONLY;
 	SDL_SetError("MpqStream_Write: read-only stream");
 	return 0;
 }
@@ -183,7 +190,13 @@ using SizeType = int;
 static Sint64 SDLCALL MpqStream_Size(SDL_RWops *rw)
 {
 	auto *ctx = static_cast<MpqStreamCtx *>(rw->hidden.unknown.data1);
-	return static_cast<Sint64>(mpqfs_stream_size(ctx->stream));
+	size_t size = 0;
+	const mpqfs_error_code code = mpqfs_stream_size(ctx->stream, &size);
+	if (code != MPQFS_OK) {
+		SDL_SetError("%s", mpqfs_error_message(code));
+		return -1;
+	}
+	return static_cast<Sint64>(size);
 }
 #endif
 
@@ -201,9 +214,10 @@ static OffsetType SDLCALL MpqStream_Seek(SDL_RWops *rw, OffsetType offset, int w
 		return -1;
 	}
 
-	int64_t pos = mpqfs_stream_seek(ctx->stream, offset, w);
-	if (pos < 0) {
-		SDL_SetError("MpqStream_Seek: seek failed");
+	int64_t pos = 0;
+	const mpqfs_error_code code = mpqfs_stream_seek(ctx->stream, offset, w, &pos);
+	if (code != MPQFS_OK) {
+		SDL_SetError("%s", mpqfs_error_message(code));
 		return -1;
 	}
 
@@ -216,9 +230,12 @@ static SizeType SDLCALL MpqStream_Read(SDL_RWops *rw, void *ptr,
 	auto *ctx = static_cast<MpqStreamCtx *>(rw->hidden.unknown.data1);
 
 	size_t totalBytes = static_cast<size_t>(size) * static_cast<size_t>(maxnum);
-	size_t n = mpqfs_stream_read(ctx->stream, ptr, totalBytes);
-	if (n == static_cast<size_t>(-1))
+	size_t n = 0;
+	const mpqfs_error_code code = mpqfs_stream_read(ctx->stream, ptr, totalBytes, &n);
+	if (code != MPQFS_OK) {
+		SDL_SetError("%s", mpqfs_error_message(code));
 		return 0;
+	}
 
 	/* Return number of whole objects read. */
 	return (size > 0) ? static_cast<SizeType>(n / static_cast<size_t>(size)) : 0;

--- a/Source/mpq/mpq_writer.cpp
+++ b/Source/mpq/mpq_writer.cpp
@@ -1,6 +1,8 @@
 #include "mpq/mpq_writer.hpp"
 
+#include <cerrno>
 #include <cstring>
+#include <string>
 #include <utility>
 
 #include <mpqfs/mpqfs.h>
@@ -8,8 +10,24 @@
 #include "mpq/mpq_common.hpp"
 #include "utils/file_util.h"
 #include "utils/log.hpp"
+#include "utils/str_cat.hpp"
 
 namespace devilution {
+
+namespace {
+
+// mpqfs_error_message() only describes the general category of failure; for
+// I/O errors the specific OS error is only available via errno immediately
+// after the failing call, so it's folded in here for diagnostics.
+std::string FormatMpqfsError(mpqfs_error_code code)
+{
+	if (code == MPQFS_ERR_IO) {
+		return StrCat(mpqfs_error_message(code), ": ", std::strerror(errno));
+	}
+	return mpqfs_error_message(code);
+}
+
+} // namespace
 
 MpqWriter::MpqWriter(const char *path, bool carryForward)
     : path_(path)
@@ -30,14 +48,14 @@ MpqWriter::MpqWriter(const char *path, bool carryForward)
 		// Remove any stale temp file, then rename old → tmp.
 		::devilution::RemoveFile(tmpPath.c_str());
 		::devilution::RenameFile(path, tmpPath.c_str());
-		oldArchive = mpqfs_open(tmpPath.c_str());
 		// If it fails to open (e.g. corrupt), we proceed without
 		// carry-forward — the file will be recreated from scratch.
+		(void)mpqfs_open(tmpPath.c_str(), &oldArchive);
 	}
 
-	writer_ = mpqfs_writer_create(path, MpqWriterHashTableSize);
-	if (writer_ == nullptr) {
-		LogError("Failed to create MPQ archive: {}", mpqfs_last_error());
+	const mpqfs_error_code code = mpqfs_writer_create(path, MpqWriterHashTableSize, &writer_);
+	if (code != MPQFS_OK) {
+		LogError("Failed to write MPQ archive to {}: {}", path, FormatMpqfsError(code));
 		if (oldArchive != nullptr)
 			mpqfs_close(oldArchive);
 		if (!tmpPath.empty())
@@ -46,8 +64,9 @@ MpqWriter::MpqWriter(const char *path, bool carryForward)
 	}
 
 	if (oldArchive != nullptr) {
-		if (!mpqfs_writer_carry_forward_all(writer_, oldArchive)) {
-			LogError("Failed to carry forward files from existing archive: {}", mpqfs_last_error());
+		const mpqfs_error_code carryForwardCode = mpqfs_writer_carry_forward_all(writer_, oldArchive);
+		if (carryForwardCode != MPQFS_OK) {
+			LogError("Failed to carry forward files from existing archive {}: {}", path, FormatMpqfsError(carryForwardCode));
 		}
 		mpqfs_close(oldArchive);
 	}
@@ -82,8 +101,9 @@ MpqWriter::~MpqWriter()
 
 	LogVerbose("Closing {}", path_);
 
-	if (!mpqfs_writer_close(writer_)) {
-		LogError("Failed to close MPQ archive: {}", mpqfs_last_error());
+	const mpqfs_error_code code = mpqfs_writer_close(writer_);
+	if (code != MPQFS_OK) {
+		LogError("Failed to close MPQ archive {}: {}", path_, FormatMpqfsError(code));
 	}
 }
 
@@ -112,7 +132,8 @@ void MpqWriter::RemoveHashEntry(std::string_view filename)
 	std::memcpy(buf, filename.data(), filename.size());
 	buf[filename.size()] = '\0';
 
-	mpqfs_writer_remove_file(writer_, buf);
+	// Not found (or already removed) is not an error condition here.
+	(void)mpqfs_writer_remove_file(writer_, buf);
 }
 
 void MpqWriter::RemoveHashEntries(bool (*fnGetName)(uint8_t, char *))
@@ -136,10 +157,11 @@ bool MpqWriter::WriteFile(std::string_view filename, const std::byte *data, size
 
 	// Remove any previous entry with this name so that
 	// only the latest write is included in the archive.
-	mpqfs_writer_remove_file(writer_, buf);
+	(void)mpqfs_writer_remove_file(writer_, buf);
 
-	if (!mpqfs_writer_add_file(writer_, buf, data, size)) {
-		LogError("Failed to write file '{}' to MPQ: {}", filename, mpqfs_last_error());
+	const mpqfs_error_code code = mpqfs_writer_add_file(writer_, buf, data, size);
+	if (code != MPQFS_OK) {
+		LogError("Failed to write file '{}' to MPQ {}: {}", filename, path_, FormatMpqfsError(code));
 		return false;
 	}
 	return true;
@@ -159,7 +181,7 @@ void MpqWriter::RenameFile(std::string_view name, std::string_view newName)
 	std::memcpy(newBuf, newName.data(), newName.size());
 	newBuf[newName.size()] = '\0';
 
-	mpqfs_writer_rename_file(writer_, oldBuf, newBuf);
+	(void)mpqfs_writer_rename_file(writer_, oldBuf, newBuf);
 }
 
 } // namespace devilution

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -5,7 +5,9 @@
  */
 #include "pfile.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -19,6 +21,7 @@
 #include <SDL.h>
 #endif
 
+#include "appfat.h"
 #include "codec.h"
 #include "engine/load_file.hpp"
 #include "engine/render/primitive_render.hpp"
@@ -251,8 +254,9 @@ std::optional<SaveReader> CreateSaveReader(std::string &&path)
 		return std::nullopt;
 	return SaveReader(std::move(path));
 #else
-	std::int32_t error;
-	return MpqArchive::Open(path.c_str(), error);
+	tl::expected<MpqArchive, std::string> opened = MpqArchive::Open(path.c_str());
+	if (!opened.has_value()) return std::nullopt;
+	return std::move(*opened);
 #endif
 }
 

--- a/Source/platform/android/android.cpp
+++ b/Source/platform/android/android.cpp
@@ -8,9 +8,8 @@ namespace {
 
 bool AreExtraFontsOutOfDateForMpqPath(const char *mpqPath)
 {
-	int32_t error = 0;
-	std::optional<MpqArchive> archive = MpqArchive::Open(mpqPath, error);
-	return error == 0 && archive && AreExtraFontsOutOfDate(*archive);
+	tl::expected<MpqArchive, std::string> archive = MpqArchive::Open(mpqPath);
+	return archive.has_value() && AreExtraFontsOutOfDate(*archive);
 }
 
 } // namespace


### PR DESCRIPTION
`mpqfs` API changed from bool/NULL return values and a global `mpqfs_last_error()` to `mpqfs_error_code` return values.

`MpqArchive::Open/Clone` now return `tl::expected<MpqArchive, std::string>`