### PR TITLE
Fix compiler warning in ProcessWeaponExplosion()

### DIFF
--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -3608,7 +3608,6 @@ void ProcessWeaponExplosion(Missile &missile)
 	constexpr int ExpLight[10] = { 9, 10, 11, 12, 11, 10, 8, 6, 4, 2 };
 
 	missile.duration--;
-	const Player &player = Players[missile._misource];
 	if (missile.var1 == 0) {
 		missile._mlid = AddLight(missile.position.tile, 9);
 	} else {


### PR DESCRIPTION
```
.../DevilutionX/Source/missiles.cpp: In function ‘void devilution::ProcessWeaponExplosion(Missile&)’:
.../DevilutionX/Source/missiles.cpp:3611:23: warning: unused variable ‘player’ [-Wunused-variable]
 3611 |         const Player &player = Players[missile._misource];
      |                       ^~~~~~
```