### PR TITLE
Fix town level loading in HeadlessMode when Hellfire data is absent

### DIFF
--- a/Source/engine/load_file.hpp
+++ b/Source/engine/load_file.hpp
@@ -10,7 +10,6 @@
 
 #include "appfat.h"
 #include "engine/assets.hpp"
-#include "headless_mode.hpp"
 #include "mpq/mpq_common.hpp"
 #include "utils/static_vector.hpp"
 #include "utils/str_cat.hpp"
@@ -23,7 +22,6 @@ tl::expected<void, std::string> LoadFileInMemWithStatus(const char *path, T *dat
 	size_t size;
 	AssetHandle handle = OpenAsset(path, size);
 	if (!handle.ok()) {
-		if (HeadlessMode) return {};
 		return tl::make_unexpected(FailedToOpenFileErrorMessage(path, handle.error()));
 	}
 	if ((size % sizeof(T)) != 0) {
@@ -41,7 +39,6 @@ tl::expected<void, std::string> LoadIntegralFileInMemWithStatus(const char *path
 	size_t size;
 	AssetHandle handle = OpenIntegralAsset(path, size);
 	if (!handle.ok()) {
-		if (HeadlessMode) return {};
 		return tl::make_unexpected(FailedToOpenFileErrorMessage(path, handle.error()));
 	}
 	if ((size % sizeof(T)) != 0) {
@@ -65,7 +62,6 @@ tl::expected<void, std::string> LoadFileInMemWithStatus(const char *path, T *dat
 {
 	AssetHandle handle = OpenAsset(path);
 	if (!handle.ok()) {
-		if (HeadlessMode) return {};
 		return tl::make_unexpected(FailedToOpenFileErrorMessage(path, handle.error()));
 	}
 	if (!handle.read(data, count * sizeof(T))) {
@@ -106,7 +102,6 @@ tl::expected<std::unique_ptr<T[]>, std::string> LoadFileInMemWithStatus(const ch
 	size_t size;
 	AssetHandle handle = OpenAsset(path, size);
 	if (!handle.ok()) {
-		if (HeadlessMode) return {};
 		return tl::make_unexpected(FailedToOpenFileErrorMessage(path, handle.error()));
 	}
 	if ((size % sizeof(T)) != 0) {


### PR DESCRIPTION
## Root cause

In `HeadlessMode`, a failed open in the file loaders reports **success with a null buffer** (`load_file.hpp` early-returns `{}`). The Hellfire→Diablo town asset fallbacks in `LoadLvlGFX` / `LoadMinData` only probe `has_value()`, so with Diablo-only data — the same data shape the timedemo CI uses (`spawn.mpq`) — the fallback never triggers.

## Consequences (headless, Diablo-only data, entering town)

- `LoadMinData` returns a null `town.min` with **uninitialized `tileCount`**, and `SetDungeonMicros` walks garbage bounds over a null pointer;
- `T_FillSector` dereferences a null `pMegaTiles` (note `CleanTownFountain` already defends against exactly this null);
- town `SOLData` silently keeps the previous level's values, breaking walkability/collision and demo sync.

## Fix

Treat "success with a null buffer" as missing for the town cel/til/min fallbacks, and probe the asset before choosing the SOL source. No behavior change outside `HeadlessMode`: in graphical builds a successful load never yields a null buffer, so the new checks are dead branches there.

## Testing

Running in our headless RL embedding ([diablogym](https://github.com/diasurgical/devilutionX/pull/7974)) across thousands of episodes with both `spawn.mpq` and full `DIABDAT.MPQ`. Follow-up to #8606, per @rouming's suggestion in #7974 to upstream headless fixes.

An alternative root-cause fix would be changing the headless success-with-null contract in `load_file.hpp` itself; this PR keeps the targeted fix in the spirit of #8606 — happy to rework if you prefer the contract change.

---

**Update (rework per review):** now fixed at the source instead — the four `if (HeadlessMode) return {};` swallows in `load_file.hpp` are removed (with the now-unused include), so missing files report the same error as in graphical builds and the existing town fallbacks work unmodified. −5 lines, no call-site changes. Details in the comment below.