### PR TITLE
Fixed info in spellbook regarding Healing and HealOther

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -117,9 +117,7 @@ int AddClassHealingBonus(int hp, HeroClass heroClass, SpellID spellId)
 	case HeroClass::Bard:
 		return hp + (hp / 2);
 	case HeroClass::Monk:
-		return spellId == SpellID::HealOther
-			? hp * 3
-			: hp * 2;
+		return spellId == SpellID::HealOther ? hp * 3 : hp * 2;
 	default:
 		return hp;
 	}

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -107,16 +107,19 @@ void Missile::setAnimation(MissileGraphicID animtype)
 
 namespace {
 
-int AddClassHealingBonus(int hp, HeroClass heroClass)
+int AddClassHealingBonus(int hp, HeroClass heroClass, SpellID spellId)
 {
 	switch (heroClass) {
 	case HeroClass::Warrior:
-	case HeroClass::Monk:
 	case HeroClass::Barbarian:
 		return hp * 2;
 	case HeroClass::Rogue:
 	case HeroClass::Bard:
 		return hp + (hp / 2);
+	case HeroClass::Monk:
+		return spellId == SpellID::HealOther
+			? hp * 3
+			: hp * 2;
 	default:
 		return hp;
 	}
@@ -891,8 +894,8 @@ DamageRange GetDamageAmt(SpellID spell, int spellLevel)
 	case SpellID::HealOther:
 		/// BUGFIX: healing calculation is unused
 		return {
-			AddClassHealingBonus(myPlayer.getCharacterLevel() + spellLevel + 1, myPlayer._pClass),
-			AddClassHealingBonus((4 * myPlayer.getCharacterLevel()) + (6 * spellLevel) + 10, myPlayer._pClass)
+			AddClassHealingBonus(myPlayer.getCharacterLevel() + spellLevel + 1, myPlayer._pClass, spell),
+			AddClassHealingBonus((4 * myPlayer.getCharacterLevel()) + (6 * spellLevel) + 10, myPlayer._pClass, spell)
 		};
 	case SpellID::RuneOfLight:
 	case SpellID::Lightning:

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -891,8 +891,8 @@ DamageRange GetDamageAmt(SpellID spell, int spellLevel)
 	case SpellID::HealOther:
 		/// BUGFIX: healing calculation is unused
 		return {
-			AddClassHealingBonus(myPlayer.getCharacterLevel() + spellLevel + 1, myPlayer._pClass) - 1,
-			AddClassHealingBonus((4 * myPlayer.getCharacterLevel()) + (6 * spellLevel) + 10, myPlayer._pClass) - 1
+			AddClassHealingBonus(myPlayer.getCharacterLevel() + spellLevel + 1, myPlayer._pClass),
+			AddClassHealingBonus((4 * myPlayer.getCharacterLevel()) + (6 * spellLevel) + 10, myPlayer._pClass)
 		};
 	case SpellID::RuneOfLight:
 	case SpellID::Lightning:


### PR DESCRIPTION
Spellbook had two errors regarding these spells:
• Min and max were incorrectly lowered by 1.
• HealOther didn't include Monk's buff (his multiplier is 3x, not 2x).

These are the actual healing values:
https://github.com/diasurgical/DevilutionX/blob/d8150ec6dac1672f9a705b6d4ebd6ad90825d012/Source/missiles.cpp#L2455-L2475
https://github.com/diasurgical/DevilutionX/blob/d8150ec6dac1672f9a705b6d4ebd6ad90825d012/Source/spells.cpp#L281-L309