### PR TITLE
Skip video playback in HeadlessMode

### DIFF
--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -21,6 +21,7 @@
 #include "engine/demomode.h"
 #include "engine/events.hpp"
 #include "engine/sound.h"
+#include "headless_mode.hpp"
 #include "hwcursor.hpp"
 #include "storm/storm_svid.h"
 #include "utils/display.h"
@@ -36,6 +37,11 @@ bool loop_movie;
 void play_movie(const char *pszMovie, bool userCanClose)
 {
 	if (demo::IsRunning())
+		return;
+
+	// Video playback requires the SDL video subsystem, which HeadlessMode
+	// intentionally does not initialize.
+	if (HeadlessMode)
 		return;
 
 	movie_playing = true;


### PR DESCRIPTION
`play_movie()` only early-outs for demo playback, but `SVidPlayBegin` requires the SDL video subsystem that `HeadlessMode` intentionally never initializes — so any **real-time (non-demo) headless session** crashes on the first movie it reaches. In practice that is:

- the Lazarus in-game movie (`gendata\fprst3.smk`, `LazarusAi`), and
- the victory/ending cinematics (`diabvic*/diabend.smk`) when Diablo dies.

## Fix

Early-return from `play_movie()` in `HeadlessMode`, mirroring the existing `demo::IsRunning()` guard right above it. One guard covers every callsite (intro logos, Lazarus movie, victory/ending, credits loop). The fade/redraw code around `PlayInGameMovie` is already headless-safe (`palette.cpp`/`dx.cpp` carry `HeadlessMode` guards), so the early-out is sufficient.

No behavior change in graphical builds.

## Context

Found in our headless RL embedding (see #7974): a real-time agent reaching Lazarus deterministically crashed here. Same family as #8606 (approved) — upstreaming per @rouming's suggestion in #7974.