### PR TITLE
Add "Enemies Remaining" counter (Lua mod) + right-column alignment cleanup

### DIFF
--- a/CMake/Assets.cmake
+++ b/CMake/Assets.cmake
@@ -164,6 +164,7 @@ set(devilutionx_assets
   lua/inspect.lua
   lua/mods/adria_refills_mana/init.lua
   lua/mods/clock/init.lua
+  lua/mods/enemies_remaining/init.lua
   "lua/mods/Floating Numbers - Damage/init.lua"
   "lua/mods/Floating Numbers - XP/init.lua"
   lua/repl_prelude.lua

--- a/Source/lua/modules/monsters.cpp
+++ b/Source/lua/modules/monsters.cpp
@@ -9,8 +9,6 @@
 #include "lua/metadoc.hpp"
 #include "monster.h"
 #include "tables/monstdat.h"
-#include "utils/language.h"
-#include "utils/str_split.hpp"
 
 namespace devilution {
 
@@ -43,6 +41,16 @@ void InitMonsterUserType(sol::state_view &lua)
 	    });
 }
 
+int AliveEnemyCount()
+{
+	return GetAliveEnemyCount();
+}
+
+int TotalSpawnedEnemies()
+{
+	return LevelSpawnedMonsters - ReservedMonsterSlotsForGolems;
+}
+
 } // namespace
 
 sol::table LuaMonstersModule(sol::state_view &lua)
@@ -51,6 +59,12 @@ sol::table LuaMonstersModule(sol::state_view &lua)
 	sol::table table = lua.create_table();
 	LuaSetDocFn(table, "addMonsterDataFromTsv", "(path: string)", AddMonsterDataFromTsv);
 	LuaSetDocFn(table, "addUniqueMonsterDataFromTsv", "(path: string)", AddUniqueMonsterDataFromTsv);
+	LuaSetDocFn(table, "aliveEnemyCount", "() -> integer",
+	    "Returns the number of hostile monsters currently alive on the active level (excludes player-summoned golems).",
+	    AliveEnemyCount);
+	LuaSetDocFn(table, "totalSpawnedEnemies", "() -> integer",
+	    "Returns the high-water-mark of hostile monsters ever spawned on the active level (excludes the 4 reserved golem slots). Returns <= 0 when no enemies have spawned this level.",
+	    TotalSpawnedEnemies);
 	return table;
 }
 

--- a/Source/lua/modules/render.cpp
+++ b/Source/lua/modules/render.cpp
@@ -6,16 +6,29 @@
 #include "engine/dx.h"
 #include "engine/render/text_render.hpp"
 #include "lua/metadoc.hpp"
