### PR TITLE
Fix two crashes when running in HeadlessMode

### DIFF
--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -322,10 +322,19 @@ void effects_play_sound(SfxID id)
 
 int GetSFXLength(SfxID nSFX)
 {
+	// Headless/no-audio: the SFX table is never loaded -- indexing the empty
+	// vector is UB and crashed on the Butcher's greeting (InitQTextMsg, L2).
+	if (sgSFX.empty())
+		return 0;
 	TSFX &sfx = sgSFX[static_cast<int16_t>(nSFX)];
 	if (sfx.pSnd == nullptr)
 		sfx.pSnd = sound_file_load(sfx.pszName.c_str(),
 		    /*stream=*/AllowStreaming && (sfx.bFlags & sfx_STREAM) != 0);
+	// Headless/no-audio: sound_file_load may legitimately return nullptr;
+	// quest text (InitQTextMsg) then times itself from text length instead
+	// of crashing here (e.g. the Butcher's greeting on L2).
+	if (sfx.pSnd == nullptr)
+		return 0;
 	return sfx.pSnd->DSB.GetLength();
 }
 

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -67,6 +67,10 @@ uint32_t CalculateTextSpeed(SfxID nSFX)
 
 #ifndef NOSOUND
 	uint32_t sfxFrames = GetSFXLength(nSFX);
+	// Headless/no-audio: sound length is unavailable (0) -- fall back to the
+	// same line-count estimate the NOSOUND build uses.
+	if (sfxFrames == 0)
+		sfxFrames = numLines * 3000;
 #else
 	// Sound is disabled -- estimate length from the number of lines.
 	uint32_t sfxFrames = numLines * 3000;

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2240,13 +2240,22 @@ void InitMissileAnimationFromMonster(Missile &mis, Direction midir, const Monste
 	const AnimStruct &anim = mon.type().getAnimData(graphic);
 	mis.setDirection(midir);
 	mis._miAnimFlags = MissileGraphicsFlags::None;
-	const ClxSpriteList sprites = *anim.spritesForDirection(midir);
-	const uint16_t width = sprites[0].width();
-	mis._miAnimData.emplace(sprites);
+	// In HeadlessMode monster sprites are not loaded and spritesForDirection()
+	// returns nullopt; dereferencing it unconditionally crashes (e.g. bat swoop
+	// via AddRhino). Skip only the graphic fields; missile logic stays intact.
+	const OptionalClxSpriteList spritesOpt = anim.spritesForDirection(midir);
+	if (spritesOpt) {
+		const ClxSpriteList sprites = *spritesOpt;
+		const uint16_t width = sprites[0].width();
+		mis._miAnimData.emplace(sprites);
+		mis._miAnimWidth = width;
+		mis._miAnimWidth2 = CalculateSpriteTileCenterX(width);
+	} else {
+		mis._miAnimWidth = 0;
+		mis._miAnimWidth2 = 0;
+	}
 	mis._miAnimDelay = anim.rate;
 	mis._miAnimLen = anim.frames;
-	mis._miAnimWidth = width;
-	mis._miAnimWidth2 = CalculateSpriteTileCenterX(width);
 	mis._miAnimAdd = 1;
 	mis.var1 = 0;
 	mis.var2 = 0;


### PR DESCRIPTION
Context: I run the engine headless (no graphics, no audio) as an RL training environment ([AlphaDiablo / DiabloGym](https://github.com/Diabolically-Handsome/AlphaDiablo)). Two reproducible crashes surfaced once agents reached dungeon level 2, both from resources that are legitimately absent in that mode. Upstreaming them as suggested by @rouming in #7974.

**1. Monster-sourced missiles (`Source/missiles.cpp`)**

`InitMissileAnimationFromMonster()` dereferences `anim.spritesForDirection(midir)` unconditionally. In HeadlessMode monster sprites are never loaded, so it is `nullopt` — first hit when a bat's swoop spawned a Rhino missile. The fix guards only the sprite fields; direction, frame count and timing are still set, so missile behavior is unchanged.

**2. Quest-text SFX length (`Source/effects.cpp`, `Source/minitext.cpp`)**

The Butcher's greeting calls `InitQTextMsg` → `CalculateTextSpeed` → `GetSFXLength`, which indexes `sgSFX` — an empty vector when audio never initialized. The fix also guards `pSnd == nullptr` after `sound_file_load()`, which can legitimately fail even with audio present. `GetSFXLength` now returns 0 in both cases, and `CalculateTextSpeed` falls back to the same line-count estimate the `NOSOUND` build already uses.

**Testing**

- Both fixes have been running in my headless fork (based on 34c4cfc) for several days across thousands of RL episodes, including the exact former crash sites (bat swoops on L2, the Butcher's greeting).
- Graphics/audio builds are unaffected: the new branches only trigger when sprites/SFX are absent; when resources load, behavior is identical.
- Branch is based on current `master`; the only intervening change to these files (GuardianTryFireAt damage) does not interact.
