### PR TITLE
Use computed damage variable in GuardianTryFireAt

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -731,7 +731,7 @@ bool GuardianTryFireAt(Missile &missile, Point target)
 	dmg = ScaleSpellEffect(dmg, missile._mispllvl);
 
 	const Direction dir = GetDirection(position, target);
-	AddMissile(position, target, dir, MissileID::Firebolt, TARGET_MONSTERS, missile._misource, missile._midam, missile.sourcePlayer()->GetSpellLevel(SpellID::Guardian), &missile);
+	AddMissile(position, target, dir, MissileID::Firebolt, TARGET_MONSTERS, missile._misource, dmg, missile.sourcePlayer()->GetSpellLevel(SpellID::Guardian), &missile);
 	missile.setFrameGroup<GuardianFrame>(GuardianFrame::Attack);
 	missile.var2 = 3;
 


### PR DESCRIPTION
Guardian damage was adjusted to use the Guardian-specific damage formula instead of recomputing damage based on the Firebolt spell. This was done in #5731 and #5740. Unfortunately, this was reverted by accident in a rebase of #5681 very shortly afterward so there has never been a release version of DevilutionX that includes the proper fix.