-#include "utils/display.h"
+#include "utils/ui_fwd.h"
 
 namespace devilution {
 
 sol::table LuaRenderModule(sol::state_view &lua)
 {
 	sol::table table = lua.create_table();
-	LuaSetDocFn(table, "string", "(text: string, x: integer, y: integer)",
+	LuaSetDocFn(table, "string", "(text: string, x: integer, y: integer, opts: { flags?: integer, width?: integer })",
 	    "Renders a string at the given coordinates",
-	    [](std::string_view text, int x, int y) { DrawString(GlobalBackBuffer(), text, { x, y }); });
+	    [](std::string_view text, int x, int y, sol::table opts) {
+		    TextRenderOptions renderOpts {};
+		    int rectWidth = GlobalBackBuffer().w() - x;
+
+		    sol::object flagsObj = opts["flags"];
+		    if (flagsObj.is<lua_Number>() || flagsObj.is<lua_Integer>())
+			    renderOpts.flags = static_cast<UiFlags>(flagsObj.as<int>());
+
+		    sol::object widthObj = opts["width"];
+		    if (widthObj.is<lua_Number>() || widthObj.is<lua_Integer>())
+			    rectWidth = widthObj.as<int>();
+
+		    DrawString(GlobalBackBuffer(), text, { { x, y }, { rectWidth, 0 } }, renderOpts);
+	    });
 	LuaSetDocFn(table, "screen_width", "()",
 	    "Returns the screen width", []() { return gnScreenWidth; });
 	LuaSetDocFn(table, "screen_height", "()",

--- a/Source/lua/modules/system.cpp
+++ b/Source/lua/modules/system.cpp
@@ -1,5 +1,8 @@
 #include "lua/modules/system.hpp"
 
+#include <algorithm>
+#include <string>
+
 #include <sol/sol.hpp>
 
 #ifdef USE_SDL3
@@ -9,6 +12,7 @@
 #endif
 
 #include "lua/metadoc.hpp"
+#include "options.h"
 
 namespace devilution {
 
@@ -18,6 +22,13 @@ sol::table LuaSystemModule(sol::state_view &lua)
 
 	LuaSetDocFn(table, "get_ticks", "() -> integer", "Returns the number of milliseconds since the game started.",
 	    []() { return static_cast<int>(SDL_GetTicks()); });
+
+	LuaSetDocFn(table, "is_mod_active", "(name: string) -> boolean",
+	    "Returns true if the named mod is currently enabled.",
+	    [](const std::string &name) {
+		    const auto activeMods = GetOptions().Mods.GetActiveModList();
+		    return std::ranges::find(activeMods.begin(), activeMods.end(), name) != activeMods.end();
+	    });
 
 	return table;
 }

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -9,7 +9,6 @@
 #include <array>
 #include <bitset>
 #include <cassert>
-#include <climits>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -37,7 +36,6 @@
 #include "cursor.h"
 #include "dead.h"
 #include "diablo.h"
-#include "dvlnet/leaveinfo.hpp"
 #include "effects.h"
 #include "engine/animationinfo.h"
 #include "engine/backbuffer_state.hpp"
@@ -113,6 +111,8 @@ size_t LevelMonsterTypeCount;
 Monster Monsters[MaxMonsters];
 unsigned ActiveMonsters[MaxMonsters];
 size_t ActiveMonsterCount;
+/** High-water-mark of hostile monsters (non-golem) ever spawned on the current level. */
+int LevelSpawnedMonsters;
 /** Tracks the total number of monsters killed per monster_id. */
 int MonsterKillCounts[NUM_MAX_MTYPES];
 bool sgbSaveSoundOn;
@@ -124,9 +124,6 @@ constexpr int HellToHitBonus = 120;
 
 constexpr int NightmareAcBonus = 50;
 constexpr int HellAcBonus = 80;
-
-/** @brief Reserved some entries in @Monster for golems. For vanilla compatibility, this must remain 4. */
-constexpr int ReservedMonsterSlotsForGolems = 4;
 
 /** Tracks which missile files are already loaded */
 size_t totalmonsters;
@@ -3423,6 +3420,7 @@ void InitLevelMonsters()
 
 	ClrAllMonsters();
 	ActiveMonsterCount = 0;
+	LevelSpawnedMonsters = 0;
 	totalmonsters = MaxMonsters;
 
 	std::iota(std::begin(ActiveMonsters), std::end(ActiveMonsters), 0U);
@@ -3744,7 +3742,29 @@ std::expected<void, std::string> InitMonsters()
 		}
 	}
 
+	LevelSpawnedMonsters = static_cast<int>(ActiveMonsterCount);
+
 	return InitAllMonsterGFX();
+}
+
+int GetAliveEnemyCount()
+{
+	int alive = 0;
+	for (size_t i = 0; i < ActiveMonsterCount; ++i) {
+		const Monster &monster = Monsters[ActiveMonsters[i]];
+		if (monster.isInvalid)
+			continue;
+		if ((monster.flags & MFLAG_GOLEM) != 0)
+			continue;
+		if (monster.mode == MonsterMode::Death)
+			continue;
+		if (monster.hasNoLife())
+			continue;
+		if (monster.position.tile == GolemHoldingCell)
+			continue;
+		++alive;
+	}
+	return alive;
 }
 
 std::expected<void, std::string> SetMapMonsters(const uint16_t *dunData, Point startPosition)
@@ -3777,15 +3797,15 @@ std::expected<void, std::string> SetMapMonsters(const uint16_t *dunData, Point s
 
 Monster *AddMonster(Point position, Direction dir, size_t typeIndex, bool inMap)
 {
-	if (ActiveMonsterCount < MaxMonsters) {
-		Monster &monster = Monsters[ActiveMonsters[ActiveMonsterCount++]];
-		if (inMap)
-			monster.occupyTile(position, false);
-		InitMonster(monster, dir, typeIndex, position);
-		return &monster;
-	}
-
-	return nullptr;
+	if (ActiveMonsterCount >= MaxMonsters)
+		return nullptr;
+	Monster &monster = Monsters[ActiveMonsters[ActiveMonsterCount++]];
+	if (inMap)
+		monster.occupyTile(position, false);
+	InitMonster(monster, dir, typeIndex, position);
+	if ((monster.flags & MFLAG_GOLEM) == 0)
+		++LevelSpawnedMonsters;
+	return &monster;
 }
 
 void SpawnMonster(Point position, Direction dir, size_t typeIndex)
@@ -3799,6 +3819,7 @@ void SpawnMonster(Point position, Direction dir, size_t typeIndex)
 
 	const size_t monsterIndex = ActiveMonsters[ActiveMonsterCount];
 	ActiveMonsterCount += 1;
+	++LevelSpawnedMonsters;
 	const uint32_t seed = GetLCGEngineState();
 	// Update local state immediately to increase ActiveMonsterCount instantly (this allows multiple monsters to be spawned in one game tick)
 	InitializeSpawnedMonster(position, dir, typeIndex, monsterIndex, seed, 0, 0);

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -35,6 +35,8 @@ struct Missile;
 struct Player;
 
 constexpr size_t MaxMonsters = 200;
+/** @brief Number of inactive golem placeholder slots always present in @ActiveMonsters. For vanilla compatibility, this must remain 4. */
+inline constexpr int ReservedMonsterSlotsForGolems = 4;
 constexpr size_t MaxLvlMTypes = 24;
 
 enum monster_flag : uint16_t {
@@ -493,8 +495,13 @@ extern size_t LevelMonsterTypeCount;
 extern Monster Monsters[MaxMonsters];
 extern unsigned ActiveMonsters[MaxMonsters];
 extern size_t ActiveMonsterCount;
+/** @brief High-water-mark of hostile monsters (non-golem) ever spawned on the current level. */
+extern int LevelSpawnedMonsters;
 extern int MonsterKillCounts[NUM_MAX_MTYPES];
 extern bool sgbSaveSoundOn;
+
+/** @brief Counts the number of currently-alive hostile monsters on the current level (excludes player-summoned golems). */
+int GetAliveEnemyCount();
 
 std::expected<void, std::string> PrepareUniqueMonst(Monster &monster, UniqueMonsterType monsterType, size_t miniontype, int bosspacksize, const UniqueMonsterData &uniqueMonsterData);
 void InitLevelMonsters();

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -44,7 +44,6 @@
 #include "utils/log.hpp"
 #include "utils/logged_fstream.hpp"
 #include "utils/paths.h"
-#include "utils/sdl_ptrs.h"
 #include "utils/str_cat.hpp"
 #include "utils/str_split.hpp"
 #include "utils/utf8.hpp"
@@ -72,7 +71,7 @@ namespace {
 void DiscoverMods()
 {
 	// Add mods available by default:
-	std::unordered_set<std::string> modNames = { "clock", "adria_refills_mana", "Floating Numbers - Damage", "Floating Numbers - XP" };
+	std::unordered_set<std::string> modNames = { "clock", "adria_refills_mana", "enemies_remaining", "Floating Numbers - Damage", "Floating Numbers - XP" };
 
 	if (HaveHellfire()) {
 		modNames.insert("hf");

--- a/assets/lua/mods/clock/init.lua
+++ b/assets/lua/mods/clock/init.lua
@@ -2,5 +2,8 @@ local events = require("devilutionx.events")
 local render = require("devilutionx.render")
 
 events.GameDrawComplete.add(function()
-  render.string(os.date('%H:%M:%S', os.time()), render.screen_width() - 76, 6)
+  local x = 8
+  local width = render.screen_width() - 16
+  render.string(os.date('%H:%M:%S', os.time()), x, 8,
+    { flags = render.UiFlags.AlignRight, width = width })
 end)

--- a/assets/lua/mods/enemies_remaining/init.lua
+++ b/assets/lua/mods/enemies_remaining/init.lua
@@ -1,0 +1,22 @@
+-- Enemies Remaining counter
+-- Displays the number of hostile monsters still alive on the current level,
+-- e.g. "Enemies: 106 / 150".
+
+local events = require("devilutionx.events")
+local monsters = require("devilutionx.monsters")
+local render = require("devilutionx.render")
+local system = require("devilutionx.system")
+
+events.GameDrawComplete.add(function()
+	local total = monsters.totalSpawnedEnemies()
+	if total <= 0 then
+		return
+	end
+	local alive = monsters.aliveEnemyCount()
+	local text = string.format("Enemies: %d / %d", alive, total)
+	local y = system.is_mod_active("clock") and 23 or 8
+	local x = 8
+	local width = render.screen_width() - 16
+	render.string(text, x, y,
+		{ flags = render.UiFlags.AlignRight, width = width })
+end)


### PR DESCRIPTION
Adds a built-in Lua mod `enemies_remaining` that shows hostile monsters still alive on the current level 
(e.g. `Enemies: 12 / 150`), enabled under **Settings → Mods**. 
Also re-aligns the clock mod to match the left column's 8px margin convention.

Per prior review feedback, the mod is implemented in Lua; the engine surface is limited to small helper bindings and counter bookkeeping.

---

**Why the `render.string` change looks heavier than expected**

`UiFlags::AlignRight` is **rect-relative**, not point-relative. The convenience `DrawString` overload at `text_render.hpp:244` auto-constructs a rect of `{position, {out.w() - position.x, 0}}`.  so its right edge always lands at `screen_width`, no matter what `x` you pass. With `AlignRight` the text's right edge follows the rect's right edge, so passing `x = screen_width - 8` would still put the text flush against the screen edge with **zero** margin.

To get a real 8px right margin the rect itself has to end at `screen_width - 8`, which is why the right column passes `width = screen_width - 16` (left margin 8 + right margin 8). The two extra `is<lua_Number>()` checks per field are there because Lua types are dynamic, `as<int>()` would throw on a string or table, and we want `render.string` to degrade gracefully on bad input rather than aborting the whole draw.

PS: also cleaned up some imports (unused) 

<img width="1032" height="578" alt="image" src="https://github.com/user-attachments/assets/7e3c2a62-5271-4010-9f93-e7c71d258958" />

