### PR TITLE
Translation: Update zh_CN.po

### DIFF
--- a/Translations/zh_CN.po
+++ b/Translations/zh_CN.po
@@ -1,12 +1,12 @@
 # Translation of DevilutionX to Chinese (Simplified)
 # @muziling, 2021.
-# @tytannial, 2021.
+# @tytannial, 2026.
 # Aaron Sun <AaronSun.Test@gmail.com>, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: DevilutionX\n"
-"POT-Creation-Date: 2025-10-02 15:21+0200\n"
+"POT-Creation-Date: 2026-07-13 16:55+0800\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Tytannial <Tytannial@outlook.com>\n"
 "Language-Team: Emiliano Augusto Gonzalez\n"
@@ -15,31 +15,31 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.6\n"
-"X-Poedit-SourceCharset: UTF-8\n"
-"X-Poedit-KeywordsList: _;N_;P_:1c,2\n"
+"X-Generator: Poedit 3.9\n"
 "X-Poedit-Basepath: ..\n"
+"X-Poedit-KeywordsList: _;N_;P_:1c,2\n"
+"X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: Source\n"
 
 #: Source/DiabloUI/credits_lines.cpp:9
 msgid "Game Design"
-msgstr "游戏​设计"
+msgstr "游戏设计"
 
 #: Source/DiabloUI/credits_lines.cpp:12
 msgid "Senior Designers"
-msgstr "高级​设计师"
+msgstr "高级设计师"
 
 #: Source/DiabloUI/credits_lines.cpp:15 Source/DiabloUI/credits_lines.cpp:234
 msgid "Additional Design"
-msgstr "附加​设计"
+msgstr "附加设计"
 
 #: Source/DiabloUI/credits_lines.cpp:18 Source/DiabloUI/credits_lines.cpp:217
 msgid "Lead Programmer"
-msgstr "首席​程序员"
+msgstr "首席程序员"
 
 #: Source/DiabloUI/credits_lines.cpp:21
 msgid "Senior Programmers"
-msgstr "高级​程序员"
+msgstr "高级程序员"
 
 #: Source/DiabloUI/credits_lines.cpp:25
 msgid "Programming"
@@ -47,23 +47,23 @@ msgstr "编程"
 
 #: Source/DiabloUI/credits_lines.cpp:28
 msgid "Special Guest Programmers"
-msgstr "特​邀​程序员"
+msgstr "特邀程序员"
 
 #: Source/DiabloUI/credits_lines.cpp:31
 msgid "Battle.net Programming"
-msgstr "战网​编程"
+msgstr "战网编程"
 
 #: Source/DiabloUI/credits_lines.cpp:34
 msgid "Serial Communications Programming"
-msgstr "串行​通信​编程"
+msgstr "串行通信编程"
 
 #: Source/DiabloUI/credits_lines.cpp:37
 msgid "Installer Programming"
-msgstr "安装​程序​编程"
+msgstr "安装程序编程"
 
 #: Source/DiabloUI/credits_lines.cpp:40
 msgid "Art Directors"
-msgstr "艺术​总监"
+msgstr "艺术总监"
 
 #: Source/DiabloUI/credits_lines.cpp:43
 msgid "Artwork"
@@ -71,23 +71,23 @@ msgstr "艺术品"
 
 #: Source/DiabloUI/credits_lines.cpp:50
 msgid "Technical Artwork"
-msgstr "技术​艺术品"
+msgstr "技术艺术品"
 
 #: Source/DiabloUI/credits_lines.cpp:54
 msgid "Cinematic Art Directors"
-msgstr "电影​艺术​导演"
+msgstr "电影艺术导演"
 
 #: Source/DiabloUI/credits_lines.cpp:57
 msgid "3D Cinematic Artwork"
-msgstr "3D​电影​艺术品"
+msgstr "3D电影艺术品"
 
 #: Source/DiabloUI/credits_lines.cpp:63
 msgid "Cinematic Technical Artwork"
-msgstr "电影​技术​艺术品"
+msgstr "电影技术艺术品"
 
 #: Source/DiabloUI/credits_lines.cpp:66
 msgid "Executive Producer"
-msgstr "执行​制片人"
+msgstr "执行制片人"
 
 #: Source/DiabloUI/credits_lines.cpp:69
 msgid "Producer"
@@ -95,36 +95,36 @@ msgstr "制作人"
 
 #: Source/DiabloUI/credits_lines.cpp:72
 msgid "Associate Producer"
-msgstr "副​制片人"
+msgstr "副制片人"
 
 #. TRANSLATORS: Keep Strike Team as Name
 #: Source/DiabloUI/credits_lines.cpp:75
 msgid "Diablo Strike Team"
-msgstr "破坏​神​突击队"
+msgstr "破坏神突击队"
 
-#: Source/DiabloUI/credits_lines.cpp:79 Source/gamemenu.cpp:79
+#: Source/DiabloUI/credits_lines.cpp:79 Source/gamemenu.cpp:83
 msgid "Music"
 msgstr "音乐"
 
 #: Source/DiabloUI/credits_lines.cpp:82
 msgid "Sound Design"
-msgstr "音响​设计"
+msgstr "音响设计"
 
 #: Source/DiabloUI/credits_lines.cpp:85
 msgid "Cinematic Music & Sound"
-msgstr "电影​音乐​与​声音"
+msgstr "电影音乐与声音"
 
 #: Source/DiabloUI/credits_lines.cpp:88
 msgid "Voice Production, Direction & Casting"
-msgstr "声音​制作、导演​和​播音"
+msgstr "声音制作、导演和播音"
 
 #: Source/DiabloUI/credits_lines.cpp:91
 msgid "Script & Story"
-msgstr "脚​本​和​故事"
+msgstr "脚本和故事"
 
 #: Source/DiabloUI/credits_lines.cpp:95
 msgid "Voice Editing"
-msgstr "语音​编辑"
+msgstr "语音编辑"
 
 #: Source/DiabloUI/credits_lines.cpp:98 Source/DiabloUI/credits_lines.cpp:252
 msgid "Voices"
@@ -132,44 +132,44 @@ msgstr "声音"
 
 #: Source/DiabloUI/credits_lines.cpp:103
 msgid "Recording Engineer"
-msgstr "录音​工程师"
+msgstr "录音工程师"
 
 #: Source/DiabloUI/credits_lines.cpp:106
 msgid "Manual Design & Layout"
-msgstr "手动​设计​和​布局"
+msgstr "手动设计和布局"
 
 #: Source/DiabloUI/credits_lines.cpp:110
 msgid "Manual Artwork"
-msgstr "手工​艺术品"
+msgstr "手工艺术品"
 
 #: Source/DiabloUI/credits_lines.cpp:114
 msgid "Provisional Director of QA (Lead Tester)"
-msgstr "QA​临时​总监​（​首席测试）"
+msgstr "QA临时总监（首席测试）"
 
 #: Source/DiabloUI/credits_lines.cpp:117
 msgid "QA Assault Team (Testers)"
-msgstr "QA​突击队​（​测试​人员​）"
+msgstr "QA突击队（测试人员）"
 
 #: Source/DiabloUI/credits_lines.cpp:122
 msgid "QA Special Ops Team (Compatibility Testers)"
-msgstr "QA​特别​行动​小组​（​兼容性​测试​人员​）"
+msgstr "QA特别行动小组（兼容性测试人员）"
 
 #: Source/DiabloUI/credits_lines.cpp:125
 msgid "QA Artillery Support (Additional Testers) "
-msgstr "QA​火力​支援​（​附加​测试​人员​） "
+msgstr "QA火力支援（附加测试人员） "
 
 #: Source/DiabloUI/credits_lines.cpp:129
 msgid "QA Counterintelligence"
-msgstr "QA​反​情报"
+msgstr "QA反情报"
 
 #. TRANSLATORS: A group of people
 #: Source/DiabloUI/credits_lines.cpp:132
 msgid "Order of Network Information Services"
-msgstr "网络​信息​服务​秩序"
+msgstr "网络信息服务部"
 
 #: Source/DiabloUI/credits_lines.cpp:136
 msgid "Customer Support"
-msgstr "客户​支持"
+msgstr "客户支持"
 
 #: Source/DiabloUI/credits_lines.cpp:141
 msgid "Sales"
@@ -181,11 +181,11 @@ msgstr "邓塞尔"
 
 #: Source/DiabloUI/credits_lines.cpp:147
 msgid "Mr. Dabiri's Background Vocalists"
-msgstr "达​比​里​先生​的​背景​歌手"
+msgstr "达比里先生的背景歌手"
 
 #: Source/DiabloUI/credits_lines.cpp:151
 msgid "Public Relations"
-msgstr "公共​关系"
+msgstr "公共关系"
 
 #: Source/DiabloUI/credits_lines.cpp:154
 msgid "Marketing"
@@ -193,11 +193,11 @@ msgstr "营销"
 
 #: Source/DiabloUI/credits_lines.cpp:157
 msgid "International Sales"
-msgstr "国际​销售"
+msgstr "国际销售"
 
 #: Source/DiabloUI/credits_lines.cpp:160
 msgid "U.S. Sales"
-msgstr "美国​销售"
+msgstr "美国销售"
 
 #: Source/DiabloUI/credits_lines.cpp:163
 msgid "Manufacturing"
@@ -205,11 +205,11 @@ msgstr "制造业"
 
 #: Source/DiabloUI/credits_lines.cpp:166
 msgid "Legal & Business"
-msgstr "法律​与​商业"
+msgstr "法律与商业"
 
 #: Source/DiabloUI/credits_lines.cpp:169
 msgid "Special Thanks To"
-msgstr "特别​感谢"
+msgstr "特别感谢"
 
 #: Source/DiabloUI/credits_lines.cpp:173
 msgid "Thanks To"
@@ -217,11 +217,11 @@ msgstr "感谢"
 
 #: Source/DiabloUI/credits_lines.cpp:202
 msgid "In memory of"
-msgstr "为了​纪念"
+msgstr "为了纪念"
 
 #: Source/DiabloUI/credits_lines.cpp:208
 msgid "Very Special Thanks to"
-msgstr "非常​特别​感谢"
+msgstr "非常特别感谢"
 
 #: Source/DiabloUI/credits_lines.cpp:214
 msgid "General Manager"
@@ -229,11 +229,11 @@ msgstr "总经理"
 
 #: Source/DiabloUI/credits_lines.cpp:220
 msgid "Software Engineering"
-msgstr "软件​工程"
+msgstr "软件工程"
 
 #: Source/DiabloUI/credits_lines.cpp:223
 msgid "Art Director"
-msgstr "艺术​总监"
+msgstr "艺术总监"
 
 #: Source/DiabloUI/credits_lines.cpp:226
 msgid "Artists"
@@ -245,15 +245,15 @@ msgstr "设计"
 
 #: Source/DiabloUI/credits_lines.cpp:237
 msgid "Sound Design, SFX & Audio Engineering"
-msgstr "声音​设计、SFX​和​音频​工程"
+msgstr "声音设计、SFX和音频工程"
 
 #: Source/DiabloUI/credits_lines.cpp:240
 msgid "Quality Assurance Lead"
-msgstr "质量​保证​负责人"
+msgstr "质量保证负责人"
 
 #: Source/DiabloUI/credits_lines.cpp:243
 msgid "Testers"
-msgstr "测试​人员"
+msgstr "测试人员"
 
 #: Source/DiabloUI/credits_lines.cpp:248
 msgid "Manual"
@@ -261,11 +261,11 @@ msgstr "手册"
 
 #: Source/DiabloUI/credits_lines.cpp:257
 msgid "\tAdditional Work"
-msgstr "\t​附加​工作"
+msgstr "\t附加工作"
 
 #: Source/DiabloUI/credits_lines.cpp:259
 msgid "Quest Text Writing"
-msgstr "任务​文本​写作"
+msgstr "任务文本写作"
 
 #: Source/DiabloUI/credits_lines.cpp:262 Source/DiabloUI/credits_lines.cpp:297
 msgid "Thanks to"
@@ -273,7 +273,7 @@ msgstr "感谢"
 
 #: Source/DiabloUI/credits_lines.cpp:267
 msgid "\t\t\tSpecial Thanks to Blizzard Entertainment"
-msgstr "\t\t\t​特别​感谢​暴雪​娱乐"
+msgstr "\t\t\t特别感谢暴雪娱乐"
 
 #: Source/DiabloUI/credits_lines.cpp:272
 msgid "\t\t\tSierra On-Line Inc. Northwest"
@@ -281,536 +281,527 @@ msgstr "\t\t\tSierra On-Line Inc. Northwest"
 
 #: Source/DiabloUI/credits_lines.cpp:274
 msgid "Quality Assurance Manager"
-msgstr "质量​保证​经理"
+msgstr "质量保证经理"
 
 #: Source/DiabloUI/credits_lines.cpp:277
 msgid "Quality Assurance Lead Tester"
-msgstr "质量​保证​铅​测试仪"
+msgstr "质量保证铅测试仪"
 
 #: Source/DiabloUI/credits_lines.cpp:280
 msgid "Main Testers"
-msgstr "主要​测试​人员"
+msgstr "主要测试人员"
 
 #: Source/DiabloUI/credits_lines.cpp:283
 msgid "Additional Testers"
-msgstr "附加​测试​人员"
+msgstr "附加测试人员"
 
 #: Source/DiabloUI/credits_lines.cpp:288
 msgid "Product Marketing Manager"
-msgstr "产品​营销​经理"
+msgstr "产品营销经理"
 
 #: Source/DiabloUI/credits_lines.cpp:291
 msgid "Public Relations Manager"
-msgstr "公共​关系​经理"
+msgstr "公共关系经理"
 
 #: Source/DiabloUI/credits_lines.cpp:294
 msgid "Associate Product Manager"
-msgstr "副产品​经理"
+msgstr "副产品经理"
 
 #: Source/DiabloUI/credits_lines.cpp:303
 msgid "The Ring of One Thousand"
-msgstr "千​人​之​戒"
+msgstr "千人之戒"
 
 #: Source/DiabloUI/credits_lines.cpp:549
 msgid "\tNo souls were sold in the making of this game."
-msgstr "\t​在​这​个​游戏​的​制作​过程​中​没有​灵魂​被​出卖。"
+msgstr "\t在这个游戏的制作过程中没有灵魂被出卖。"
 
-#: Source/DiabloUI/dialogs.cpp:97 Source/DiabloUI/dialogs.cpp:109
-#: Source/DiabloUI/hero/selhero.cpp:199 Source/DiabloUI/hero/selhero.cpp:225
-#: Source/DiabloUI/hero/selhero.cpp:310 Source/DiabloUI/hero/selhero.cpp:550
-#: Source/DiabloUI/multi/selconn.cpp:94 Source/DiabloUI/multi/selgame.cpp:187
-#: Source/DiabloUI/multi/selgame.cpp:350 Source/DiabloUI/multi/selgame.cpp:376
-#: Source/DiabloUI/multi/selgame.cpp:518 Source/DiabloUI/multi/selgame.cpp:595
-#: Source/DiabloUI/selok.cpp:82
+#: Source/DiabloUI/dialogs.cpp:108 Source/DiabloUI/dialogs.cpp:120
+#: Source/DiabloUI/hero/selhero.cpp:205 Source/DiabloUI/hero/selhero.cpp:231
+#: Source/DiabloUI/hero/selhero.cpp:316 Source/DiabloUI/hero/selhero.cpp:556
+#: Source/DiabloUI/multi/selconn.cpp:100 Source/DiabloUI/multi/selgame.cpp:180
+#: Source/DiabloUI/multi/selgame.cpp:348 Source/DiabloUI/multi/selgame.cpp:374
+#: Source/DiabloUI/multi/selgame.cpp:516 Source/DiabloUI/multi/selgame.cpp:593
+#: Source/DiabloUI/selok.cpp:86
 msgid "OK"
 msgstr "确定"
 
-#: Source/DiabloUI/hero/selhero.cpp:168
+#: Source/DiabloUI/hero/selhero.cpp:174
 msgid "Choose Class"
-msgstr "选择​职业"
+msgstr "选择职业"
 
-#: Source/DiabloUI/hero/selhero.cpp:202 Source/DiabloUI/hero/selhero.cpp:228
-#: Source/DiabloUI/hero/selhero.cpp:313 Source/DiabloUI/hero/selhero.cpp:558
-#: Source/DiabloUI/multi/selconn.cpp:97 Source/DiabloUI/progress.cpp:50
+#: Source/DiabloUI/hero/selhero.cpp:208 Source/DiabloUI/hero/selhero.cpp:234
+#: Source/DiabloUI/hero/selhero.cpp:319 Source/DiabloUI/hero/selhero.cpp:564
+#: Source/DiabloUI/multi/selconn.cpp:103 Source/DiabloUI/progress.cpp:57
 msgid "Cancel"
 msgstr "取消"
 
-#: Source/DiabloUI/hero/selhero.cpp:208 Source/DiabloUI/hero/selhero.cpp:298
+#: Source/DiabloUI/hero/selhero.cpp:214 Source/DiabloUI/hero/selhero.cpp:304
 msgid "New Multi Player Hero"
-msgstr "新建​多​人​游戏​英雄"
+msgstr "新建多人游戏英雄"
 
-#: Source/DiabloUI/hero/selhero.cpp:208 Source/DiabloUI/hero/selhero.cpp:298
+#: Source/DiabloUI/hero/selhero.cpp:214 Source/DiabloUI/hero/selhero.cpp:304
 msgid "New Single Player Hero"
-msgstr "新​建​单人​游戏​英雄"
+msgstr "新建单人游戏英雄"
 
-#: Source/DiabloUI/hero/selhero.cpp:217
+#: Source/DiabloUI/hero/selhero.cpp:223
 msgid "Save File Exists"
-msgstr "保存​文件​已​存在"
+msgstr "保存文件已存在"
 
-#: Source/DiabloUI/hero/selhero.cpp:220 Source/gamemenu.cpp:50
+#: Source/DiabloUI/hero/selhero.cpp:226 Source/gamemenu.cpp:54
 msgid "Load Game"
-msgstr "加载​游戏"
+msgstr "加载游戏"
 
-#: Source/DiabloUI/hero/selhero.cpp:221 Source/multi.cpp:835
+#: Source/DiabloUI/hero/selhero.cpp:227 Source/multi.cpp:896
 msgid "New Game"
-msgstr "新​游戏"
+msgstr "新游戏"
 
-#: Source/DiabloUI/hero/selhero.cpp:231 Source/DiabloUI/hero/selhero.cpp:564
+#: Source/DiabloUI/hero/selhero.cpp:237 Source/DiabloUI/hero/selhero.cpp:570
 msgid "Single Player Characters"
-msgstr "单人​游戏​角色"
+msgstr "单人游戏角色"
 
-#: Source/DiabloUI/hero/selhero.cpp:290
+#: Source/DiabloUI/hero/selhero.cpp:296
 msgid ""
 "The Rogue and Sorcerer are only available in the full retail version of "
 "Diablo. Visit https://www.gog.com/game/diablo to purchase."
 msgstr ""
-"流亡者​和​巫师​只​在​暗黑​破坏​神​的​完整​零售版​中​提供。前往 https://www.gog.com/game/"
+"游侠和法师只在暗黑破坏神的完整零售版中提供。前往 https://www.gog.com/game/"
 "diablo 购买。"
 
-#: Source/DiabloUI/hero/selhero.cpp:304 Source/DiabloUI/hero/selhero.cpp:307
+#: Source/DiabloUI/hero/selhero.cpp:310 Source/DiabloUI/hero/selhero.cpp:313
 msgid "Enter Name"
-msgstr "输入​名称"
+msgstr "输入名称"
 
-#: Source/DiabloUI/hero/selhero.cpp:336
+#: Source/DiabloUI/hero/selhero.cpp:342
 msgid ""
 "Invalid name. A name cannot contain spaces, reserved characters, or reserved "
 "words.\n"
-msgstr "名称​无效。名称​不​能​包含​空格、保留​字符​或​保留​词语。\n"
+msgstr "名称无效。名称不能包含空格、保留字符或保留词语。\n"
 
 #. TRANSLATORS: Error Message
-#: Source/DiabloUI/hero/selhero.cpp:343
+#: Source/DiabloUI/hero/selhero.cpp:349
 msgid "Unable to create character."
-msgstr "无法​创建​角色。"
+msgstr "无法创建角色。"
 
-#: Source/DiabloUI/hero/selhero.cpp:509
+#: Source/DiabloUI/hero/selhero.cpp:515
 msgid "Level:"
 msgstr "等级:"
 
-#: Source/DiabloUI/hero/selhero.cpp:513
+#: Source/DiabloUI/hero/selhero.cpp:519
 msgid "Strength:"
 msgstr "力量:"
 
-#: Source/DiabloUI/hero/selhero.cpp:513
+#: Source/DiabloUI/hero/selhero.cpp:519
 msgid "Magic:"
 msgstr "魔法:"
 
-#: Source/DiabloUI/hero/selhero.cpp:513
+#: Source/DiabloUI/hero/selhero.cpp:519
 msgid "Dexterity:"
 msgstr "敏捷:"
 
-#: Source/DiabloUI/hero/selhero.cpp:513
+#: Source/DiabloUI/hero/selhero.cpp:519
 msgid "Vitality:"
 msgstr "活力:"
 
-#: Source/DiabloUI/hero/selhero.cpp:515
+#: Source/DiabloUI/hero/selhero.cpp:521
 msgid "Savegame:"
-msgstr "保存​游戏​："
+msgstr "保存游戏："
 
-#: Source/DiabloUI/hero/selhero.cpp:534
+#: Source/DiabloUI/hero/selhero.cpp:540
 msgid "Select Hero"
-msgstr "选择​英雄"
+msgstr "选择英雄"
 
-#: Source/DiabloUI/hero/selhero.cpp:542
+#: Source/DiabloUI/hero/selhero.cpp:548
 msgid "New Hero"
-msgstr "新​英雄"
+msgstr "新英雄"
 
-#: Source/DiabloUI/hero/selhero.cpp:553
+#: Source/DiabloUI/hero/selhero.cpp:559
 msgid "Delete"
-msgstr "删​除"
+msgstr "删除"
 
-#: Source/DiabloUI/hero/selhero.cpp:562
+#: Source/DiabloUI/hero/selhero.cpp:568
 msgid "Multi Player Characters"
-msgstr "多​人​游戏​角色"
+msgstr "多人游戏角色"
 
-#: Source/DiabloUI/hero/selhero.cpp:613
+#: Source/DiabloUI/hero/selhero.cpp:619
 msgid "Delete Multi Player Hero"
-msgstr "删​除​多​人​游戏​英雄"
+msgstr "删除多人游戏英雄"
 
-#: Source/DiabloUI/hero/selhero.cpp:615
+#: Source/DiabloUI/hero/selhero.cpp:621
 msgid "Delete Single Player Hero"
-msgstr "删​除​单人​游戏​英雄"
+msgstr "删除单人游戏英雄"
 
-#: Source/DiabloUI/hero/selhero.cpp:617
+#: Source/DiabloUI/hero/selhero.cpp:623
 #, c++-format
 msgid "Are you sure you want to delete the character \"{:s}\"?"
-msgstr "是否​确实​要​删除​角色​\"​{:s}​\"？"
+msgstr "是否确实要删除角色\"{:s}\"？"
 
-#: Source/DiabloUI/mainmenu.cpp:48
+#: Source/DiabloUI/mainmenu.cpp:53
 msgid "Single Player"
-msgstr "单人​游戏"
+msgstr "单人游戏"
 
-#: Source/DiabloUI/mainmenu.cpp:49
+#: Source/DiabloUI/mainmenu.cpp:54
 msgid "Multi Player"
-msgstr "多​人​游戏"
+msgstr "多人游戏"
 
-#: Source/DiabloUI/mainmenu.cpp:50 Source/DiabloUI/settingsmenu.cpp:384
+#: Source/DiabloUI/mainmenu.cpp:55 Source/DiabloUI/settingsmenu.cpp:392
 msgid "Settings"
 msgstr "设置"
 
-#: Source/DiabloUI/mainmenu.cpp:51
+#: Source/DiabloUI/mainmenu.cpp:56
 msgid "Support"
 msgstr "支持"
 
-#: Source/DiabloUI/mainmenu.cpp:52
+#: Source/DiabloUI/mainmenu.cpp:57
 msgid "Show Credits"
-msgstr "显示​制作组"
+msgstr "显示制作组"
 
-#: Source/DiabloUI/mainmenu.cpp:54
+#: Source/DiabloUI/mainmenu.cpp:59
 msgid "Exit Hellfire"
-msgstr "退出​地狱火"
+msgstr "退出地狱火"
 
-#: Source/DiabloUI/mainmenu.cpp:54
+#: Source/DiabloUI/mainmenu.cpp:59
 msgid "Exit Diablo"
-msgstr "退出​暗黑​破坏​神"
+msgstr "退出暗黑破坏神"
 
-#: Source/DiabloUI/mainmenu.cpp:71
+#: Source/DiabloUI/mainmenu.cpp:76
 msgid "Shareware"
-msgstr "共​享版"
+msgstr "共享版"
 
-#: Source/DiabloUI/multi/selconn.cpp:26
+#: Source/DiabloUI/multi/selconn.cpp:32
 msgid "Client-Server (TCP)"
-msgstr "客户​端​-​服务器​(​TCP)"
+msgstr "客户端-服务器(TCP)"
 
-#: Source/DiabloUI/multi/selconn.cpp:27
+#: Source/DiabloUI/multi/selconn.cpp:33
 msgid "Offline"
 msgstr "离线"
 
-#: Source/DiabloUI/multi/selconn.cpp:68 Source/DiabloUI/multi/selgame.cpp:662
-#: Source/DiabloUI/multi/selgame.cpp:688
+#: Source/DiabloUI/multi/selconn.cpp:74 Source/DiabloUI/multi/selgame.cpp:660
+#: Source/DiabloUI/multi/selgame.cpp:686 Source/menu.cpp:86
 msgid "Multi Player Game"
-msgstr "多​人​游戏"
+msgstr "多人游戏"
 
-#: Source/DiabloUI/multi/selconn.cpp:74
+#: Source/DiabloUI/multi/selconn.cpp:80
 msgid "Requirements:"
 msgstr "要求:"
 
-#: Source/DiabloUI/multi/selconn.cpp:80
-msgid "no gateway needed"
-msgstr "不​需要​网关"
-
 #: Source/DiabloUI/multi/selconn.cpp:86
+msgid "no gateway needed"
+msgstr "不需要网关"
+
+#: Source/DiabloUI/multi/selconn.cpp:92
 msgid "Select Connection"
-msgstr "选择​连接"
+msgstr "选择连接"
 
-#: Source/DiabloUI/multi/selconn.cpp:89
+#: Source/DiabloUI/multi/selconn.cpp:95
 msgid "Change Gateway"
-msgstr "更改​网关"
+msgstr "更改网关"
 
-#: Source/DiabloUI/multi/selconn.cpp:122
+#: Source/DiabloUI/multi/selconn.cpp:128
 msgid "All computers must be connected to a TCP-compatible network."
-msgstr "所有​计算机​必须​连接​到​与​TCP​兼容​的​网络。"
+msgstr "所有计算机必须连接到与TCP兼容的网络。"
 
-#: Source/DiabloUI/multi/selconn.cpp:126
+#: Source/DiabloUI/multi/selconn.cpp:132
 msgid "All computers must be connected to the internet."
-msgstr "所有​计算机​都​必须​连接​到​因特网。"
+msgstr "所有计算机都必须连接到因特网。"
 
-#: Source/DiabloUI/multi/selconn.cpp:130
+#: Source/DiabloUI/multi/selconn.cpp:136
 msgid "Play by yourself with no network exposure."
-msgstr "在​没有​网络​开放​的​情况​下​自己​游玩。"
+msgstr "在没有网络开放的情况下自己游玩。"
 
-#: Source/DiabloUI/multi/selconn.cpp:135
+#: Source/DiabloUI/multi/selconn.cpp:141
 #, c++-format
 msgid "Players Supported: {:d}"
-msgstr "支持​的​玩家: {:d}"
+msgstr "支持的玩家: {:d}"
 
-#: Source/DiabloUI/multi/selgame.cpp:100 Source/options.cpp:425
-#: Source/options.cpp:473 Source/translation_dummy.cpp:630
-msgid "Diablo"
-msgstr "迪亚波罗"
+#: Source/DiabloUI/multi/selgame.cpp:106
+msgid "The host is running the shareware edition."
+msgstr "主机正在运行共享版。"
 
-#: Source/DiabloUI/multi/selgame.cpp:103
-msgid "Diablo Shareware"
-msgstr "《​暗黑​破坏​神​》​共​享版"
-
-#: Source/DiabloUI/multi/selgame.cpp:106 Source/options.cpp:427
-#: Source/options.cpp:487
-msgid "Hellfire"
-msgstr "地​狱火"
-
-#: Source/DiabloUI/multi/selgame.cpp:109
-msgid "Hellfire Shareware"
-msgstr "《​地狱火​》​共​享版"
-
-#: Source/DiabloUI/multi/selgame.cpp:112
-msgid "The host is running a different game than you."
-msgstr "主机​运行​的​游戏​与​您​不同。"
-
-#: Source/DiabloUI/multi/selgame.cpp:114
-#, c++-format
-msgid "The host is running a different game mode ({:s}) than you."
-msgstr "主机​运行​的​({:s})​模式​与​你​当前​的​模式​不同。"
+#: Source/DiabloUI/multi/selgame.cpp:108
+msgid "You need to full version of the game to join this game."
+msgstr "您需要游戏的完整版才能加入此游戏。"
 
 #. TRANSLATORS: Error message when somebody tries to join a game running another version.
-#: Source/DiabloUI/multi/selgame.cpp:116
+#: Source/DiabloUI/multi/selgame.cpp:110
 #, c++-format
 msgid "Your version {:s} does not match the host {:d}.{:d}.{:d}."
-msgstr "您​的​版本​{:s}​与​主机{:d}.{:d}.{:d}​不​匹配。"
+msgstr "您的版本{:s}与主机{:d}.{:d}.{:d}不匹配。"
 
-#: Source/DiabloUI/multi/selgame.cpp:153 Source/DiabloUI/multi/selgame.cpp:581
+#: Source/DiabloUI/multi/selgame.cpp:146 Source/DiabloUI/multi/selgame.cpp:579
 msgid "Description:"
 msgstr "说明:"
 
-#: Source/DiabloUI/multi/selgame.cpp:159
+#: Source/DiabloUI/multi/selgame.cpp:152
 msgid "Select Action"
-msgstr "选择​操作"
+msgstr "选择操作"
 
-#: Source/DiabloUI/multi/selgame.cpp:162 Source/DiabloUI/multi/selgame.cpp:338
-#: Source/DiabloUI/multi/selgame.cpp:499
+#: Source/DiabloUI/multi/selgame.cpp:155 Source/DiabloUI/multi/selgame.cpp:336
+#: Source/DiabloUI/multi/selgame.cpp:497
 msgid "Create Game"
-msgstr "创建​游戏"
+msgstr "创建游戏"
 
-#: Source/DiabloUI/multi/selgame.cpp:164
+#: Source/DiabloUI/multi/selgame.cpp:157
 msgid "Create Public Game"
-msgstr "创建​公开​游戏"
+msgstr "创建公开游戏"
 
-#: Source/DiabloUI/multi/selgame.cpp:165
+#: Source/DiabloUI/multi/selgame.cpp:158
 msgid "Join Game"
-msgstr "加入​游戏"
+msgstr "加入游戏"
 
-#: Source/DiabloUI/multi/selgame.cpp:169
+#: Source/DiabloUI/multi/selgame.cpp:162
 msgid "Public Games"
-msgstr "公开​游戏"
+msgstr "公开游戏"
 
-#: Source/DiabloUI/multi/selgame.cpp:174 Source/diablo_msg.cpp:72
+#: Source/DiabloUI/multi/selgame.cpp:167 Source/diablo_msg.cpp:78
 msgid "Loading..."
-msgstr "加载​中​…​…"
+msgstr "加载中……"
 
 #. TRANSLATORS: type of dungeon (i.e. Cathedral, Caves)
-#: Source/DiabloUI/multi/selgame.cpp:176 Source/discord/discord.cpp:86
-#: Source/options.cpp:459 Source/options.cpp:730
+#: Source/DiabloUI/multi/selgame.cpp:169 Source/discord/discord.cpp:86
+#: Source/options.cpp:471 Source/options.cpp:790
 #: Source/panels/charpanel.cpp:142
 msgid "None"
 msgstr "没有"
 
-#: Source/DiabloUI/multi/selgame.cpp:190 Source/DiabloUI/multi/selgame.cpp:353
-#: Source/DiabloUI/multi/selgame.cpp:379 Source/DiabloUI/multi/selgame.cpp:521
-#: Source/DiabloUI/multi/selgame.cpp:598
+#: Source/DiabloUI/multi/selgame.cpp:183 Source/DiabloUI/multi/selgame.cpp:351
+#: Source/DiabloUI/multi/selgame.cpp:377 Source/DiabloUI/multi/selgame.cpp:519
+#: Source/DiabloUI/multi/selgame.cpp:596
 msgid "CANCEL"
 msgstr "取消"
 
-#: Source/DiabloUI/multi/selgame.cpp:229
+#: Source/DiabloUI/multi/selgame.cpp:222
 msgid "Create a new game with a difficulty setting of your choice."
-msgstr "从​你​选择​的​难度​设置​创建​游戏。"
+msgstr "从你选择的难度设置创建游戏。"
 
-#: Source/DiabloUI/multi/selgame.cpp:232
+#: Source/DiabloUI/multi/selgame.cpp:225
 msgid ""
 "Create a new public game that anyone can join with a difficulty setting of "
 "your choice."
-msgstr "创建​一​个​公开​游戏，任何​人​都​可​加入​的，游戏​难度​将​依据​你​的​设定。"
+msgstr "创建一个公开游戏，任何人都可加入的，游戏难度将依据你的设定。"
+
+#: Source/DiabloUI/multi/selgame.cpp:229
+msgid "Enter Game ID to join a game already in progress."
+msgstr "输入游戏ID来加入一个正在进行的游戏。"
+
+#: Source/DiabloUI/multi/selgame.cpp:231
+msgid "Enter an IP or a hostname to join a game already in progress."
+msgstr "输入一个IP或者主机名称来加入一个正在进行的游戏。"
 
 #: Source/DiabloUI/multi/selgame.cpp:236
-msgid "Enter Game ID to join a game already in progress."
-msgstr "输入​游戏​ID​来​加入​一​个​正在​进行​的​游戏。"
-
-#: Source/DiabloUI/multi/selgame.cpp:238
-msgid "Enter an IP or a hostname to join a game already in progress."
-msgstr "输入​一​个​IP​或者​主机​名称​来​加入​一​个​正在​进行​的​游戏。"
-
-#: Source/DiabloUI/multi/selgame.cpp:243
 msgid "Join the public game already in progress."
-msgstr "加入​一​个​正在​进行​的​公开​游戏。"
+msgstr "加入一个正在进行的公开游戏。"
 
-#: Source/DiabloUI/multi/selgame.cpp:249 Source/DiabloUI/multi/selgame.cpp:343
-#: Source/DiabloUI/multi/selgame.cpp:404 Source/DiabloUI/multi/selgame.cpp:510
-#: Source/DiabloUI/multi/selgame.cpp:530 Source/automap.cpp:1461
+#: Source/DiabloUI/multi/selgame.cpp:242 Source/DiabloUI/multi/selgame.cpp:341
+#: Source/DiabloUI/multi/selgame.cpp:402 Source/DiabloUI/multi/selgame.cpp:508
+#: Source/DiabloUI/multi/selgame.cpp:528 Source/automap.cpp:1488
 #: Source/discord/discord.cpp:114
 msgid "Normal"
 msgstr "正常"
 
-#: Source/DiabloUI/multi/selgame.cpp:252 Source/DiabloUI/multi/selgame.cpp:344
-#: Source/DiabloUI/multi/selgame.cpp:408 Source/automap.cpp:1464
+#: Source/DiabloUI/multi/selgame.cpp:245 Source/DiabloUI/multi/selgame.cpp:342
+#: Source/DiabloUI/multi/selgame.cpp:406 Source/automap.cpp:1491
 #: Source/discord/discord.cpp:114
 msgid "Nightmare"
-msgstr "噩​梦"
+msgstr "噩梦"
 
-#: Source/DiabloUI/multi/selgame.cpp:255 Source/DiabloUI/multi/selgame.cpp:345
-#: Source/DiabloUI/multi/selgame.cpp:412 Source/automap.cpp:1467
+#: Source/DiabloUI/multi/selgame.cpp:248 Source/DiabloUI/multi/selgame.cpp:343
+#: Source/DiabloUI/multi/selgame.cpp:410 Source/automap.cpp:1494
 #: Source/discord/discord.cpp:81 Source/discord/discord.cpp:114
 msgid "Hell"
 msgstr "地狱"
 
 #. TRANSLATORS: {:s} means: Game Difficulty.
-#: Source/DiabloUI/multi/selgame.cpp:258 Source/automap.cpp:1471
+#: Source/DiabloUI/multi/selgame.cpp:251 Source/automap.cpp:1498
 #, c++-format
 msgid "Difficulty: {:s}"
 msgstr "难度: {:s}"
 
-#: Source/DiabloUI/multi/selgame.cpp:262 Source/gamemenu.cpp:165
+#: Source/DiabloUI/multi/selgame.cpp:255 Source/gamemenu.cpp:169
 msgid "Speed: Normal"
 msgstr "速度: 正常"
 
-#: Source/DiabloUI/multi/selgame.cpp:265 Source/gamemenu.cpp:163
+#: Source/DiabloUI/multi/selgame.cpp:258 Source/gamemenu.cpp:167
 msgid "Speed: Fast"
 msgstr "速度: 快速"
 
-#: Source/DiabloUI/multi/selgame.cpp:268 Source/gamemenu.cpp:161
+#: Source/DiabloUI/multi/selgame.cpp:261 Source/gamemenu.cpp:165
 msgid "Speed: Faster"
-msgstr "速度: 更​快"
+msgstr "速度: 更快"
 
-#: Source/DiabloUI/multi/selgame.cpp:271 Source/gamemenu.cpp:159
+#: Source/DiabloUI/multi/selgame.cpp:264 Source/gamemenu.cpp:163
 msgid "Speed: Fastest"
-msgstr "速度: 最​快"
+msgstr "速度: 最快"
+
+#: Source/DiabloUI/multi/selgame.cpp:272
+msgid "Players: "
+msgstr "玩家数: "
 
 #: Source/DiabloUI/multi/selgame.cpp:279
-msgid "Players: "
-msgstr "玩​家数: "
+#, c++-format
+msgid "Ping: {:d} ms (RELAYED)"
+msgstr "延迟: {:d} 毫秒（中继）"
 
-#: Source/DiabloUI/multi/selgame.cpp:341
+#: Source/DiabloUI/multi/selgame.cpp:281
+#, c++-format
+msgid "Ping: {:d} ms"
+msgstr "延迟: {:d} 毫秒"
+
+#: Source/DiabloUI/multi/selgame.cpp:339
 msgid "Select Difficulty"
-msgstr "选择​难度"
+msgstr "选择难度"
 
-#: Source/DiabloUI/multi/selgame.cpp:359
+#: Source/DiabloUI/multi/selgame.cpp:357
 #, c++-format
 msgid "Join {:s} Games"
 msgstr "加入 {:s} 游戏"
 
-#: Source/DiabloUI/multi/selgame.cpp:364
+#: Source/DiabloUI/multi/selgame.cpp:362
 msgid "Enter Game ID"
-msgstr "输入​游戏​ID"
+msgstr "输入游戏ID"
 
-#: Source/DiabloUI/multi/selgame.cpp:366
+#: Source/DiabloUI/multi/selgame.cpp:364
 msgid "Enter address"
-msgstr "输入​地址"
+msgstr "输入地址"
 
-#: Source/DiabloUI/multi/selgame.cpp:405
+#: Source/DiabloUI/multi/selgame.cpp:403
 msgid ""
 "Normal Difficulty\n"
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
-"正常​难度​\n"
-"​一​个​新​角色​应​从此​开始，最终​击败迪亚波罗。"
+"正常难度\n"
+"一个新角色应从此开始，最终击败迪亚波罗。"
 
-#: Source/DiabloUI/multi/selgame.cpp:409
+#: Source/DiabloUI/multi/selgame.cpp:407
 msgid ""
 "Nightmare Difficulty\n"
 "The denizens of the Labyrinth have been bolstered and will prove to be a "
 "greater challenge. This is recommended for experienced characters only."
 msgstr ""
-"噩​梦​难度​\n"
-"迷宫​里​的​怪物​将​被​强化，这​将​是​一​个​更​大​的​挑战。只​建议​经验​丰富​的​角色​进行​挑战。"
+"噩梦难度\n"
+"迷宫里的怪物将被强化，这将是一个更大的挑战。只建议经验丰富的角色进行挑战。"
 
-#: Source/DiabloUI/multi/selgame.cpp:413
+#: Source/DiabloUI/multi/selgame.cpp:411
 msgid ""
 "Hell Difficulty\n"
 "The most powerful of the underworld's creatures lurk at the gateway into "
 "Hell. Only the most experienced characters should venture in this realm."
 msgstr ""
-"地狱​困难​\n"
-"​最​强大​的​地底​世界​的​生物​潜伏​在地狱​的​大门。只​有​最​有​经验​的​角色​才​能​在​这个​国度​中​冒"
+"地狱困难\n"
+"最强大的地底世界的生物潜伏在地狱的大门。只有最有经验的角色才能在这个国度中冒"
 "险。"
 
-#: Source/DiabloUI/multi/selgame.cpp:428
+#: Source/DiabloUI/multi/selgame.cpp:426
 msgid ""
 "Your character must reach level 20 before you can enter a multiplayer game "
 "of Nightmare difficulty."
-msgstr "你​的​角色​必须​达到​20​级​才​能​进入​噩梦​难度​的​多​人​游戏。"
+msgstr "你的角色必须达到20级才能进入噩梦难度的多人游戏。"
 
-#: Source/DiabloUI/multi/selgame.cpp:430
+#: Source/DiabloUI/multi/selgame.cpp:428
 msgid ""
 "Your character must reach level 30 before you can enter a multiplayer game "
 "of Hell difficulty."
-msgstr "你​的​角色​必须​达到​30​级​才​能​进入​地狱​难度​的​多​人​游戏。"
+msgstr "你的角色必须达到30级才能进入地狱难度的多人游戏。"
 
-#: Source/DiabloUI/multi/selgame.cpp:508
+#: Source/DiabloUI/multi/selgame.cpp:506
 msgid "Select Game Speed"
-msgstr "选择​游戏​速度"
+msgstr "选择游戏速度"
 
-#: Source/DiabloUI/multi/selgame.cpp:511 Source/DiabloUI/multi/selgame.cpp:534
+#: Source/DiabloUI/multi/selgame.cpp:509 Source/DiabloUI/multi/selgame.cpp:532
 msgid "Fast"
 msgstr "快速"
 
-#: Source/DiabloUI/multi/selgame.cpp:512 Source/DiabloUI/multi/selgame.cpp:538
+#: Source/DiabloUI/multi/selgame.cpp:510 Source/DiabloUI/multi/selgame.cpp:536
 msgid "Faster"
-msgstr "更​快"
+msgstr "更快"
 
-#: Source/DiabloUI/multi/selgame.cpp:513 Source/DiabloUI/multi/selgame.cpp:542
+#: Source/DiabloUI/multi/selgame.cpp:511 Source/DiabloUI/multi/selgame.cpp:540
 msgid "Fastest"
-msgstr "最​快"
+msgstr "最快"
 
-#: Source/DiabloUI/multi/selgame.cpp:531
+#: Source/DiabloUI/multi/selgame.cpp:529
 msgid ""
 "Normal Speed\n"
 "This is where a starting character should begin the quest to defeat Diablo."
 msgstr ""
-"正常​\n"
-"​一​个​新​角色​应​从此​开始，最终​击败迪亚波罗。"
+"正常\n"
+"一个新角色应从此开始，最终击败迪亚波罗。"
 
-#: Source/DiabloUI/multi/selgame.cpp:535
+#: Source/DiabloUI/multi/selgame.cpp:533
 msgid ""
 "Fast Speed\n"
 "The denizens of the Labyrinth have been hastened and will prove to be a "
 "greater challenge. This is recommended for experienced characters only."
 msgstr ""
-"快速​\n"
-"迷宫​的​居民们​已经​被​催促​了，这​将​是​一​个​更​大​的​挑战。只​建议​经验​丰富​的​角色​进行​挑"
+"快速\n"
+"迷宫的居民们已经被催促了，这将是一个更大的挑战。只建议经验丰富的角色进行挑"
 "战。"
 
-#: Source/DiabloUI/multi/selgame.cpp:539
+#: Source/DiabloUI/multi/selgame.cpp:537
 msgid ""
 "Faster Speed\n"
 "Most monsters of the dungeon will seek you out quicker than ever before. "
 "Only an experienced champion should try their luck at this speed."
 msgstr ""
-"更​快​\n"
-"​地​牢里​的​大多数​怪物会​比​以前​更​快​地​找到​你。只有​经验​丰富​的​勇士​才​能​在​这个​速度​下​砰"
-"砰​运气。"
+"更快\n"
+"地牢里的大多数怪物会比以前更快地找到你。只有经验丰富的勇士才能在这个速度下试"
+"试运气。"
 
-#: Source/DiabloUI/multi/selgame.cpp:543
+#: Source/DiabloUI/multi/selgame.cpp:541
 msgid ""
 "Fastest Speed\n"
 "The minions of the underworld will rush to attack without hesitation. Only a "
 "true speed demon should enter at this pace."
 msgstr ""
-"最​快​\n"
-"​地下​世界​的​仆从们​会​毫​不​犹豫​地​冲​过​来​袭击。只有​真正​的​速度​恶魔​才​能​赶​得​上​脚步。"
+"最快\n"
+"地下世界的仆从们会毫不犹豫地冲过来袭击。只有真正的速度恶魔才能赶得上脚步。"
 
-#: Source/DiabloUI/multi/selgame.cpp:587 Source/DiabloUI/multi/selgame.cpp:592
+#: Source/DiabloUI/multi/selgame.cpp:585 Source/DiabloUI/multi/selgame.cpp:590
 msgid "Enter Password"
-msgstr "输入​密码"
+msgstr "输入密码"
 
 #: Source/DiabloUI/selstart.cpp:49
 msgid "Enter Hellfire"
-msgstr "进入​《​地狱火​》"
+msgstr "进入《地狱火》"
 
 #: Source/DiabloUI/selstart.cpp:50
 msgid "Switch to Diablo"
-msgstr "切换​到​原版"
+msgstr "切换到原版"
 
-#: Source/DiabloUI/selyesno.cpp:68 Source/stores.cpp:967
+#: Source/DiabloUI/selyesno.cpp:72 Source/stores.cpp:967
 msgid "Yes"
 msgstr "是"
 
-#: Source/DiabloUI/selyesno.cpp:69 Source/stores.cpp:968
+#: Source/DiabloUI/selyesno.cpp:73 Source/stores.cpp:968
 msgid "No"
 msgstr "否"
 
-#: Source/DiabloUI/settingsmenu.cpp:162
+#: Source/DiabloUI/settingsmenu.cpp:170
 msgid "Press gamepad buttons to change."
-msgstr "按​下任​意手柄按键​进行​修改。"
+msgstr "按下任意手柄按键进行修改。"
 
-#: Source/DiabloUI/settingsmenu.cpp:439
+#: Source/DiabloUI/settingsmenu.cpp:447
 msgid "Bound key:"
-msgstr "绑​定​键位​："
+msgstr "绑定键位："
 
-#: Source/DiabloUI/settingsmenu.cpp:488
+#: Source/DiabloUI/settingsmenu.cpp:496
 msgid "Press any key to change."
-msgstr "按​下任​意键​进行​修改。"
+msgstr "按下任意键进行修改。"
 
-#: Source/DiabloUI/settingsmenu.cpp:490
+#: Source/DiabloUI/settingsmenu.cpp:498
 msgid "Unbind key"
-msgstr "取消​绑​定键位"
+msgstr "取消绑定键位"
 
-#: Source/DiabloUI/settingsmenu.cpp:494
+#: Source/DiabloUI/settingsmenu.cpp:502
 msgid "Bound button combo:"
 msgstr "绑定按键组合："
 
-#: Source/DiabloUI/settingsmenu.cpp:503
+#: Source/DiabloUI/settingsmenu.cpp:511
 msgid "Unbind button combo"
 msgstr "解绑按键组合"
 
-#: Source/DiabloUI/settingsmenu.cpp:547 Source/gamemenu.cpp:73
+#: Source/DiabloUI/settingsmenu.cpp:555 Source/gamemenu.cpp:77
 msgid "Previous Menu"
-msgstr "上​一​个​菜单"
+msgstr "上一个菜单"
 
 #: Source/DiabloUI/support_lines.cpp:10
 msgid ""
@@ -818,8 +809,8 @@ msgid ""
 "our community where we talk about things related to Diablo, and the Hellfire "
 "expansion."
 msgstr ""
-"我们​维护​的​聊天​服务器​部署​在 Discord.gg/devilutionx ，点击​连接​加入​我们​的​社群，"
-"我们​在​那里​谈论​有关​暗黑​破坏​神​以及​地狱火​资料片。"
+"我们维护的聊天服务器部署在 Discord.gg/devilutionx ，点击连接加入我们的社群，"
+"我们在那里谈论有关暗黑破坏神以及地狱火资料片。"
 
 #: Source/DiabloUI/support_lines.cpp:12
 msgid ""
@@ -828,13 +819,13 @@ msgid ""
 "serve you, please be sure to include the version number, operating system, "
 "and the nature of the problem."
 msgstr ""
-"DevilutionX​由​Diasurgical​维护，可以​报告​问题​和​错误​地址: https://github.com/"
-"diasurgical/devilutionX​为了​帮助​我们​更​好​地​为​您​服务，请​务必​提供​所​使用​的​版本​号，"
-"操作​系统，以及​问题​的​性质。"
+"DevilutionX由Diasurgical维护，可以报告问题和错误地址: https://github.com/"
+"diasurgical/devilutionX为了帮助我们更好地为您服务，请务必提供所使用的版本号，"
+"操作系统，以及问题的性质。"
 
 #: Source/DiabloUI/support_lines.cpp:15
 msgid "Disclaimer:"
-msgstr "免责​声明:"
+msgstr "免责声明:"
 
 #: Source/DiabloUI/support_lines.cpp:16
 msgid ""
@@ -844,8 +835,8 @@ msgid ""
 "DevilutionX should be directed to Diasurgical, not to Blizzard Entertainment "
 "or GOG.com."
 msgstr ""
-"\t​暴雪​娱乐​和​GOG.com​不​提供​支持​和​维护​DevilutionX，他们​也​没有​对​DevilutionX​进行​质"
-"量​和​兼容性​测试。所有​相关​问题​咨询，请​直接​联系​Diasurgical，而​不​是​暴雪​娱乐​或​"
+"\t暴雪娱乐和GOG.com不提供支持和维护DevilutionX，他们也没有对DevilutionX进行质"
+"量和兼容性测试。所有相关问题咨询，请直接联系Diasurgical，而不是暴雪娱乐或"
 "GOG.com。"
 
 #: Source/DiabloUI/support_lines.cpp:19
@@ -855,20 +846,20 @@ msgid ""
 "which is licensed under CC-BY 4.0. The port also makes use of SDL which is "
 "licensed under the zlib-license. See the ReadMe for further details."
 msgstr ""
-"\t​这个​移植​使用​了 Charis SIL、New Athena Unicode、Unifont 和 Noto，它们​处于​"
-"SIL Open Font License、CC-BY 4.0​和​Twitmoji许可​授权。该​移植​还​使用​了​SDL，处于​"
-"zlib-license许可。更​多​细节​请​参见​ReadMe。"
+"\t这个移植使用了 Charis SIL、New Athena Unicode、Unifont 和 Noto，它们处于"
+"SIL Open Font License、CC-BY 4.0和Twitmoji许可授权。该移植还使用了SDL，处于"
+"zlib-license许可。更多细节请参见ReadMe。"
 
-#: Source/DiabloUI/title.cpp:67
+#: Source/DiabloUI/title.cpp:74
 msgid "Copyright © 1996-2001 Blizzard Entertainment"
 msgstr "Copyright © 1996-2001 Blizzard Entertainment"
 
-#: Source/appfat.cpp:63
+#: Source/appfat.cpp:72
 msgid "Error"
 msgstr "错误"
 
 #. TRANSLATORS: Error message that displays relevant information for bug report
-#: Source/appfat.cpp:77
+#: Source/appfat.cpp:86
 #, c++-format
 msgid ""
 "{:s}\n"
@@ -877,129 +868,92 @@ msgid ""
 msgstr ""
 "{:s}\n"
 "\n"
-"​错误​发生​在: {:s}，行{:d}"
+"错误发生在: {:s}，行{:d}"
 
-#: Source/appfat.cpp:83
+#: Source/appfat.cpp:92
 msgid "Data File Error"
-msgstr "数据​文件​错误"
+msgstr "数据文件错误"
 
-#: Source/appfat.cpp:84
+#: Source/appfat.cpp:93
 #, c++-format
 msgid ""
 "Unable to open main data archive ({:s}).\n"
 "\n"
 "Make sure that it is in the game folder."
 msgstr ""
-"无法​打开​主​数据​存档​({:s})。\n"
+"无法打开主数据存档({:s})。\n"
 "\n"
-"​确保​它​在​游戏​文件​夹​中，并且​文件​名​都​是​小​写​的。"
+"确保它在游戏文件夹中，并且文件名都是小写的。"
 
-#: Source/appfat.cpp:93
+#: Source/appfat.cpp:102
 msgid "Read-Only Directory Error"
-msgstr "只​读​目录​错误"
+msgstr "只读目录错误"
 
 #. TRANSLATORS: Error when Program is not allowed to write data
-#: Source/appfat.cpp:94
+#: Source/appfat.cpp:103
 #, c++-format
 msgid ""
 "Unable to write to location:\n"
 "{:s}"
 msgstr ""
-"无法​写入​位置: \n"
+"无法写入位置: \n"
 "{:s}"
 
-#: Source/automap.cpp:1416
+#: Source/automap.cpp:1447
 msgid "Game: "
 msgstr "游戏: "
 
-#: Source/automap.cpp:1424
+#: Source/automap.cpp:1454
 msgid "Offline Game"
 msgstr "离线游戏"
 
-#: Source/automap.cpp:1426
+#: Source/automap.cpp:1456
+msgid "Public Game"
+msgstr "公开游戏"
+
+#: Source/automap.cpp:1458
 msgid "Password: "
 msgstr "密码: "
 
-#: Source/automap.cpp:1429
-msgid "Public Game"
-msgstr "公开​游戏"
-
-#: Source/automap.cpp:1443
+#: Source/automap.cpp:1470
 #, c++-format
 msgid "Level: Nest {:d}"
-msgstr "巢​穴: {:d} 层"
+msgstr "巢穴: {:d} 层"
 
-#: Source/automap.cpp:1446
+#: Source/automap.cpp:1473
 #, c++-format
 msgid "Level: Crypt {:d}"
 msgstr "墓穴: {:d} 层"
 
-#: Source/automap.cpp:1449 Source/discord/discord.cpp:81 Source/objects.cpp:157
+#: Source/automap.cpp:1476 Source/discord/discord.cpp:81 Source/objects.cpp:157
 msgid "Town"
 msgstr "城镇"
 
-#: Source/automap.cpp:1452
+#: Source/automap.cpp:1479
 #, c++-format
 msgid "Level: {:d}"
-msgstr "层​数: {:d}"
+msgstr "层数: {:d}"
 
-#: Source/control.cpp:203
-msgid "Tab"
-msgstr "Tab"
-
-#: Source/control.cpp:203
-msgid "Esc"
-msgstr "Esc"
-
-#: Source/control.cpp:203
-msgid "Enter"
-msgstr "Enter"
-
-#: Source/control.cpp:206
-msgid "Character Information"
-msgstr "角色​信息"
-
-#: Source/control.cpp:207
-msgid "Quests log"
-msgstr "任务​日志"
-
-#: Source/control.cpp:208
-msgid "Automap"
-msgstr "自动​地图"
-
-#: Source/control.cpp:209
-msgid "Main Menu"
-msgstr "主​菜​单"
-
-#: Source/control.cpp:210 Source/diablo.cpp:1912 Source/diablo.cpp:2264
-msgid "Inventory"
-msgstr "物品​栏"
-
-#: Source/control.cpp:211
-msgid "Spell book"
-msgstr "法术书"
-
-#: Source/control.cpp:212
-msgid "Send Message"
-msgstr "发送​消息"
-
-#: Source/control.cpp:622
+#: Source/control/control_chat_commands.cpp:38
 msgid "Available Commands:"
 msgstr "可用命令："
 
-#: Source/control.cpp:630 Source/control.cpp:814
+#: Source/control/control_chat_commands.cpp:46
+#: Source/control/control_chat_commands.cpp:268
 msgid "Command "
 msgstr "命令"
 
-#: Source/control.cpp:630 Source/control.cpp:814
+#: Source/control/control_chat_commands.cpp:46
+#: Source/control/control_chat_commands.cpp:268
 msgid " is unknown."
 msgstr "是未知的。"
 
-#: Source/control.cpp:633 Source/control.cpp:634
+#: Source/control/control_chat_commands.cpp:49
+#: Source/control/control_chat_commands.cpp:50
 msgid "Description: "
 msgstr "说明:"
 
-#: Source/control.cpp:633
+#: Source/control/control_chat_commands.cpp:49
 msgid ""
 "\n"
 "Parameters: No additional parameter needed."
@@ -1007,7 +961,7 @@ msgstr ""
 "\n"
 "参数：无需额外参数。"
 
-#: Source/control.cpp:634
+#: Source/control/control_chat_commands.cpp:50
 msgid ""
 "\n"
 "Parameters: "
@@ -1015,221 +969,292 @@ msgstr ""
 "\n"
 "参数: "
 
-#: Source/control.cpp:648 Source/control.cpp:680
+#: Source/control/control_chat_commands.cpp:64
+#: Source/control/control_chat_commands.cpp:96
 msgid "Arenas are only supported in multiplayer."
 msgstr "竞技场仅支持多人模式。"
 
-#: Source/control.cpp:653
+#: Source/control/control_chat_commands.cpp:69
 msgid "What arena do you want to visit?"
-msgstr "您​想访问哪个竞技场？"
+msgstr "您想访问哪个竞技场？"
 
-#: Source/control.cpp:661
+#: Source/control/control_chat_commands.cpp:77
 msgid "Invalid arena-number. Valid numbers are:"
 msgstr "无效的竞技场数字。有效的数字是："
 
-#: Source/control.cpp:667
+#: Source/control/control_chat_commands.cpp:83
 msgid "To enter a arena, you need to be in town or another arena."
 msgstr "要进入竞技场，你需要在城镇或其他竞技场。"
 
-#: Source/control.cpp:705
+#: Source/control/control_chat_commands.cpp:121
 msgid "Inspecting only supported in multiplayer."
 msgstr "检查仅支持多人模式。"
 
-#: Source/control.cpp:710 Source/control.cpp:1001
+#: Source/control/control_chat_commands.cpp:126
+#: Source/control/control_panel.cpp:320
 msgid "Stopped inspecting players."
 msgstr "停止检查玩家。"
 
-#: Source/control.cpp:725
+#: Source/control/control_chat_commands.cpp:141
+#: Source/control/control_chat_commands.cpp:228
 msgid "No players found with such a name"
 msgstr "该游戏中没有发现玩家"
 
-#: Source/control.cpp:731
+#: Source/control/control_chat_commands.cpp:147
 msgid "Inspecting player: "
 msgstr "检查玩家："
 
-#: Source/control.cpp:800
+#. TRANSLATORS: {:s} means: Character Name
+#: Source/control/control_chat_commands.cpp:235
+#, c++-format
+msgid "Latency statistics for {:s}:"
+msgstr "{:s} 的延迟统计："
+
+#. TRANSLATORS: Network connectivity statistics
+#: Source/control/control_chat_commands.cpp:237 Source/diablo.cpp:1594
+#, c++-format
+msgid "Echo latency: {:d} ms"
+msgstr "回显延迟：{:d} 毫秒"
+
+#. TRANSLATORS: Network connectivity statistics
+#: Source/control/control_chat_commands.cpp:241 Source/diablo.cpp:1598
+#, c++-format
+msgid "Provider latency: {:d} ms (Relayed)"
+msgstr "服务商延迟：{:d} 毫秒（中继）"
+
+#. TRANSLATORS: Network connectivity statistics
+#: Source/control/control_chat_commands.cpp:243 Source/diablo.cpp:1600
+#, c++-format
+msgid "Provider latency: {:d} ms"
+msgstr "服务商延迟：{:d} 毫秒"
+
+#: Source/control/control_chat_commands.cpp:251
 msgid "Prints help overview or help for a specific command."
 msgstr "打印帮助概览或指定命令的帮助信息。"
 
-#: Source/control.cpp:800
+#: Source/control/control_chat_commands.cpp:251
 msgid "[command]"
 msgstr "[命令]"
 
-#: Source/control.cpp:801
+#: Source/control/control_chat_commands.cpp:252
 msgid "Enter a PvP Arena."
 msgstr "进入一个 PvP 竞技场。"
 
-#: Source/control.cpp:801
+#: Source/control/control_chat_commands.cpp:252
 msgid "<arena-number>"
 msgstr "<竞技场数字>"
 
-#: Source/control.cpp:802
+#: Source/control/control_chat_commands.cpp:253
 msgid "Gives Arena Potions."
 msgstr "给与竞技场点数。"
 
-#: Source/control.cpp:802
+#: Source/control/control_chat_commands.cpp:253
 msgid "<number>"
 msgstr "<数字>"
 
-#: Source/control.cpp:803
+#: Source/control/control_chat_commands.cpp:254
 msgid "Inspects stats and equipment of another player."
 msgstr "查看另一个玩家的状态和装备。"
 
-#: Source/control.cpp:803
+#: Source/control/control_chat_commands.cpp:254
+#: Source/control/control_chat_commands.cpp:256
 msgid "<player name>"
 msgstr "<玩家名>"
 
-#: Source/control.cpp:804
+#: Source/control/control_chat_commands.cpp:255
 msgid "Show seed infos for current level."
 msgstr "显示当前层的种子信息。"
 
-#: Source/control.cpp:1311
-msgid "Player friendly"
-msgstr "对​玩家​友好"
-
-#: Source/control.cpp:1313
-msgid "Player attack"
-msgstr "玩​家​攻击"
-
-#: Source/control.cpp:1316
-#, c++-format
-msgid "Hotkey: {:s}"
-msgstr "热键: {:s}"
-
-#: Source/control.cpp:1328
-msgid "Select current spell button"
-msgstr "当前​选择​的​法术​按钮"
-
-#: Source/control.cpp:1331
-msgid "Hotkey: 's'"
-msgstr "热键: “​s​”"
-
-#: Source/control.cpp:1337 Source/panels/spell_list.cpp:153
-#, c++-format
-msgid "{:s} Skill"
-msgstr "技能​：​{:s}"
-
-#: Source/control.cpp:1340 Source/panels/spell_list.cpp:160
-#, c++-format
-msgid "{:s} Spell"
-msgstr "法术​：​{:s}"
-
-#: Source/control.cpp:1342 Source/panels/spell_list.cpp:165
-msgid "Spell Level 0 - Unusable"
-msgstr "法术​等级 0 - 无法​使用"
-
-#: Source/control.cpp:1342 Source/panels/spell_list.cpp:167
-#, c++-format
-msgid "Spell Level {:d}"
-msgstr "法术​等级 {:d}"
-
-#: Source/control.cpp:1345 Source/panels/spell_list.cpp:174
-#, c++-format
-msgid "Scroll of {:s}"
-msgstr "{:s}​卷轴"
-
-#: Source/control.cpp:1349 Source/panels/spell_list.cpp:178
-#, c++-format
-msgid "{:d} Scroll"
-msgid_plural "{:d} Scrolls"
-msgstr[0] "{:d}卷轴"
-
-#: Source/control.cpp:1352 Source/panels/spell_list.cpp:185
-#, c++-format
-msgid "Staff of {:s}"
-msgstr "{:s}​法​杖"
-
-#: Source/control.cpp:1353 Source/panels/spell_list.cpp:187
-#, c++-format
-msgid "{:d} Charge"
-msgid_plural "{:d} Charges"
-msgstr[0] "{:d}充能"
-
-#: Source/control.cpp:1487 Source/inv.cpp:1979 Source/inv.cpp:1980
-#: Source/items.cpp:3808
-#, c++-format
-msgid "{:s} gold piece"
-msgid_plural "{:s} gold pieces"
-msgstr[0] "{:s}金币堆"
-
-#: Source/control.cpp:1489
-msgid "Requirements not met"
-msgstr "未​满足​条件"
-
-#: Source/control.cpp:1518
-#, c++-format
-msgid "{:s}, Level: {:d}"
-msgstr "{:s}, 等级: {:d}"
-
-#: Source/control.cpp:1519
-#, c++-format
-msgid "Hit Points {:d} of {:d}"
-msgstr "生命值 {:d} 的 {:d}"
-
-#: Source/control.cpp:1525
-#, fuzzy
-#| msgid "Right-click to use"
-msgid "Right click to inspect"
-msgstr "右击​使用"
-
-#: Source/control.cpp:1573
-msgid "Level Up"
-msgstr "升级"
-
-#: Source/control.cpp:1687
-msgid "You have died"
-msgstr ""
-
-#: Source/control.cpp:1695
-msgid "ESC"
-msgstr ""
-
-#: Source/control.cpp:1701
-msgid "Menu Button"
-msgstr ""
-
-#: Source/control.cpp:1709
-#, c++-format
-msgid "Press {} to load last save."
-msgstr ""
-
-#: Source/control.cpp:1711
-#, c++-format
-msgid "Press {} to return to Main Menu."
-msgstr ""
-
-#: Source/control.cpp:1714
-#, c++-format
-msgid "Press {} to restart in town."
-msgstr ""
+#: Source/control/control_chat_commands.cpp:256
+msgid "Show latency statistics for another player."
+msgstr "显示另一位玩家的延迟统计信息。"
 
 #. TRANSLATORS: {:s} is a number with separators. Dialog is shown when splitting a stash of Gold.
-#: Source/control.cpp:1732
+#: Source/control/control_gold.cpp:62
 #, c++-format
 msgid "You have {:s} gold piece. How many do you want to remove?"
 msgid_plural "You have {:s} gold pieces. How many do you want to remove?"
 msgstr[0] "你有 {:s} 金币。你想要取出多少？"
 
-#: Source/cursor.cpp:621
-msgid "Town Portal"
-msgstr "城镇​传送门"
+#: Source/control/control_infobox.cpp:326
+msgid "Player friendly"
+msgstr "对玩家友好"
 
-#: Source/cursor.cpp:622
+#: Source/control/control_infobox.cpp:328
+msgid "Player attack"
+msgstr "玩家攻击"
+
+#: Source/control/control_infobox.cpp:331
+#, c++-format
+msgid "Hotkey: {:s}"
+msgstr "热键: {:s}"
+
+#: Source/control/control_infobox.cpp:343
+msgid "Select current spell button"
+msgstr "当前选择的法术按钮"
+
+#: Source/control/control_infobox.cpp:346
+msgid "Hotkey: 's'"
+msgstr "热键: “s”"
+
+#: Source/control/control_infobox.cpp:352 Source/panels/spell_list.cpp:153
+#, c++-format
+msgid "{:s} Skill"
+msgstr "技能：{:s}"
+
+#: Source/control/control_infobox.cpp:355 Source/panels/spell_list.cpp:160
+#, c++-format
+msgid "{:s} Spell"
+msgstr "法术：{:s}"
+
+#: Source/control/control_infobox.cpp:357 Source/panels/spell_list.cpp:165
+msgid "Spell Level 0 - Unusable"
+msgstr "法术等级 0 - 无法使用"
+
+#: Source/control/control_infobox.cpp:357 Source/panels/spell_list.cpp:167
+#, c++-format
+msgid "Spell Level {:d}"
+msgstr "法术等级 {:d}"
+
+#: Source/control/control_infobox.cpp:360 Source/panels/spell_list.cpp:174
+#, c++-format
+msgid "Scroll of {:s}"
+msgstr "{:s}卷轴"
+
+#: Source/control/control_infobox.cpp:364 Source/panels/spell_list.cpp:178
+#, c++-format
+msgid "{:d} Scroll"
+msgid_plural "{:d} Scrolls"
+msgstr[0] "{:d}卷轴"
+
+#: Source/control/control_infobox.cpp:367 Source/panels/spell_list.cpp:185
+#, c++-format
+msgid "Staff of {:s}"
+msgstr "{:s}法杖"
+
+#: Source/control/control_infobox.cpp:368 Source/panels/spell_list.cpp:187
+#, c++-format
+msgid "{:d} Charge"
+msgid_plural "{:d} Charges"
+msgstr[0] "{:d}充能"
+
+#: Source/control/control_infobox.cpp:400 Source/inv.cpp:2005
+#: Source/inv.cpp:2006 Source/items.cpp:3830
+#, c++-format
+msgid "{:s} gold piece"
+msgid_plural "{:s} gold pieces"
+msgstr[0] "{:s}金币堆"
+
+#: Source/control/control_infobox.cpp:402
+msgid "Requirements not met"
+msgstr "未满足条件"
+
+#: Source/control/control_infobox.cpp:431
+#, c++-format
+msgid "{:s}, Level: {:d}"
+msgstr "{:s}, 等级: {:d}"
+
+#: Source/control/control_infobox.cpp:432
+#, c++-format
+msgid "Hit Points {:d} of {:d}"
+msgstr "生命值 {:d} 的 {:d}"
+
+#: Source/control/control_infobox.cpp:438
+msgid "Right click to inspect"
+msgstr "右击查看"
+
+#: Source/control/control_panel.cpp:109
+msgid "Character Information"
+msgstr "角色信息"
+
+#: Source/control/control_panel.cpp:110
+msgid "Quests log"
+msgstr "任务日志"
+
+#: Source/control/control_panel.cpp:111
+msgid "Automap"
+msgstr "自动地图"
+
+#: Source/control/control_panel.cpp:112
+msgid "Main Menu"
+msgstr "主菜单"
+
+#: Source/control/control_panel.cpp:113 Source/diablo.cpp:1987
+#: Source/diablo.cpp:2339
+msgid "Inventory"
+msgstr "物品栏"
+
+#: Source/control/control_panel.cpp:114
+msgid "Spell book"
+msgstr "法术书"
+
+#: Source/control/control_panel.cpp:115
+msgid "Send Message"
+msgstr "发送消息"
+
+#: Source/control/control_panel.cpp:120
+msgid "Tab"
+msgstr "Tab"
+
+#: Source/control/control_panel.cpp:120
+msgid "Esc"
+msgstr "Esc"
+
+#: Source/control/control_panel.cpp:120
+msgid "Enter"
+msgstr "Enter"
+
+#: Source/control/control_panel.cpp:679
+msgid "Level Up"
+msgstr "升级"
+
+#: Source/control/control_panel.cpp:801
+msgid "You have died"
+msgstr "你已死亡"
+
+#: Source/control/control_panel.cpp:809
+msgid "ESC"
+msgstr "ESC"
+
+#: Source/control/control_panel.cpp:815
+msgid "Menu Button"
+msgstr "菜单按钮"
+
+#: Source/control/control_panel.cpp:823
+#, c++-format
+msgid "Press {} to load last save."
+msgstr "按 {} 加载上次存档。"
+
+#: Source/control/control_panel.cpp:825
+#, c++-format
+msgid "Press {} to return to Main Menu."
+msgstr "按 {} 返回主菜单。"
+
+#: Source/control/control_panel.cpp:828
+#, c++-format
+msgid "Press {} to restart in town."
+msgstr "按 {} 在城镇重新开始。"
+
+#: Source/cursor.cpp:630
+msgid "Town Portal"
+msgstr "城镇传送门"
+
+#: Source/cursor.cpp:631
 #, c++-format
 msgid "from {:s}"
-msgstr "从​{:s}"
+msgstr "从{:s}"
 
-#: Source/cursor.cpp:635
+#: Source/cursor.cpp:644
 msgid "Portal to"
-msgstr "通​向"
+msgstr "通向"
 
-#: Source/cursor.cpp:636
+#: Source/cursor.cpp:645
 msgid "The Unholy Altar"
-msgstr "不​洁​祭坛"
+msgstr "不洁祭坛"
 
-#: Source/cursor.cpp:636
+#: Source/cursor.cpp:645
 msgid "level 15"
-msgstr "15​层"
+msgstr "15层"
 
 #. TRANSLATORS: Error message when a data file is missing or corrupt. Arguments are {file name}
 #: Source/data/file.cpp:52
@@ -1269,852 +1294,848 @@ msgstr "{2} 中用于 {1} 的值 {0} 越界，在  {3} 行  {4} 列"
 msgid "Invalid value {0} for {1} in {2} at row {3} and column {4}"
 msgstr "{2} 中用于 {1} 的值 {0} 无效 在  {3} 行  {4} 列"
 
+#: Source/diablo.cpp:908 Source/menu.cpp:86
+msgid "Cannot play Multiplayer with overridden *.lua, *.tsv, or *.sol assets."
+msgstr "无法在使用被覆盖的 *.lua、*.tsv 或 *.sol 资源时进行多人游戏。"
+
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:989
+#: Source/diablo.cpp:1019
 msgid "Print this message and exit"
-msgstr "打​印​此​消息​并​退出"
+msgstr "打印此消息并退出"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:990
+#: Source/diablo.cpp:1020
 msgid "Print the version and exit"
-msgstr "打​印​版本​并​退出"
+msgstr "打印版本并退出"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:991
+#: Source/diablo.cpp:1021
 msgid "Specify the folder of diabdat.mpq"
-msgstr "指定​diabdat.mpq​的​文件​夹"
+msgstr "指定diabdat.mpq的文件夹"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:992
+#: Source/diablo.cpp:1022
 msgid "Specify the folder of save files"
-msgstr "指定​保存​文件​的​文件​夹"
+msgstr "指定保存文件的文件夹"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:993
+#: Source/diablo.cpp:1023
 msgid "Specify the location of diablo.ini"
-msgstr "指定​diablo.ini​的​位置"
+msgstr "指定diablo.ini的位置"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:994
+#: Source/diablo.cpp:1024
 msgid "Specify the language code (e.g. en or pt_BR)"
 msgstr "指定语言代码（例如 en 或 pt_BR）"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:995
+#: Source/diablo.cpp:1025
 msgid "Skip startup videos"
-msgstr "跳​过​启动​视频"
+msgstr "跳过启动视频"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:996
+#: Source/diablo.cpp:1026
 msgid "Display frames per second"
-msgstr "每​秒​显示​帧数"
+msgstr "每秒显示帧数"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:997
+#: Source/diablo.cpp:1027
 msgid "Enable verbose logging"
-msgstr "启用​详细​日志​记录"
+msgstr "启用详细日志记录"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:999
+#: Source/diablo.cpp:1029
 msgid "Log to a file instead of stderr"
-msgstr ""
+msgstr "将日志记录到文件而非标准错误输出"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:1002
+#: Source/diablo.cpp:1032
 msgid "Record a demo file"
-msgstr "记录​一​个​录像​文件"
+msgstr "记录一个录像文件"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:1003
+#: Source/diablo.cpp:1033
 msgid "Play a demo file"
-msgstr "播放​录像​文件"
+msgstr "播放录像文件"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:1004
+#: Source/diablo.cpp:1034
 msgid "Disable all frame limiting during demo playback"
-msgstr "播放​录像​回放​时​禁​用​帧​数​限制"
+msgstr "播放录像回放时禁用帧数限制"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:1007
+#: Source/diablo.cpp:1037
 msgid "Game selection:"
-msgstr "游戏​选项​："
+msgstr "游戏选项："
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:1009
+#: Source/diablo.cpp:1039
 msgid "Force Shareware mode"
-msgstr "强制​共​享版​模式"
+msgstr "强制共享版模式"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:1010
+#: Source/diablo.cpp:1040
 msgid "Force Diablo mode"
-msgstr "强制​原版​模式"
+msgstr "强制原版模式"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:1011
+#: Source/diablo.cpp:1041
 msgid "Force Hellfire mode"
-msgstr "强制​地狱火​模式"
+msgstr "强制地狱火模式"
 
 #. TRANSLATORS: Commandline Option
-#: Source/diablo.cpp:1012
+#: Source/diablo.cpp:1042
 msgid "Hellfire options:"
-msgstr "地​狱火​选项:"
+msgstr "地狱火选项:"
 
-#: Source/diablo.cpp:1022
+#: Source/diablo.cpp:1052
 msgid "Report bugs at https://github.com/diasurgical/devilutionX/"
-msgstr "报告​错误​https://github.com/diasurgical/devilutionX/"
+msgstr "报告错误https://github.com/diasurgical/devilutionX/"
 
-#: Source/diablo.cpp:1202
+#: Source/diablo.cpp:1232
 msgid "Please update devilutionx.mpq and fonts.mpq to the latest version"
 msgstr "请更新 devilutionx.mpq 和 fonts.mpq 到最新版"
 
-#: Source/diablo.cpp:1204
+#: Source/diablo.cpp:1234
 msgid ""
 "Failed to load UI resources.\n"
 "\n"
 "Make sure devilutionx.mpq is in the game folder and that it is up to date."
 msgstr ""
-"无法​加载​UI​资源。\n"
+"无法加载UI资源。\n"
 "\n"
-"​请​检查​DevilutionX.mpq​是否​在​游戏​目录​为​最新​版本。"
+"请检查DevilutionX.mpq是否在游戏目录为最新版本。"
 
-#: Source/diablo.cpp:1208
+#: Source/diablo.cpp:1238
 msgid "Please update fonts.mpq to the latest version"
 msgstr "请更新 fonts.mpq 到最新版"
 
-#: Source/diablo.cpp:1551
+#: Source/diablo.cpp:1581
 msgid "-- Network timeout --"
-msgstr "--​网络​超时--"
+msgstr "--网络超时--"
 
-#: Source/diablo.cpp:1552
+#: Source/diablo.cpp:1582
 msgid "-- Waiting for players --"
-msgstr "--​等待​玩​家​--"
+msgstr "--等待玩家--"
 
-#: Source/diablo.cpp:1575
+#. TRANSLATORS: {:s} means: Character Name
+#: Source/diablo.cpp:1591
+#, c++-format
+msgid "Player {:s} is timing out!"
+msgstr "玩家 {:s} 即将超时！"
+
+#: Source/diablo.cpp:1627
 msgid "No help available"
-msgstr "没有​可用​的​帮助"
+msgstr "没有可用的帮助"
 
-#: Source/diablo.cpp:1576
+#: Source/diablo.cpp:1628
 msgid "while in stores"
-msgstr "在​商店​里"
+msgstr "在商店里"
 
-#: Source/diablo.cpp:1774 Source/diablo.cpp:2094
+#: Source/diablo.cpp:1849 Source/diablo.cpp:2169
 #, c++-format
 msgid "Belt item {}"
-msgstr "腰​带​物品 {}"
+msgstr "腰带物品 {}"
 
-#: Source/diablo.cpp:1775 Source/diablo.cpp:2095
+#: Source/diablo.cpp:1850 Source/diablo.cpp:2170
 msgid "Use Belt item."
-msgstr "使用​腰带​中​的​物品。"
+msgstr "使用腰带中的物品。"
 
-#: Source/diablo.cpp:1790 Source/diablo.cpp:2110
+#: Source/diablo.cpp:1865 Source/diablo.cpp:2185
 #, c++-format
 msgid "Quick spell {}"
-msgstr "快捷​施法 {}"
+msgstr "快捷施法 {}"
 
-#: Source/diablo.cpp:1791 Source/diablo.cpp:2111
+#: Source/diablo.cpp:1866 Source/diablo.cpp:2186
 msgid "Hotkey for skill or spell."
-msgstr "设置​技能​或​法术​热键。"
+msgstr "设置技能或法术热键。"
 
-#: Source/diablo.cpp:1809
+#: Source/diablo.cpp:1884
 msgid "Previous quick spell"
-msgstr "上​一​个​快捷施法"
+msgstr "上一个快捷施法"
 
-#: Source/diablo.cpp:1810
+#: Source/diablo.cpp:1885
 msgid "Selects the previous quick spell (cycles)."
 msgstr "选择前一个快捷施法（循环）。"
 
-#: Source/diablo.cpp:1817
+#: Source/diablo.cpp:1892
 msgid "Next quick spell"
 msgstr "下一个快捷施法"
 
-#: Source/diablo.cpp:1818
+#: Source/diablo.cpp:1893
 msgid "Selects the next quick spell (cycles)."
 msgstr "选择后一个快捷施法（循环）。"
 
-#: Source/diablo.cpp:1825 Source/diablo.cpp:2238
+#: Source/diablo.cpp:1900 Source/diablo.cpp:2313
 msgid "Use health potion"
 msgstr "使用生命药水"
 
-#: Source/diablo.cpp:1826 Source/diablo.cpp:2239
+#: Source/diablo.cpp:1901 Source/diablo.cpp:2314
 msgid "Use health potions from belt."
 msgstr "使用腰带的生命药水。"
 
-#: Source/diablo.cpp:1833 Source/diablo.cpp:2246
+#: Source/diablo.cpp:1908 Source/diablo.cpp:2321
 msgid "Use mana potion"
 msgstr "使用法力药水"
 
-#: Source/diablo.cpp:1834 Source/diablo.cpp:2247
+#: Source/diablo.cpp:1909 Source/diablo.cpp:2322
 msgid "Use mana potions from belt."
 msgstr "使用腰带的玛丽药水。"
 
-#: Source/diablo.cpp:1841 Source/diablo.cpp:2294
+#: Source/diablo.cpp:1916 Source/diablo.cpp:2369
 msgid "Speedbook"
-msgstr "快捷​法术书"
+msgstr "快捷法术书"
 
-#: Source/diablo.cpp:1842 Source/diablo.cpp:2295
+#: Source/diablo.cpp:1917 Source/diablo.cpp:2370
 msgid "Open Speedbook."
-msgstr "打开​快捷​法术​书。"
+msgstr "打开快捷法术书。"
 
-#: Source/diablo.cpp:1849 Source/diablo.cpp:2451
+#: Source/diablo.cpp:1924 Source/diablo.cpp:2526
 msgid "Quick save"
-msgstr "快速​保存"
+msgstr "快速保存"
 
-#: Source/diablo.cpp:1850 Source/diablo.cpp:2452
+#: Source/diablo.cpp:1925 Source/diablo.cpp:2527
 msgid "Saves the game."
-msgstr "保存​游戏。"
+msgstr "保存游戏。"
 
-#: Source/diablo.cpp:1857 Source/diablo.cpp:2459
+#: Source/diablo.cpp:1932 Source/diablo.cpp:2534
 msgid "Quick load"
-msgstr "快速​加载"
+msgstr "快速加载"
 
-#: Source/diablo.cpp:1858 Source/diablo.cpp:2460
+#: Source/diablo.cpp:1933 Source/diablo.cpp:2535
 msgid "Loads the game."
-msgstr "加载​游戏。"
+msgstr "加载游戏。"
 
-#: Source/diablo.cpp:1866
+#: Source/diablo.cpp:1941
 msgid "Quit game"
-msgstr "退出​游戏"
+msgstr "退出游戏"
 
-#: Source/diablo.cpp:1867
+#: Source/diablo.cpp:1942
 msgid "Closes the game."
-msgstr "关闭​游戏。"
+msgstr "关闭游戏。"
 
-#: Source/diablo.cpp:1873
+#: Source/diablo.cpp:1948
 msgid "Stop hero"
-msgstr "停止​英雄"
+msgstr "停止英雄"
 
-#: Source/diablo.cpp:1874
+#: Source/diablo.cpp:1949
 msgid "Stops walking and cancel pending actions."
-msgstr "停止​移动​和​正在​执行​的​动作。"
+msgstr "停止移动和正在执行的动作。"
 
-#: Source/diablo.cpp:1881 Source/diablo.cpp:2467
+#: Source/diablo.cpp:1956 Source/diablo.cpp:2542
 msgid "Item highlighting"
-msgstr "物品​高亮"
+msgstr "物品高亮"
 
-#: Source/diablo.cpp:1882 Source/diablo.cpp:2468
+#: Source/diablo.cpp:1957 Source/diablo.cpp:2543
 msgid "Show/hide items on ground."
-msgstr "显示​/​隐藏​地面​物品。"
+msgstr "显示/隐藏地面物品。"
 
-#: Source/diablo.cpp:1888 Source/diablo.cpp:2474
+#: Source/diablo.cpp:1963 Source/diablo.cpp:2549
 msgid "Toggle item highlighting"
-msgstr "切换​物品​高亮"
+msgstr "切换物品高亮"
 
-#: Source/diablo.cpp:1889 Source/diablo.cpp:2475
+#: Source/diablo.cpp:1964 Source/diablo.cpp:2550
 msgid "Permanent show/hide items on ground."
-msgstr "永久​显示​/​隐藏​地面​上​的​物品。"
+msgstr "永久显示/隐藏地面上的物品。"
 
-#: Source/diablo.cpp:1895 Source/diablo.cpp:2304
+#: Source/diablo.cpp:1970 Source/diablo.cpp:2379
 msgid "Toggle automap"
-msgstr "开关​自动​地图"
+msgstr "开关自动地图"
 
-#: Source/diablo.cpp:1896 Source/diablo.cpp:2305
+#: Source/diablo.cpp:1971 Source/diablo.cpp:2380
 msgid "Toggles if automap is displayed."
-msgstr "切换​是否​显示​自动​地图。"
+msgstr "切换是否显示自动地图。"
 
-#: Source/diablo.cpp:1903
+#: Source/diablo.cpp:1978
 msgid "Cycle map type"
 msgstr "循环地图类型"
 
-#: Source/diablo.cpp:1904
+#: Source/diablo.cpp:1979
 msgid "Opaque -> Transparent -> Minimap -> None"
 msgstr "不透明 -> 透明 -> 小地图 -> 无"
 
-#: Source/diablo.cpp:1913 Source/diablo.cpp:2265
+#: Source/diablo.cpp:1988 Source/diablo.cpp:2340
 msgid "Open Inventory screen."
-msgstr "打开​物品​栏​界面。"
+msgstr "打开物品栏界面。"
 
-#: Source/diablo.cpp:1920 Source/diablo.cpp:2254
+#: Source/diablo.cpp:1995 Source/diablo.cpp:2329
 msgid "Character"
 msgstr "角色"
 
-#: Source/diablo.cpp:1921 Source/diablo.cpp:2255
+#: Source/diablo.cpp:1996 Source/diablo.cpp:2330
 msgid "Open Character screen."
-msgstr "打开​角色​界面。"
+msgstr "打开角色界面。"
 
-#: Source/diablo.cpp:1928
+#: Source/diablo.cpp:2003
 msgid "Party"
-msgstr ""
+msgstr "队伍"
 
-#: Source/diablo.cpp:1929
+#: Source/diablo.cpp:2004
 msgid "Open side Party panel."
-msgstr ""
+msgstr "打开侧边队伍面板。"
 
-#: Source/diablo.cpp:1936 Source/diablo.cpp:2274
+#: Source/diablo.cpp:2011 Source/diablo.cpp:2349
 msgid "Quest log"
-msgstr "任务​日志"
+msgstr "任务日志"
 
-#: Source/diablo.cpp:1937 Source/diablo.cpp:2275
+#: Source/diablo.cpp:2012 Source/diablo.cpp:2350
 msgid "Open Quest log."
-msgstr "打开​任务​日志​界面。"
+msgstr "打开任务日志界面。"
 
-#: Source/diablo.cpp:1944 Source/diablo.cpp:2284
+#: Source/diablo.cpp:2019 Source/diablo.cpp:2359
 msgid "Spellbook"
 msgstr "法术书"
 
-#: Source/diablo.cpp:1945 Source/diablo.cpp:2285
+#: Source/diablo.cpp:2020 Source/diablo.cpp:2360
 msgid "Open Spellbook."
-msgstr "打开​法术​书。"
+msgstr "打开法术书。"
 
-#: Source/diablo.cpp:1953
+#: Source/diablo.cpp:2028
 #, c++-format
 msgid "Quick Message {}"
-msgstr "快捷​消息 {}"
+msgstr "快捷消息 {}"
 
-#: Source/diablo.cpp:1954
+#: Source/diablo.cpp:2029
 msgid "Use Quick Message in chat."
-msgstr "使用​快捷​消息​进行​交谈。"
+msgstr "使用快捷消息进行交谈。"
 
-#: Source/diablo.cpp:1963 Source/diablo.cpp:2481
+#: Source/diablo.cpp:2038 Source/diablo.cpp:2556
 msgid "Hide Info Screens"
-msgstr "隐藏​屏幕​提示"
+msgstr "隐藏屏幕提示"
 
-#: Source/diablo.cpp:1964 Source/diablo.cpp:2482
+#: Source/diablo.cpp:2039 Source/diablo.cpp:2557
 msgid "Hide all info screens."
-msgstr "隐藏​所有​屏幕​提示。"
+msgstr "隐藏所有屏幕提示。"
 
-#: Source/diablo.cpp:1987 Source/diablo.cpp:2505 Source/options.cpp:737
+#: Source/diablo.cpp:2062 Source/diablo.cpp:2580 Source/options.cpp:797
 msgid "Zoom"
 msgstr "缩放"
 
-#: Source/diablo.cpp:1988 Source/diablo.cpp:2506
+#: Source/diablo.cpp:2063 Source/diablo.cpp:2581
 msgid "Zoom Game Screen."
-msgstr "缩放​游戏​界面。"
+msgstr "缩放游戏界面。"
 
-#: Source/diablo.cpp:1998 Source/diablo.cpp:2516
+#: Source/diablo.cpp:2073 Source/diablo.cpp:2591
 msgid "Pause Game"
-msgstr "暂停​游戏"
+msgstr "暂停游戏"
 
-#: Source/diablo.cpp:1999 Source/diablo.cpp:2005 Source/diablo.cpp:2517
+#: Source/diablo.cpp:2074 Source/diablo.cpp:2080 Source/diablo.cpp:2592
 msgid "Pauses the game."
-msgstr "暂停​当前​游戏。"
+msgstr "暂停当前游戏。"
 
-#: Source/diablo.cpp:2004
+#: Source/diablo.cpp:2079
 msgid "Pause Game (Alternate)"
-msgstr "暂停​游戏（备用）"
+msgstr "暂停游戏（备用）"
 
-#: Source/diablo.cpp:2010 Source/diablo.cpp:2522
-#, fuzzy
-#| msgid "Increase screen brightness."
+#: Source/diablo.cpp:2085 Source/diablo.cpp:2597
 msgid "Decrease Brightness"
-msgstr "增加​屏幕​亮度。"
+msgstr "降低亮度"
 
-#: Source/diablo.cpp:2011 Source/diablo.cpp:2523
+#: Source/diablo.cpp:2086 Source/diablo.cpp:2598
 msgid "Reduce screen brightness."
-msgstr "减少​屏幕​亮度。"
+msgstr "减少屏幕亮度。"
 
-#: Source/diablo.cpp:2018 Source/diablo.cpp:2530
-#, fuzzy
-#| msgid "Increase screen brightness."
+#: Source/diablo.cpp:2093 Source/diablo.cpp:2605
 msgid "Increase Brightness"
-msgstr "增加​屏幕​亮度。"
+msgstr "增加亮度"
 
-#: Source/diablo.cpp:2019 Source/diablo.cpp:2531
+#: Source/diablo.cpp:2094 Source/diablo.cpp:2606
 msgid "Increase screen brightness."
-msgstr "增加​屏幕​亮度。"
+msgstr "增加屏幕亮度。"
 
-#: Source/diablo.cpp:2026 Source/diablo.cpp:2538
+#: Source/diablo.cpp:2101 Source/diablo.cpp:2613
 msgid "Help"
 msgstr "帮助"
 
-#: Source/diablo.cpp:2027 Source/diablo.cpp:2539
+#: Source/diablo.cpp:2102 Source/diablo.cpp:2614
 msgid "Open Help Screen."
-msgstr "打开​帮助​屏幕。"
+msgstr "打开帮助屏幕。"
 
-#: Source/diablo.cpp:2034 Source/diablo.cpp:2546
+#: Source/diablo.cpp:2109 Source/diablo.cpp:2621
 msgid "Screenshot"
-msgstr "屏幕​截图"
+msgstr "屏幕截图"
 
-#: Source/diablo.cpp:2035 Source/diablo.cpp:2547
+#: Source/diablo.cpp:2110 Source/diablo.cpp:2622
 msgid "Takes a screenshot."
-msgstr "截取​当前​屏幕​画面​的​图片。"
+msgstr "截取当前屏幕画面的图片。"
 
-#: Source/diablo.cpp:2041 Source/diablo.cpp:2553
+#: Source/diablo.cpp:2116 Source/diablo.cpp:2628
 msgid "Game info"
-msgstr "游戏​信息"
+msgstr "游戏信息"
 
-#: Source/diablo.cpp:2042 Source/diablo.cpp:2554
+#: Source/diablo.cpp:2117 Source/diablo.cpp:2629
 msgid "Displays game infos."
-msgstr "显示​游戏​信息。"
+msgstr "显示游戏信息。"
 
-#. TRANSLATORS: {:s} means: Character Name, Game Version, Game Difficulty.
-#: Source/diablo.cpp:2046 Source/diablo.cpp:2558
+#. TRANSLATORS: {:s} means: Project Name, Game Version.
+#: Source/diablo.cpp:2121 Source/diablo.cpp:2633
 #, c++-format
 msgid "{:s} {:s}"
 msgstr "{:s} {:s}"
 
-#: Source/diablo.cpp:2055 Source/diablo.cpp:2575
+#: Source/diablo.cpp:2130 Source/diablo.cpp:2650
 msgid "Chat Log"
-msgstr "聊天​记录"
+msgstr "聊天记录"
 
-#: Source/diablo.cpp:2056 Source/diablo.cpp:2576
+#: Source/diablo.cpp:2131 Source/diablo.cpp:2651
 msgid "Displays chat log."
-msgstr "显示​聊天​记录。"
+msgstr "显示聊天记录。"
 
-#: Source/diablo.cpp:2063 Source/diablo.cpp:2567
+#: Source/diablo.cpp:2138 Source/diablo.cpp:2642
 msgid "Sort Inventory"
-msgstr "整理物品​栏"
+msgstr "整理物品栏"
 
-#: Source/diablo.cpp:2064 Source/diablo.cpp:2568
+#: Source/diablo.cpp:2139 Source/diablo.cpp:2643
 msgid "Sorts the inventory."
 msgstr "整理物品栏。"
 
-#: Source/diablo.cpp:2072
+#: Source/diablo.cpp:2147
 msgid "Console"
 msgstr "控制台"
 
-#: Source/diablo.cpp:2073
+#: Source/diablo.cpp:2148
 msgid "Opens Lua console."
 msgstr "打开 Lua 控制台。"
 
-#: Source/diablo.cpp:2129
+#: Source/diablo.cpp:2204
 msgid "Primary action"
 msgstr "主要动作"
 
-#: Source/diablo.cpp:2130
+#: Source/diablo.cpp:2205
 msgid "Attack monsters, talk to towners, lift and place inventory items."
 msgstr "工具怪物，和镇民交谈，捡起物品并放到物品栏。"
 
-#: Source/diablo.cpp:2144
+#: Source/diablo.cpp:2219
 msgid "Secondary action"
 msgstr "次要动作"
 
-#: Source/diablo.cpp:2145
+#: Source/diablo.cpp:2220
 msgid "Open chests, interact with doors, pick up items."
 msgstr "打开箱子，和门交互，捡起物品。"
 
-#: Source/diablo.cpp:2159
+#: Source/diablo.cpp:2234
 msgid "Spell action"
 msgstr "咒语动作"
 
-#: Source/diablo.cpp:2160
+#: Source/diablo.cpp:2235
 msgid "Cast the active spell."
 msgstr "施放激活的法术。"
 
-#: Source/diablo.cpp:2174
+#: Source/diablo.cpp:2249
 msgid "Cancel action"
 msgstr "取消动作"
 
-#: Source/diablo.cpp:2175
+#: Source/diablo.cpp:2250
 msgid "Close menus."
-msgstr "关闭​菜单。"
+msgstr "关闭菜单。"
 
-#: Source/diablo.cpp:2200
+#: Source/diablo.cpp:2275
 msgid "Move up"
 msgstr "向上移动"
 
-#: Source/diablo.cpp:2201
+#: Source/diablo.cpp:2276
 msgid "Moves the player character up."
 msgstr "玩家角色上移。"
 
-#: Source/diablo.cpp:2206
+#: Source/diablo.cpp:2281
 msgid "Move down"
 msgstr "向下移动"
 
-#: Source/diablo.cpp:2207
+#: Source/diablo.cpp:2282
 msgid "Moves the player character down."
 msgstr "玩家角色下移。"
 
-#: Source/diablo.cpp:2212
+#: Source/diablo.cpp:2287
 msgid "Move left"
 msgstr "左移"
 
-#: Source/diablo.cpp:2213
+#: Source/diablo.cpp:2288
 msgid "Moves the player character left."
 msgstr "玩家角色左移。"
 
-#: Source/diablo.cpp:2218
+#: Source/diablo.cpp:2293
 msgid "Move right"
 msgstr "右移"
 
-#: Source/diablo.cpp:2219
+#: Source/diablo.cpp:2294
 msgid "Moves the player character right."
 msgstr "玩家角色右移。"
 
-#: Source/diablo.cpp:2224
+#: Source/diablo.cpp:2299
 msgid "Stand ground"
 msgstr "站定"
 
-#: Source/diablo.cpp:2225
+#: Source/diablo.cpp:2300
 msgid "Hold to prevent the player from moving."
 msgstr "按住以防止角色移动。"
 
-#: Source/diablo.cpp:2230
+#: Source/diablo.cpp:2305
 msgid "Toggle stand ground"
 msgstr "启用站定"
 
-#: Source/diablo.cpp:2231
+#: Source/diablo.cpp:2306
 msgid "Toggle whether the player moves."
 msgstr "开关角色是否可移动。"
 
-#: Source/diablo.cpp:2310
-#, fuzzy
-#| msgid "Automap"
+#: Source/diablo.cpp:2385
 msgid "Automap Move Up"
-msgstr "自动​地图"
+msgstr "自动地图上移"
 
-#: Source/diablo.cpp:2311
+#: Source/diablo.cpp:2386
 msgid "Moves the automap up when active."
-msgstr ""
+msgstr "激活时向上移动自动地图。"
 
-#: Source/diablo.cpp:2316
-#, fuzzy
-#| msgid "Move down"
+#: Source/diablo.cpp:2391
 msgid "Automap Move Down"
-msgstr "向下移动"
+msgstr "自动地图下移"
 
-#: Source/diablo.cpp:2317
+#: Source/diablo.cpp:2392
 msgid "Moves the automap down when active."
-msgstr ""
+msgstr "激活时向下移动自动地图。"
 
-#: Source/diablo.cpp:2322
-#, fuzzy
-#| msgid "Move left"
+#: Source/diablo.cpp:2397
 msgid "Automap Move Left"
-msgstr "左移"
+msgstr "自动地图左移"
 
-#: Source/diablo.cpp:2323
-#, fuzzy
-#| msgid "Moves the player character up."
+#: Source/diablo.cpp:2398
 msgid "Moves the automap left when active."
-msgstr "玩家角色上移。"
+msgstr "激活时向左移动自动地图。"
 
-#: Source/diablo.cpp:2328
-#, fuzzy
-#| msgid "Move right"
+#: Source/diablo.cpp:2403
 msgid "Automap Move Right"
-msgstr "右移"
+msgstr "自动地图右移"
 
-#: Source/diablo.cpp:2329
+#: Source/diablo.cpp:2404
 msgid "Moves the automap right when active."
-msgstr ""
+msgstr "激活时向右移动自动地图。"
 
-#: Source/diablo.cpp:2334
+#: Source/diablo.cpp:2409
 msgid "Move mouse up"
 msgstr "向上移动鼠标"
 
-#: Source/diablo.cpp:2335
+#: Source/diablo.cpp:2410
 msgid "Simulates upward mouse movement."
 msgstr "模拟鼠标向上移动。"
 
-#: Source/diablo.cpp:2340
+#: Source/diablo.cpp:2415
 msgid "Move mouse down"
 msgstr "向下移动鼠标"
 
-#: Source/diablo.cpp:2341
+#: Source/diablo.cpp:2416
 msgid "Simulates downward mouse movement."
 msgstr "模拟鼠标向下移动。"
 
-#: Source/diablo.cpp:2346
+#: Source/diablo.cpp:2421
 msgid "Move mouse left"
 msgstr "向左移动鼠标"
 
-#: Source/diablo.cpp:2347
+#: Source/diablo.cpp:2422
 msgid "Simulates leftward mouse movement."
 msgstr "模拟鼠标向左移动。"
 
-#: Source/diablo.cpp:2352
+#: Source/diablo.cpp:2427
 msgid "Move mouse right"
 msgstr "向右移动鼠标"
 
-#: Source/diablo.cpp:2353
+#: Source/diablo.cpp:2428
 msgid "Simulates rightward mouse movement."
 msgstr "模拟鼠标向右移动。"
 
-#: Source/diablo.cpp:2371 Source/diablo.cpp:2378
+#: Source/diablo.cpp:2446 Source/diablo.cpp:2453
 msgid "Left mouse click"
 msgstr "鼠标左键点击"
 
-#: Source/diablo.cpp:2372 Source/diablo.cpp:2379
+#: Source/diablo.cpp:2447 Source/diablo.cpp:2454
 msgid "Simulates the left mouse button."
 msgstr "模拟鼠标左键点击。"
 
-#: Source/diablo.cpp:2396 Source/diablo.cpp:2403
+#: Source/diablo.cpp:2471 Source/diablo.cpp:2478
 msgid "Right mouse click"
 msgstr "鼠标右键点击"
 
-#: Source/diablo.cpp:2397 Source/diablo.cpp:2404
+#: Source/diablo.cpp:2472 Source/diablo.cpp:2479
 msgid "Simulates the right mouse button."
 msgstr "模拟鼠标右键点击。"
 
-#: Source/diablo.cpp:2410
+#: Source/diablo.cpp:2485
 msgid "Gamepad hotspell menu"
 msgstr "游戏手柄快捷法术菜单"
 
-#: Source/diablo.cpp:2411
+#: Source/diablo.cpp:2486
 msgid "Hold to set or use spell hotkeys."
 msgstr "按住以设置法术快捷键。"
 
-#: Source/diablo.cpp:2417
+#: Source/diablo.cpp:2492
 msgid "Gamepad menu navigator"
 msgstr "游戏手柄菜单导航"
 
-#: Source/diablo.cpp:2418
+#: Source/diablo.cpp:2493
 msgid "Hold to access gamepad menu navigation."
 msgstr "按住开启手柄菜单导航。"
 
-#: Source/diablo.cpp:2433 Source/diablo.cpp:2442
+#: Source/diablo.cpp:2508 Source/diablo.cpp:2517
 msgid "Toggle game menu"
 msgstr "切换游戏菜单"
 
-#: Source/diablo.cpp:2434 Source/diablo.cpp:2443
+#: Source/diablo.cpp:2509 Source/diablo.cpp:2518
 msgid "Opens the game menu."
 msgstr "打开游戏菜单。"
 
-#: Source/diablo_msg.cpp:63
+#: Source/diablo_msg.cpp:69
 msgid "Game saved"
 msgstr "游戏已保存"
 
-#: Source/diablo_msg.cpp:64
-msgid "No multiplayer functions in demo"
-msgstr "演示版​没有​多​人​游戏​功能"
-
-#: Source/diablo_msg.cpp:65
-msgid "Direct Sound Creation Failed"
-msgstr "Direct Sound 创建​失败"
-
-#: Source/diablo_msg.cpp:66
-msgid "Not available in shareware version"
-msgstr "在​共​享版​中​不​可​用"
-
-#: Source/diablo_msg.cpp:67
-msgid "Not enough space to save"
-msgstr "没有​足够​的​空间​保存​游戏"
-
-#: Source/diablo_msg.cpp:68
-msgid "No Pause in town"
-msgstr "城镇​中​无法​暂停"
-
-#: Source/diablo_msg.cpp:69
-msgid "Copying to a hard disk is recommended"
-msgstr "建议​复制​到​硬盘"
-
 #: Source/diablo_msg.cpp:70
-msgid "Multiplayer sync problem"
-msgstr "多​人​同步​问题"
+msgid "No multiplayer functions in demo"
+msgstr "演示版没有多人游戏功能"
 
 #: Source/diablo_msg.cpp:71
-msgid "No pause in multiplayer"
-msgstr "多​人​游戏​中​无法​暂停"
+msgid "Direct Sound Creation Failed"
+msgstr "Direct Sound 创建失败"
+
+#: Source/diablo_msg.cpp:72
+msgid "Not available in shareware version"
+msgstr "在共享版中不可用"
 
 #: Source/diablo_msg.cpp:73
-msgid "Saving..."
-msgstr "保存​中​…​…"
+msgid "Not enough space to save"
+msgstr "没有足够的空间保存游戏"
 
-#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:74
-msgid "Some are weakened as one grows strong"
-msgstr "一​种​力量​变强​的​背后​潜藏​着​其他​力量​的​衰弱"
+msgid "No Pause in town"
+msgstr "城镇中无法暂停"
 
-#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:75
-msgid "New strength is forged through destruction"
-msgstr "毁灭​塑造​了​新​的​力量"
+msgid "Copying to a hard disk is recommended"
+msgstr "建议复制到硬盘"
 
-#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:76
-msgid "Those who defend seldom attack"
-msgstr "专注​防御​意味​着​放弃​进攻"
+msgid "Multiplayer sync problem"
+msgstr "多人同步问题"
 
-#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:77
-msgid "The sword of justice is swift and sharp"
-msgstr "正义​之​剑​迅捷​而​锋利"
+msgid "No pause in multiplayer"
+msgstr "多人游戏中无法暂停"
 
-#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
-#: Source/diablo_msg.cpp:78
-msgid "While the spirit is vigilant the body thrives"
-msgstr "君子​终日​乾乾夕惕若厉无咎"
-
-#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:79
-msgid "The powers of mana refocused renews"
-msgstr "法力​的​能量​奔流​不息"
+msgid "Saving..."
+msgstr "保存中……"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:80
-msgid "Time cannot diminish the power of steel"
-msgstr "时间​也​无法​削弱​钢铁​之​力"
+msgid "Some are weakened as one grows strong"
+msgstr "一种力量变强的背后潜藏着其他力量的衰弱"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:81
-msgid "Magic is not always what it seems to be"
-msgstr "魔法​并不​总是​看​起来​的​那样"
+msgid "New strength is forged through destruction"
+msgstr "毁灭塑造了新的力量"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:82
-msgid "What once was opened now is closed"
-msgstr "曾​今​开启​的，如今​却​关上​了"
+msgid "Those who defend seldom attack"
+msgstr "专注防御意味着放弃进攻"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:83
-msgid "Intensity comes at the cost of wisdom"
-msgstr "无妄​的​力量，以​智慧​为​代价"
+msgid "The sword of justice is swift and sharp"
+msgstr "正义之剑迅捷而锋利"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:84
-msgid "Arcane power brings destruction"
-msgstr "神秘​力量​带来​毁灭"
+msgid "While the spirit is vigilant the body thrives"
+msgstr "君子终日乾乾夕惕若厉无咎"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:85
-msgid "That which cannot be held cannot be harmed"
-msgstr "不​能​持有​的​东西​不​能​受到​伤害"
+msgid "The powers of mana refocused renews"
+msgstr "法力的能量奔流不息"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:86
-msgid "Crimson and Azure become as the sun"
-msgstr "深​红​和​湛蓝​如​太阳​和​天空"
+msgid "Time cannot diminish the power of steel"
+msgstr "时间也无法削弱钢铁之力"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:87
-msgid "Knowledge and wisdom at the cost of self"
-msgstr "以​牺牲​自我​为​代价​的​知识​和​智慧"
+msgid "Magic is not always what it seems to be"
+msgstr "魔法并不总是看起来的那样"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:88
-msgid "Drink and be refreshed"
-msgstr "一饮而尽，酣畅​淋漓"
+msgid "What once was opened now is closed"
+msgstr "曾今开启的，如今却关上了"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:89
-msgid "Wherever you go, there you are"
-msgstr "身​在，心​在"
+msgid "Intensity comes at the cost of wisdom"
+msgstr "无妄的力量，以智慧为代价"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:90
-msgid "Energy comes at the cost of wisdom"
-msgstr "能量​是​以​智慧​为​代价​的"
+msgid "Arcane power brings destruction"
+msgstr "神秘力量带来毁灭"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:91
-msgid "Riches abound when least expected"
-msgstr "无​心​插柳柳​成荫"
+msgid "That which cannot be held cannot be harmed"
+msgstr "不能持有的东西不能受到伤害"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:92
-msgid "Where avarice fails, patience gains reward"
-msgstr "贪​婪​导致​失败，谦逊​得到​奖励"
+msgid "Crimson and Azure become as the sun"
+msgstr "深红和湛蓝如太阳和天空"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:93
-msgid "Blessed by a benevolent companion!"
-msgstr "被​仁慈​的​同伴​祝福！"
+msgid "Knowledge and wisdom at the cost of self"
+msgstr "以牺牲自我为代价的知识和智慧"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:94
-msgid "The hands of men may be guided by fate"
-msgstr "命运​之​手​无形​的​操控​一切"
+msgid "Drink and be refreshed"
+msgstr "一饮而尽，酣畅淋漓"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:95
-msgid "Strength is bolstered by heavenly faith"
-msgstr "天行健​君子​以​自强不息"
+msgid "Wherever you go, there you are"
+msgstr "身在，心在"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:96
-msgid "The essence of life flows from within"
-msgstr "生命​的​本质​来自​内在"
+msgid "Energy comes at the cost of wisdom"
+msgstr "能量是以智慧为代价的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:97
-msgid "The way is made clear when viewed from above"
-msgstr "当局​者迷，旁观者​清"
+msgid "Riches abound when least expected"
+msgstr "无心插柳柳成荫"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:98
-msgid "Salvation comes at the cost of wisdom"
-msgstr "拯救​是​以​智慧​为​代价​的"
+msgid "Where avarice fails, patience gains reward"
+msgstr "贪婪导致失败，谦逊得到奖励"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:99
-msgid "Mysteries are revealed in the light of reason"
-msgstr "神秘​将​在​光芒​中​揭露"
+msgid "Blessed by a benevolent companion!"
+msgstr "被仁慈的同伴祝福！"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:100
-msgid "Those who are last may yet be first"
-msgstr "最后​一​个​可能​还​是​第一​个"
+msgid "The hands of men may be guided by fate"
+msgstr "命运之手无形的操控一切"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:101
-msgid "Generosity brings its own rewards"
-msgstr "慷慨​自​有​回报"
+msgid "Strength is bolstered by heavenly faith"
+msgstr "天行健君子以自强不息"
 
+#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:102
-msgid "You must be at least level 8 to use this."
-msgstr "你​必须​至少​达到​8​级​才​能​使用​这个。"
+msgid "The essence of life flows from within"
+msgstr "生命的本质来自内在"
 
+#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:103
-msgid "You must be at least level 13 to use this."
-msgstr "你​必须​至少​达到​13级​才​能​使用​这个。"
+msgid "The way is made clear when viewed from above"
+msgstr "当局者迷，旁观者清"
 
+#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:104
-msgid "You must be at least level 17 to use this."
-msgstr "你​必须​至少​达到​17级​才​能​使用​这个。"
+msgid "Salvation comes at the cost of wisdom"
+msgstr "拯救是以智慧为代价的"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:105
-msgid "Arcane knowledge gained!"
-msgstr "获得​奥术​知识！"
+msgid "Mysteries are revealed in the light of reason"
+msgstr "神秘将在光芒中揭露"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:106
-msgid "That which does not kill you..."
-msgstr "那​不​会​杀掉​你​…​…"
+msgid "Those who are last may yet be first"
+msgstr "最后一个可能还是第一个"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:107
-msgid "Knowledge is power."
-msgstr "知识​就​是​力量。"
+msgid "Generosity brings its own rewards"
+msgstr "慷慨自有回报"
 
-#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:108
-msgid "Give and you shall receive."
-msgstr "付出​才​有​回报。"
+msgid "You must be at least level 8 to use this."
+msgstr "你必须至少达到8级才能使用这个。"
 
-#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:109
-msgid "Some experience is gained by touch."
-msgstr "通过​触碰​获得​了​一些​经验值。"
+msgid "You must be at least level 13 to use this."
+msgstr "你必须至少达到13级才能使用这个。"
 
-#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:110
-msgid "There's no place like home."
-msgstr "没有​比家​更​好​的​地方​了。"
+msgid "You must be at least level 17 to use this."
+msgstr "你必须至少达到17级才能使用这个。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:111
-msgid "Spiritual energy is restored."
-msgstr "精神​能量​被​恢复。"
+msgid "Arcane knowledge gained!"
+msgstr "获得奥术知识！"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:112
-msgid "You feel more agile."
-msgstr "你​感觉​更加​敏捷。"
+msgid "That which does not kill you..."
+msgstr "那不会杀掉你……"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:113
-msgid "You feel stronger."
-msgstr "你​感觉​更​加强​壮。"
+msgid "Knowledge is power."
+msgstr "知识就是力量。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:114
-msgid "You feel wiser."
-msgstr "你​觉得​更加​睿智。"
+msgid "Give and you shall receive."
+msgstr "付出才有回报。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:115
-msgid "You feel refreshed."
-msgstr "你​感觉​神清气爽。"
+msgid "Some experience is gained by touch."
+msgstr "通过触碰获得了一些经验值。"
 
 #. TRANSLATORS: Shrine Text. Keep atmospheric. :)
 #: Source/diablo_msg.cpp:116
+msgid "There's no place like home."
+msgstr "没有比家更好的地方了。"
+
+#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
+#: Source/diablo_msg.cpp:117
+msgid "Spiritual energy is restored."
+msgstr "精神能量被恢复。"
+
+#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
+#: Source/diablo_msg.cpp:118
+msgid "You feel more agile."
+msgstr "你感觉更加敏捷。"
+
+#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
+#: Source/diablo_msg.cpp:119
+msgid "You feel stronger."
+msgstr "你感觉更加强壮。"
+
+#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
+#: Source/diablo_msg.cpp:120
+msgid "You feel wiser."
+msgstr "你觉得更加睿智。"
+
+#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
+#: Source/diablo_msg.cpp:121
+msgid "You feel refreshed."
+msgstr "你感觉神清气爽。"
+
+#. TRANSLATORS: Shrine Text. Keep atmospheric. :)
+#: Source/diablo_msg.cpp:122
 msgid "That which can break will."
-msgstr "这​会​让​意志​崩溃。"
+msgstr "这会让意志崩溃。"
 
 #: Source/discord/discord.cpp:81
 msgid "Cathedral"
-msgstr "大​教堂"
+msgstr "大教堂"
 
 #: Source/discord/discord.cpp:81
 msgid "Catacombs"
@@ -2126,7 +2147,7 @@ msgstr "洞窟"
 
 #: Source/discord/discord.cpp:81
 msgid "Nest"
-msgstr "巢​穴"
+msgstr "巢穴"
 
 #: Source/discord/discord.cpp:81
 msgid "Crypt"
@@ -2148,26 +2169,32 @@ msgstr "层 {} {}"
 #: Source/discord/discord.cpp:116
 #, c++-format
 msgid "{} difficulty"
-msgstr "难度​：​{}"
+msgstr "难度：{}"
 
 #. TRANSLATORS: Discord activity, not in game
 #: Source/discord/discord.cpp:197
 msgid "In Menu"
-msgstr "菜​单​中"
+msgstr "菜单中"
 
 #: Source/dvlnet/loopback.cpp:117
 msgid "loopback"
 msgstr "环回"
 
-#: Source/dvlnet/tcp_client.cpp:112
+#: Source/dvlnet/tcp_client.cpp:119
 msgid "Unable to connect"
-msgstr "无法​连接"
+msgstr "无法连接"
 
-#: Source/dvlnet/tcp_client.cpp:150
+#: Source/dvlnet/tcp_client.cpp:157
 msgid "error: read 0 bytes from server"
-msgstr "错误: 从​服务器​读取​了​0​个​字节"
+msgstr "错误: 从服务器读取了0个字节"
 
-#: Source/engine/assets.cpp:244
+#: Source/dvlnet/tcp_client.cpp:217
+msgid ""
+"Server failed to decrypt your packet. Check if you typed the password "
+"correctly."
+msgstr "服务器无法解密您的数据包。请检查密码是否输入正确。"
+
+#: Source/engine/assets.cpp:360
 #, c++-format
 msgid ""
 "Failed to open file:\n"
@@ -2177,266 +2204,266 @@ msgid ""
 "\n"
 "The MPQ file(s) might be damaged. Please check the file integrity."
 msgstr ""
+"无法打开文件：\n"
+"{:s}\n"
+"\n"
+"{:s}\n"
+"\n"
+"MPQ 文件可能已损坏，请检查文件完整性。"
 
-#: Source/engine/assets.cpp:426
+#: Source/engine/assets.cpp:551
 msgid "diabdat.mpq or spawn.mpq"
 msgstr "diabdat.mpq或spawn.mpq"
 
-#: Source/engine/assets.cpp:464
+#: Source/engine/assets.cpp:589
 msgid "Some Hellfire MPQs are missing"
-msgstr "一些​地狱火​MPQ​无法​找到"
+msgstr "一些地狱火MPQ无法找到"
 
-#: Source/engine/assets.cpp:464
+#: Source/engine/assets.cpp:589
 msgid ""
 "Not all Hellfire MPQs were found.\n"
 "Please copy all the hf*.mpq files."
 msgstr ""
-"地​狱火​MPQ​未​能​全部​找到。\n"
-"​请​复制​所有​hf​*​.mpq​文件。"
+"地狱火MPQ未能全部找到。\n"
+"请复制所有hf*.mpq文件。"
 
-#: Source/engine/demomode.cpp:181 Source/options.cpp:535
+#: Source/engine/demomode.cpp:189 Source/options.cpp:549
 msgid "Resolution"
 msgstr "分辨率"
 
-#: Source/engine/demomode.cpp:183 Source/options.cpp:784
+#: Source/engine/demomode.cpp:191 Source/options.cpp:844
 msgid "Run in Town"
-msgstr "城镇​中​奔跑"
+msgstr "城镇中奔跑"
 
-#: Source/engine/demomode.cpp:184 Source/options.cpp:787
+#: Source/engine/demomode.cpp:192 Source/options.cpp:847
 msgid "Theo Quest"
-msgstr "西奥​任务"
+msgstr "西奥任务"
 
-#: Source/engine/demomode.cpp:185 Source/options.cpp:788
+#: Source/engine/demomode.cpp:193 Source/options.cpp:848
 msgid "Cow Quest"
-msgstr "奶牛​任务"
+msgstr "奶牛任务"
 
-#: Source/engine/demomode.cpp:186 Source/options.cpp:800
+#: Source/engine/demomode.cpp:194 Source/options.cpp:860
 msgid "Auto Gold Pickup"
-msgstr "自动​拾取​金币"
+msgstr "自动拾取金币"
 
-#: Source/engine/demomode.cpp:187 Source/options.cpp:801
+#: Source/engine/demomode.cpp:195 Source/options.cpp:861
 msgid "Auto Elixir Pickup"
-msgstr "自动​拾取​药剂"
+msgstr "自动拾取药剂"
 
-#: Source/engine/demomode.cpp:188 Source/options.cpp:802
+#: Source/engine/demomode.cpp:196 Source/options.cpp:862
 msgid "Auto Oil Pickup"
-msgstr "自动​拾取​油"
+msgstr "自动拾取油"
 
-#: Source/engine/demomode.cpp:189 Source/options.cpp:803
+#: Source/engine/demomode.cpp:197 Source/options.cpp:863
 msgid "Auto Pickup in Town"
-msgstr "城镇​中​自动​拾取"
+msgstr "城镇中自动拾取"
 
-#: Source/engine/demomode.cpp:190 Source/options.cpp:804
-msgid "Adria Refills Mana"
-msgstr "艾德莉亚​补充​法​力值"
-
-#: Source/engine/demomode.cpp:191 Source/options.cpp:805
+#: Source/engine/demomode.cpp:198 Source/options.cpp:864
 msgid "Auto Equip Weapons"
-msgstr "自动​装备​武器"
+msgstr "自动装备武器"
 
-#: Source/engine/demomode.cpp:192 Source/options.cpp:806
+#: Source/engine/demomode.cpp:199 Source/options.cpp:865
 msgid "Auto Equip Armor"
-msgstr "自动​装备​护甲"
+msgstr "自动装备护甲"
 
-#: Source/engine/demomode.cpp:193 Source/options.cpp:807
+#: Source/engine/demomode.cpp:200 Source/options.cpp:866
 msgid "Auto Equip Helms"
-msgstr "自动​装备​头盔"
+msgstr "自动装备头盔"
 
-#: Source/engine/demomode.cpp:194 Source/options.cpp:808
+#: Source/engine/demomode.cpp:201 Source/options.cpp:867
 msgid "Auto Equip Shields"
-msgstr "自动​装备​盾​牌"
+msgstr "自动装备盾牌"
 
-#: Source/engine/demomode.cpp:195 Source/options.cpp:809
+#: Source/engine/demomode.cpp:202 Source/options.cpp:868
 msgid "Auto Equip Jewelry"
-msgstr "自动​装备​首饰"
+msgstr "自动装备首饰"
 
-#: Source/engine/demomode.cpp:196 Source/options.cpp:810
+#: Source/engine/demomode.cpp:203 Source/options.cpp:869
 msgid "Randomize Quests"
-msgstr "随机化​任务"
+msgstr "随机化任务"
 
-#: Source/engine/demomode.cpp:197 Source/options.cpp:812
+#: Source/engine/demomode.cpp:204 Source/options.cpp:871
 msgid "Show Item Labels"
-msgstr "显示​物品标签"
+msgstr "显示物品标签"
 
-#: Source/engine/demomode.cpp:198 Source/options.cpp:813
+#: Source/engine/demomode.cpp:205 Source/options.cpp:872
 msgid "Auto Refill Belt"
-msgstr "自动​填充腰​带"
+msgstr "自动填充腰带"
 
-#: Source/engine/demomode.cpp:199 Source/options.cpp:814
+#: Source/engine/demomode.cpp:206 Source/options.cpp:873
 msgid "Disable Crippling Shrines"
-msgstr "停用​坑​爹​神殿"
+msgstr "停用坑爹神殿"
 
-#: Source/engine/demomode.cpp:203 Source/options.cpp:816
+#: Source/engine/demomode.cpp:210 Source/options.cpp:875
 msgid "Heal Potion Pickup"
-msgstr "拾​取 生命​恢复​药剂"
+msgstr "拾取 生命恢复药剂"
 
-#: Source/engine/demomode.cpp:204 Source/options.cpp:817
+#: Source/engine/demomode.cpp:211 Source/options.cpp:876
 msgid "Full Heal Potion Pickup"
-msgstr "拾​取 完全​生命​恢复​药剂"
+msgstr "拾取 完全生命恢复药剂"
 
-#: Source/engine/demomode.cpp:205 Source/options.cpp:818
+#: Source/engine/demomode.cpp:212 Source/options.cpp:877
 msgid "Mana Potion Pickup"
-msgstr "拾​取 法力​恢复​药剂"
+msgstr "拾取 法力恢复药剂"
 
-#: Source/engine/demomode.cpp:206 Source/options.cpp:819
+#: Source/engine/demomode.cpp:213 Source/options.cpp:878
 msgid "Full Mana Potion Pickup"
-msgstr "拾​取 完全​法力​恢复​药剂"
+msgstr "拾取 完全法力恢复药剂"
 
-#: Source/engine/demomode.cpp:207 Source/options.cpp:820
+#: Source/engine/demomode.cpp:214 Source/options.cpp:879
 msgid "Rejuvenation Potion Pickup"
-msgstr "拾​取 活力​恢复​药​水"
+msgstr "拾取 活力恢复药水"
 
-#: Source/engine/demomode.cpp:208 Source/options.cpp:821
+#: Source/engine/demomode.cpp:215 Source/options.cpp:880
 msgid "Full Rejuvenation Potion Pickup"
-msgstr "拾​取 完全​活力​恢复​药​水"
+msgstr "拾取 完全活力恢复药水"
 
-#: Source/gamemenu.cpp:48 Source/gamemenu.cpp:60
+#: Source/gamemenu.cpp:52 Source/gamemenu.cpp:64
 msgid "Options"
-msgstr "选​项"
+msgstr "选项"
 
-#: Source/gamemenu.cpp:49
+#: Source/gamemenu.cpp:53
 msgid "Save Game"
-msgstr "保存​游戏"
+msgstr "保存游戏"
 
-#: Source/gamemenu.cpp:51 Source/gamemenu.cpp:61
-#, fuzzy
-#| msgid "Main Menu"
+#: Source/gamemenu.cpp:55 Source/gamemenu.cpp:65
 msgid "Exit to Main Menu"
-msgstr "主​菜​单"
+msgstr "返回主菜单"
 
-#: Source/gamemenu.cpp:52 Source/gamemenu.cpp:62
+#: Source/gamemenu.cpp:56 Source/gamemenu.cpp:66
 msgid "Quit Game"
-msgstr "退出​游戏"
+msgstr "退出游戏"
 
-#: Source/gamemenu.cpp:71
+#: Source/gamemenu.cpp:75
 msgid "Gamma"
 msgstr "伽马"
 
-#: Source/gamemenu.cpp:72 Source/gamemenu.cpp:171
+#: Source/gamemenu.cpp:76 Source/gamemenu.cpp:175
 msgid "Speed"
 msgstr "速度"
 
-#: Source/gamemenu.cpp:80
-msgid "Music Disabled"
-msgstr "音乐​已​禁​用"
-
 #: Source/gamemenu.cpp:84
+msgid "Music Disabled"
+msgstr "音乐已禁用"
+
+#: Source/gamemenu.cpp:88
 msgid "Sound"
 msgstr "声音"
 
-#: Source/gamemenu.cpp:85
+#: Source/gamemenu.cpp:89
 msgid "Sound Disabled"
-msgstr "声音​已​禁​用"
+msgstr "声音已禁用"
 
-#: Source/gmenu.cpp:179
+#: Source/gmenu.cpp:190
 msgid "Pause"
 msgstr "暂停"
 
 #: Source/help.cpp:28
 msgid "$Keyboard Shortcuts:"
-msgstr "快​捷键​(​$​K):"
+msgstr "快捷键($K):"
 
 #: Source/help.cpp:29
 msgid "F1:    Open Help Screen"
-msgstr "F1:    打开​帮助​屏幕"
+msgstr "F1:    打开帮助屏幕"
 
 #: Source/help.cpp:30
 msgid "Esc:   Display Main Menu"
-msgstr "Esc:   无法​显示​主菜​单"
+msgstr "Esc:   显示主菜单"
 
 #: Source/help.cpp:31
 msgid "Tab:   Display Auto-map"
-msgstr "Tab:   显示​自动​地图"
+msgstr "Tab:   显示自动地图"
 
 #: Source/help.cpp:32
 msgid "Space: Hide all info screens"
-msgstr "空​格: 隐藏​所有​信息​栏"
+msgstr "空格: 隐藏所有信息栏"
 
 #: Source/help.cpp:33
 msgid "S: Open Speedbook"
-msgstr "S: 打开​快捷​法术书"
+msgstr "S: 打开快捷法术书"
 
 #: Source/help.cpp:34
 msgid "B: Open Spellbook"
-msgstr "B: 打开​法术书"
+msgstr "B: 打开法术书"
 
 #: Source/help.cpp:35
 msgid "I: Open Inventory screen"
-msgstr "I: 打开​物品​栏"
+msgstr "I: 打开物品栏"
 
 #: Source/help.cpp:36
 msgid "C: Open Character screen"
-msgstr "C: 打开​角色​栏"
+msgstr "C: 打开角色栏"
 
 #: Source/help.cpp:37
 msgid "Q: Open Quest log"
-msgstr "Q: 任务​日志"
+msgstr "Q: 任务日志"
 
 #: Source/help.cpp:38
 msgid "F: Reduce screen brightness"
-msgstr "F: 降低​屏幕​亮度"
+msgstr "F: 降低屏幕亮度"
 
 #: Source/help.cpp:39
 msgid "G: Increase screen brightness"
-msgstr "G: 提高​屏幕​亮度"
+msgstr "G: 提高屏幕亮度"
 
 #: Source/help.cpp:40
 msgid "Z: Zoom Game Screen"
-msgstr "Z: 缩放​游戏​屏幕"
+msgstr "Z: 缩放游戏屏幕"
 
 #: Source/help.cpp:41
 msgid "+ / -: Zoom Automap"
-msgstr "+ / -: 缩放​放​自动​映射"
+msgstr "+ / -: 缩放自动地图"
 
 #: Source/help.cpp:42
 msgid "1 - 8: Use Belt item"
-msgstr "1 - 8: 使用​腰带​上​的​物品"
+msgstr "1 - 8: 使用腰带上的物品"
 
 #: Source/help.cpp:43
 msgid "F5, F6, F7, F8:     Set hotkey for skill or spell"
-msgstr "F5, F6, F7, F8:     设置​技能​或​法术​热键"
+msgstr "F5, F6, F7, F8:     设置技能或法术热键"
 
 #: Source/help.cpp:44
 msgid "Shift + Left Mouse Button: Attack without moving"
-msgstr "Shift + 鼠标​左​键: 静止​攻击"
+msgstr "Shift + 鼠标左键: 静止攻击"
 
 #: Source/help.cpp:45
 msgid "Shift + Left Mouse Button (on character screen): Assign all stat points"
-msgstr "Shift + 鼠标​左​键(​在​角色​栏): 分配​所有​统计​点数"
+msgstr "Shift + 鼠标左键(在角色栏): 分配所有统计点数"
 
 #: Source/help.cpp:46
 msgid ""
 "Shift + Left Mouse Button (on inventory): Move item to belt or equip/unequip "
 "item"
-msgstr "Shift + 鼠标​左​键(​在​物品​栏): 移动​物品​到​腰带​或​装备​/​卸下​物品"
+msgstr "Shift + 鼠标左键(在物品栏): 移动物品到腰带或装备/卸下物品"
 
 #: Source/help.cpp:47
 msgid "Shift + Left Mouse Button (on belt): Move item to inventory"
-msgstr "Shift + 鼠标​左​键(​在​腰带​栏​): 移动​物品​到​腰带"
+msgstr "Shift + 鼠标左键(在腰带栏): 移动物品到腰带"
 
 #: Source/help.cpp:49
 msgid "$Movement:"
-msgstr "移动​(​$​M)​："
+msgstr "移动($M)："
 
 #: Source/help.cpp:50
 msgid ""
 "If you hold the mouse button down while moving, the character will continue "
 "to move in that direction."
-msgstr "如果​你​按​住鼠​标键​并且​移动，角色​会​继续​跟着​鼠标​移动。"
+msgstr "如果你按住鼠标键并且移动，角色会继续跟着鼠标移动。"
 
 #: Source/help.cpp:53
 msgid "$Combat:"
-msgstr "进攻​(​$​C)​："
+msgstr "进攻($C)："
 
 #: Source/help.cpp:54
 msgid ""
 "Holding down the shift key and then left-clicking allows the character to "
 "attack without moving."
-msgstr "按​住​shift键​点击​左键，可以​让​角色​攻击​时​不​移动。"
+msgstr "按住shift键点击左键，可以让角色攻击时不移动。"
 
 #: Source/help.cpp:57
 msgid "$Auto-map:"
-msgstr "自动​地图​(​$​A)​："
+msgstr "自动地图($A)："
 
 #: Source/help.cpp:58
 msgid ""
@@ -2444,12 +2471,12 @@ msgid ""
 "press 'TAB' on the keyboard. Zooming in and out of the map is done with the "
 "+ and - keys. Scrolling the map uses the arrow keys."
 msgstr ""
-"要​访问​自动​地图，点击​信息栏​的​'MAP'​按钮​或​按​一下​'​TAB​'键。使用 + 和 - 来​放大​或​缩"
-"小。使用​箭头键​滚动​动图。"
+"要访问自动地图，点击信息栏的'MAP'按钮或按一下'TAB'键。使用 + 和 - 来放大或缩"
+"小。使用箭头键滚动地图。"
 
 #: Source/help.cpp:63
 msgid "$Picking up Objects:"
-msgstr "拾​起​物品​(​$​P):"
+msgstr "拾起物品($P):"
 
 #: Source/help.cpp:64
 msgid ""
@@ -2459,23 +2486,23 @@ msgid ""
 "box. Items may be used by either pressing the corresponding number or right-"
 "clicking on the item."
 msgstr ""
-"常​用​的​物品​都​比较​小，比如​药水​和​卷轴，会​被​自动​放入​面板​上方​的​腰带栏。当​一样​物品​"
-"放入腰​带栏，一​个​小小​的​数字会​显示​在​那​一​格。物品​可以​通过​按​对应​的​数字​或​右边​点​击"
-"来​使用。"
+"常用的物品都比较小，比如药水和卷轴，会被自动放入面板上方的腰带栏。当一样物品"
+"放入腰带栏，一个小小的数字会显示在那一格。物品可以通过按对应的数字或右键点击"
+"来使用。"
 
 #: Source/help.cpp:70
 msgid "$Gold:"
-msgstr "金币​(​$​G):"
+msgstr "金币($G):"
 
 #: Source/help.cpp:71
 msgid ""
 "You can select a specific amount of gold to drop by right-clicking on a pile "
 "of gold in your inventory."
-msgstr "你​可以​在​物品​栏​里​的​一​堆​金币​上​点击​右键​以​移动​指定​的​数量。"
+msgstr "你可以在物品栏里的一堆金币上点击右键以移动指定的数量。"
 
 #: Source/help.cpp:74
 msgid "$Skills & Spells:"
-msgstr "技能 & 法术​(​$​S):"
+msgstr "技能 & 法术($S):"
 
 #: Source/help.cpp:75
 msgid ""
@@ -2485,13 +2512,13 @@ msgid ""
 "will ready the spell. A readied spell may be cast by simply right-clicking "
 "in the play area."
 msgstr ""
-"你​可以​点击​面板​的​'​SPELLS'​按钮​来​查看​技能​和​法术​列表。此​处​列出​了​记忆​的​法术​和​可​通"
-"过​法杖​获得​的​法术。 左键​单击​您​要​施放​的​法术​将​使​该​法术​准备​就绪。 一​个​准备​好​的​法"
-"术​可以​通过​在​游戏​区域​中​单击​右键​来​施放。"
+"你可以点击面板的'SPELLS'按钮来查看技能和法术列表。此处列出了记忆的法术和可通"
+"过法杖获得的法术。 左键单击您要施放的法术将使该法术准备就绪。 一个准备好的法"
+"术可以通过在游戏区域中单击右键来施放。"
 
 #: Source/help.cpp:81
 msgid "$Using the Speedbook for Spells:"
-msgstr "使用​快捷​法术​书施法​(​$​U)​："
+msgstr "使用快捷法术书施法($U)："
 
 #: Source/help.cpp:82
 msgid ""
@@ -2499,18 +2526,18 @@ msgid ""
 "allows you to select a skill or spell for immediate use. To use a readied "
 "skill or spell, simply right-click in the main play area."
 msgstr ""
-"左键​单击​“​准备​就绪​的​技能​”​按钮​将​打开​“​快捷​法术​书​”，它​将​让​您​能够​选择​技能​或者​法术​"
-"快速​使用。要​使用​准备​好​的​技能​或​法术，仅​需​右​键​点击​游戏​可​用​区域。"
+"左键单击“准备就绪的技能”按钮将打开“快捷法术书”，它将让您能够选择技能或者法术"
+"快速使用。要使用准备好的技能或法术，仅需右键点击游戏可用区域。"
 
 #: Source/help.cpp:86
 msgid ""
 "Shift + Left-clicking on the 'select current spell' button will clear the "
 "readied spell."
-msgstr "Shift + 左键​单击​“​选择​当前​法术​”​按钮​将​清除​准备​好​的​法术。"
+msgstr "Shift + 左键单击“选择当前法术”按钮将清除准备好的法术。"
 
 #: Source/help.cpp:88
 msgid "$Setting Spell Hotkeys:"
-msgstr "设置​技能​热键(​$​S)​："
+msgstr "设置技能热键($S)："
 
 #: Source/help.cpp:89
 msgid ""
@@ -2518,803 +2545,807 @@ msgid ""
 "opening the 'speedbook' as described in the section above. Press the F5, F6, "
 "F7 or F8 keys after highlighting the spell you wish to assign."
 msgstr ""
-"您​最多​可以​为​技能、法术​或​卷轴​分配​四​个​热键。 首先​打开​上​一​节​所述​的​“​快捷​法术书​"
-"”。 选​中​施法​目标​后，它​将​高亮，这时​按 F5、F6、F7 或 F8 键施法。"
+"您最多可以为技能、法术或卷轴分配四个热键。 首先打开上一节所述的“快捷法术"
+"书”。 选中施法目标后，它将高亮，这时按 F5、F6、F7 或 F8 键施法。"
 
 #: Source/help.cpp:94
 msgid "$Spell Books:"
-msgstr "法术书(​$​S)​："
+msgstr "法术书($S)："
 
 #: Source/help.cpp:95
 msgid ""
 "Reading more than one book increases your knowledge of that spell, allowing "
 "you to cast the spell more effectively."
-msgstr "阅读​不止​一​本​书​可以​增加​您​对​该​法术​的​了解，使​您​能够​更​有效​地​施展​该​法术。"
+msgstr "阅读不止一本书可以增加您对该法术的了解，使您能够更有效地施展该法术。"
 
 #: Source/help.cpp:200
 msgid "Shareware Hellfire Help"
-msgstr "共​享版​地​狱火​帮助"
+msgstr "共享版地狱火帮助"
 
 #: Source/help.cpp:200
 msgid "Hellfire Help"
-msgstr "地​狱火​帮助"
+msgstr "地狱火帮助"
 
 #: Source/help.cpp:202
 msgid "Shareware Diablo Help"
-msgstr "共​享版​暗黑​破坏​神​帮助"
+msgstr "共享版暗黑破坏神帮助"
 
 #: Source/help.cpp:202
 msgid "Diablo Help"
-msgstr "暗​黑​破坏​神​帮助"
+msgstr "暗黑破坏神帮助"
 
 #: Source/help.cpp:234 Source/qol/chatlog.cpp:202
 msgid "Press ESC to end or the arrow keys to scroll."
-msgstr "按​ESC键​结束，或​按​方向​键​滚动。"
+msgstr "按ESC键结束，或按方向键滚动。"
 
-#: Source/init.cpp:130
+#: Source/init.cpp:132
 msgid "Unable to create main window"
-msgstr "无法​创建主​窗口"
+msgstr "无法创建主窗口"
 
-#: Source/inv.cpp:2228
+#: Source/inv.cpp:2002
+msgid "Fully Repaired"
+msgstr "已完全修复"
+
+#: Source/inv.cpp:2255
 msgid "No room for item"
 msgstr "没有存放物品的空间"
 
-#: Source/items.cpp:212 Source/translation_dummy.cpp:298
+#: Source/items.cpp:218 Source/translation_dummy.cpp:298
 msgid "Oil of Accuracy"
-msgstr "精准​之​油"
-
-#: Source/items.cpp:213
-msgid "Oil of Mastery"
-msgstr "掌控​之​油"
-
-#: Source/items.cpp:214 Source/translation_dummy.cpp:299
-msgid "Oil of Sharpness"
-msgstr "锐利​之​油"
-
-#: Source/items.cpp:215
-msgid "Oil of Death"
-msgstr "死亡​之​油"
-
-#: Source/items.cpp:216
-msgid "Oil of Skill"
-msgstr "技能​之​油"
-
-#: Source/items.cpp:217 Source/translation_dummy.cpp:251
-msgid "Blacksmith Oil"
-msgstr "铁匠​之​油"
-
-#: Source/items.cpp:218
-msgid "Oil of Fortitude"
-msgstr "坚韧​之​油"
+msgstr "精准之油"
 
 #: Source/items.cpp:219
-msgid "Oil of Permanence"
-msgstr "永恒​之​油"
+msgid "Oil of Mastery"
+msgstr "掌控之油"
 
-#: Source/items.cpp:220
-msgid "Oil of Hardening"
-msgstr "硬化​之​油"
+#: Source/items.cpp:220 Source/translation_dummy.cpp:299
+msgid "Oil of Sharpness"
+msgstr "锐利之油"
 
 #: Source/items.cpp:221
+msgid "Oil of Death"
+msgstr "死亡之油"
+
+#: Source/items.cpp:222
+msgid "Oil of Skill"
+msgstr "技能之油"
+
+#: Source/items.cpp:223 Source/translation_dummy.cpp:251
+msgid "Blacksmith Oil"
+msgstr "铁匠之油"
+
+#: Source/items.cpp:224
+msgid "Oil of Fortitude"
+msgstr "坚韧之油"
+
+#: Source/items.cpp:225
+msgid "Oil of Permanence"
+msgstr "永恒之油"
+
+#: Source/items.cpp:226
+msgid "Oil of Hardening"
+msgstr "硬化之油"
+
+#: Source/items.cpp:227
 msgid "Oil of Imperviousness"
-msgstr "防水​之​油"
+msgstr "坚不可摧之油"
 
 #. TRANSLATORS: Constructs item names. Format: {Item} of {Spell}. Example: War Staff of Firewall
-#: Source/items.cpp:1104
+#: Source/items.cpp:1110
 #, c++-format
 msgctxt "spell"
 msgid "{0} of {1}"
 msgstr "{1}{0}"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Spell}. Example: King's War Staff of Firewall
-#: Source/items.cpp:1116
+#: Source/items.cpp:1122
 #, c++-format
 msgctxt "spell"
 msgid "{0} {1} of {2}"
 msgstr "{2}{0}{1}"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item} of {Suffix}. Example: King's Long Sword of the Whale
-#: Source/items.cpp:1154
+#: Source/items.cpp:1160
 #, c++-format
 msgid "{0} {1} of {2}"
 msgstr "{2}{0}{1}"
 
 #. TRANSLATORS: Constructs item names. Format: {Prefix} {Item}. Example: King's Long Sword
-#: Source/items.cpp:1158
+#: Source/items.cpp:1164
 #, c++-format
 msgid "{0} {1}"
 msgstr "{0}{1}"
 
 #. TRANSLATORS: Constructs item names. Format: {Item} of {Suffix}. Example: Long Sword of the Whale
-#: Source/items.cpp:1162
+#: Source/items.cpp:1168
 #, c++-format
 msgid "{0} of {1}"
 msgstr "{1}{0}"
 
-#: Source/items.cpp:1643 Source/items.cpp:1651
+#: Source/items.cpp:1647 Source/items.cpp:1655
 msgid "increases a weapon's"
-msgstr "增加​武器​的"
-
-#: Source/items.cpp:1644
-msgid "chance to hit"
-msgstr "命​中​概率"
-
-#: Source/items.cpp:1647
-msgid "greatly increases a"
-msgstr "显著​增加​一​件"
+msgstr "增加武器的"
 
 #: Source/items.cpp:1648
-msgid "weapon's chance to hit"
-msgstr "武器​命​中​概率"
+msgid "chance to hit"
+msgstr "命中概率"
+
+#: Source/items.cpp:1651
+msgid "greatly increases a"
+msgstr "显著增加一件"
 
 #: Source/items.cpp:1652
-msgid "damage potential"
-msgstr "伤害​潜力"
-
-#: Source/items.cpp:1655
-msgid "greatly increases a weapon's"
-msgstr "大大​提高​非弓类​武器"
+msgid "weapon's chance to hit"
+msgstr "武器命中概率"
 
 #: Source/items.cpp:1656
-msgid "damage potential - not bows"
-msgstr "的​伤害​潜力"
+msgid "damage potential"
+msgstr "伤害潜力"
 
 #: Source/items.cpp:1659
-msgid "reduces attributes needed"
-msgstr "减少​护甲​或​武器"
+msgid "greatly increases a weapon's"
+msgstr "大大提高非弓类武器"
 
 #: Source/items.cpp:1660
-msgid "to use armor or weapons"
-msgstr "使用​所​需​属性"
+msgid "damage potential - not bows"
+msgstr "的伤害潜力"
 
 #: Source/items.cpp:1663
-#, no-c-format
-msgid "restores 20% of an"
-msgstr "恢复​20​%​的"
+msgid "reduces attributes needed"
+msgstr "减少护甲或武器"
 
 #: Source/items.cpp:1664
-msgid "item's durability"
-msgstr "物品​耐久度"
+msgid "to use armor or weapons"
+msgstr "使用所需属性"
 
 #: Source/items.cpp:1667
-msgid "increases an item's"
-msgstr "增加​一​件​物品​的"
+#, no-c-format
+msgid "restores 20% of an"
+msgstr "恢复20%的"
 
 #: Source/items.cpp:1668
-msgid "current and max durability"
-msgstr "当前​和​最​大​耐久度"
+msgid "item's durability"
+msgstr "物品耐久度"
 
 #: Source/items.cpp:1671
-msgid "makes an item indestructible"
-msgstr "使​物品​坚​不​可​摧"
+msgid "increases an item's"
+msgstr "增加一件物品的"
 
-#: Source/items.cpp:1674
-msgid "increases the armor class"
-msgstr "增加​护甲​和​盾牌​的"
+#: Source/items.cpp:1672
+msgid "current and max durability"
+msgstr "当前和最大耐久度"
 
 #: Source/items.cpp:1675
-msgid "of armor and shields"
-msgstr "护甲​等级"
+msgid "makes an item indestructible"
+msgstr "使物品坚不可摧"
 
 #: Source/items.cpp:1678
-msgid "greatly increases the armor"
-msgstr "极​大​增加​护甲​和​盾牌"
+msgid "increases the armor class"
+msgstr "增加护甲和盾牌的"
 
 #: Source/items.cpp:1679
+msgid "of armor and shields"
+msgstr "护甲等级"
+
+#: Source/items.cpp:1682
+msgid "greatly increases the armor"
+msgstr "极大增加护甲和盾牌"
+
+#: Source/items.cpp:1683
 msgid "class of armor and shields"
-msgstr "的​护甲​等级"
+msgstr "的护甲等级"
 
-#: Source/items.cpp:1682 Source/items.cpp:1689
+#: Source/items.cpp:1686 Source/items.cpp:1693
 msgid "sets fire trap"
-msgstr "设置​火焰​陷阱"
+msgstr "设置火焰陷阱"
 
-#: Source/items.cpp:1686
+#: Source/items.cpp:1690
 msgid "sets lightning trap"
-msgstr "设置​闪电​陷阱"
+msgstr "设置闪电陷阱"
 
-#: Source/items.cpp:1692
+#: Source/items.cpp:1696
 msgid "sets petrification trap"
-msgstr "设置​石化​陷阱"
+msgstr "设置石化陷阱"
 
-#: Source/items.cpp:1695
+#: Source/items.cpp:1699
 msgid "restore all life"
-msgstr "恢复​所有​生命​值"
+msgstr "恢复所有生命值"
 
-#: Source/items.cpp:1698
+#: Source/items.cpp:1702
 msgid "restore some life"
-msgstr "恢复​部分​生命​值"
+msgstr "恢复部分生命值"
 
-#: Source/items.cpp:1701
+#: Source/items.cpp:1705
 msgid "restore some mana"
-msgstr "恢复​部分​法力"
+msgstr "恢复部分法力"
 
-#: Source/items.cpp:1704
+#: Source/items.cpp:1708
 msgid "restore all mana"
-msgstr "恢复​所有​法力"
+msgstr "恢复所有法力"
 
-#: Source/items.cpp:1707
+#: Source/items.cpp:1711
 msgid "increase strength"
-msgstr "增加​力量"
+msgstr "增加力量"
 
-#: Source/items.cpp:1710
+#: Source/items.cpp:1714
 msgid "increase magic"
-msgstr "增加​魔法"
+msgstr "增加魔法"
 
-#: Source/items.cpp:1713
+#: Source/items.cpp:1717
 msgid "increase dexterity"
-msgstr "增加​敏捷"
+msgstr "增加敏捷"
 
-#: Source/items.cpp:1716
+#: Source/items.cpp:1720
 msgid "increase vitality"
-msgstr "增加​活力"
+msgstr "增加活力"
 
-#: Source/items.cpp:1719
+#: Source/items.cpp:1723
 msgid "restore some life and mana"
-msgstr "恢复​部分​生命​和​法力"
+msgstr "恢复部分生命和法力"
 
-#: Source/items.cpp:1722 Source/items.cpp:1725
+#: Source/items.cpp:1726 Source/items.cpp:1729
 msgid "restore all life and mana"
-msgstr "恢复​所有​生命​和​法力"
+msgstr "恢复所有生命和法力"
 
-#: Source/items.cpp:1726
+#: Source/items.cpp:1730
 msgid "(works only in arenas)"
 msgstr "（只在竞技场有效）"
 
-#: Source/items.cpp:1761
+#: Source/items.cpp:1765
 msgid "Right-click to view"
-msgstr "右击​查看"
+msgstr "右击查看"
 
-#: Source/items.cpp:1764
+#: Source/items.cpp:1768
 msgid "Right-click to use"
-msgstr "右击​使用"
+msgstr "右击使用"
 
-#: Source/items.cpp:1766
+#: Source/items.cpp:1770
 msgid ""
 "Right-click to read, then\n"
 "left-click to target"
 msgstr ""
-"右击​阅读，然后\n"
-"左击​目标"
+"右击阅读，然后\n"
+"左击目标"
 
-#: Source/items.cpp:1768
+#: Source/items.cpp:1772
 msgid "Right-click to read"
-msgstr "右击​阅读"
+msgstr "右击阅读"
 
-#: Source/items.cpp:1775
+#: Source/items.cpp:1779
 msgid "Activate to view"
-msgstr "激活​显示"
+msgstr "激活显示"
 
-#: Source/items.cpp:1779 Source/items.cpp:1804
+#: Source/items.cpp:1783 Source/items.cpp:1808
 msgid "Open inventory to use"
-msgstr "打开​物品​使用"
+msgstr "打开物品使用"
 
-#: Source/items.cpp:1781
+#: Source/items.cpp:1785
 msgid "Activate to use"
-msgstr "激活​使用"
+msgstr "激活使用"
 
-#: Source/items.cpp:1784
+#: Source/items.cpp:1788
 msgid ""
 "Select from spell book, then\n"
 "cast spell to read"
 msgstr ""
-"从​法术​书​中​选择，之后\n"
-"施放​法术​进行​阅读"
+"从法术书中选择，之后\n"
+"施放法术进行阅读"
 
-#: Source/items.cpp:1786
+#: Source/items.cpp:1790
 msgid "Activate to read"
-msgstr "激活​阅读"
+msgstr "激活阅读"
 
-#: Source/items.cpp:1800
+#: Source/items.cpp:1804
 #, c++-format
 msgid "{} to view"
 msgstr "{}显示"
 
-#: Source/items.cpp:1806
+#: Source/items.cpp:1810
 #, c++-format
 msgid "{} to use"
 msgstr "{} 使用"
 
-#: Source/items.cpp:1809
+#: Source/items.cpp:1813
 #, c++-format
 msgid ""
 "Select from spell book,\n"
 "then {} to read"
 msgstr ""
-"从​法术​书​中​选择，之后\n"
-"{} 进行​阅读"
+"从法术书中选择，之后\n"
+"{} 进行阅读"
 
-#: Source/items.cpp:1811
+#: Source/items.cpp:1815
 #, c++-format
 msgid "{} to read"
-msgstr "{}激活​阅读"
+msgstr "{}激活阅读"
 
-#: Source/items.cpp:1818
+#: Source/items.cpp:1822
 #, c++-format
 msgctxt "player"
 msgid "Level: {:d}"
 msgstr "等级: {:d}"
 
-#: Source/items.cpp:1822
+#: Source/items.cpp:1826
 msgid "Doubles gold capacity"
-msgstr "金币​容量​翻倍"
+msgstr "金币容量翻倍"
 
-#: Source/items.cpp:1855 Source/stores.cpp:327
+#: Source/items.cpp:1859 Source/stores.cpp:399
 msgid "Required:"
 msgstr "需求:"
 
-#: Source/items.cpp:1857 Source/stores.cpp:329
+#: Source/items.cpp:1861 Source/stores.cpp:401
 #, c++-format
 msgid " {:d} Str"
 msgstr " {:d} 力量"
 
-#: Source/items.cpp:1859 Source/stores.cpp:331
+#: Source/items.cpp:1863 Source/stores.cpp:403
 #, c++-format
 msgid " {:d} Mag"
 msgstr " {:d} 魔法"
 
-#: Source/items.cpp:1861 Source/stores.cpp:333
+#: Source/items.cpp:1865 Source/stores.cpp:405
 #, c++-format
 msgid " {:d} Dex"
 msgstr " {:d} 敏捷"
 
 #. TRANSLATORS: {:s} will be a spell name
-#: Source/items.cpp:2217
+#: Source/items.cpp:2221
 #, c++-format
 msgid "Book of {:s}"
-msgstr "{:s}法术​书​"
+msgstr "{:s}法术书"
 
 #. TRANSLATORS: {:s} will be a Character Name
-#: Source/items.cpp:2220
+#: Source/items.cpp:2224
 #, c++-format
 msgid "Ear of {:s}"
-msgstr "{:s}​的​耳朵"
+msgstr "{:s}的耳朵"
 
-#: Source/items.cpp:3874
+#: Source/items.cpp:3896
 #, c++-format
 msgid "chance to hit: {:+d}%"
-msgstr "命​中​几​率: {:+d}%"
+msgstr "命中几率: {:+d}%"
 
-#: Source/items.cpp:3877
+#: Source/items.cpp:3899
 #, no-c-format, c++-format
 msgid "{:+d}% damage"
 msgstr "{:+d}% 伤害"
 
-#: Source/items.cpp:3880 Source/items.cpp:4062
+#: Source/items.cpp:3902 Source/items.cpp:4084
 #, c++-format
 msgid "to hit: {:+d}%, {:+d}% damage"
-msgstr "命​中: {:+d}%​, {:+d}%​伤害"
+msgstr "命中: {:+d}%, {:+d}%伤害"
 
-#: Source/items.cpp:3883
+#: Source/items.cpp:3905
 #, no-c-format, c++-format
 msgid "{:+d}% armor"
 msgstr "{:+d}% 护甲"
 
-#: Source/items.cpp:3886
+#: Source/items.cpp:3908
 #, c++-format
 msgid "armor class: {:d}"
-msgstr "护甲​等级: {:d}"
-
-#: Source/items.cpp:3890
-#, c++-format
-msgid "Resist Fire: {:+d}%"
-msgstr "火焰​抗性: {:+d}%"
-
-#: Source/items.cpp:3892
-#, c++-format
-msgid "Resist Fire: {:+d}% MAX"
-msgstr "火焰​抗性: {:+d}% 最​大​值"
-
-#: Source/items.cpp:3896
-#, c++-format
-msgid "Resist Lightning: {:+d}%"
-msgstr "闪电​抗性: {:+d}%"
-
-#: Source/items.cpp:3898
-#, c++-format
-msgid "Resist Lightning: {:+d}% MAX"
-msgstr "闪电​抗性: {:+d}% 最​大​值"
-
-#: Source/items.cpp:3902
-#, c++-format
-msgid "Resist Magic: {:+d}%"
-msgstr "抵抗​魔法: {:+d}%"
-
-#: Source/items.cpp:3904
-#, c++-format
-msgid "Resist Magic: {:+d}% MAX"
-msgstr "抵抗​魔法: {:+d}% 最​大​值"
-
-#: Source/items.cpp:3907
-#, c++-format
-msgid "Resist All: {:+d}%"
-msgstr "所有​抗性: {:+d}%"
-
-#: Source/items.cpp:3909
-#, c++-format
-msgid "Resist All: {:+d}% MAX"
-msgstr "所有​抗性: {:+d}% 最​大​值"
+msgstr "护甲等级: {:d}"
 
 #: Source/items.cpp:3912
+#, c++-format
+msgid "Resist Fire: {:+d}%"
+msgstr "火焰抗性: {:+d}%"
+
+#: Source/items.cpp:3914
+#, c++-format
+msgid "Resist Fire: {:+d}% MAX"
+msgstr "火焰抗性: {:+d}% 最大值"
+
+#: Source/items.cpp:3918
+#, c++-format
+msgid "Resist Lightning: {:+d}%"
+msgstr "闪电抗性: {:+d}%"
+
+#: Source/items.cpp:3920
+#, c++-format
+msgid "Resist Lightning: {:+d}% MAX"
+msgstr "闪电抗性: {:+d}% 最大值"
+
+#: Source/items.cpp:3924
+#, c++-format
+msgid "Resist Magic: {:+d}%"
+msgstr "抵抗魔法: {:+d}%"
+
+#: Source/items.cpp:3926
+#, c++-format
+msgid "Resist Magic: {:+d}% MAX"
+msgstr "抵抗魔法: {:+d}% 最大值"
+
+#: Source/items.cpp:3929
+#, c++-format
+msgid "Resist All: {:+d}%"
+msgstr "所有抗性: {:+d}%"
+
+#: Source/items.cpp:3931
+#, c++-format
+msgid "Resist All: {:+d}% MAX"
+msgstr "所有抗性: {:+d}% 最大值"
+
+#: Source/items.cpp:3934
 #, c++-format
 msgid "spells are increased {:d} level"
 msgid_plural "spells are increased {:d} levels"
 msgstr[0] "法术增加{:d}级"
 
-#: Source/items.cpp:3914
+#: Source/items.cpp:3936
 #, c++-format
 msgid "spells are decreased {:d} level"
 msgid_plural "spells are decreased {:d} levels"
 msgstr[0] "法术降低{:d}级"
 
-#: Source/items.cpp:3916
+#: Source/items.cpp:3938
 msgid "spell levels unchanged (?)"
-msgstr "法术​等级​不​变(?)"
+msgstr "法术等级不变(?)"
 
-#: Source/items.cpp:3918
+#: Source/items.cpp:3940
 msgid "Extra charges"
-msgstr "额外​充能​次数"
+msgstr "额外充能次数"
 
-#: Source/items.cpp:3920
+#: Source/items.cpp:3942
 #, c++-format
 msgid "{:d} {:s} charge"
 msgid_plural "{:d} {:s} charges"
 msgstr[0] "{:d} {:s} 充能"
 
-#: Source/items.cpp:3923
+#: Source/items.cpp:3945
 #, c++-format
 msgid "Fire hit damage: {:d}"
-msgstr "火焰​伤害: {:d}"
+msgstr "火焰伤害: {:d}"
 
-#: Source/items.cpp:3925
+#: Source/items.cpp:3947
 #, c++-format
 msgid "Fire hit damage: {:d}-{:d}"
-msgstr "火焰​伤害: {:d}-{:d}"
+msgstr "火焰伤害: {:d}-{:d}"
 
-#: Source/items.cpp:3928
+#: Source/items.cpp:3950
 #, c++-format
 msgid "Lightning hit damage: {:d}"
-msgstr "闪电​伤害: {:d}"
+msgstr "闪电伤害: {:d}"
 
-#: Source/items.cpp:3930
+#: Source/items.cpp:3952
 #, c++-format
 msgid "Lightning hit damage: {:d}-{:d}"
-msgstr "闪电​伤害: {:d}-{:d}"
+msgstr "闪电伤害: {:d}-{:d}"
 
-#: Source/items.cpp:3933
+#: Source/items.cpp:3955
 #, c++-format
 msgid "{:+d} to strength"
 msgstr "{:+d} 力量"
 
-#: Source/items.cpp:3936
+#: Source/items.cpp:3958
 #, c++-format
 msgid "{:+d} to magic"
 msgstr "{:+d} 魔法"
 
-#: Source/items.cpp:3939
+#: Source/items.cpp:3961
 #, c++-format
 msgid "{:+d} to dexterity"
 msgstr "{:+d} 敏捷"
 
-#: Source/items.cpp:3942
+#: Source/items.cpp:3964
 #, c++-format
 msgid "{:+d} to vitality"
 msgstr "{:+d} 活力"
 
-#: Source/items.cpp:3945
+#: Source/items.cpp:3967
 #, c++-format
 msgid "{:+d} to all attributes"
-msgstr "{:+d} 所有​属性"
+msgstr "{:+d} 所有属性"
 
-#: Source/items.cpp:3948
+#: Source/items.cpp:3970
 #, c++-format
 msgid "{:+d} damage from enemies"
-msgstr "{:+d} 来自​敌人​的​伤害"
+msgstr "{:+d} 来自敌人的伤害"
 
-#: Source/items.cpp:3951
+#: Source/items.cpp:3973
 #, c++-format
 msgid "Hit Points: {:+d}"
-msgstr "生命​值: {:+d}"
+msgstr "生命值: {:+d}"
 
-#: Source/items.cpp:3954
+#: Source/items.cpp:3976
 #, c++-format
 msgid "Mana: {:+d}"
 msgstr "法力值: {:+d}"
 
-#: Source/items.cpp:3956
+#: Source/items.cpp:3978
 msgid "high durability"
-msgstr "高​耐​久度"
+msgstr "高耐久度"
 
-#: Source/items.cpp:3958
+#: Source/items.cpp:3980
 msgid "decreased durability"
-msgstr "耐​久度​降低"
+msgstr "耐久度降低"
 
-#: Source/items.cpp:3960
+#: Source/items.cpp:3982
 msgid "indestructible"
-msgstr "坚​不​可​摧"
+msgstr "坚不可摧"
 
-#: Source/items.cpp:3962
+#: Source/items.cpp:3984
 #, no-c-format, c++-format
 msgid "+{:d}% light radius"
-msgstr "+{:d}% 照亮​范围"
+msgstr "+{:d}% 照亮范围"
 
-#: Source/items.cpp:3964
+#: Source/items.cpp:3986
 #, no-c-format, c++-format
 msgid "-{:d}% light radius"
-msgstr "-{:d}% 照亮​范围"
+msgstr "-{:d}% 照亮范围"
 
-#: Source/items.cpp:3966
+#: Source/items.cpp:3988
 msgid "multiple arrows per shot"
-msgstr "多​重​射击"
-
-#: Source/items.cpp:3969
-#, c++-format
-msgid "fire arrows damage: {:d}"
-msgstr "火箭​伤害: {:d}"
-
-#: Source/items.cpp:3971
-#, c++-format
-msgid "fire arrows damage: {:d}-{:d}"
-msgstr "火箭​伤害: {:d}-{:d}"
-
-#: Source/items.cpp:3974
-#, c++-format
-msgid "lightning arrows damage {:d}"
-msgstr "闪​电箭​伤害​{:d}"
-
-#: Source/items.cpp:3976
-#, c++-format
-msgid "lightning arrows damage {:d}-{:d}"
-msgstr "闪​电箭​伤害​{:d}-{:d}"
-
-#: Source/items.cpp:3979
-#, c++-format
-msgid "fireball damage: {:d}"
-msgstr "火球​伤害: {:d}"
-
-#: Source/items.cpp:3981
-#, c++-format
-msgid "fireball damage: {:d}-{:d}"
-msgstr "火球​伤害: {:d}-{:d}"
-
-#: Source/items.cpp:3983
-msgid "attacker takes 1-3 damage"
-msgstr "攻击者​受到​1-3点​伤害"
-
-#: Source/items.cpp:3985
-msgid "user loses all mana"
-msgstr "使用者​失去​所有​法力值"
-
-#: Source/items.cpp:3987
-msgid "absorbs half of trap damage"
-msgstr "吸收​一半​陷阱​伤害"
-
-#: Source/items.cpp:3989
-msgid "knocks target back"
-msgstr "击​退​目标"
+msgstr "多重射击"
 
 #: Source/items.cpp:3991
-#, no-c-format
-msgid "+200% damage vs. demons"
-msgstr "+200​% 对​恶魔​的​伤害"
+#, c++-format
+msgid "fire arrows damage: {:d}"
+msgstr "火箭伤害: {:d}"
 
 #: Source/items.cpp:3993
-msgid "All Resistance equals 0"
-msgstr "所有​抗性​变为​0"
+#, c++-format
+msgid "fire arrows damage: {:d}-{:d}"
+msgstr "火箭伤害: {:d}-{:d}"
 
 #: Source/items.cpp:3996
-#, no-c-format
-msgid "hit steals 3% mana"
-msgstr "命​中时​3​%法力​偷取"
+#, c++-format
+msgid "lightning arrows damage {:d}"
+msgstr "闪电箭伤害{:d}"
 
 #: Source/items.cpp:3998
-#, no-c-format
-msgid "hit steals 5% mana"
-msgstr "命​中时​5​%​法力​偷取"
+#, c++-format
+msgid "lightning arrows damage {:d}-{:d}"
+msgstr "闪电箭伤害{:d}-{:d}"
 
-#: Source/items.cpp:4002
-#, no-c-format
-msgid "hit steals 3% life"
-msgstr "命​中时​3​%​生命​偷取"
+#: Source/items.cpp:4001
+#, c++-format
+msgid "fireball damage: {:d}"
+msgstr "火球伤害: {:d}"
 
-#: Source/items.cpp:4004
-#, no-c-format
-msgid "hit steals 5% life"
-msgstr "命​中时​5​%​生命​偷取"
+#: Source/items.cpp:4003
+#, c++-format
+msgid "fireball damage: {:d}-{:d}"
+msgstr "火球伤害: {:d}-{:d}"
+
+#: Source/items.cpp:4005
+msgid "attacker takes 1-3 damage"
+msgstr "攻击者受到1-3点伤害"
 
 #: Source/items.cpp:4007
-msgid "penetrates target's armor"
-msgstr "穿透​目标​的​护甲"
+msgid "user loses all mana"
+msgstr "使用者失去所有法力值"
 
-#: Source/items.cpp:4010
-msgid "quick attack"
-msgstr "快速​攻击"
+#: Source/items.cpp:4009
+msgid "absorbs half of trap damage"
+msgstr "吸收一半陷阱伤害"
 
-#: Source/items.cpp:4012
-msgid "fast attack"
-msgstr "更​快​攻击"
+#: Source/items.cpp:4011
+msgid "knocks target back"
+msgstr "击退目标"
 
-#: Source/items.cpp:4014
-msgid "faster attack"
-msgstr "极​速​攻击"
+#: Source/items.cpp:4013
+#, no-c-format
+msgid "+200% damage vs. demons"
+msgstr "+200% 对恶魔的伤害"
 
-#: Source/items.cpp:4016
-msgid "fastest attack"
-msgstr "最​快​攻击"
+#: Source/items.cpp:4015
+msgid "All Resistance equals 0"
+msgstr "所有抗性变为0"
 
-#: Source/items.cpp:4017 Source/items.cpp:4025 Source/items.cpp:4072
-msgid "Another ability (NW)"
-msgstr "另​一​种​能力​(​NW)"
+#: Source/items.cpp:4018
+#, no-c-format
+msgid "hit steals 3% mana"
+msgstr "命中时3%法力偷取"
 
 #: Source/items.cpp:4020
-msgid "fast hit recovery"
-msgstr "快速​打击​回复"
-
-#: Source/items.cpp:4022
-msgid "faster hit recovery"
-msgstr "更​快​打击​回复"
+#, no-c-format
+msgid "hit steals 5% mana"
+msgstr "命中时5%法力偷取"
 
 #: Source/items.cpp:4024
-msgid "fastest hit recovery"
-msgstr "最​快​打击​回复"
+#, no-c-format
+msgid "hit steals 3% life"
+msgstr "命中时3%生命偷取"
 
-#: Source/items.cpp:4027
-msgid "fast block"
-msgstr "快速​格挡"
+#: Source/items.cpp:4026
+#, no-c-format
+msgid "hit steals 5% life"
+msgstr "命中时5%生命偷取"
 
 #: Source/items.cpp:4029
+msgid "penetrates target's armor"
+msgstr "穿透目标的护甲"
+
+#: Source/items.cpp:4032
+msgid "quick attack"
+msgstr "快速攻击"
+
+#: Source/items.cpp:4034
+msgid "fast attack"
+msgstr "更快攻击"
+
+#: Source/items.cpp:4036
+msgid "faster attack"
+msgstr "极速攻击"
+
+#: Source/items.cpp:4038
+msgid "fastest attack"
+msgstr "最快攻击"
+
+#: Source/items.cpp:4039 Source/items.cpp:4047 Source/items.cpp:4094
+msgid "Another ability (NW)"
+msgstr "另一种能力(NW)"
+
+#: Source/items.cpp:4042
+msgid "fast hit recovery"
+msgstr "快速打击回复"
+
+#: Source/items.cpp:4044
+msgid "faster hit recovery"
+msgstr "更快打击回复"
+
+#: Source/items.cpp:4046
+msgid "fastest hit recovery"
+msgstr "最快打击回复"
+
+#: Source/items.cpp:4049
+msgid "fast block"
+msgstr "快速格挡"
+
+#: Source/items.cpp:4051
 #, c++-format
 msgid "adds {:d} point to damage"
 msgid_plural "adds {:d} points to damage"
 msgstr[0] "增加{:d}点伤害"
 
-#: Source/items.cpp:4031
+#: Source/items.cpp:4053
 msgid "fires random speed arrows"
-msgstr "发射​随机​速度​箭矢"
+msgstr "发射随机速度箭矢"
 
-#: Source/items.cpp:4033
+#: Source/items.cpp:4055
 msgid "unusual item damage"
-msgstr "异常​的​物品​损坏"
+msgstr "异常的物品损坏"
 
-#: Source/items.cpp:4035
+#: Source/items.cpp:4057
 msgid "altered durability"
-msgstr "改变​耐​久度"
+msgstr "改变耐久度"
 
-#: Source/items.cpp:4037
+#: Source/items.cpp:4059
 msgid "one handed sword"
-msgstr "单手​剑"
+msgstr "单手剑"
 
-#: Source/items.cpp:4039
+#: Source/items.cpp:4061
 msgid "constantly lose hit points"
-msgstr "持续​失去​生命值"
+msgstr "持续失去生命值"
 
-#: Source/items.cpp:4041
+#: Source/items.cpp:4063
 msgid "life stealing"
-msgstr "生命​偷取"
+msgstr "生命偷取"
 
-#: Source/items.cpp:4043
+#: Source/items.cpp:4065
 msgid "no strength requirement"
-msgstr "无​力量​要求"
-
-#: Source/items.cpp:4046
-#, c++-format
-msgid "lightning damage: {:d}"
-msgstr "闪电​伤害: {:d}"
-
-#: Source/items.cpp:4048
-#, c++-format
-msgid "lightning damage: {:d}-{:d}"
-msgstr "闪电​伤害: {:d}-{:d}"
-
-#: Source/items.cpp:4050
-msgid "charged bolts on hits"
-msgstr "击​中时​触发电​荷弹"
-
-#: Source/items.cpp:4052
-msgid "occasional triple damage"
-msgstr "有​概率​造成​三​倍​伤害"
-
-#: Source/items.cpp:4054
-#, no-c-format, c++-format
-msgid "decaying {:+d}% damage"
-msgstr "减少​{:+d}%​伤害"
-
-#: Source/items.cpp:4056
-msgid "2x dmg to monst, 1x to you"
-msgstr "2x 对​怪物​伤害，1x 反噬​自身"
-
-#: Source/items.cpp:4058
-#, no-c-format
-msgid "Random 0 - 600% damage"
-msgstr "随机​0-600​%​伤害"
-
-#: Source/items.cpp:4060
-#, no-c-format, c++-format
-msgid "low dur, {:+d}% damage"
-msgstr "低​耐久，{:+d}% d​伤害"
-
-#: Source/items.cpp:4064
-msgid "extra AC vs demons"
-msgstr "对抗​恶魔​的​额外​精准"
-
-#: Source/items.cpp:4066
-msgid "extra AC vs undead"
-msgstr "对抗​亡灵​的​额外​精准"
+msgstr "无力量要求"
 
 #: Source/items.cpp:4068
-msgid "50% Mana moved to Health"
-msgstr "50​%​法​力值​转换​至​生命​值"
+#, c++-format
+msgid "lightning damage: {:d}"
+msgstr "闪电伤害: {:d}"
 
 #: Source/items.cpp:4070
-msgid "40% Health moved to Mana"
-msgstr "40​%​的​生命值​转换​至​法力值"
+#, c++-format
+msgid "lightning damage: {:d}-{:d}"
+msgstr "闪电伤害: {:d}-{:d}"
 
-#: Source/items.cpp:4113 Source/items.cpp:4154
+#: Source/items.cpp:4072
+msgid "charged bolts on hits"
+msgstr "击中时触发电荷弹"
+
+#: Source/items.cpp:4074
+msgid "occasional triple damage"
+msgstr "有概率造成三倍伤害"
+
+#: Source/items.cpp:4076
+#, no-c-format, c++-format
+msgid "decaying {:+d}% damage"
+msgstr "减少{:+d}%伤害"
+
+#: Source/items.cpp:4078
+msgid "2x dmg to monst, 1x to you"
+msgstr "2x 对怪物伤害，1x 反噬自身"
+
+#: Source/items.cpp:4080
+#, no-c-format
+msgid "Random 0 - 600% damage"
+msgstr "随机0-600%伤害"
+
+#: Source/items.cpp:4082
+#, no-c-format, c++-format
+msgid "low dur, {:+d}% damage"
+msgstr "低耐久，{:+d}% 伤害"
+
+#: Source/items.cpp:4086
+msgid "extra AC vs demons"
+msgstr "对抗恶魔的额外精准"
+
+#: Source/items.cpp:4088
+msgid "extra AC vs undead"
+msgstr "对抗亡灵的额外精准"
+
+#: Source/items.cpp:4090
+msgid "50% Mana moved to Health"
+msgstr "50%法力值转换至生命值"
+
+#: Source/items.cpp:4092
+msgid "40% Health moved to Mana"
+msgstr "40%的生命值转换至法力值"
+
+#: Source/items.cpp:4135 Source/items.cpp:4176
 #, c++-format
 msgid "damage: {:d}  Indestructible"
-msgstr "伤害: {:d}  坚不​可​摧"
+msgstr "伤害: {:d}  坚不可摧"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4115 Source/items.cpp:4156
+#: Source/items.cpp:4137 Source/items.cpp:4178
 #, c++-format
 msgid "damage: {:d}  Dur: {:d}/{:d}"
 msgstr "伤害: {:d} 耐久: {:d}/{:d}"
 
-#: Source/items.cpp:4118 Source/items.cpp:4159
+#: Source/items.cpp:4140 Source/items.cpp:4181
 #, c++-format
 msgid "damage: {:d}-{:d}  Indestructible"
-msgstr "伤害: {:d}-{:d} 坚不​可​摧"
+msgstr "伤害: {:d}-{:d} 坚不可摧"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4120 Source/items.cpp:4161
+#: Source/items.cpp:4142 Source/items.cpp:4183
 #, c++-format
 msgid "damage: {:d}-{:d}  Dur: {:d}/{:d}"
 msgstr "伤害: {:d}-{:d} 耐久: {:d}/{:d}"
 
-#: Source/items.cpp:4125 Source/items.cpp:4171
+#: Source/items.cpp:4147 Source/items.cpp:4193
 #, c++-format
 msgid "armor: {:d}  Indestructible"
-msgstr "护​甲: {:d} 坚不​可​摧"
+msgstr "护甲: {:d} 坚不可摧"
 
 #. TRANSLATORS: Dur: is durability
-#: Source/items.cpp:4127 Source/items.cpp:4173
+#: Source/items.cpp:4149 Source/items.cpp:4195
 #, c++-format
 msgid "armor: {:d}  Dur: {:d}/{:d}"
-msgstr "护​甲: {:d} 耐久: {:d}/{:d}"
+msgstr "护甲: {:d} 耐久: {:d}/{:d}"
 
-#: Source/items.cpp:4130 Source/items.cpp:4164 Source/items.cpp:4177
-#: Source/stores.cpp:301
+#: Source/items.cpp:4152 Source/items.cpp:4186 Source/items.cpp:4199
+#: Source/stores.cpp:373
 #, c++-format
 msgid "Charges: {:d}/{:d}"
 msgstr "充能: {:d}/{:d}"
 
-#: Source/items.cpp:4139
+#: Source/items.cpp:4161
 msgid "unique item"
-msgstr "独特​装备"
+msgstr "独特装备"
 
-#: Source/items.cpp:4167 Source/items.cpp:4175 Source/items.cpp:4181
+#: Source/items.cpp:4189 Source/items.cpp:4197 Source/items.cpp:4203
 msgid "Not Identified"
-msgstr "未​鉴定"
+msgstr "未鉴定"
 
 #: Source/levels/setmaps.cpp:27
 msgid "Skeleton King's Lair"
-msgstr "骷​髅王​的​巢穴"
+msgstr "骷髅王的巢穴"
 
 #: Source/levels/setmaps.cpp:28
 msgid "Chamber of Bone"
 msgstr "白骨密室"
 
 #. TRANSLATORS: Quest Map
-#: Source/levels/setmaps.cpp:29 Source/quests.cpp:78
+#: Source/levels/setmaps.cpp:29 Source/quests.cpp:80
 msgid "Maze"
 msgstr "迷宫"
 
 #: Source/levels/setmaps.cpp:30 Source/translation_dummy.cpp:637
 msgid "Poisoned Water Supply"
-msgstr "有毒​的​水源​补给"
+msgstr "有毒的水源补给"
 
 #: Source/levels/setmaps.cpp:31
 msgid "Archbishop Lazarus' Lair"
-msgstr "大​主教​拉扎鲁斯​的​巢穴"
+msgstr "大主教拉扎鲁斯的巢穴"
 
 #: Source/levels/setmaps.cpp:32
 msgid "Church Arena"
@@ -3330,243 +3361,223 @@ msgstr "生命之环竞技场"
 
 #: Source/levels/trigs.cpp:355
 msgid "Down to dungeon"
-msgstr "下​到​地​牢"
+msgstr "下到地牢"
 
 #: Source/levels/trigs.cpp:364
 msgid "Down to catacombs"
-msgstr "下​到​墓穴"
+msgstr "下到墓穴"
 
 #: Source/levels/trigs.cpp:374
 msgid "Down to caves"
-msgstr "下​到​洞窟"
+msgstr "下到洞窟"
 
 #: Source/levels/trigs.cpp:384
 msgid "Down to hell"
-msgstr "下​到​地狱"
+msgstr "下到地狱"
 
 #: Source/levels/trigs.cpp:394
 msgid "Down to Hive"
-msgstr "下​到​巢穴"
+msgstr "下到巢穴"
 
 #: Source/levels/trigs.cpp:404
 msgid "Down to Crypt"
-msgstr "下​到​地​穴"
+msgstr "下到地穴"
 
 #: Source/levels/trigs.cpp:419 Source/levels/trigs.cpp:454
 #: Source/levels/trigs.cpp:500 Source/levels/trigs.cpp:552
 #, c++-format
 msgid "Up to level {:d}"
-msgstr "上​到 {:d} 层"
+msgstr "上到 {:d} 层"
 
 #: Source/levels/trigs.cpp:421 Source/levels/trigs.cpp:483
 #: Source/levels/trigs.cpp:535 Source/levels/trigs.cpp:582
 #: Source/levels/trigs.cpp:644 Source/levels/trigs.cpp:693
 #: Source/levels/trigs.cpp:800
 msgid "Up to town"
-msgstr "上​到​城镇"
+msgstr "上到城镇"
 
 #: Source/levels/trigs.cpp:432 Source/levels/trigs.cpp:465
 #: Source/levels/trigs.cpp:517 Source/levels/trigs.cpp:564
 #: Source/levels/trigs.cpp:626
 #, c++-format
 msgid "Down to level {:d}"
-msgstr "下​到 {:d} 层"
+msgstr "下到 {:d} 层"
 
 #: Source/levels/trigs.cpp:595
 msgid "Down to Diablo"
-msgstr "下​到​迪亚波罗"
+msgstr "下到迪亚波罗"
 
 #: Source/levels/trigs.cpp:613
 #, c++-format
 msgid "Up to Nest level {:d}"
-msgstr "上​到​巢穴 {:d} 层"
+msgstr "上到巢穴 {:d} 层"
 
 #: Source/levels/trigs.cpp:661
 #, c++-format
 msgid "Up to Crypt level {:d}"
-msgstr "上​到​墓穴 {:d} 层"
+msgstr "上到墓穴 {:d} 层"
 
 #: Source/levels/trigs.cpp:671 Source/translation_dummy.cpp:646
 msgid "Cornerstone of the World"
-msgstr "世界​的​基石"
+msgstr "世界的基石"
 
 #: Source/levels/trigs.cpp:676
 #, c++-format
 msgid "Down to Crypt level {:d}"
-msgstr "下​到​墓穴 {:d} 层"
+msgstr "下到墓穴 {:d} 层"
 
 #: Source/levels/trigs.cpp:724 Source/levels/trigs.cpp:738
 #: Source/levels/trigs.cpp:752
 #, c++-format
 msgid "Back to Level {:d}"
-msgstr "返回​到 {:d} 层"
+msgstr "返回到 {:d} 层"
 
-#: Source/loadsave.cpp:2013 Source/loadsave.cpp:2470
+#: Source/loadsave.cpp:2016 Source/loadsave.cpp:2473
 msgid "Unable to open save file archive"
-msgstr "无法​打开​存档​文件"
+msgstr "无法打开存档文件"
 
-#: Source/loadsave.cpp:2424
+#: Source/loadsave.cpp:2427
 msgid ""
 "Stash version invalid. If you attempt to access your stash, data will be "
 "overwritten!!"
-msgstr ""
+msgstr "储物箱版本无效。若尝试访问储物箱，数据将被覆盖！！"
 
-#: Source/loadsave.cpp:2443
+#: Source/loadsave.cpp:2446
 msgid ""
 "Stash size invalid. If you attempt to access your stash, data will be "
 "overwritten!!"
-msgstr ""
+msgstr "储物箱大小无效。若尝试访问储物箱，数据将被覆盖！！"
 
-#: Source/loadsave.cpp:2474
+#: Source/loadsave.cpp:2477
 msgid "Invalid save file"
-msgstr "无效​的​存档​文件"
+msgstr "无效的存档文件"
 
-#: Source/loadsave.cpp:2506
+#: Source/loadsave.cpp:2509
 msgid "Player is on a Hellfire only level"
-msgstr "玩​家​处于​地狱火​特有​地图"
+msgstr "玩家处于地狱火特有地图"
 
-#: Source/loadsave.cpp:2772
+#: Source/loadsave.cpp:2775
 msgid "Invalid game state"
-msgstr "无效​的​游戏​状态"
+msgstr "无效的游戏状态"
 
-#: Source/menu.cpp:157
+#: Source/menu.cpp:171
 msgid "Unable to display mainmenu"
-msgstr "无法​显示​主菜​单"
+msgstr "无法显示主菜单"
 
-#: Source/monstdat.cpp:331 Source/monstdat.cpp:344
-msgid "Loading Monster Data Failed"
-msgstr ""
-
-#: Source/monstdat.cpp:331
-#, c++-format
-msgid ""
-"Could not add a monster, since the maximum monster type number of {} has "
-"already been reached."
-msgstr ""
-
-#: Source/monstdat.cpp:344
-#, c++-format
-msgid "A monster type already exists for ID \"{}\"."
-msgstr ""
-
-#: Source/monster.cpp:2990
+#: Source/monster.cpp:3072
 msgid "Animal"
 msgstr "野兽"
 
-#: Source/monster.cpp:2992
+#: Source/monster.cpp:3074
 msgid "Demon"
 msgstr "恶魔"
 
-#: Source/monster.cpp:2994
+#: Source/monster.cpp:3076
 msgid "Undead"
 msgstr "亡灵"
 
-#: Source/monster.cpp:4413
+#: Source/monster.cpp:4474
 #, c++-format
 msgid "Type: {:s}  Kills: {:d}"
 msgstr "类型: {:s} 击杀: {:d}"
 
-#: Source/monster.cpp:4415
+#: Source/monster.cpp:4476
 #, c++-format
 msgid "Total kills: {:d}"
-msgstr "击杀​总数: {:d}"
+msgstr "击杀总数: {:d}"
 
-#: Source/monster.cpp:4441
+#: Source/monster.cpp:4502
 #, c++-format
 msgid "Hit Points: {:d}-{:d}"
-msgstr "生命​值: {:d}-{:d}"
+msgstr "生命值: {:d}-{:d}"
 
-#: Source/monster.cpp:4446
+#: Source/monster.cpp:4507
 msgid "No magic resistance"
-msgstr "没有​魔法​抗性"
+msgstr "没有魔法抗性"
 
-#: Source/monster.cpp:4449
+#: Source/monster.cpp:4510
 msgid "Resists:"
 msgstr "抗性:"
 
-#: Source/monster.cpp:4451 Source/monster.cpp:4461
+#: Source/monster.cpp:4512 Source/monster.cpp:4522
 msgid " Magic"
 msgstr " 魔法"
 
-#: Source/monster.cpp:4453 Source/monster.cpp:4463
+#: Source/monster.cpp:4514 Source/monster.cpp:4524
 msgid " Fire"
 msgstr " 火焰"
 
-#: Source/monster.cpp:4455 Source/monster.cpp:4465
+#: Source/monster.cpp:4516 Source/monster.cpp:4526
 msgid " Lightning"
-msgstr " 闪​电"
+msgstr " 闪电"
 
-#: Source/monster.cpp:4459
+#: Source/monster.cpp:4520
 msgid "Immune:"
 msgstr "免疫:"
 
-#: Source/monster.cpp:4476
+#: Source/monster.cpp:4537
 #, c++-format
 msgid "Type: {:s}"
 msgstr "类型: {:s}"
 
-#: Source/monster.cpp:4481 Source/monster.cpp:4487
+#: Source/monster.cpp:4542 Source/monster.cpp:4548
 msgid "No resistances"
-msgstr "无​抗性"
+msgstr "无抗性"
 
-#: Source/monster.cpp:4482 Source/monster.cpp:4491
+#: Source/monster.cpp:4543 Source/monster.cpp:4552
 msgid "No Immunities"
-msgstr "无​免疫"
+msgstr "无免疫"
 
-#: Source/monster.cpp:4485
+#: Source/monster.cpp:4546
 msgid "Some Magic Resistances"
-msgstr "部分​魔法​抗性"
+msgstr "部分魔法抗性"
 
-#: Source/monster.cpp:4489
+#: Source/monster.cpp:4550
 msgid "Some Magic Immunities"
-msgstr "部分​魔法​免疫"
-
-#: Source/mpq/mpq_writer.cpp:174
-msgid "Failed to open archive for writing."
-msgstr "无法​打开​储藏​档案​进行​写入。"
+msgstr "部分魔法免疫"
 
 #: Source/msg.cpp:1701
 #, c++-format
 msgid "{:s} has cast an invalid spell."
-msgstr "{:s}​施放​了​无效法术。"
+msgstr "{:s}施放了无效法术。"
 
 #: Source/msg.cpp:1705
 #, c++-format
 msgid "{:s} has cast an illegal spell."
-msgstr "{:s}​施放​了​非法​法术。"
+msgstr "{:s}施放了非法法术。"
 
-#: Source/msg.cpp:2286 Source/multi.cpp:836 Source/multi.cpp:886
+#: Source/msg.cpp:2316 Source/multi.cpp:897 Source/multi.cpp:957
 #, c++-format
 msgid "Player '{:s}' (level {:d}) just joined the game"
-msgstr "玩​家​{:s}(​等级​{:d}​)​刚​加入​了​游戏"
+msgstr "玩家{:s}(等级{:d})刚加入了游戏"
 
-#: Source/msg.cpp:2718
+#: Source/msg.cpp:2748
 msgid "The game ended"
-msgstr "比赛​结束​了"
+msgstr "比赛结束了"
 
-#: Source/msg.cpp:2724
+#: Source/msg.cpp:2754
 msgid "Unable to get level data"
-msgstr "无法​获取​场景​数据"
-
-#: Source/multi.cpp:283
-#, c++-format
-msgid "Player '{:s}' just left the game"
-msgstr "玩​家​{:s}​刚刚​离开​了​游戏"
+msgstr "无法获取场景数据"
 
 #: Source/multi.cpp:286
 #, c++-format
-msgid "Player '{:s}' killed Diablo and left the game!"
-msgstr "玩​家​{:s}​杀死​了​迪亚波罗​并​离开​了​游戏！"
+msgid "Player '{:s}' just left the game"
+msgstr "玩家{:s}刚刚离开了游戏"
 
-#: Source/multi.cpp:290
+#: Source/multi.cpp:291
+#, c++-format
+msgid "Player '{:s}' killed Diablo and left the game!"
+msgstr "玩家{:s}杀死了迪亚波罗并离开了游戏！"
+
+#: Source/multi.cpp:295
 #, c++-format
 msgid "Player '{:s}' dropped due to timeout"
-msgstr "由于​超时，玩​家​{:s}​的​掉落物​被​删除"
+msgstr "由于超时，玩家{:s}的掉落物被删除"
 
-#: Source/multi.cpp:888
+#: Source/multi.cpp:961
 #, c++-format
 msgid "Player '{:s}' (level {:d}) is already in the game"
-msgstr "玩​家​{:s}(​等级​{:d})​已经​在​游戏​中"
+msgstr "玩家{:s}(等级{:d})已经在游戏中"
 
 #. TRANSLATORS: Shrine Name Block
 #: Source/objects.cpp:127
@@ -3583,7 +3594,7 @@ msgstr "阴郁"
 
 #: Source/objects.cpp:130 Source/translation_dummy.cpp:460
 msgid "Weird"
-msgstr "诡​异"
+msgstr "诡异"
 
 #: Source/objects.cpp:131 Source/objects.cpp:138
 msgid "Magical"
@@ -3595,7 +3606,7 @@ msgstr "岩石"
 
 #: Source/objects.cpp:133
 msgid "Religious"
-msgstr "教​法"
+msgstr "教法"
 
 #: Source/objects.cpp:134
 msgid "Enchanted"
@@ -3607,7 +3618,7 @@ msgstr "奇幻"
 
 #: Source/objects.cpp:136
 msgid "Fascinating"
-msgstr "炫​目"
+msgstr "炫目"
 
 #: Source/objects.cpp:137
 msgid "Cryptic"
@@ -3615,7 +3626,7 @@ msgstr "奥秘"
 
 #: Source/objects.cpp:139
 msgid "Eldritch"
-msgstr "奇​异"
+msgstr "奇异"
 
 #: Source/objects.cpp:140
 msgid "Eerie"
@@ -3655,7 +3666,7 @@ msgstr "静谧"
 
 #: Source/objects.cpp:149
 msgid "Secluded"
-msgstr "隔​世"
+msgstr "隔世"
 
 #: Source/objects.cpp:150
 msgid "Ornate"
@@ -3675,7 +3686,7 @@ msgstr "油腻"
 
 #: Source/objects.cpp:154
 msgid "Glowing"
-msgstr "辉​光"
+msgstr "辉光"
 
 #: Source/objects.cpp:155
 msgid "Mendicant's"
@@ -3701,47 +3712,47 @@ msgstr "浑浊"
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:214
 msgid "The Great Conflict"
-msgstr "大​分歧"
+msgstr "永恒之战"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:215
 msgid "The Wages of Sin are War"
-msgstr "原罪​的​代价​即​是​战争"
+msgstr "原罪的代价即是战争"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:216
 msgid "The Tale of the Horadrim"
-msgstr "赫拉迪姆​的​故事"
+msgstr "赫拉迪姆的故事"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:217
 msgid "The Dark Exile"
-msgstr "黑暗​的​流放"
+msgstr "黑暗流放"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:218
 msgid "The Sin War"
-msgstr "原罪​之​战"
+msgstr "原罪之战"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:219
 msgid "The Binding of the Three"
-msgstr "三​位​一体"
+msgstr "三位一体"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:220
 msgid "The Realms Beyond"
-msgstr "超越​的​王国"
+msgstr "超越的王国"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:221
 msgid "Tale of the Three"
-msgstr "三​部​曲"
+msgstr "三部曲"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:222
 msgid "The Black King"
-msgstr "黑色​国王"
+msgstr "黑色国王"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:223
@@ -3756,12 +3767,12 @@ msgstr "日记: 会议"
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:225
 msgid "Journal: The Tirade"
-msgstr "日记: 长篇​大论"
+msgstr "日记: 长篇大论"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:226
 msgid "Journal: His Power Grows"
-msgstr "日记: 他​的​力量​在​增长"
+msgstr "日记: 他的力量在增长"
 
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:227
@@ -3776,803 +3787,804 @@ msgstr "日记: 结束"
 #. TRANSLATORS: Book Title
 #: Source/objects.cpp:229
 msgid "A Spellbook"
-msgstr "一​本法术书"
+msgstr "一本法术书"
 
-#: Source/objects.cpp:4795
+#: Source/objects.cpp:4793
 msgid "Crucified Skeleton"
-msgstr "钉死​的​骷髅"
+msgstr "钉死的骷髅"
 
-#: Source/objects.cpp:4799
+#: Source/objects.cpp:4797
 msgid "Lever"
-msgstr "控制​杆"
+msgstr "控制杆"
+
+#: Source/objects.cpp:4807
+msgid "Open Door"
+msgstr "打开的门"
 
 #: Source/objects.cpp:4809
-msgid "Open Door"
-msgstr "打开​的​门"
+msgid "Closed Door"
+msgstr "关闭的门"
 
 #: Source/objects.cpp:4811
-msgid "Closed Door"
-msgstr "关闭​的​门"
-
-#: Source/objects.cpp:4813
 msgid "Blocked Door"
-msgstr "封死​的​门"
+msgstr "封死的门"
 
-#: Source/objects.cpp:4818
+#: Source/objects.cpp:4816
 msgid "Ancient Tome"
 msgstr "古籍"
 
-#: Source/objects.cpp:4820
+#: Source/objects.cpp:4818
 msgid "Book of Vileness"
-msgstr "卑鄙​之​书"
+msgstr "卑鄙之书"
+
+#: Source/objects.cpp:4823
+msgid "Skull Lever"
+msgstr "骸骨控制杆"
 
 #: Source/objects.cpp:4825
-msgid "Skull Lever"
-msgstr "骸​骨​控制杆"
-
-#: Source/objects.cpp:4827
 msgid "Mythical Book"
-msgstr "神秘​之​书"
+msgstr "神秘之书"
 
-#: Source/objects.cpp:4830
+#: Source/objects.cpp:4828
 msgid "Small Chest"
-msgstr "小​箱子"
+msgstr "小箱子"
 
-#: Source/objects.cpp:4833
+#: Source/objects.cpp:4831
 msgid "Chest"
 msgstr "箱子"
 
-#: Source/objects.cpp:4837
+#: Source/objects.cpp:4835
 msgid "Large Chest"
-msgstr "大​箱子"
+msgstr "大箱子"
+
+#: Source/objects.cpp:4838
+msgid "Sarcophagus"
+msgstr "石棺"
 
 #: Source/objects.cpp:4840
-msgid "Sarcophagus"
-msgstr "石​棺"
-
-#: Source/objects.cpp:4842
 msgid "Bookshelf"
 msgstr "书架"
 
-#: Source/objects.cpp:4845
+#: Source/objects.cpp:4843
 msgid "Bookcase"
 msgstr "书柜"
 
-#: Source/objects.cpp:4848
+#: Source/objects.cpp:4846
 msgid "Barrel"
 msgstr "木桶"
 
-#: Source/objects.cpp:4851
+#: Source/objects.cpp:4849
 msgid "Pod"
 msgstr "茧"
 
-#: Source/objects.cpp:4854
+#: Source/objects.cpp:4852
 msgid "Urn"
 msgstr "罐子"
 
 #. TRANSLATORS: {:s} will be a name from the Shrine block above
-#: Source/objects.cpp:4857
+#: Source/objects.cpp:4855
 #, c++-format
 msgid "{:s} Shrine"
-msgstr "{:s}​圣坛"
+msgstr "{:s}圣坛"
+
+#: Source/objects.cpp:4857
+msgid "Skeleton Tome"
+msgstr "骸骨堆"
 
 #: Source/objects.cpp:4859
-msgid "Skeleton Tome"
-msgstr "骸​骨堆"
-
-#: Source/objects.cpp:4861
 msgid "Library Book"
 msgstr "典籍"
 
-#: Source/objects.cpp:4863
+#: Source/objects.cpp:4861
 msgid "Blood Fountain"
 msgstr "血泉"
 
-#: Source/objects.cpp:4865
+#: Source/objects.cpp:4863
 msgid "Decapitated Body"
-msgstr "无​头​尸"
+msgstr "无头尸"
+
+#: Source/objects.cpp:4865
+msgid "Book of the Blind"
+msgstr "目盲之书"
 
 #: Source/objects.cpp:4867
-msgid "Book of the Blind"
-msgstr "目盲​之​书"
+msgid "Book of Blood"
+msgstr "鲜血之书"
 
 #: Source/objects.cpp:4869
-msgid "Book of Blood"
-msgstr "鲜血​之​书"
-
-#: Source/objects.cpp:4871
 msgid "Purifying Spring"
-msgstr "纯​净​之泉"
+msgstr "纯净之泉"
 
-#: Source/objects.cpp:4874 Source/translation_dummy.cpp:275
+#: Source/objects.cpp:4872 Source/translation_dummy.cpp:275
 msgid "Armor"
-msgstr "护​甲"
+msgstr "护甲"
 
-#: Source/objects.cpp:4876 Source/objects.cpp:4893
+#: Source/objects.cpp:4874 Source/objects.cpp:4891
 msgid "Weapon Rack"
-msgstr "武器​架"
+msgstr "武器架"
+
+#: Source/objects.cpp:4876
+msgid "Goat Shrine"
+msgstr "山羊圣坛"
 
 #: Source/objects.cpp:4878
-msgid "Goat Shrine"
-msgstr "山​羊​圣坛"
+msgid "Cauldron"
+msgstr "坩埚"
 
 #: Source/objects.cpp:4880
-msgid "Cauldron"
-msgstr "坩​埚"
+msgid "Murky Pool"
+msgstr "浑浊的水池"
 
 #: Source/objects.cpp:4882
-msgid "Murky Pool"
-msgstr "浑浊​的​水池"
-
-#: Source/objects.cpp:4884
 msgid "Fountain of Tears"
 msgstr "泪泉"
 
-#: Source/objects.cpp:4886
+#: Source/objects.cpp:4884
 msgid "Steel Tome"
-msgstr "钢铁​之​书"
+msgstr "钢铁之书"
 
-#: Source/objects.cpp:4888
+#: Source/objects.cpp:4886
 msgid "Pedestal of Blood"
-msgstr "鲜血​底​座"
+msgstr "鲜血底座"
+
+#: Source/objects.cpp:4893
+msgid "Mushroom Patch"
+msgstr "蘑菇碎片"
 
 #: Source/objects.cpp:4895
-msgid "Mushroom Patch"
-msgstr "蘑菇​碎片"
+msgid "Vile Stand"
+msgstr "卑鄙旗帜"
 
 #: Source/objects.cpp:4897
-msgid "Vile Stand"
-msgstr "卑鄙​旗帜"
-
-#: Source/objects.cpp:4899
 msgid "Slain Hero"
-msgstr "被​杀​英雄"
+msgstr "被杀英雄"
 
 #. TRANSLATORS: {:s} will either be a chest or a door
-#: Source/objects.cpp:4912
+#: Source/objects.cpp:4910
 #, c++-format
 msgid "Trapped {:s}"
-msgstr "机关​{:s}"
+msgstr "机关{:s}"
 
 #. TRANSLATORS: If user enabled diablo.ini setting "Disable Crippling Shrines" is set to 1; also used for Na-Kruls lever
-#: Source/objects.cpp:4917
+#: Source/objects.cpp:4915
 #, c++-format
 msgid "{:s} (disabled)"
-msgstr "{:s}(​已​禁​用​)"
+msgstr "{:s}(已禁用)"
 
-#: Source/options.cpp:310 Source/options.cpp:447 Source/options.cpp:453
+#: Source/options.cpp:322 Source/options.cpp:459 Source/options.cpp:465
 msgid "ON"
 msgstr "开"
 
-#: Source/options.cpp:310 Source/options.cpp:445 Source/options.cpp:451
+#: Source/options.cpp:322 Source/options.cpp:457 Source/options.cpp:463
 msgid "OFF"
 msgstr "关"
 
-#: Source/options.cpp:422 Source/options.cpp:423
+#: Source/options.cpp:434 Source/options.cpp:435
 msgid "Game Mode"
-msgstr "游戏​模式"
+msgstr "游戏模式"
 
-#: Source/options.cpp:422
-#, fuzzy
-#| msgid "Gameplay Settings"
+#: Source/options.cpp:434
 msgid "Game Mode Settings"
-msgstr "游戏性​设置"
+msgstr "游戏模式设置"
 
-#: Source/options.cpp:423
+#: Source/options.cpp:435
 msgid "Play Diablo or Hellfire."
-msgstr "游玩​暗黑​破坏​神原版​或​地狱火​资料片。"
+msgstr "游玩暗黑破坏神原版或地狱火资料片。"
 
-#: Source/options.cpp:429
+#: Source/options.cpp:437 Source/options.cpp:485
+#: Source/translation_dummy.cpp:630
+msgid "Diablo"
+msgstr "迪亚波罗"
+
+#: Source/options.cpp:439 Source/options.cpp:499
+msgid "Hellfire"
+msgstr "地狱火"
+
+#: Source/options.cpp:441
 msgid "Restrict to Shareware"
-msgstr "限制​只​使用​共​享版"
+msgstr "限制只使用共享版"
 
-#: Source/options.cpp:429
+#: Source/options.cpp:441
 msgid ""
 "Makes the game compatible with the demo. Enables multiplayer with friends "
 "who don't own a full copy of Diablo."
-msgstr "使得​游戏​兼容​DEMO版。使得​那些​没有​完整版​的​玩家​可以​游玩​多​人​模式。"
+msgstr "使得游戏兼容DEMO版。使得那些没有完整版的玩家可以游玩多人模式。"
 
-#: Source/options.cpp:442
+#: Source/options.cpp:454
 msgid "Start Up"
-msgstr "起​始​模式"
+msgstr "起始模式"
 
-#: Source/options.cpp:442
+#: Source/options.cpp:454
 msgid "Start Up Settings"
-msgstr "起​始​模式​设置"
+msgstr "起始模式设置"
 
-#: Source/options.cpp:443 Source/options.cpp:449
+#: Source/options.cpp:455 Source/options.cpp:461
 msgid "Intro"
-msgstr "开​场​动画"
+msgstr "开场动画"
 
-#: Source/options.cpp:443 Source/options.cpp:449
+#: Source/options.cpp:455 Source/options.cpp:461
 msgid "Shown Intro cinematic."
-msgstr "播​放​开场​动画。"
+msgstr "播放开场动画。"
 
-#: Source/options.cpp:455
+#: Source/options.cpp:467
 msgid "Splash"
 msgstr "花絮"
 
-#: Source/options.cpp:455
+#: Source/options.cpp:467
 msgid "Shown splash screen."
-msgstr "显示​花絮​界面。"
+msgstr "显示花絮界面。"
 
-#: Source/options.cpp:457
+#: Source/options.cpp:469
 msgid "Logo and Title Screen"
-msgstr "标志​和​标题界面"
+msgstr "标志和标题界面"
 
-#: Source/options.cpp:458
+#: Source/options.cpp:470
 msgid "Title Screen"
 msgstr "标题界面"
 
-#: Source/options.cpp:473
+#: Source/options.cpp:485
 msgid "Diablo specific Settings"
-msgstr "暗​黑​破坏​神原版​特殊​设置"
+msgstr "暗黑破坏神原版特殊设置"
 
-#: Source/options.cpp:487
+#: Source/options.cpp:499
 msgid "Hellfire specific Settings"
-msgstr "地​狱火​特殊​设置"
+msgstr "地狱火特殊设置"
 
-#: Source/options.cpp:501
+#: Source/options.cpp:513
 msgid "Audio"
-msgstr "音​频"
+msgstr "音频"
 
-#: Source/options.cpp:501
+#: Source/options.cpp:513
 msgid "Audio Settings"
-msgstr "音​频​设置"
+msgstr "音频设置"
 
-#: Source/options.cpp:504
+#: Source/options.cpp:517
 msgid "Walking Sound"
-msgstr "行走​音效"
+msgstr "行走音效"
 
-#: Source/options.cpp:504
+#: Source/options.cpp:517
 msgid "Player emits sound when walking."
-msgstr "玩​家​行走​的​时候​发出​的​脚步声。"
+msgstr "玩家行走的时候发出的脚步声。"
 
-#: Source/options.cpp:505
+#: Source/options.cpp:518
 msgid "Auto Equip Sound"
-msgstr "自动​装备​音效"
+msgstr "自动装备音效"
 
-#: Source/options.cpp:505
+#: Source/options.cpp:518
 msgid "Automatically equipping items on pickup emits the equipment sound."
-msgstr "拾​取​到​物品​后​自动​装备​物品​时​发出​的​音效。"
+msgstr "拾取到物品后自动装备物品时发出的音效。"
 
-#: Source/options.cpp:506
+#: Source/options.cpp:519
 msgid "Item Pickup Sound"
-msgstr "物品​拾取​音效"
+msgstr "物品拾取音效"
 
-#: Source/options.cpp:506
+#: Source/options.cpp:519
 msgid "Picking up items emits the items pickup sound."
-msgstr "拾​取​物品​时​发出​的​音效。"
+msgstr "拾取物品时发出的音效。"
 
-#: Source/options.cpp:507
+#: Source/options.cpp:520
 msgid "Sample Rate"
 msgstr "采样率"
 
-#: Source/options.cpp:507
+#: Source/options.cpp:520
 msgid "Output sample rate (Hz)."
-msgstr "音​频​输出​采样率​(​赫兹)"
+msgstr "音频输出采样率(赫兹)"
 
-#: Source/options.cpp:508
+#: Source/options.cpp:521
 msgid "Channels"
-msgstr "声道​数量"
+msgstr "声道数量"
 
-#: Source/options.cpp:508
+#: Source/options.cpp:521
 msgid "Number of output channels."
-msgstr "音频​输出​使用​的​声道​数量。"
+msgstr "音频输出使用的声道数量。"
 
-#: Source/options.cpp:509
+#: Source/options.cpp:522
 msgid "Buffer Size"
-msgstr "缓冲​大​小"
+msgstr "缓冲大小"
 
-#: Source/options.cpp:509
+#: Source/options.cpp:522
 msgid "Buffer size (number of frames per channel)."
-msgstr "缓冲​大​小​(​每​个​通道​每​帧​)"
+msgstr "缓冲大小(每个通道每帧)"
 
-#: Source/options.cpp:510
+#: Source/options.cpp:523
 msgid "Resampling Quality"
-msgstr "重​采样​质量"
+msgstr "重采样质量"
 
-#: Source/options.cpp:510
-#, fuzzy
-#| msgid "Quality of the resampler, from 0 (lowest) to 10 (highest)."
+#: Source/options.cpp:523
 msgid "Quality of the resampler, from 0 (lowest) to 5 (highest)."
-msgstr "重​采样​质量，0​(​最​低​)​至​10(​最​大​)。"
+msgstr "重采样质量，从 0（最低）到 5（最高）。"
 
-#: Source/options.cpp:535
+#: Source/options.cpp:549
 msgid ""
 "Affect the game's internal resolution and determine your view area. Note: "
 "This can differ from screen resolution, when Upscaling, Integer Scaling or "
 "Fit to Screen is used."
 msgstr ""
-"分辨率​将​影响​你​在​游戏​中​的​可​见​范围。注意​：​当​使用​缩放、整​倍​缩放​或​适应​屏幕​时​可能​"
-"不同​于​屏幕​使用​的​分辨率。"
+"分辨率将影响你在游戏中的可见范围。注意：当使用缩放、整倍缩放或适应屏幕时可能"
+"不同于屏幕使用的分辨率。"
 
-#: Source/options.cpp:574
+#: Source/options.cpp:588
 msgid "Resampler"
 msgstr "重采样"
 
-#: Source/options.cpp:574
+#: Source/options.cpp:588
 msgid "Audio resampler"
 msgstr "音频重采样"
 
-#: Source/options.cpp:631
+#: Source/options.cpp:645
 msgid "Device"
 msgstr "设备"
 
-#: Source/options.cpp:631
+#: Source/options.cpp:645
 msgid "Audio device"
-msgstr "音​频​设备"
+msgstr "音频设备"
 
-#: Source/options.cpp:688
+#: Source/options.cpp:742
 msgid "Graphics"
 msgstr "图像"
 
-#: Source/options.cpp:688
+#: Source/options.cpp:742
 msgid "Graphics Settings"
-msgstr "图像​设置"
+msgstr "图像设置"
 
-#: Source/options.cpp:689
+#: Source/options.cpp:743
 msgid "Fullscreen"
-msgstr "全​屏幕"
+msgstr "全屏幕"
 
-#: Source/options.cpp:689
+#: Source/options.cpp:743
 msgid "Display the game in windowed or fullscreen mode."
-msgstr "显示​游戏​以​窗口​或是​全​屏幕​模式。"
+msgstr "显示游戏以窗口或是全屏幕模式。"
 
-#: Source/options.cpp:691
+#: Source/options.cpp:751
 msgid "Fit to Screen"
-msgstr "适应​屏幕"
+msgstr "适应屏幕"
 
-#: Source/options.cpp:691
+#: Source/options.cpp:751
 msgid ""
 "Automatically adjust the game window to your current desktop screen aspect "
 "ratio and resolution."
-msgstr "自动​设置​游戏​窗口​大小​为​你​的​桌面​比例​和​对应​分辨率。"
+msgstr "自动设置游戏窗口大小为你的桌面比例和对应分辨率。"
 
-#: Source/options.cpp:700
+#: Source/options.cpp:760
 msgid "Upscale"
 msgstr "缩放"
 
-#: Source/options.cpp:700
+#: Source/options.cpp:760
 msgid ""
 "Enables image scaling from the game resolution to your monitor resolution. "
 "Prevents changing the monitor resolution and allows window resizing."
 msgstr ""
-"允许​图像​按照​游戏​分辨率缩放​到​你​的​显示器​分辨率。在​不​改变​显示器​分辨率​大​小时，调"
-"整​窗口​调整​大小。"
+"允许图像按照游戏分辨率缩放到你的显示器分辨率。在不改变显示器分辨率大小时，调"
+"整窗口调整大小。"
 
-#: Source/options.cpp:707
+#: Source/options.cpp:767
 msgid "Scaling Quality"
-msgstr "缩​放​品质"
+msgstr "缩放品质"
 
-#: Source/options.cpp:707
+#: Source/options.cpp:767
 msgid "Enables optional filters to the output image when upscaling."
-msgstr "在​输出​缩放​图像​时​启用​可选​的​过滤​方式。"
+msgstr "在输出缩放图像时启用可选的过滤方式。"
 
-#: Source/options.cpp:709
+#: Source/options.cpp:769
 msgid "Nearest Pixel"
-msgstr "近似​采样"
+msgstr "近似采样"
 
-#: Source/options.cpp:710
+#: Source/options.cpp:770
 msgid "Bilinear"
 msgstr "双线性"
 
-#: Source/options.cpp:711
+#: Source/options.cpp:771
 msgid "Anisotropic"
-msgstr "各​向​异性"
+msgstr "各向异性"
 
-#: Source/options.cpp:713
+#: Source/options.cpp:773
 msgid "Integer Scaling"
-msgstr "整​倍​缩放"
+msgstr "整倍缩放"
 
-#: Source/options.cpp:713
+#: Source/options.cpp:773
 msgid "Scales the image using whole number pixel ratio."
-msgstr "点​对​点​对​图像​进行​缩放。"
+msgstr "点对点对图像进行缩放。"
 
-#: Source/options.cpp:721
+#: Source/options.cpp:781
 msgid "Frame Rate Control"
-msgstr ""
+msgstr "帧率控制"
 
-#: Source/options.cpp:722
+#: Source/options.cpp:782
 msgid ""
 "Manages frame rate to balance performance, reduce tearing, or save power."
-msgstr ""
+msgstr "管理帧率以平衡性能、减少画面撕裂或节省电量。"
 
-#: Source/options.cpp:732
+#: Source/options.cpp:792
 msgid "Vertical Sync"
-msgstr "垂直​同步"
+msgstr "垂直同步"
 
-#: Source/options.cpp:734
+#: Source/options.cpp:794
 msgid "Limit FPS"
-msgstr ""
+msgstr "限制帧率"
 
-#: Source/options.cpp:737
+#: Source/options.cpp:797
 msgid "Zoom on when enabled."
 msgstr "在可能的时候缩放。"
 
-#: Source/options.cpp:738
-#, fuzzy
-#| msgid " Lightning"
+#: Source/options.cpp:798
 msgid "Per-pixel Lighting"
-msgstr " 闪​电"
+msgstr "逐像素光照"
 
-#: Source/options.cpp:738
+#: Source/options.cpp:798
 msgid "Subtile lighting for smoother light gradients."
-msgstr ""
+msgstr "子瓦片光照，使光线过渡更平滑。"
 
-#: Source/options.cpp:739
+#: Source/options.cpp:799
 msgid "Color Cycling"
-msgstr "颜色​循环"
+msgstr "颜色循环"
 
-#: Source/options.cpp:739
+#: Source/options.cpp:799
 msgid "Color cycling effect used for water, lava, and acid animation."
-msgstr "在​水流、岩浆​和​酸​液​动画​上​使用​颜色​循环​特效。"
+msgstr "在水流、岩浆和酸液动画上使用颜色循环特效。"
 
-#: Source/options.cpp:740
+#: Source/options.cpp:800
 msgid "Alternate nest art"
-msgstr "替​换巢​穴​美术"
+msgstr "替换巢穴美术"
 
-#: Source/options.cpp:740
+#: Source/options.cpp:800
 msgid "The game will use an alternative palette for Hellfire’s nest tileset."
-msgstr "游戏​将​会​使用​一​个​其他​的​调色板​来​显示​地狱火​资料​片​中​的​巢穴​地图​地面​贴图。"
+msgstr "游戏将会使用一个其他的调色板来显示地狱火资料片中的巢穴地图地面贴图。"
 
-#: Source/options.cpp:742
+#: Source/options.cpp:802
 msgid "Hardware Cursor"
-msgstr "硬件​指针"
+msgstr "硬件指针"
 
-#: Source/options.cpp:742
+#: Source/options.cpp:802
 msgid "Use a hardware cursor"
-msgstr "使用​硬件​鼠​标"
+msgstr "使用硬件鼠标"
 
-#: Source/options.cpp:743
+#: Source/options.cpp:803
 msgid "Hardware Cursor For Items"
-msgstr "物品​使用​硬件​鼠​标"
+msgstr "物品使用硬件鼠标"
 
-#: Source/options.cpp:743
+#: Source/options.cpp:803
 msgid "Use a hardware cursor for items."
-msgstr "物品​装备​拾起​的​鼠标​使用​硬件​鼠标​模式。"
+msgstr "物品装备拾起的鼠标使用硬件鼠标模式。"
 
-#: Source/options.cpp:744
+#: Source/options.cpp:804
 msgid "Hardware Cursor Maximum Size"
-msgstr "硬件​鼠标​最​大​尺寸"
+msgstr "硬件鼠标最大尺寸"
 
-#: Source/options.cpp:744
+#: Source/options.cpp:804
 msgid ""
 "Maximum width / height for the hardware cursor. Larger cursors fall back to "
 "software."
-msgstr "硬件​鼠​标的​最​大​宽​高。软件​的​回报​的​最​大​鼠标​尺寸。"
+msgstr "硬件鼠标的最大宽高。软件的回报的最大鼠标尺寸。"
 
-#: Source/options.cpp:746
+#: Source/options.cpp:806
 msgid "Show FPS"
-msgstr "显示​FPS"
+msgstr "显示FPS"
 
-#: Source/options.cpp:746
+#: Source/options.cpp:806
 msgid "Displays the FPS in the upper left corner of the screen."
-msgstr "在​屏幕​的​左上角​显示​每​秒​帧数。"
+msgstr "在屏幕的左上角显示每秒帧数。"
 
-#: Source/options.cpp:782
+#: Source/options.cpp:842
 msgid "Gameplay"
 msgstr "游戏性"
 
-#: Source/options.cpp:782
+#: Source/options.cpp:842
 msgid "Gameplay Settings"
-msgstr "游戏性​设置"
+msgstr "游戏性设置"
 
-#: Source/options.cpp:784
+#: Source/options.cpp:844
 msgid ""
 "Enable jogging/fast walking in town for Diablo and Hellfire. This option was "
 "introduced in the expansion."
-msgstr "在​原版​或​地狱​火​的​城镇​中​启用​慢跑​和​快跑。这个​选​项​已经​在​资料​片​中​被​应用。"
+msgstr "在原版或地狱火的城镇中启用慢跑和快跑。这个选项已经在资料片中被应用。"
 
-#: Source/options.cpp:785
+#: Source/options.cpp:845
 msgid "Grab Input"
-msgstr "限制​鼠​标"
+msgstr "限制鼠标"
 
-#: Source/options.cpp:785
+#: Source/options.cpp:845
 msgid "When enabled mouse is locked to the game window."
-msgstr "启用​后​鼠标​将​被​限制​在​游戏​窗口​中。"
+msgstr "启用后鼠标将被限制在游戏窗口中。"
 
-#: Source/options.cpp:786
+#: Source/options.cpp:846
 msgid "Pause Game When Window Loses Focus"
 msgstr "当窗口失去焦点时暂停游戏"
 
-#: Source/options.cpp:786
+#: Source/options.cpp:846
 msgid "When enabled, the game will pause when focus is lost."
 msgstr "当启用时，游戏会在失去焦点时暂停。"
 
-#: Source/options.cpp:787
+#: Source/options.cpp:847
 msgid "Enable Little Girl quest."
-msgstr "启动​小​女孩​任务。"
+msgstr "启动小女孩任务。"
 
-#: Source/options.cpp:788
+#: Source/options.cpp:848
 msgid ""
 "Enable Jersey's quest. Lester the farmer is replaced by the Complete Nut."
-msgstr "启用​小丑​任务。农夫​莱斯特​将​被​替换​为​完整​的​纳特。"
+msgstr "启用小丑任务。农夫莱斯特将被替换为完整的纳特。"
 
-#: Source/options.cpp:789
+#: Source/options.cpp:849
 msgid "Friendly Fire"
-msgstr "友方​伤害"
+msgstr "友方伤害"
 
-#: Source/options.cpp:789
+#: Source/options.cpp:849
 msgid ""
 "Allow arrow/spell damage between players in multiplayer even when the "
 "friendly mode is on."
-msgstr "是否​允许​发射物​或​法术​在​多​人​游戏​中​伤害​友方​玩家。"
+msgstr "是否允许发射物或法术在多人游戏中伤害友方玩家。"
 
-#: Source/options.cpp:790
+#: Source/options.cpp:850
 msgid "Full quests in Multiplayer"
 msgstr "多人游戏中启用全部任务"
 
-#: Source/options.cpp:790
+#: Source/options.cpp:850
 msgid "Enables the full/uncut singleplayer version of quests."
 msgstr "启用完整/未删减的单人版本任务。"
 
-#: Source/options.cpp:791
+#: Source/options.cpp:851
 msgid "Test Bard"
-msgstr "测试​吟游​诗人"
+msgstr "测试吟游诗人"
 
-#: Source/options.cpp:791
+#: Source/options.cpp:851
 msgid "Force the Bard character type to appear in the hero selection menu."
-msgstr "强制​吟游​诗人​角色​出现​在​英雄​选择​菜单。"
+msgstr "强制吟游诗人角色出现在英雄选择菜单。"
 
-#: Source/options.cpp:792
+#: Source/options.cpp:852
 msgid "Test Barbarian"
-msgstr "测试​野​蛮​人"
+msgstr "测试野蛮人"
 
-#: Source/options.cpp:792
+#: Source/options.cpp:852
 msgid ""
 "Force the Barbarian character type to appear in the hero selection menu."
-msgstr "强制​野蛮人​角色​出现​在​英雄​选择​菜单。"
+msgstr "强制野蛮人角色出现在英雄选择菜单。"
 
-#: Source/options.cpp:793
+#: Source/options.cpp:853
 msgid "Experience Bar"
-msgstr "经验​条"
+msgstr "经验条"
 
-#: Source/options.cpp:793
+#: Source/options.cpp:853
 msgid "Experience Bar is added to the UI at the bottom of the screen."
-msgstr "在​用户​界面​的​底部​显示​经验条。"
+msgstr "在用户界面的底部显示经验条。"
 
-#: Source/options.cpp:794
+#: Source/options.cpp:854
 msgid "Show Item Graphics in Stores"
 msgstr "在商店显示物品图标"
 
-#: Source/options.cpp:794
+#: Source/options.cpp:854
 msgid "Show item graphics to the left of item descriptions in store menus."
 msgstr "在商店界面物品描述的左侧显示物品图标。"
 
-#: Source/options.cpp:795
+#: Source/options.cpp:855
 msgid "Show health values"
-msgstr "显示​生命​值"
+msgstr "显示生命值"
 
-#: Source/options.cpp:795
+#: Source/options.cpp:855
 msgid "Displays current / max health value on health globe."
-msgstr "在​法力球​上​显示​当前​/​最大​生命值。"
+msgstr "在法力球上显示当前/最大生命值。"
 
-#: Source/options.cpp:796
+#: Source/options.cpp:856
 msgid "Show mana values"
-msgstr "显示​法力值"
+msgstr "显示法力值"
 
-#: Source/options.cpp:796
+#: Source/options.cpp:856
 msgid "Displays current / max mana value on mana globe."
-msgstr "在​法力球​上​显示​当前​/​最​大​法​力值。"
+msgstr "在法力球上显示当前/最大法力值。"
 
-#: Source/options.cpp:797
-#, fuzzy
-#| msgid "Character Information"
+#: Source/options.cpp:857
 msgid "Show Party Information"
-msgstr "角色​信息"
+msgstr "显示队伍信息"
 
-#: Source/options.cpp:797
+#: Source/options.cpp:857
 msgid ""
 "Displays the health and mana of all connected multiplayer party members."
-msgstr ""
+msgstr "显示所有联机队伍成员的生命值和法力值。"
 
-#: Source/options.cpp:798
+#: Source/options.cpp:858
 msgid "Enemy Health Bar"
-msgstr "敌对​生命​条"
+msgstr "敌对生命条"
 
-#: Source/options.cpp:798
+#: Source/options.cpp:858
 msgid "Enemy Health Bar is displayed at the top of the screen."
-msgstr "敌人​的​生命​条​将​被​显示​在​屏幕​的​顶部。"
+msgstr "敌人的生命条将被显示在屏幕的顶部。"
 
-#: Source/options.cpp:799
+#: Source/options.cpp:859
 msgid "Floating Item Info Box"
-msgstr ""
+msgstr "悬浮物品信息框"
 
-#: Source/options.cpp:799
+#: Source/options.cpp:859
 msgid "Displays item info in a floating box when hovering over an item."
-msgstr ""
+msgstr "鼠标悬停在物品上时以浮动窗口显示物品信息。"
 
-#: Source/options.cpp:800
+#: Source/options.cpp:860
 msgid "Gold is automatically collected when in close proximity to the player."
-msgstr "靠近​玩家​的​金币​将​会​被​自动​拾取。"
+msgstr "靠近玩家的金币将会被自动拾取。"
 
-#: Source/options.cpp:801
+#: Source/options.cpp:861
 msgid ""
 "Elixirs are automatically collected when in close proximity to the player."
-msgstr "靠近​玩家​的​药剂​将​会​被​自动​拾取。"
+msgstr "靠近玩家的药剂将会被自动拾取。"
 
-#: Source/options.cpp:802
+#: Source/options.cpp:862
 msgid "Oils are automatically collected when in close proximity to the player."
-msgstr "靠近​玩家​的​油将​会​被​自动​拾取。"
+msgstr "靠近玩家的油将会被自动拾取。"
 
-#: Source/options.cpp:803
+#: Source/options.cpp:863
 msgid "Automatically pickup items in town."
-msgstr "是否​城镇​中​也​会​自动​拾取​物品。"
+msgstr "是否城镇中也会自动拾取物品。"
 
-#: Source/options.cpp:804
-msgid "Adria will refill your mana when you visit her shop."
-msgstr "艾德莉亚​将​会​在​你​光顾​他​的​商店​时​为​你​完全​回复​你​的​法力值。"
-
-#: Source/options.cpp:805
+#: Source/options.cpp:864
 msgid ""
 "Weapons will be automatically equipped on pickup or purchase if enabled."
-msgstr "启用​时​会​自动​装备​拾取​的​武器。"
+msgstr "启用时会自动装备拾取的武器。"
 
-#: Source/options.cpp:806
+#: Source/options.cpp:865
 msgid "Armor will be automatically equipped on pickup or purchase if enabled."
-msgstr "启用​时​会​自动​装备​拾取​的​护甲。"
+msgstr "启用时会自动装备拾取的护甲。"
 
-#: Source/options.cpp:807
+#: Source/options.cpp:866
 msgid "Helms will be automatically equipped on pickup or purchase if enabled."
-msgstr "启用​时​会​自动​装备​拾取​的​头盔。"
+msgstr "启用时会自动装备拾取的头盔。"
 
-#: Source/options.cpp:808
+#: Source/options.cpp:867
 msgid ""
 "Shields will be automatically equipped on pickup or purchase if enabled."
-msgstr "启用​时​会​自动​装备​拾取​的​盾牌。"
+msgstr "启用时会自动装备拾取的盾牌。"
 
-#: Source/options.cpp:809
+#: Source/options.cpp:868
 msgid ""
 "Jewelry will be automatically equipped on pickup or purchase if enabled."
-msgstr "启用​时​会​自动​装备​拾取​的​首饰。"
+msgstr "启用时会自动装备拾取的首饰。"
 
-#: Source/options.cpp:810
+#: Source/options.cpp:869
 msgid "Randomly selecting available quests for new games."
-msgstr "在​新​游戏​中​随机化​选择​的​可用​任务。"
+msgstr "在新游戏中随机化选择的可用任务。"
 
-#: Source/options.cpp:811
+#: Source/options.cpp:870
 msgid "Show Monster Type"
-msgstr "显示​怪物​类型"
+msgstr "显示怪物类型"
 
-#: Source/options.cpp:811
+#: Source/options.cpp:870
 msgid ""
 "Hovering over a monster will display the type of monster in the description "
 "box in the UI."
-msgstr "鼠​标悬停​在​怪物​身​上​将​会​在​用户​界面​中​显示​描述框，描述​怪物​类型​等​信息。"
+msgstr "鼠标悬停在怪物身上将会在用户界面中显示描述框，描述怪物类型等信息。"
 
-#: Source/options.cpp:812
+#: Source/options.cpp:871
 msgid "Show labels for items on the ground when enabled."
 msgstr "启用后显示地上物品的标签。"
 
-#: Source/options.cpp:813
+#: Source/options.cpp:872
 msgid "Refill belt from inventory when belt item is consumed."
-msgstr "背包​中​的​消耗​品会​自动​填充​到​腰带​中。"
+msgstr "背包中的消耗品会自动填充到腰带中。"
 
-#: Source/options.cpp:814
+#: Source/options.cpp:873
 msgid ""
 "When enabled Cauldrons, Fascinating Shrines, Goat Shrines, Ornate Shrines, "
 "Sacred Shrines and Murphy's Shrines are not able to be clicked on and "
 "labeled as disabled."
 msgstr ""
-"当​启用​后​药锅、炫目圣坛、山羊圣坛、华丽圣坛​和​破碎​圣坛​将​无法​被​点击，标签​也​将​提"
-"示​关闭。"
+"当启用后药锅、炫目圣坛、山羊圣坛、华丽圣坛和破碎圣坛将无法被点击，标签也将提"
+"示关闭。"
 
-#: Source/options.cpp:815
+#: Source/options.cpp:874
 msgid "Quick Cast"
-msgstr "快速​施法"
+msgstr "快速施法"
 
-#: Source/options.cpp:815
+#: Source/options.cpp:874
 msgid ""
 "Spell hotkeys instantly cast the spell, rather than switching the readied "
 "spell."
-msgstr "法术​快捷键​会​立即​释放​该​法术​而​不​是​切换施法​按钮。"
+msgstr "法术快捷键会立即释放该法术而不是切换施法按钮。"
 
-#: Source/options.cpp:816
+#: Source/options.cpp:875
 msgid "Number of Healing potions to pick up automatically."
-msgstr "生命​恢复​药水​自动​拾取​数量。"
+msgstr "生命恢复药水自动拾取数量。"
 
-#: Source/options.cpp:817
+#: Source/options.cpp:876
 msgid "Number of Full Healing potions to pick up automatically."
-msgstr "完全​生命​恢复​药水​自动​拾取​数量。"
+msgstr "完全生命恢复药水自动拾取数量。"
 
-#: Source/options.cpp:818
+#: Source/options.cpp:877
 msgid "Number of Mana potions to pick up automatically."
-msgstr "法力​恢复​药水​自动​拾取​数量。"
+msgstr "法力恢复药水自动拾取数量。"
 
-#: Source/options.cpp:819
+#: Source/options.cpp:878
 msgid "Number of Full Mana potions to pick up automatically."
-msgstr "完全​法力​恢复​药水​自动​拾取​数量。"
+msgstr "完全法力恢复药水自动拾取数量。"
 
-#: Source/options.cpp:820
+#: Source/options.cpp:879
 msgid "Number of Rejuvenation potions to pick up automatically."
-msgstr "活力​恢复​药水​自动​拾取​数量。"
-
-#: Source/options.cpp:821
-msgid "Number of Full Rejuvenation potions to pick up automatically."
-msgstr "完全​活力​恢复​药水​自动​拾取​数量。"
-
-#: Source/options.cpp:822
-msgid "Enable floating numbers"
-msgstr "允许浮动数字"
-
-#: Source/options.cpp:822
-msgid "Enables floating numbers on gaining XP / dealing damage etc."
-msgstr "在获得 XP/造成伤害等时启用浮动数字。"
-
-#: Source/options.cpp:824
-msgid "Off"
-msgstr "关"
-
-#: Source/options.cpp:825
-msgid "Random Angles"
-msgstr "随机角度"
-
-#: Source/options.cpp:826
-msgid "Vertical Only"
-msgstr "仅垂直"
+msgstr "活力恢复药水自动拾取数量。"
 
 #: Source/options.cpp:880
+msgid "Number of Full Rejuvenation potions to pick up automatically."
+msgstr "完全活力恢复药水自动拾取数量。"
+
+#: Source/options.cpp:881
+msgid "Visual Store UI"
+msgstr "视觉商店界面"
+
+#: Source/options.cpp:881
+msgid ""
+"Use visual grid-based store interface instead of text-based menus. Both "
+"store and inventory panels open together."
+msgstr ""
+"使用基于网格的视觉商店界面，而非基于文本的菜单。商店与物品栏面板将同时打开。"
+
+#: Source/options.cpp:933
 msgid "Controller"
 msgstr "控制器"
 
-#: Source/options.cpp:880
+#: Source/options.cpp:933
 msgid "Controller Settings"
-msgstr "控制器​设置"
+msgstr "控制器设置"
 
-#: Source/options.cpp:889
+#: Source/options.cpp:942
 msgid "Network"
 msgstr "网络"
 
-#: Source/options.cpp:889
+#: Source/options.cpp:942
 msgid "Network Settings"
-msgstr "网络​设置"
+msgstr "网络设置"
 
-#: Source/options.cpp:901
+#: Source/options.cpp:954
 msgid "Chat"
 msgstr "交谈"
 
-#: Source/options.cpp:901
+#: Source/options.cpp:954
 msgid "Chat Settings"
-msgstr "聊天​设置"
+msgstr "聊天设置"
 
-#: Source/options.cpp:910 Source/options.cpp:1029
+#: Source/options.cpp:963 Source/options.cpp:1081
 msgid "Language"
 msgstr "语言"
 
-#: Source/options.cpp:910
+#: Source/options.cpp:963
 msgid "Define what language to use in game."
-msgstr "设置​游戏​将​使用​哪​种​语言。"
+msgstr "设置游戏将使用哪种语言。"
 
-#: Source/options.cpp:1029
+#: Source/options.cpp:1081
 msgid "Language Settings"
-msgstr "语言​设置"
+msgstr "语言设置"
 
-#: Source/options.cpp:1040
+#: Source/options.cpp:1092
 msgid "Keymapping"
-msgstr "键鼠键位​映射"
+msgstr "键鼠键位映射"
 
-#: Source/options.cpp:1040
+#: Source/options.cpp:1092
 msgid "Keymapping Settings"
-msgstr "键鼠键位​映射​设置"
+msgstr "键鼠键位映射设置"
 
-#: Source/options.cpp:1260
+#: Source/options.cpp:1312
 msgid "Padmapping"
 msgstr "手柄键位映射"
 
-#: Source/options.cpp:1260
+#: Source/options.cpp:1312
 msgid "Padmapping Settings"
-msgstr "手柄键位映射​设置"
+msgstr "手柄键位映射设置"
 
-#: Source/options.cpp:1512
+#: Source/options.cpp:1558
 msgid "Mods"
-msgstr ""
+msgstr "模组"
 
-#: Source/options.cpp:1512
-#, fuzzy
-#| msgid "Settings"
+#: Source/options.cpp:1558
 msgid "Mod Settings"
-msgstr "设置"
+msgstr "模组设置"
+
+#: Source/options.cpp:1643
+#, c++-format
+msgid "Version {:s} by {:s}"
+msgstr "版本 {:s} 由 {:s} 制作"
+
+#: Source/options.cpp:1645
+#, c++-format
+msgid "Version {:s}"
+msgstr "版本 {:s}"
+
+#: Source/options.cpp:1647
+#, c++-format
+msgid "By {:s}"
+msgstr "由 {:s}"
 
 #: Source/panels/charpanel.cpp:133
 msgid "Level"
@@ -4584,7 +4596,7 @@ msgstr "经验"
 
 #: Source/panels/charpanel.cpp:139
 msgid "Next level"
-msgstr "下​一​级"
+msgstr "下一级"
 
 #: Source/panels/charpanel.cpp:148
 msgid "Base"
@@ -4612,7 +4624,7 @@ msgstr "活力"
 
 #: Source/panels/charpanel.cpp:164
 msgid "Points to distribute"
-msgstr "可​分配​点​数"
+msgstr "可分配点数"
 
 #: Source/panels/charpanel.cpp:170 Source/translation_dummy.cpp:216
 msgid "Gold"
@@ -4620,13 +4632,11 @@ msgstr "金币"
 
 #: Source/panels/charpanel.cpp:174
 msgid "Armor class"
-msgstr "护甲​等级"
+msgstr "护甲等级"
 
 #: Source/panels/charpanel.cpp:176
-#, fuzzy
-#| msgid "chance to hit"
 msgid "Chance To Hit"
-msgstr "命​中​概率"
+msgstr "命中几率"
 
 #: Source/panels/charpanel.cpp:178
 msgid "Damage"
@@ -4642,15 +4652,15 @@ msgstr "法力"
 
 #: Source/panels/charpanel.cpp:193
 msgid "Resist magic"
-msgstr "魔法​抗性"
+msgstr "魔法抗性"
 
 #: Source/panels/charpanel.cpp:195
 msgid "Resist fire"
-msgstr "火焰​抗性"
+msgstr "火焰抗性"
 
 #: Source/panels/charpanel.cpp:197
 msgid "Resist lightning"
-msgstr "闪电​抗性"
+msgstr "闪电抗性"
 
 #: Source/panels/mainpanel.cpp:91
 msgid "char"
@@ -4666,11 +4676,11 @@ msgstr "地图"
 
 #: Source/panels/mainpanel.cpp:94
 msgid "menu"
-msgstr "菜​单"
+msgstr "菜单"
 
 #: Source/panels/mainpanel.cpp:95
 msgid "inv"
-msgstr "物品​栏"
+msgstr "物品栏"
 
 #: Source/panels/mainpanel.cpp:96
 msgid "spells"
@@ -4684,16 +4694,16 @@ msgstr "语音"
 #: Source/panels/mainpanel.cpp:127 Source/panels/mainpanel.cpp:129
 #: Source/panels/mainpanel.cpp:131
 msgid "mute"
-msgstr "静​音"
+msgstr "静音"
 
 #: Source/panels/spell_book.cpp:105
 msgid "Unusable"
-msgstr "无法​使用"
+msgstr "无法使用"
 
 #. TRANSLATORS: UI constraints, keep short please.
 #: Source/panels/spell_book.cpp:108
 msgid "Dmg: 1/3 target hp"
-msgstr "伤害: 1/3 目标​生命"
+msgstr "伤害: 1/3 目标生命"
 
 #. TRANSLATORS: UI constraints, keep short please.
 #: Source/panels/spell_book.cpp:115
@@ -4737,7 +4747,7 @@ msgstr "法术"
 
 #: Source/panels/spell_list.cpp:162
 msgid "Damages undead only"
-msgstr "只​能​伤害​亡灵"
+msgstr "只能伤害亡灵"
 
 #: Source/panels/spell_list.cpp:173
 msgid "Scroll"
@@ -4745,116 +4755,152 @@ msgstr "卷轴"
 
 #: Source/panels/spell_list.cpp:184 Source/translation_dummy.cpp:354
 msgid "Staff"
-msgstr "法​杖"
+msgstr "法杖"
 
 #: Source/panels/spell_list.cpp:194
 #, c++-format
 msgid "Spell Hotkey {:s}"
-msgstr "法术​热键 {:s}"
+msgstr "法术热键 {:s}"
 
-#: Source/pfile.cpp:762
+#: Source/pfile.cpp:791
 msgid "Unable to open archive"
-msgstr "无法​打开​存档"
+msgstr "无法打开存档"
 
-#: Source/pfile.cpp:764
+#: Source/pfile.cpp:793
 msgid "Unable to load character"
-msgstr "无法​加载​角色"
+msgstr "无法加载角色"
 
-#: Source/playerdat.cpp:320
-msgid "Loading Class Data Failed"
-msgstr ""
-
-#: Source/playerdat.cpp:320
-#, c++-format
-msgid ""
-"Could not add a class, since the maximum class number of {} has already been "
-"reached."
-msgstr ""
-
-#: Source/plrmsg.cpp:79 Source/qol/chatlog.cpp:130
+#: Source/plrmsg.cpp:85 Source/qol/chatlog.cpp:130
 #, c++-format
 msgid "{:s} (lvl {:d}): "
-msgstr "{:s} (​等级 {:d}): "
+msgstr "{:s} (等级 {:d}): "
 
 #: Source/qol/chatlog.cpp:170
 #, c++-format
 msgid "Chat History (Messages: {:d})"
-msgstr "聊天​历史 (​消息: {:d}​)"
+msgstr "聊天历史 (消息: {:d})"
 
 #: Source/qol/itemlabels.cpp:113
 #, c++-format
 msgid "{:s} gold"
 msgstr "{:s} 金币"
 
-#: Source/qol/stash.cpp:648
+#: Source/qol/stash.cpp:657
 msgid "How many gold pieces do you want to withdraw?"
-msgstr "你​想要​取出​多少​金币？"
+msgstr "你想要取出多少金币？"
 
-#: Source/qol/xpbar.cpp:139
+#: Source/qol/visual_store.cpp:442 Source/qol/visual_store.cpp:531
+#: Source/qol/visual_store.cpp:532
+msgid "Basic"
+msgstr "基础"
+
+#: Source/qol/visual_store.cpp:446 Source/qol/visual_store.cpp:545
+#: Source/qol/visual_store.cpp:546
+msgid "Premium"
+msgstr "高级"
+
+#: Source/qol/visual_store.cpp:454 Source/qol/visual_store.cpp:536
+#: Source/qol/visual_store.cpp:537
+msgid "Misc"
+msgstr "杂项"
+
+#: Source/qol/visual_store.cpp:502
+msgid "Gold: "
+msgstr "金币: "
+
+#: Source/qol/visual_store.cpp:533 Source/qol/visual_store.cpp:534
+msgid "Basic items"
+msgstr "基础物品"
+
+#: Source/qol/visual_store.cpp:538 Source/qol/visual_store.cpp:539
+msgid "Miscellaneous items"
+msgstr "杂项物品"
+
+#: Source/qol/visual_store.cpp:547 Source/qol/visual_store.cpp:548
+msgid "Premium items"
+msgstr "高级物品"
+
+#: Source/qol/visual_store.cpp:560 Source/qol/visual_store.cpp:561
+msgid "Repair All"
+msgstr "全部修理"
+
+#: Source/qol/visual_store.cpp:566 Source/qol/visual_store.cpp:567
+msgid "Nothing to repair"
+msgstr "无需修理"
+
+#: Source/qol/visual_store.cpp:573 Source/qol/visual_store.cpp:574
+msgid "Repair"
+msgstr "修理"
+
+#: Source/qol/visual_store.cpp:575 Source/qol/visual_store.cpp:576
+msgid "Repair a single item"
+msgstr "修理单件物品"
+
+#: Source/qol/xpbar.cpp:140
 #, c++-format
 msgid "Level {:d}"
 msgstr "等级 {:d}"
 
-#: Source/qol/xpbar.cpp:145 Source/qol/xpbar.cpp:153
+#: Source/qol/xpbar.cpp:146 Source/qol/xpbar.cpp:154
 #, c++-format
 msgid "Experience: {:s}"
 msgstr "经验: {:s}"
 
-#: Source/qol/xpbar.cpp:146
+#: Source/qol/xpbar.cpp:147
 msgid "Maximum Level"
-msgstr "最​大​等级"
-
-#: Source/qol/xpbar.cpp:155
-#, c++-format
-msgid "Next Level: {:s}"
-msgstr "下​一​级: {:s}"
+msgstr "最大等级"
 
 #: Source/qol/xpbar.cpp:156
+#, c++-format
+msgid "Next Level: {:s}"
+msgstr "下一级: {:s}"
+
+#: Source/qol/xpbar.cpp:157
 #, c++-format
 msgid "{:s} to Level {:d}"
 msgstr "{:s} 到 {:d} 级"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:76
+#: Source/quests.cpp:78
 msgid "King Leoric's Tomb"
-msgstr "国王​李奥瑞克​的​陵寝"
+msgstr "国王李奥瑞克的陵寝"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:77 Source/translation_dummy.cpp:638
+#: Source/quests.cpp:79 Source/translation_dummy.cpp:638
 msgid "The Chamber of Bone"
 msgstr "白骨密室"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:79
+#: Source/quests.cpp:81
 msgid "A Dark Passage"
-msgstr "黑暗​的​通道"
+msgstr "黑暗的通道"
 
 #. TRANSLATORS: Quest Map
-#: Source/quests.cpp:80
+#: Source/quests.cpp:82
 msgid "Unholy Altar"
-msgstr "邪恶​祭坛"
+msgstr "邪恶祭坛"
 
 #. TRANSLATORS: Used for Quest Portals. {:s} is a Map Name
-#: Source/quests.cpp:355
+#: Source/quests.cpp:357
 #, c++-format
 msgid "To {:s}"
-msgstr "到​{:s}"
+msgstr "到{:s}"
 
 #: Source/quick_messages.cpp:10
 msgid "I need help! Come here!"
-msgstr "我​需要​帮助！过来！"
+msgstr "我需要帮助！过来！"
 
 #: Source/quick_messages.cpp:11
 msgid "Follow me."
-msgstr "跟​着​我。"
+msgstr "跟着我。"
 
 #: Source/quick_messages.cpp:12
 msgid "Here's something for you."
-msgstr "这​是​给​你​的。"
+msgstr "这是给你的。"
 
 #: Source/quick_messages.cpp:13
 msgid "Now you DIE!"
-msgstr "现在​你​死定​了！"
+msgstr "现在你死定了！"
 
 #: Source/quick_messages.cpp:14
 msgid "Heal yourself!"
@@ -4880,219 +4926,227 @@ msgstr "对不起。"
 msgid "I'm waiting."
 msgstr "我在等待。"
 
-#: Source/stores.cpp:131
+#: Source/stores.cpp:203
 msgid "Griswold"
 msgstr "格里斯沃尔德"
 
-#: Source/stores.cpp:132
+#: Source/stores.cpp:204
 msgid "Pepin"
-msgstr "佩​金"
+msgstr "佩金"
 
-#: Source/stores.cpp:134
+#: Source/stores.cpp:206
 msgid "Ogden"
 msgstr "奥格登"
 
-#: Source/stores.cpp:135
+#: Source/stores.cpp:207
 msgid "Cain"
 msgstr "凯恩"
 
-#: Source/stores.cpp:136
+#: Source/stores.cpp:208
 msgid "Farnham"
 msgstr "法恩汉"
 
-#: Source/stores.cpp:137
+#: Source/stores.cpp:209
 msgid "Adria"
 msgstr "艾德莉亚"
 
-#: Source/stores.cpp:138 Source/stores.cpp:1267
+#: Source/stores.cpp:210 Source/stores.cpp:1264
 msgid "Gillian"
 msgstr "吉莉安"
 
-#: Source/stores.cpp:139
+#: Source/stores.cpp:211
 msgid "Wirt"
-msgstr "怀​特"
+msgstr "怀特"
 
-#: Source/stores.cpp:265 Source/stores.cpp:272
+#: Source/stores.cpp:337 Source/stores.cpp:344
 msgid "Back"
 msgstr "返回"
 
-#: Source/stores.cpp:294 Source/stores.cpp:300 Source/stores.cpp:326
+#: Source/stores.cpp:366 Source/stores.cpp:372 Source/stores.cpp:398
 msgid ",  "
 msgstr ",  "
 
-#: Source/stores.cpp:311
+#: Source/stores.cpp:383
 #, c++-format
 msgid "Damage: {:d}-{:d}  "
 msgstr "伤害: {:d}-{:d} "
 
-#: Source/stores.cpp:313
+#: Source/stores.cpp:385
 #, c++-format
 msgid "Armor: {:d}  "
-msgstr "护​甲: {:d} "
+msgstr "护甲: {:d} "
 
-#: Source/stores.cpp:315
+#: Source/stores.cpp:387
 #, c++-format
 msgid "Dur: {:d}/{:d}"
 msgstr "耐久: {:d}/{:d}"
 
-#: Source/stores.cpp:317
+#: Source/stores.cpp:389
 msgid "Indestructible"
-msgstr "坚​不​可​摧的"
+msgstr "坚不可摧的"
 
-#: Source/stores.cpp:387 Source/stores.cpp:1035 Source/stores.cpp:1254
+#: Source/stores.cpp:436 Source/stores.cpp:1035 Source/stores.cpp:1251
 msgid "Welcome to the"
-msgstr "欢迎​来到"
+msgstr "欢迎来到"
 
-#: Source/stores.cpp:388
+#: Source/stores.cpp:437
 msgid "Blacksmith's shop"
-msgstr "铁匠​铺"
+msgstr "铁匠铺"
 
-#: Source/stores.cpp:389 Source/stores.cpp:686 Source/stores.cpp:1037
-#: Source/stores.cpp:1080 Source/stores.cpp:1256 Source/stores.cpp:1268
-#: Source/stores.cpp:1281
+#: Source/stores.cpp:438 Source/stores.cpp:695 Source/stores.cpp:1037
+#: Source/stores.cpp:1077 Source/stores.cpp:1253 Source/stores.cpp:1265
+#: Source/stores.cpp:1278
 msgid "Would you like to:"
-msgstr "您​想:"
+msgstr "您想:"
 
-#: Source/stores.cpp:390
+#: Source/stores.cpp:439
 msgid "Talk to Griswold"
-msgstr "与​格里斯沃尔德​交谈"
+msgstr "与格里斯沃尔德交谈"
 
-#: Source/stores.cpp:391
-msgid "Buy basic items"
-msgstr "购买​基础​物品"
+#: Source/stores.cpp:441
+msgid "Trade / Repair"
+msgstr "交易 / 修理"
 
-#: Source/stores.cpp:392
-msgid "Buy premium items"
-msgstr "购买​高级​物品"
-
-#: Source/stores.cpp:393 Source/stores.cpp:689
-msgid "Sell items"
-msgstr "出售​物品"
-
-#: Source/stores.cpp:394
-msgid "Repair items"
-msgstr "修理​物品"
-
-#: Source/stores.cpp:395
+#: Source/stores.cpp:442 Source/stores.cpp:448
 msgid "Leave the shop"
-msgstr "离开​商店"
+msgstr "离开商店"
 
-#: Source/stores.cpp:423 Source/stores.cpp:725 Source/stores.cpp:1057
+#: Source/stores.cpp:444
+msgid "Buy basic items"
+msgstr "购买基础物品"
+
+#: Source/stores.cpp:445
+msgid "Buy premium items"
+msgstr "购买高级物品"
+
+#: Source/stores.cpp:446 Source/stores.cpp:704
+msgid "Sell items"
+msgstr "出售物品"
+
+#: Source/stores.cpp:447
+msgid "Repair items"
+msgstr "修理物品"
+
+#: Source/stores.cpp:471 Source/stores.cpp:742 Source/stores.cpp:1057
 msgid "I have these items for sale:"
-msgstr "我​有​这些​东西​要​卖:"
+msgstr "我有这些东西要卖:"
 
-#: Source/stores.cpp:472
+#: Source/stores.cpp:514
 msgid "I have these premium items for sale:"
-msgstr "我​这​有些​高档品​出售:"
+msgstr "我这有些高档品出售:"
 
-#: Source/stores.cpp:568 Source/stores.cpp:818
+#: Source/stores.cpp:593 Source/stores.cpp:818
 msgid "You have nothing I want."
-msgstr "你​没有​我​想要​的​东西。"
+msgstr "你没有我想要的东西。"
 
-#: Source/stores.cpp:579 Source/stores.cpp:830
+#: Source/stores.cpp:604 Source/stores.cpp:830
 msgid "Which item is for sale?"
-msgstr "要​出售​哪​件​物品？"
+msgstr "要出售哪件物品？"
 
-#: Source/stores.cpp:647
+#: Source/stores.cpp:672
 msgid "You have nothing to repair."
-msgstr "你​没有​需要​修理​的​物品。"
+msgstr "你没有需要修理的物品。"
 
-#: Source/stores.cpp:658
+#: Source/stores.cpp:683
 msgid "Repair which item?"
-msgstr "哪​件​物品​需要​修理？"
+msgstr "哪件物品需要修理？"
 
-#: Source/stores.cpp:685
+#: Source/stores.cpp:694
 msgid "Witch's shack"
-msgstr "女​巫小屋"
+msgstr "女巫小屋"
 
-#: Source/stores.cpp:687
+#: Source/stores.cpp:696
 msgid "Talk to Adria"
-msgstr "与​艾德莉亚​交谈"
+msgstr "与艾德莉亚交谈"
 
-#: Source/stores.cpp:688 Source/stores.cpp:1039
-msgid "Buy items"
-msgstr "购买​物品"
+#: Source/stores.cpp:698
+msgid "Buy / Sell"
+msgstr "购买 / 出售"
 
-#: Source/stores.cpp:690
+#: Source/stores.cpp:699 Source/stores.cpp:705
 msgid "Recharge staves"
-msgstr "给​魔杖​重新​充能"
+msgstr "给魔杖重新充能"
 
-#: Source/stores.cpp:691
+#: Source/stores.cpp:700 Source/stores.cpp:706
 msgid "Leave the shack"
-msgstr "离开​小​屋"
+msgstr "离开小屋"
+
+#: Source/stores.cpp:703 Source/stores.cpp:1039
+msgid "Buy items"
+msgstr "购买物品"
 
 #: Source/stores.cpp:892
 msgid "You have nothing to recharge."
-msgstr "你​没有​物品​需要​充能。"
+msgstr "你没有物品需要充能。"
 
 #: Source/stores.cpp:903
 msgid "Recharge which item?"
-msgstr "给​哪​件​物品​充能？"
+msgstr "给哪件物品充能？"
 
 #: Source/stores.cpp:916
 msgid "You do not have enough gold"
-msgstr "你​没有​足够​的​金币"
+msgstr "你没有足够的金币"
 
 #: Source/stores.cpp:924
 msgid "You do not have enough room in inventory"
-msgstr "您​的​物品​栏​空间​不​足"
+msgstr "您的物品栏空间不足"
 
 #: Source/stores.cpp:942
 msgid "Do we have a deal?"
-msgstr "我们​有​生意​往来​吗？"
+msgstr "我们有生意往来吗？"
 
 #: Source/stores.cpp:945
 msgid "Are you sure you want to identify this item?"
-msgstr "您​确定​要​鉴定​这​件​物品​吗？"
+msgstr "您确定要鉴定这件物品吗？"
 
 #: Source/stores.cpp:951
 msgid "Are you sure you want to buy this item?"
-msgstr "您​确定​要​购买​这​件​物品​吗？"
+msgstr "您确定要购买这件物品吗？"
 
 #: Source/stores.cpp:954
 msgid "Are you sure you want to recharge this item?"
-msgstr "您​确定​要​为​该​物品​充能​吗？"
+msgstr "您确定要为该物品充能吗？"
 
 #: Source/stores.cpp:958
 msgid "Are you sure you want to sell this item?"
-msgstr "您​确定​要​出售​这​件​物品​吗？"
+msgstr "您确定要出售这件物品吗？"
 
 #: Source/stores.cpp:961
 msgid "Are you sure you want to repair this item?"
-msgstr "您​确定​要​修理​这​件​物品​吗？"
+msgstr "您确定要修理这件物品吗？"
 
-#: Source/stores.cpp:975 Source/towners.cpp:785
+#: Source/stores.cpp:975
 msgid "Wirt the Peg-legged boy"
-msgstr "假腿​男孩​怀​特"
+msgstr "假腿男孩怀特"
 
 #: Source/stores.cpp:978 Source/stores.cpp:985
 msgid "Talk to Wirt"
-msgstr "和​怀特​谈​谈"
+msgstr "和怀特谈谈"
 
 #: Source/stores.cpp:979
 msgid "I have something for sale,"
-msgstr "我​有​东西​要​出售，"
+msgstr "我有东西要出售，"
 
 #: Source/stores.cpp:980
 msgid "but it will cost 50 gold"
-msgstr "但​要​花 50 金币"
+msgstr "但要花 50 金币"
 
 #: Source/stores.cpp:981
 msgid "just to take a look. "
-msgstr "才​能​看上​一​眼。"
+msgstr "才能看上一眼。"
 
 #: Source/stores.cpp:982
 msgid "What have you got?"
-msgstr "你​找到​了​什么​东西？"
+msgstr "你找到了什么东西？"
 
-#: Source/stores.cpp:983 Source/stores.cpp:986 Source/stores.cpp:1083
-#: Source/stores.cpp:1271
+#: Source/stores.cpp:983 Source/stores.cpp:986 Source/stores.cpp:1080
+#: Source/stores.cpp:1268
 msgid "Say goodbye"
 msgstr "再见"
 
 #: Source/stores.cpp:996
 msgid "I have this item for sale:"
-msgstr "我​有​这个​东西​要​卖:"
+msgstr "我有这个东西要卖:"
 
 #: Source/stores.cpp:1013
 msgid "Leave"
@@ -5100,163 +5154,146 @@ msgstr "离开"
 
 #: Source/stores.cpp:1036
 msgid "Healer's home"
-msgstr "治疗者​的​家"
+msgstr "治疗者的家"
 
 #: Source/stores.cpp:1038
 msgid "Talk to Pepin"
-msgstr "与​佩金​交谈"
+msgstr "与佩金交谈"
 
 #: Source/stores.cpp:1040
 msgid "Leave Healer's home"
-msgstr "离开​治疗者​的​家"
+msgstr "离开治疗者的家"
+
+#: Source/stores.cpp:1076
+msgid "The Town Elder"
+msgstr "镇上的长老"
+
+#: Source/stores.cpp:1078
+msgid "Talk to Cain"
+msgstr "与凯恩交谈"
 
 #: Source/stores.cpp:1079
-msgid "The Town Elder"
-msgstr "镇​上​的​长老"
-
-#: Source/stores.cpp:1081
-msgid "Talk to Cain"
-msgstr "与​凯恩​交谈"
-
-#: Source/stores.cpp:1082
 msgid "Identify an item"
-msgstr "鉴定​一​件​物品"
+msgstr "鉴定一件物品"
 
-#: Source/stores.cpp:1175
+#: Source/stores.cpp:1172
 msgid "You have nothing to identify."
-msgstr "你​没有​可以​鉴定​的​物品。你​的​金币: {:d}"
+msgstr "你没有可以鉴定的物品。"
 
-#: Source/stores.cpp:1186
+#: Source/stores.cpp:1183
 msgid "Identify which item?"
-msgstr "鉴定​哪​一​件​物品？"
+msgstr "鉴定哪一件物品？"
+
+#: Source/stores.cpp:1198
+msgid "This item is:"
+msgstr "这件物品是:"
 
 #: Source/stores.cpp:1201
-msgid "This item is:"
-msgstr "这​件​物品​是:"
-
-#: Source/stores.cpp:1204
 msgid "Done"
 msgstr "完成"
 
-#: Source/stores.cpp:1213
+#: Source/stores.cpp:1210
 #, c++-format
 msgid "Talk to {:s}"
-msgstr "与​{:s}​交谈"
+msgstr "与{:s}交谈"
 
-#: Source/stores.cpp:1216
+#: Source/stores.cpp:1213
 #, c++-format
 msgid "Talking to {:s}"
-msgstr "与​{:s}​交谈"
+msgstr "与{:s}交谈"
 
-#: Source/stores.cpp:1217
+#: Source/stores.cpp:1214
 msgid "is not available"
-msgstr "不​可​用"
+msgstr "不可用"
 
-#: Source/stores.cpp:1218
+#: Source/stores.cpp:1215
 msgid "in the shareware"
-msgstr "在​共​享版​中"
+msgstr "在共享版中"
 
-#: Source/stores.cpp:1219
+#: Source/stores.cpp:1216
 msgid "version"
 msgstr "版本"
 
-#: Source/stores.cpp:1246
+#: Source/stores.cpp:1243
 msgid "Gossip"
 msgstr "闲聊"
 
-#: Source/stores.cpp:1255
+#: Source/stores.cpp:1252
 msgid "Rising Sun"
-msgstr "朝阳​旅店"
+msgstr "旭日旅店"
 
-#: Source/stores.cpp:1257
+#: Source/stores.cpp:1254
 msgid "Talk to Ogden"
-msgstr "与​奥格登​交谈"
+msgstr "与奥格登交谈"
 
-#: Source/stores.cpp:1258
+#: Source/stores.cpp:1255
 msgid "Leave the tavern"
-msgstr "离开​酒馆"
+msgstr "离开酒馆"
 
-#: Source/stores.cpp:1269
+#: Source/stores.cpp:1266
 msgid "Talk to Gillian"
-msgstr "与​吉莉安​交谈"
+msgstr "与吉莉安交谈"
 
-#: Source/stores.cpp:1270
+#: Source/stores.cpp:1267
 msgid "Access Storage"
-msgstr "访问​储藏"
+msgstr "访问储藏"
 
-#: Source/stores.cpp:1280 Source/towners.cpp:782
+#: Source/stores.cpp:1277
 msgid "Farnham the Drunk"
-msgstr "醉​汉法恩汉"
+msgstr "醉汉法恩汉"
 
-#: Source/stores.cpp:1282
+#: Source/stores.cpp:1279
 msgid "Talk to Farnham"
-msgstr "与​法恩汉​交谈"
+msgstr "与法恩汉交谈"
 
-#: Source/stores.cpp:1283
+#: Source/stores.cpp:1280
 msgid "Say Goodbye"
 msgstr "再见"
 
-#: Source/stores.cpp:2413
+#: Source/stores.cpp:2474
 #, c++-format
 msgid "Your gold: {:s}"
-msgstr "你​的​金币: {:s}"
+msgstr "你的金币: {:s}"
 
-#: Source/textdat.cpp:72
+#: Source/tables/monstdat.cpp:332 Source/tables/monstdat.cpp:345
+msgid "Loading Monster Data Failed"
+msgstr "加载怪物数据失败"
+
+#: Source/tables/monstdat.cpp:332
+#, c++-format
+msgid ""
+"Could not add a monster, since the maximum monster type number of {} has "
+"already been reached."
+msgstr "无法添加怪物，怪物类型数量已达到上限{}。"
+
+#: Source/tables/monstdat.cpp:345
+#, c++-format
+msgid "A monster type already exists for ID \"{}\"."
+msgstr "已有怪物类型使用ID \"{}\"。"
+
+#: Source/tables/playerdat.cpp:320
+msgid "Loading Class Data Failed"
+msgstr "加载职业数据失败"
+
+#: Source/tables/playerdat.cpp:320
+#, c++-format
+msgid ""
+"Could not add a class, since the maximum class number of {} has already been "
+"reached."
+msgstr "无法添加职业，职业数量已达到上限{}。"
+
+#: Source/tables/textdat.cpp:73
 msgid "Loading Text Data Failed"
-msgstr ""
+msgstr "加载文本数据失败"
 
-#: Source/textdat.cpp:72
+#: Source/tables/textdat.cpp:73
 #, c++-format
 msgid "A text data entry already exists for ID \"{}\"."
-msgstr ""
+msgstr "已有文本数据条目使用ID \"{}\"。"
 
-#: Source/towners.cpp:269
+#: Source/towners.cpp:200
 msgid "Slain Townsman"
-msgstr "被​杀​的​镇民"
-
-#: Source/towners.cpp:777
-msgid "Griswold the Blacksmith"
-msgstr "铁匠​格里斯沃尔德"
-
-#: Source/towners.cpp:778
-msgid "Pepin the Healer"
-msgstr "医治者​佩​金"
-
-#: Source/towners.cpp:779
-msgid "Wounded Townsman"
-msgstr "受伤​的​镇民"
-
-#: Source/towners.cpp:780
-msgid "Ogden the Tavern owner"
-msgstr "酒馆​老板​奥格登"
-
-#: Source/towners.cpp:781
-msgid "Cain the Elder"
-msgstr "长者​凯恩"
-
-#: Source/towners.cpp:783
-msgid "Adria the Witch"
-msgstr "女​巫艾德莉亚"
-
-#: Source/towners.cpp:784
-msgid "Gillian the Barmaid"
-msgstr "酒吧​女​招待​吉莉安"
-
-#: Source/towners.cpp:786
-msgid "Cow"
-msgstr "奶牛"
-
-#: Source/towners.cpp:787
-msgid "Lester the farmer"
-msgstr "农夫​莱斯特"
-
-#: Source/towners.cpp:788
-msgid "Celia"
-msgstr "西莉亚"
-
-#: Source/towners.cpp:789
-msgid "Complete Nut"
-msgstr "完整​的​纳特"
+msgstr "被杀的镇民"
 
 #: Source/translation_dummy.cpp:11
 msgid "Warrior"
@@ -5264,11 +5301,11 @@ msgstr "战士"
 
 #: Source/translation_dummy.cpp:12
 msgid "Rogue"
-msgstr "流亡者"
+msgstr "游侠"
 
 #: Source/translation_dummy.cpp:13
 msgid "Sorcerer"
-msgstr "巫师"
+msgstr "法师"
 
 #: Source/translation_dummy.cpp:14
 msgid "Monk"
@@ -5276,11 +5313,11 @@ msgstr "武僧"
 
 #: Source/translation_dummy.cpp:15
 msgid "Bard"
-msgstr "吟游​诗人"
+msgstr "吟游诗人"
 
 #: Source/translation_dummy.cpp:16
 msgid "Barbarian"
-msgstr "野​蛮​人"
+msgstr "野蛮人"
 
 #: Source/translation_dummy.cpp:17
 msgctxt "monster"
@@ -5300,7 +5337,7 @@ msgstr "腐尸"
 #: Source/translation_dummy.cpp:20
 msgctxt "monster"
 msgid "Black Death"
-msgstr "黑​死​病躯"
+msgstr "黑死病躯"
 
 #: Source/translation_dummy.cpp:21
 msgctxt "monster"
@@ -5310,7 +5347,7 @@ msgstr "堕落者"
 #: Source/translation_dummy.cpp:22
 msgctxt "monster"
 msgid "Carver"
-msgstr "剁​肉​魔"
+msgstr "剁肉魔"
 
 #: Source/translation_dummy.cpp:23
 msgctxt "monster"
@@ -5320,42 +5357,42 @@ msgstr "魔皮"
 #: Source/translation_dummy.cpp:24
 msgctxt "monster"
 msgid "Dark One"
-msgstr "暗​魔"
+msgstr "暗魔"
 
 #: Source/translation_dummy.cpp:25
 msgctxt "monster"
 msgid "Skeleton"
-msgstr "骷​髅"
+msgstr "骷髅"
 
 #: Source/translation_dummy.cpp:26
 msgctxt "monster"
 msgid "Corpse Axe"
-msgstr "尸骸​斧兵"
+msgstr "尸骸斧兵"
 
 #: Source/translation_dummy.cpp:27
 msgctxt "monster"
 msgid "Burning Dead"
-msgstr "烈​焰​亡灵"
+msgstr "烈焰亡灵"
 
 #: Source/translation_dummy.cpp:28
 msgctxt "monster"
 msgid "Horror"
-msgstr "骇​魔"
+msgstr "骇魔"
 
 #: Source/translation_dummy.cpp:29
 msgctxt "monster"
 msgid "Scavenger"
-msgstr "食​腐魔"
+msgstr "食腐魔"
 
 #: Source/translation_dummy.cpp:30
 msgctxt "monster"
 msgid "Plague Eater"
-msgstr "食疫​魔"
+msgstr "食疫魔"
 
 #: Source/translation_dummy.cpp:31
 msgctxt "monster"
 msgid "Shadow Beast"
-msgstr "暗​影兽"
+msgstr "暗影兽"
 
 #: Source/translation_dummy.cpp:32
 msgctxt "monster"
@@ -5365,52 +5402,52 @@ msgstr "噬骨魔"
 #: Source/translation_dummy.cpp:33
 msgctxt "monster"
 msgid "Corpse Bow"
-msgstr "尸骸​弓兵"
+msgstr "尸骸弓兵"
 
 #: Source/translation_dummy.cpp:34
 msgctxt "monster"
 msgid "Skeleton Captain"
-msgstr "骷​髅​队长"
+msgstr "骷髅队长"
 
 #: Source/translation_dummy.cpp:35
 msgctxt "monster"
 msgid "Corpse Captain"
-msgstr "尸骸​队长"
+msgstr "尸骸队长"
 
 #: Source/translation_dummy.cpp:36
 msgctxt "monster"
 msgid "Burning Dead Captain"
-msgstr "烈​焰​亡灵​队长"
+msgstr "烈焰亡灵队长"
 
 #: Source/translation_dummy.cpp:37
 msgctxt "monster"
 msgid "Horror Captain"
-msgstr "骇魔队​长"
+msgstr "骇魔队长"
 
 #: Source/translation_dummy.cpp:38
 msgctxt "monster"
 msgid "Invisible Lord"
-msgstr "无形​领主"
+msgstr "无形领主"
 
 #: Source/translation_dummy.cpp:39
 msgctxt "monster"
 msgid "Hidden"
-msgstr "潜行​魔"
+msgstr "潜行魔"
 
 #: Source/translation_dummy.cpp:40
 msgctxt "monster"
 msgid "Stalker"
-msgstr "追踪​魔"
+msgstr "追踪魔"
 
 #: Source/translation_dummy.cpp:41
 msgctxt "monster"
 msgid "Unseen"
-msgstr "隐形​魔"
+msgstr "隐形魔"
 
 #: Source/translation_dummy.cpp:42
 msgctxt "monster"
 msgid "Illusion Weaver"
-msgstr "幻像​编织者"
+msgstr "幻象编织者"
 
 #: Source/translation_dummy.cpp:43
 msgctxt "monster"
@@ -5420,7 +5457,7 @@ msgstr "萨特领主"
 #: Source/translation_dummy.cpp:44
 msgctxt "monster"
 msgid "Flesh Clan"
-msgstr "血​肉氏族"
+msgstr "血肉氏族"
 
 #: Source/translation_dummy.cpp:45
 msgctxt "monster"
@@ -5435,7 +5472,7 @@ msgstr "火焰氏族"
 #: Source/translation_dummy.cpp:47
 msgctxt "monster"
 msgid "Night Clan"
-msgstr "暗​夜氏族"
+msgstr "暗夜氏族"
 
 #: Source/translation_dummy.cpp:48
 msgctxt "monster"
@@ -5460,27 +5497,27 @@ msgstr "雷翼"
 #: Source/translation_dummy.cpp:52
 msgctxt "monster"
 msgid "Acid Beast"
-msgstr "酸​液​兽"
+msgstr "酸液兽"
 
 #: Source/translation_dummy.cpp:53
 msgctxt "monster"
 msgid "Poison Spitter"
-msgstr "喷毒​兽"
+msgstr "喷毒兽"
 
 #: Source/translation_dummy.cpp:54
 msgctxt "monster"
 msgid "Pit Beast"
-msgstr "深​渊兽"
+msgstr "深渊兽"
 
 #: Source/translation_dummy.cpp:55
 msgctxt "monster"
 msgid "Lava Maw"
-msgstr "岩​浆喉"
+msgstr "岩浆喉"
 
 #: Source/translation_dummy.cpp:56
 msgctxt "monster"
 msgid "Skeleton King"
-msgstr "骷​髅​王"
+msgstr "骷髅王"
 
 #: Source/translation_dummy.cpp:57
 msgctxt "monster"
@@ -5495,17 +5532,17 @@ msgstr "领主"
 #: Source/translation_dummy.cpp:59
 msgctxt "monster"
 msgid "Mud Man"
-msgstr "污泥​魔"
+msgstr "污泥魔"
 
 #: Source/translation_dummy.cpp:60
 msgctxt "monster"
 msgid "Toad Demon"
-msgstr "蟾​魔"
+msgstr "蟾魔"
 
 #: Source/translation_dummy.cpp:61
 msgctxt "monster"
 msgid "Flayed One"
-msgstr "剥​皮魔"
+msgstr "剥皮魔"
 
 #: Source/translation_dummy.cpp:62
 msgctxt "monster"
@@ -5515,7 +5552,7 @@ msgstr "游龙"
 #: Source/translation_dummy.cpp:63
 msgctxt "monster"
 msgid "Cave Slug"
-msgstr "洞​穴蛞蝓"
+msgstr "洞穴蛞蝓"
 
 #: Source/translation_dummy.cpp:64
 msgctxt "monster"
@@ -5525,67 +5562,67 @@ msgstr "邪恶游龙"
 #: Source/translation_dummy.cpp:65
 msgctxt "monster"
 msgid "Devourer"
-msgstr "吞食​虫"
+msgstr "吞食虫"
 
 #: Source/translation_dummy.cpp:66
 msgctxt "monster"
 msgid "Magma Demon"
-msgstr "岩浆​魔"
+msgstr "岩浆魔"
 
 #: Source/translation_dummy.cpp:67
 msgctxt "monster"
 msgid "Blood Stone"
-msgstr "鲜​血石"
+msgstr "鲜血石"
 
 #: Source/translation_dummy.cpp:68
 msgctxt "monster"
 msgid "Hell Stone"
-msgstr "地​狱石"
+msgstr "地狱石"
 
 #: Source/translation_dummy.cpp:69
 msgctxt "monster"
 msgid "Lava Lord"
-msgstr "岩浆​领主"
+msgstr "岩浆领主"
 
 #: Source/translation_dummy.cpp:70
 msgctxt "monster"
 msgid "Horned Demon"
-msgstr "长​角​魔"
+msgstr "长角魔"
 
 #: Source/translation_dummy.cpp:71
 msgctxt "monster"
 msgid "Mud Runner"
-msgstr "污泥​奔行​魔"
+msgstr "污泥奔行魔"
 
 #: Source/translation_dummy.cpp:72
 msgctxt "monster"
 msgid "Frost Charger"
-msgstr "冰霜​冲锋​魔"
+msgstr "冰霜冲锋魔"
 
 #: Source/translation_dummy.cpp:73
 msgctxt "monster"
 msgid "Obsidian Lord"
-msgstr "黑​曜​石领主"
+msgstr "黑曜石领主"
 
 #: Source/translation_dummy.cpp:74
 msgctxt "monster"
 msgid "oldboned"
-msgstr "老​骨头"
+msgstr "老骨头"
 
 #: Source/translation_dummy.cpp:75
 msgctxt "monster"
 msgid "Red Death"
-msgstr "红色​死神"
+msgstr "红色死神"
 
 #: Source/translation_dummy.cpp:76
 msgctxt "monster"
 msgid "Litch Demon"
-msgstr "尸妖​恶魔"
+msgstr "尸妖恶魔"
 
 #: Source/translation_dummy.cpp:77
 msgctxt "monster"
 msgid "Undead Balrog"
-msgstr "不​死炎​魔"
+msgstr "不死炎魔"
 
 #: Source/translation_dummy.cpp:78
 msgctxt "monster"
@@ -5595,57 +5632,57 @@ msgstr "焚化者"
 #: Source/translation_dummy.cpp:79
 msgctxt "monster"
 msgid "Flame Lord"
-msgstr "火焰​领主"
+msgstr "火焰领主"
 
 #: Source/translation_dummy.cpp:80
 msgctxt "monster"
 msgid "Doom Fire"
-msgstr "末​日​火焰"
+msgstr "末日火焰"
 
 #: Source/translation_dummy.cpp:81
 msgctxt "monster"
 msgid "Hell Burner"
-msgstr "地狱​燃烧者"
+msgstr "地狱燃烧者"
 
 #: Source/translation_dummy.cpp:82
 msgctxt "monster"
 msgid "Red Storm"
-msgstr "红色​风暴"
+msgstr "红色风暴"
 
 #: Source/translation_dummy.cpp:83
 msgctxt "monster"
 msgid "Storm Rider"
-msgstr "风暴​骑手"
+msgstr "风暴骑手"
 
 #: Source/translation_dummy.cpp:84
 msgctxt "monster"
 msgid "Storm Lord"
-msgstr "风暴​领主"
+msgstr "风暴领主"
 
 #: Source/translation_dummy.cpp:85
 msgctxt "monster"
 msgid "Maelstrom"
-msgstr "漩涡​魔"
+msgstr "漩涡魔"
 
 #: Source/translation_dummy.cpp:86
 msgctxt "monster"
 msgid "Devil Kin Brute"
-msgstr "魔族​凶兽"
+msgstr "魔族凶兽"
 
 #: Source/translation_dummy.cpp:87
 msgctxt "monster"
 msgid "Winged-Demon"
-msgstr "翼​魔"
+msgstr "翼魔"
 
 #: Source/translation_dummy.cpp:88
 msgctxt "monster"
 msgid "Gargoyle"
-msgstr "石​像​鬼"
+msgstr "石像鬼"
 
 #: Source/translation_dummy.cpp:89
 msgctxt "monster"
 msgid "Blood Claw"
-msgstr "血​爪"
+msgstr "血爪"
 
 #: Source/translation_dummy.cpp:90
 msgctxt "monster"
@@ -5665,92 +5702,92 @@ msgstr "守护者"
 #: Source/translation_dummy.cpp:93
 msgctxt "monster"
 msgid "Vortex Lord"
-msgstr "漩涡​王"
+msgstr "漩涡王"
 
 #: Source/translation_dummy.cpp:94
 msgctxt "monster"
 msgid "Balrog"
-msgstr "炎​魔"
+msgstr "炎魔"
 
 #: Source/translation_dummy.cpp:95
 msgctxt "monster"
 msgid "Cave Viper"
-msgstr "洞​穴虺​蛇"
+msgstr "洞穴虺蛇"
 
 #: Source/translation_dummy.cpp:96
 msgctxt "monster"
 msgid "Fire Drake"
-msgstr "火焰​蛟​蛇"
+msgstr "火焰蛟蛇"
 
 #: Source/translation_dummy.cpp:97
 msgctxt "monster"
 msgid "Gold Viper"
-msgstr "金色​虺​蛇"
+msgstr "金色虺蛇"
 
 #: Source/translation_dummy.cpp:98
 msgctxt "monster"
 msgid "Azure Drake"
-msgstr "碧蓝蛟​蛇"
+msgstr "碧蓝蛟蛇"
 
 #: Source/translation_dummy.cpp:99
 msgctxt "monster"
 msgid "Black Knight"
-msgstr "黑​骑士"
+msgstr "黑骑士"
 
 #: Source/translation_dummy.cpp:100
 msgctxt "monster"
 msgid "Doom Guard"
-msgstr "末​日守卫"
+msgstr "末日守卫"
 
 #: Source/translation_dummy.cpp:101
 msgctxt "monster"
 msgid "Steel Lord"
-msgstr "钢铁​领主"
+msgstr "钢铁领主"
 
 #: Source/translation_dummy.cpp:102
 msgctxt "monster"
 msgid "Blood Knight"
-msgstr "血​骑士"
+msgstr "血骑士"
 
 #: Source/translation_dummy.cpp:103
 msgctxt "monster"
 msgid "The Shredded"
-msgstr "撕​裂者"
+msgstr "撕裂者"
 
 #: Source/translation_dummy.cpp:104
 msgctxt "monster"
 msgid "Hollow One"
-msgstr "空壳​尸魔"
+msgstr "空壳尸魔"
 
 #: Source/translation_dummy.cpp:105
 msgctxt "monster"
 msgid "Pain Master"
-msgstr "痛楚​大师"
+msgstr "痛楚大师"
 
 #: Source/translation_dummy.cpp:106
 msgctxt "monster"
 msgid "Reality Weaver"
-msgstr "现实​编织者"
+msgstr "现实编织者"
 
 #: Source/translation_dummy.cpp:107
 msgctxt "monster"
 msgid "Succubus"
-msgstr "魅​魔"
+msgstr "魅魔"
 
 #: Source/translation_dummy.cpp:108
 msgctxt "monster"
 msgid "Snow Witch"
-msgstr "冰雪妖​女"
+msgstr "冰雪妖女"
 
 #: Source/translation_dummy.cpp:109
 msgctxt "monster"
 msgid "Hell Spawn"
-msgstr "地​狱妖​女"
+msgstr "地狱妖女"
 
 #: Source/translation_dummy.cpp:110
 msgctxt "monster"
 msgid "Soul Burner"
-msgstr "燃魂妖​女"
+msgstr "燃魂妖女"
 
 #: Source/translation_dummy.cpp:111
 msgctxt "monster"
@@ -5765,7 +5802,7 @@ msgstr "执法官"
 #: Source/translation_dummy.cpp:113
 msgctxt "monster"
 msgid "Cabalist"
-msgstr "秘​法师"
+msgstr "秘法师"
 
 #: Source/translation_dummy.cpp:114
 msgctxt "monster"
@@ -5780,22 +5817,22 @@ msgstr "魔像"
 #: Source/translation_dummy.cpp:116
 msgctxt "monster"
 msgid "The Dark Lord"
-msgstr "黑暗​之​王"
+msgstr "黑暗之王"
 
 #: Source/translation_dummy.cpp:117
 msgctxt "monster"
 msgid "The Arch-Litch Malignus"
-msgstr "高​阶​巫妖马利葛奴斯"
+msgstr "高阶巫妖马利葛奴斯"
 
 #: Source/translation_dummy.cpp:118
 msgctxt "monster"
 msgid "Gharbad the Weak"
-msgstr "虚弱​的​贾巴德"
+msgstr "虚弱的贾巴德"
 
 #: Source/translation_dummy.cpp:119
 msgctxt "monster"
 msgid "Zhar the Mad"
-msgstr "疯狂​的​扎尔"
+msgstr "疯狂的扎尔"
 
 #: Source/translation_dummy.cpp:120
 msgctxt "monster"
@@ -5805,12 +5842,12 @@ msgstr "鼻屎"
 #: Source/translation_dummy.cpp:121
 msgctxt "monster"
 msgid "Arch-Bishop Lazarus"
-msgstr "大​主教​拉扎鲁斯"
+msgstr "大主教拉扎鲁斯"
 
 #: Source/translation_dummy.cpp:122
 msgctxt "monster"
 msgid "Red Vex"
-msgstr "红色​暴戾"
+msgstr "红色暴戾"
 
 #: Source/translation_dummy.cpp:123
 msgctxt "monster"
@@ -5820,12 +5857,12 @@ msgstr "黑玉"
 #: Source/translation_dummy.cpp:124
 msgctxt "monster"
 msgid "Lachdanan"
-msgstr "拉齐达​南"
+msgstr "拉齐达南"
 
 #: Source/translation_dummy.cpp:125
 msgctxt "monster"
 msgid "Warlord of Blood"
-msgstr "鲜血​战神"
+msgstr "鲜血战神"
 
 #: Source/translation_dummy.cpp:126
 msgctxt "monster"
@@ -5845,17 +5882,17 @@ msgstr "纳·库尔"
 #: Source/translation_dummy.cpp:129
 msgctxt "monster"
 msgid "Bonehead Keenaxe"
-msgstr "骷​髅头​基纳克斯"
+msgstr "骷髅头基纳克斯"
 
 #: Source/translation_dummy.cpp:130
 msgctxt "monster"
 msgid "Bladeskin the Slasher"
-msgstr "刀​刃皮肤·鞭​笞者"
+msgstr "刀刃皮肤·鞭笞者"
 
 #: Source/translation_dummy.cpp:131
 msgctxt "monster"
 msgid "Soulpus"
-msgstr "脓​包鬼灵"
+msgstr "脓包鬼灵"
 
 #: Source/translation_dummy.cpp:132
 msgctxt "monster"
@@ -5865,32 +5902,32 @@ msgstr "普克拉特·肮脏者"
 #: Source/translation_dummy.cpp:133
 msgctxt "monster"
 msgid "Boneripper"
-msgstr "剥​骨者"
+msgstr "剥骨者"
 
 #: Source/translation_dummy.cpp:134
 msgctxt "monster"
 msgid "Rotfeast the Hungry"
-msgstr "饥饿​的​食腐狂"
+msgstr "饥饿的食腐狂"
 
 #: Source/translation_dummy.cpp:135
 msgctxt "monster"
 msgid "Gutshank the Quick"
-msgstr "迅捷​的​古特申克"
+msgstr "迅捷的古特申克"
 
 #: Source/translation_dummy.cpp:136
 msgctxt "monster"
 msgid "Brokenhead Bangshield"
-msgstr "碎​颅​·猛盾"
+msgstr "碎颅·猛盾"
 
 #: Source/translation_dummy.cpp:137
 msgctxt "monster"
 msgid "Bongo"
-msgstr "邦​戈"
+msgstr "邦戈"
 
 #: Source/translation_dummy.cpp:138
 msgctxt "monster"
 msgid "Rotcarnage"
-msgstr "腐肉​搅​碎者"
+msgstr "腐肉搅碎者"
 
 #: Source/translation_dummy.cpp:139
 msgctxt "monster"
@@ -5900,12 +5937,12 @@ msgstr "影咬"
 #: Source/translation_dummy.cpp:140
 msgctxt "monster"
 msgid "Deadeye"
-msgstr "死​眼"
+msgstr "死眼"
 
 #: Source/translation_dummy.cpp:141
 msgctxt "monster"
 msgid "Madeye the Dead"
-msgstr "疯眼​·亡魂"
+msgstr "疯眼·亡魂"
 
 #: Source/translation_dummy.cpp:142
 msgctxt "monster"
@@ -5920,27 +5957,27 @@ msgstr "火骷髅"
 #: Source/translation_dummy.cpp:144
 msgctxt "monster"
 msgid "Warpskull"
-msgstr "扭曲​颅骨"
+msgstr "扭曲颅骨"
 
 #: Source/translation_dummy.cpp:145
 msgctxt "monster"
 msgid "Goretongue"
-msgstr "血​肉舌"
+msgstr "血肉舌"
 
 #: Source/translation_dummy.cpp:146
 msgctxt "monster"
 msgid "Pulsecrawler"
-msgstr "脉​冲​爬行者"
+msgstr "脉冲爬行者"
 
 #: Source/translation_dummy.cpp:147
 msgctxt "monster"
 msgid "Moonbender"
-msgstr "月亮​狂欢者"
+msgstr "月亮狂欢者"
 
 #: Source/translation_dummy.cpp:148
 msgctxt "monster"
 msgid "Wrathraven"
-msgstr "饥​渴​怨魂"
+msgstr "饥渴怨魂"
 
 #: Source/translation_dummy.cpp:149
 msgctxt "monster"
@@ -5950,7 +5987,7 @@ msgstr "刺食者"
 #: Source/translation_dummy.cpp:150
 msgctxt "monster"
 msgid "Blackash the Burning"
-msgstr "燃烧​的​黑色​余烬"
+msgstr "燃烧的黑色余烬"
 
 #: Source/translation_dummy.cpp:151
 msgctxt "monster"
@@ -5960,17 +5997,17 @@ msgstr "影鸦"
 #: Source/translation_dummy.cpp:152
 msgctxt "monster"
 msgid "Blightstone the Weak"
-msgstr "虚弱​的​亮石"
+msgstr "虚弱的亮石"
 
 #: Source/translation_dummy.cpp:153
 msgctxt "monster"
 msgid "Bilefroth the Pit Master"
-msgstr "拜弗洛斯·深渊​领主"
+msgstr "拜弗洛斯·深渊领主"
 
 #: Source/translation_dummy.cpp:154
 msgctxt "monster"
 msgid "Bloodskin Darkbow"
-msgstr "血​皮·暗弓"
+msgstr "血皮·暗弓"
 
 #: Source/translation_dummy.cpp:155
 msgctxt "monster"
@@ -5980,12 +6017,12 @@ msgstr "邪翼"
 #: Source/translation_dummy.cpp:156
 msgctxt "monster"
 msgid "Shadowdrinker"
-msgstr "暗​饮者"
+msgstr "暗饮者"
 
 #: Source/translation_dummy.cpp:157
 msgctxt "monster"
 msgid "Hazeshifter"
-msgstr "迷​雾​移形​怪"
+msgstr "迷雾移形怪"
 
 #: Source/translation_dummy.cpp:158
 msgctxt "monster"
@@ -6000,42 +6037,42 @@ msgstr "刨脏"
 #: Source/translation_dummy.cpp:160
 msgctxt "monster"
 msgid "Deathshade Fleshmaul"
-msgstr "死亡​之​影·肉锤"
+msgstr "死亡之影·肉锤"
 
 #: Source/translation_dummy.cpp:161
 msgctxt "monster"
 msgid "Warmaggot the Mad"
-msgstr "疯狂​的​战斗蛆​虫"
+msgstr "疯狂的战斗蛆虫"
 
 #: Source/translation_dummy.cpp:162
 msgctxt "monster"
 msgid "Glasskull the Jagged"
-msgstr "玻璃​颅​·锯齿"
+msgstr "玻璃颅·锯齿"
 
 #: Source/translation_dummy.cpp:163
 msgctxt "monster"
 msgid "Blightfire"
-msgstr "死疫​之​火"
+msgstr "死疫之火"
 
 #: Source/translation_dummy.cpp:164
 msgctxt "monster"
 msgid "Nightwing the Cold"
-msgstr "冰​之​夜翼"
+msgstr "冰之夜翼"
 
 #: Source/translation_dummy.cpp:165
 msgctxt "monster"
 msgid "Gorestone"
-msgstr "血​肉石"
+msgstr "血肉石"
 
 #: Source/translation_dummy.cpp:166
 msgctxt "monster"
 msgid "Bronzefist Firestone"
-msgstr "青铜​拳​·火石"
+msgstr "青铜拳·火石"
 
 #: Source/translation_dummy.cpp:167
 msgctxt "monster"
 msgid "Wrathfire the Doomed"
-msgstr "怒火​·末日"
+msgstr "怒火·末日"
 
 #: Source/translation_dummy.cpp:168
 msgctxt "monster"
@@ -6045,12 +6082,12 @@ msgstr "火伤·凶魔"
 #: Source/translation_dummy.cpp:169
 msgctxt "monster"
 msgid "Baron Sludge"
-msgstr "污泥​男​爵"
+msgstr "污泥男爵"
 
 #: Source/translation_dummy.cpp:170
 msgctxt "monster"
 msgid "Blighthorn Steelmace"
-msgstr "病​角·钢锤"
+msgstr "病角·钢锤"
 
 #: Source/translation_dummy.cpp:171
 msgctxt "monster"
@@ -6060,7 +6097,7 @@ msgstr "疯嚎"
 #: Source/translation_dummy.cpp:172
 msgctxt "monster"
 msgid "Doomgrin the Rotting"
-msgstr "末​日微笑·腐烂者"
+msgstr "末日微笑·腐烂者"
 
 #: Source/translation_dummy.cpp:173
 msgctxt "monster"
@@ -6070,7 +6107,7 @@ msgstr "疯燃者"
 #: Source/translation_dummy.cpp:174
 msgctxt "monster"
 msgid "Bonesaw the Litch"
-msgstr "骨锯​·巫妖"
+msgstr "骨锯·巫妖"
 
 #: Source/translation_dummy.cpp:175
 msgctxt "monster"
@@ -6080,32 +6117,32 @@ msgstr "断脊"
 #: Source/translation_dummy.cpp:176
 msgctxt "monster"
 msgid "Devilskull Sharpbone"
-msgstr "鬼​颅​锐骨"
+msgstr "鬼颅锐骨"
 
 #: Source/translation_dummy.cpp:177
 msgctxt "monster"
 msgid "Brokenstorm"
-msgstr "破碎​风暴"
+msgstr "破碎风暴"
 
 #: Source/translation_dummy.cpp:178
 msgctxt "monster"
 msgid "Stormbane"
-msgstr "风暴​灾​星"
+msgstr "风暴灾星"
 
 #: Source/translation_dummy.cpp:179
 msgctxt "monster"
 msgid "Oozedrool"
-msgstr "渗​脓"
+msgstr "渗脓"
 
 #: Source/translation_dummy.cpp:180
 msgctxt "monster"
 msgid "Goldblight of the Flame"
-msgstr "火​之​金翼"
+msgstr "火之金翼"
 
 #: Source/translation_dummy.cpp:181
 msgctxt "monster"
 msgid "Blackstorm"
-msgstr "黑色​风暴"
+msgstr "黑色风暴"
 
 #: Source/translation_dummy.cpp:182
 msgctxt "monster"
@@ -6115,7 +6152,7 @@ msgstr "怒疫"
 #: Source/translation_dummy.cpp:183
 msgctxt "monster"
 msgid "The Flayer"
-msgstr "扒​皮"
+msgstr "扒皮"
 
 #: Source/translation_dummy.cpp:184
 msgctxt "monster"
@@ -6125,22 +6162,22 @@ msgstr "蓝角"
 #: Source/translation_dummy.cpp:185
 msgctxt "monster"
 msgid "Warpfire Hellspawn"
-msgstr "地狱​诞生​的​扭曲​烈​焰"
+msgstr "地狱诞生的扭曲烈焰"
 
 #: Source/translation_dummy.cpp:186
 msgctxt "monster"
 msgid "Fangspeir"
-msgstr "蟠​蛇​牙"
+msgstr "蟠蛇牙"
 
 #: Source/translation_dummy.cpp:187
 msgctxt "monster"
 msgid "Festerskull"
-msgstr "快​颅"
+msgstr "快颅"
 
 #: Source/translation_dummy.cpp:188
 msgctxt "monster"
 msgid "Lionskull the Bent"
-msgstr "扭曲​的​狮颅"
+msgstr "扭曲的狮颅"
 
 #: Source/translation_dummy.cpp:189
 msgctxt "monster"
@@ -6155,12 +6192,12 @@ msgstr "邪触"
 #: Source/translation_dummy.cpp:191
 msgctxt "monster"
 msgid "Viperflame"
-msgstr "毒​焰"
+msgstr "毒焰"
 
 #: Source/translation_dummy.cpp:192
 msgctxt "monster"
 msgid "Fangskin"
-msgstr "牙​皮"
+msgstr "牙皮"
 
 #: Source/translation_dummy.cpp:193
 msgctxt "monster"
@@ -6170,42 +6207,42 @@ msgstr "巫火·不洁者"
 #: Source/translation_dummy.cpp:194
 msgctxt "monster"
 msgid "Blackskull"
-msgstr "黑​颅"
+msgstr "黑颅"
 
 #: Source/translation_dummy.cpp:195
 msgctxt "monster"
 msgid "Soulslash"
-msgstr "灵魂​撕​裂者"
+msgstr "灵魂撕裂者"
 
 #: Source/translation_dummy.cpp:196
 msgctxt "monster"
 msgid "Windspawn"
-msgstr "风​生"
+msgstr "风生"
 
 #: Source/translation_dummy.cpp:197
 msgctxt "monster"
 msgid "Lord of the Pit"
-msgstr "地​坑领主"
+msgstr "地坑领主"
 
 #: Source/translation_dummy.cpp:198
 msgctxt "monster"
 msgid "Rustweaver"
-msgstr "骨锈​编织者"
+msgstr "骨锈编织者"
 
 #: Source/translation_dummy.cpp:199
 msgctxt "monster"
 msgid "Howlingire the Shade"
-msgstr "哀嚎​的​阴魂"
+msgstr "哀嚎的阴魂"
 
 #: Source/translation_dummy.cpp:200
 msgctxt "monster"
 msgid "Doomcloud"
-msgstr "末​日阴云"
+msgstr "末日阴云"
 
 #: Source/translation_dummy.cpp:201
 msgctxt "monster"
 msgid "Bloodmoon Soulfire"
-msgstr "血​月​魂火"
+msgstr "血月魂火"
 
 #: Source/translation_dummy.cpp:202
 msgctxt "monster"
@@ -6215,7 +6252,7 @@ msgstr "巫月"
 #: Source/translation_dummy.cpp:203
 msgctxt "monster"
 msgid "Gorefeast"
-msgstr "血​肉盛宴"
+msgstr "血肉盛宴"
 
 #: Source/translation_dummy.cpp:204
 msgctxt "monster"
@@ -6225,7 +6262,7 @@ msgstr "格雷沃·屠杀者"
 #: Source/translation_dummy.cpp:205
 msgctxt "monster"
 msgid "Dreadjudge"
-msgstr "恐惧​法官"
+msgstr "恐惧法官"
 
 #: Source/translation_dummy.cpp:206
 msgctxt "monster"
@@ -6235,12 +6272,12 @@ msgstr "星眼·女魔"
 #: Source/translation_dummy.cpp:207
 msgctxt "monster"
 msgid "Steelskull the Hunter"
-msgstr "钢颅·​猎杀者"
+msgstr "钢颅·猎杀者"
 
 #: Source/translation_dummy.cpp:208
 msgctxt "monster"
 msgid "Sir Gorash"
-msgstr "格拉什​爵士"
+msgstr "格拉什爵士"
 
 #: Source/translation_dummy.cpp:209
 msgctxt "monster"
@@ -6255,22 +6292,22 @@ msgstr "赞菲尔"
 #: Source/translation_dummy.cpp:211
 msgctxt "monster"
 msgid "Bloodlust"
-msgstr "嗜​血​者"
+msgstr "嗜血者"
 
 #: Source/translation_dummy.cpp:212
 msgctxt "monster"
 msgid "Webwidow"
-msgstr "织网​黑​寡妇"
+msgstr "织网黑寡妇"
 
 #: Source/translation_dummy.cpp:213
 msgctxt "monster"
 msgid "Fleshdancer"
-msgstr "血​肉​舞者"
+msgstr "血肉舞者"
 
 #: Source/translation_dummy.cpp:214
 msgctxt "monster"
 msgid "Grimspike"
-msgstr "恐惧​之​钉"
+msgstr "恐惧之钉"
 
 #: Source/translation_dummy.cpp:215
 msgctxt "monster"
@@ -6279,7 +6316,7 @@ msgstr "杜姆洛克"
 
 #: Source/translation_dummy.cpp:217
 msgid "Short Sword"
-msgstr "短​剑"
+msgstr "短剑"
 
 #: Source/translation_dummy.cpp:218
 msgid "Buckler"
@@ -6295,7 +6332,7 @@ msgstr "短弓"
 
 #: Source/translation_dummy.cpp:221
 msgid "Short Staff of Mana"
-msgstr "法力​短​杖"
+msgstr "法力短杖"
 
 #: Source/translation_dummy.cpp:222
 msgid "Cleaver"
@@ -6303,11 +6340,11 @@ msgstr "切肉者"
 
 #: Source/translation_dummy.cpp:223
 msgid "The Undead Crown"
-msgstr "不​死​王冠"
+msgstr "不死王冠"
 
 #: Source/translation_dummy.cpp:224
 msgid "Empyrean Band"
-msgstr "碧空​之​戒"
+msgstr "碧空之戒"
 
 #: Source/translation_dummy.cpp:225
 msgid "Magic Rock"
@@ -6315,35 +6352,35 @@ msgstr "魔石"
 
 #: Source/translation_dummy.cpp:226
 msgid "Optic Amulet"
-msgstr "明眼​护符"
+msgstr "明眼护符"
 
 #: Source/translation_dummy.cpp:227
 msgid "Ring of Truth"
-msgstr "实​相之戒"
+msgstr "实相之戒"
 
 #: Source/translation_dummy.cpp:228
 msgid "Tavern Sign"
-msgstr "酒店​招牌"
+msgstr "酒店招牌"
 
 #: Source/translation_dummy.cpp:229
 msgid "Harlequin Crest"
-msgstr "谐​角​之​冠"
+msgstr "谐角之冠"
 
 #: Source/translation_dummy.cpp:230
 msgid "Veil of Steel"
-msgstr "钢铁​面纱"
+msgstr "钢铁面纱"
 
 #: Source/translation_dummy.cpp:231
 msgid "Golden Elixir"
-msgstr "金色​药剂"
+msgstr "金色灵药"
 
 #: Source/translation_dummy.cpp:232
 msgid "Anvil of Fury"
-msgstr "愤怒​铁砧"
+msgstr "怒火铁砧"
 
 #: Source/translation_dummy.cpp:233
 msgid "Black Mushroom"
-msgstr "黑​蘑菇"
+msgstr "黑蘑菇"
 
 #: Source/translation_dummy.cpp:234
 msgid "Brain"
@@ -6351,55 +6388,55 @@ msgstr "大脑"
 
 #: Source/translation_dummy.cpp:235
 msgid "Fungal Tome"
-msgstr "长满​真菌​的​书"
+msgstr "长满真菌的书"
 
 #: Source/translation_dummy.cpp:236
 msgid "Spectral Elixir"
-msgstr "幽灵​药剂"
+msgstr "幽灵药剂"
 
 #: Source/translation_dummy.cpp:237
 msgid "Blood Stone"
-msgstr "鲜​血石"
+msgstr "鲜血石"
 
 #: Source/translation_dummy.cpp:238
 msgid "Cathedral Map"
-msgstr "大​教堂​地图"
+msgstr "大教堂地图"
 
 #: Source/translation_dummy.cpp:239
 msgid "Ear"
-msgstr ""
+msgstr "耳朵"
 
 #: Source/translation_dummy.cpp:240
 msgid "Potion of Healing"
-msgstr "治疗​药​水"
+msgstr "治疗药水"
 
 #: Source/translation_dummy.cpp:241
 msgid "Potion of Mana"
-msgstr "法力​药​水"
+msgstr "法力药水"
 
 #: Source/translation_dummy.cpp:242
 msgid "Scroll of Identify"
-msgstr "鉴定​卷轴"
+msgstr "鉴定卷轴"
 
 #: Source/translation_dummy.cpp:243
 msgid "Scroll of Town Portal"
-msgstr "城镇​传送​卷轴"
+msgstr "城镇传送卷轴"
 
 #: Source/translation_dummy.cpp:244
 msgid "Arkaine's Valor"
-msgstr "阿凯尼​的​荣耀"
+msgstr "阿凯尼的荣耀"
 
 #: Source/translation_dummy.cpp:245
 msgid "Potion of Full Healing"
-msgstr "完全​生命​恢复​药​水"
+msgstr "完全生命恢复药水"
 
 #: Source/translation_dummy.cpp:246
 msgid "Potion of Full Mana"
-msgstr "完全​法力​恢复​药​水"
+msgstr "完全法力恢复药水"
 
 #: Source/translation_dummy.cpp:247
 msgid "Griswold's Edge"
-msgstr "格里斯沃尔德​之锋"
+msgstr "格里斯沃尔德之锋"
 
 #: Source/translation_dummy.cpp:248
 msgid "Bovine Plate"
@@ -6407,15 +6444,15 @@ msgstr "公牛板甲"
 
 #: Source/translation_dummy.cpp:249
 msgid "Staff of Lazarus"
-msgstr "拉扎鲁斯之​杖"
+msgstr "拉扎鲁斯之杖"
 
 #: Source/translation_dummy.cpp:250
 msgid "Scroll of Resurrect"
-msgstr "复活​卷轴"
+msgstr "复活卷轴"
 
 #: Source/translation_dummy.cpp:252
 msgid "Short Staff"
-msgstr "短​杖"
+msgstr "短杖"
 
 #: Source/translation_dummy.cpp:253
 msgid "Sword"
@@ -6423,11 +6460,11 @@ msgstr "剑"
 
 #: Source/translation_dummy.cpp:254
 msgid "Dagger"
-msgstr "​匕首"
+msgstr "匕首"
 
 #: Source/translation_dummy.cpp:255
 msgid "Rune Bomb"
-msgstr "符文​炸弹"
+msgstr "符文炸弹"
 
 #: Source/translation_dummy.cpp:256
 msgid "Theodore"
@@ -6435,31 +6472,31 @@ msgstr "西奥多"
 
 #: Source/translation_dummy.cpp:257
 msgid "Auric Amulet"
-msgstr "金​项链"
+msgstr "金项链"
 
 #: Source/translation_dummy.cpp:258
 msgid "Torn Note 1"
-msgstr "残破​的​日记​1"
+msgstr "残破的日记1"
 
 #: Source/translation_dummy.cpp:259
 msgid "Torn Note 2"
-msgstr "残破​的​日记​2"
+msgstr "残破的日记2"
 
 #: Source/translation_dummy.cpp:260
 msgid "Torn Note 3"
-msgstr "残破​的​日记​3"
+msgstr "残破的日记3"
 
 #: Source/translation_dummy.cpp:261
 msgid "Reconstructed Note"
-msgstr "重新​拼凑​的​日记"
+msgstr "重新拼凑的日记"
 
 #: Source/translation_dummy.cpp:262
 msgid "Brown Suit"
-msgstr "棕色​大​衣"
+msgstr "棕色大衣"
 
 #: Source/translation_dummy.cpp:263
 msgid "Grey Suit"
-msgstr "灰色​大衣"
+msgstr "灰色大衣"
 
 #: Source/translation_dummy.cpp:264
 msgid "Cap"
@@ -6475,7 +6512,7 @@ msgstr "头盔"
 
 #: Source/translation_dummy.cpp:267
 msgid "Full Helm"
-msgstr "全​护盔"
+msgstr "全护盔"
 
 #: Source/translation_dummy.cpp:268
 msgid "Crown"
@@ -6491,7 +6528,7 @@ msgstr "斗篷"
 
 #: Source/translation_dummy.cpp:271
 msgid "Rags"
-msgstr "短​披风"
+msgstr "短披风"
 
 #: Source/translation_dummy.cpp:272
 msgid "Cloak"
@@ -6499,11 +6536,11 @@ msgstr "披风"
 
 #: Source/translation_dummy.cpp:273
 msgid "Robe"
-msgstr "长​袍"
+msgstr "长袍"
 
 #: Source/translation_dummy.cpp:274
 msgid "Quilted Armor"
-msgstr "内​衬甲"
+msgstr "内衬甲"
 
 #: Source/translation_dummy.cpp:276
 msgid "Leather Armor"
@@ -6511,23 +6548,23 @@ msgstr "皮甲"
 
 #: Source/translation_dummy.cpp:277
 msgid "Hard Leather Armor"
-msgstr "硬​皮甲"
+msgstr "硬皮甲"
 
 #: Source/translation_dummy.cpp:278
 msgid "Studded Leather Armor"
-msgstr "钉​皮甲"
+msgstr "钉皮甲"
 
 #: Source/translation_dummy.cpp:279
 msgid "Ring Mail"
-msgstr "环​甲"
+msgstr "环甲"
 
 #: Source/translation_dummy.cpp:280
 msgid "Mail"
-msgstr "锁​甲"
+msgstr "锁甲"
 
 #: Source/translation_dummy.cpp:281
 msgid "Chain Mail"
-msgstr "锁子​甲"
+msgstr "锁子甲"
 
 #: Source/translation_dummy.cpp:282
 msgid "Scale Mail"
@@ -6535,15 +6572,15 @@ msgstr "鱼鳞甲"
 
 #: Source/translation_dummy.cpp:283
 msgid "Breast Plate"
-msgstr "胸片​甲"
+msgstr "胸片甲"
 
 #: Source/translation_dummy.cpp:284
 msgid "Plate"
-msgstr "板​甲"
+msgstr "板甲"
 
 #: Source/translation_dummy.cpp:285
 msgid "Splint Mail"
-msgstr "板条​甲"
+msgstr "板条甲"
 
 #: Source/translation_dummy.cpp:286
 msgid "Plate Mail"
@@ -6551,15 +6588,15 @@ msgstr "板链甲"
 
 #: Source/translation_dummy.cpp:287
 msgid "Field Plate"
-msgstr "全身​板​甲"
+msgstr "全身板甲"
 
 #: Source/translation_dummy.cpp:288
 msgid "Gothic Plate"
-msgstr "哥特​甲"
+msgstr "哥特甲"
 
 #: Source/translation_dummy.cpp:289
 msgid "Full Plate Mail"
-msgstr "全身​板链甲"
+msgstr "全身板链甲"
 
 #: Source/translation_dummy.cpp:290
 msgid "Shield"
@@ -6567,11 +6604,11 @@ msgstr "盾"
 
 #: Source/translation_dummy.cpp:291
 msgid "Small Shield"
-msgstr "小​盾"
+msgstr "小盾"
 
 #: Source/translation_dummy.cpp:292
 msgid "Large Shield"
-msgstr "大​盾"
+msgstr "大盾"
 
 #: Source/translation_dummy.cpp:293
 msgid "Kite Shield"
@@ -6587,11 +6624,11 @@ msgstr "哥特盾"
 
 #: Source/translation_dummy.cpp:296
 msgid "Potion of Rejuvenation"
-msgstr "活力​恢复​药​水"
+msgstr "活力恢复药水"
 
 #: Source/translation_dummy.cpp:297
 msgid "Potion of Full Rejuvenation"
-msgstr "完全​活力​恢复​药​水"
+msgstr "完全活力恢复药水"
 
 #: Source/translation_dummy.cpp:300
 msgid "Oil"
@@ -6599,95 +6636,95 @@ msgstr "油"
 
 #: Source/translation_dummy.cpp:301
 msgid "Elixir of Strength"
-msgstr "力量​药剂"
+msgstr "力量药剂"
 
 #: Source/translation_dummy.cpp:302
 msgid "Elixir of Magic"
-msgstr "魔法​药剂"
+msgstr "魔法药剂"
 
 #: Source/translation_dummy.cpp:303
 msgid "Elixir of Dexterity"
-msgstr "敏捷​药剂"
+msgstr "敏捷药剂"
 
 #: Source/translation_dummy.cpp:304
 msgid "Elixir of Vitality"
-msgstr "活力​药剂"
+msgstr "活力药剂"
 
 #: Source/translation_dummy.cpp:305
 msgid "Scroll of Healing"
-msgstr "治疗​卷轴"
+msgstr "治疗卷轴"
 
 #: Source/translation_dummy.cpp:306
 msgid "Scroll of Search"
-msgstr "搜索​卷轴"
+msgstr "搜索卷轴"
 
 #: Source/translation_dummy.cpp:307
 msgid "Scroll of Lightning"
-msgstr "闪​电​卷轴"
+msgstr "闪电卷轴"
 
 #: Source/translation_dummy.cpp:308
 msgid "Scroll of Fire Wall"
-msgstr "火焰​墙​卷轴"
+msgstr "火焰墙卷轴"
 
 #: Source/translation_dummy.cpp:309
 msgid "Scroll of Inferno"
-msgstr "地​狱火​卷轴"
+msgstr "地狱火卷轴"
 
 #: Source/translation_dummy.cpp:310
 msgid "Scroll of Flash"
-msgstr "闪光​卷轴"
+msgstr "闪光卷轴"
 
 #: Source/translation_dummy.cpp:311
 msgid "Scroll of Infravision"
-msgstr "夜视​卷轴"
+msgstr "夜视卷轴"
 
 #: Source/translation_dummy.cpp:312
 msgid "Scroll of Phasing"
-msgstr "相​位术​卷轴"
+msgstr "相位术卷轴"
 
 #: Source/translation_dummy.cpp:313
 msgid "Scroll of Mana Shield"
-msgstr "法力​护盾​卷轴"
+msgstr "法力护盾卷轴"
 
 #: Source/translation_dummy.cpp:314
 msgid "Scroll of Flame Wave"
-msgstr "火焰​波​卷轴"
+msgstr "火焰波卷轴"
 
 #: Source/translation_dummy.cpp:315
 msgid "Scroll of Fireball"
-msgstr "火球​卷轴"
+msgstr "火球卷轴"
 
 #: Source/translation_dummy.cpp:316
 msgid "Scroll of Stone Curse"
-msgstr "石化​诅咒​卷轴"
+msgstr "石化诅咒卷轴"
 
 #: Source/translation_dummy.cpp:317
 msgid "Scroll of Chain Lightning"
-msgstr "连锁​闪电​卷轴"
+msgstr "连锁闪电卷轴"
 
 #: Source/translation_dummy.cpp:318
 msgid "Scroll of Guardian"
-msgstr "召唤​守护者​卷轴"
+msgstr "召唤守护者卷轴"
 
 #: Source/translation_dummy.cpp:319
 msgid "Scroll of Nova"
-msgstr "闪电​新​星​卷轴"
+msgstr "闪电新星卷轴"
 
 #: Source/translation_dummy.cpp:320
 msgid "Scroll of Golem"
-msgstr "召唤​魔像​卷轴"
+msgstr "召唤魔像卷轴"
 
 #: Source/translation_dummy.cpp:321
 msgid "Scroll of Teleport"
-msgstr "传​送术​卷轴"
+msgstr "传送术卷轴"
 
 #: Source/translation_dummy.cpp:322
 msgid "Scroll of Apocalypse"
-msgstr "天​启卷​轴"
+msgstr "天启卷轴"
 
 #: Source/translation_dummy.cpp:323
 msgid "Falchion"
-msgstr "弯​刃剑"
+msgstr "弯刃剑"
 
 #: Source/translation_dummy.cpp:324
 msgid "Scimitar"
@@ -6695,11 +6732,11 @@ msgstr "弯刀"
 
 #: Source/translation_dummy.cpp:325
 msgid "Claymore"
-msgstr "双​手​大​剑"
+msgstr "双手大剑"
 
 #: Source/translation_dummy.cpp:326
 msgid "Blade"
-msgstr "短​刃"
+msgstr "短刃"
 
 #: Source/translation_dummy.cpp:327
 msgid "Sabre"
@@ -6707,27 +6744,27 @@ msgstr "军刀"
 
 #: Source/translation_dummy.cpp:328
 msgid "Long Sword"
-msgstr "长​剑"
+msgstr "长剑"
 
 #: Source/translation_dummy.cpp:329
 msgid "Broad Sword"
-msgstr "阔​剑"
+msgstr "阔剑"
 
 #: Source/translation_dummy.cpp:330
 msgid "Bastard Sword"
-msgstr "手​半​剑"
+msgstr "手半剑"
 
 #: Source/translation_dummy.cpp:331
 msgid "Two-Handed Sword"
-msgstr "双​手​剑"
+msgstr "双手剑"
 
 #: Source/translation_dummy.cpp:332
 msgid "Great Sword"
-msgstr "重​剑"
+msgstr "重剑"
 
 #: Source/translation_dummy.cpp:333
 msgid "Small Axe"
-msgstr "小​斧"
+msgstr "小斧"
 
 #: Source/translation_dummy.cpp:334
 msgid "Axe"
@@ -6743,7 +6780,7 @@ msgstr "宽刃斧"
 
 #: Source/translation_dummy.cpp:337
 msgid "Battle Axe"
-msgstr "战斗​斧"
+msgstr "战斗斧"
 
 #: Source/translation_dummy.cpp:338
 msgid "Great Axe"
@@ -6751,15 +6788,15 @@ msgstr "重斧"
 
 #: Source/translation_dummy.cpp:339
 msgid "Mace"
-msgstr "钉​锤"
+msgstr "钉锤"
 
 #: Source/translation_dummy.cpp:340
 msgid "Morning Star"
-msgstr "流​星锤"
+msgstr "流星锤"
 
 #: Source/translation_dummy.cpp:341
 msgid "War Hammer"
-msgstr "战​锤"
+msgstr "战锤"
 
 #: Source/translation_dummy.cpp:342
 msgid "Hammer"
@@ -6767,15 +6804,15 @@ msgstr "锤"
 
 #: Source/translation_dummy.cpp:343
 msgid "Spiked Club"
-msgstr "狼​牙棒"
+msgstr "狼牙棒"
 
 #: Source/translation_dummy.cpp:344
 msgid "Flail"
-msgstr "连​枷"
+msgstr "连枷"
 
 #: Source/translation_dummy.cpp:345
 msgid "Maul"
-msgstr "大​锤"
+msgstr "大锤"
 
 #: Source/translation_dummy.cpp:346
 msgid "Bow"
@@ -6787,7 +6824,7 @@ msgstr "猎弓"
 
 #: Source/translation_dummy.cpp:348
 msgid "Long Bow"
-msgstr "长​弓"
+msgstr "长弓"
 
 #: Source/translation_dummy.cpp:349
 msgid "Composite Bow"
@@ -6795,35 +6832,35 @@ msgstr "复合弓"
 
 #: Source/translation_dummy.cpp:350
 msgid "Short Battle Bow"
-msgstr "短​战弓"
+msgstr "短战弓"
 
 #: Source/translation_dummy.cpp:351
 msgid "Long Battle Bow"
-msgstr "长​战弓"
+msgstr "长战弓"
 
 #: Source/translation_dummy.cpp:352
 msgid "Short War Bow"
-msgstr "短​战争​弓"
+msgstr "短战争弓"
 
 #: Source/translation_dummy.cpp:353
 msgid "Long War Bow"
-msgstr "长​战争​弓"
+msgstr "长战争弓"
 
 #: Source/translation_dummy.cpp:355
 msgid "Long Staff"
-msgstr "长​杖"
+msgstr "长杖"
 
 #: Source/translation_dummy.cpp:356
 msgid "Composite Staff"
-msgstr "复合​杖"
+msgstr "复合杖"
 
 #: Source/translation_dummy.cpp:357
 msgid "Quarter Staff"
-msgstr "铁头​棒"
+msgstr "铁头棒"
 
 #: Source/translation_dummy.cpp:358
 msgid "War Staff"
-msgstr "战​杖"
+msgstr "战杖"
 
 #: Source/translation_dummy.cpp:359
 msgid "Ring"
@@ -6835,7 +6872,7 @@ msgstr "护符"
 
 #: Source/translation_dummy.cpp:361
 msgid "Rune of Fire"
-msgstr "火焰​符文"
+msgstr "火焰符文"
 
 #: Source/translation_dummy.cpp:362
 msgid "Rune"
@@ -6847,11 +6884,11 @@ msgstr "闪电符文"
 
 #: Source/translation_dummy.cpp:364
 msgid "Greater Rune of Fire"
-msgstr "强效​火焰​符文"
+msgstr "强效火焰符文"
 
 #: Source/translation_dummy.cpp:365
 msgid "Greater Rune of Lightning"
-msgstr "强​效​闪电符文"
+msgstr "强效闪电符文"
 
 #: Source/translation_dummy.cpp:366
 msgid "Rune of Stone"
@@ -6859,7 +6896,7 @@ msgstr "符文石"
 
 #: Source/translation_dummy.cpp:367
 msgid "Short Staff of Charged Bolt"
-msgstr "电​荷弹​短​杖"
+msgstr "电荷弹短杖"
 
 #: Source/translation_dummy.cpp:368
 msgid "Arena Potion"
@@ -6867,21 +6904,19 @@ msgstr "竞技场药水"
 
 #: Source/translation_dummy.cpp:369
 msgid "The Butcher's Cleaver"
-msgstr "屠夫​的​剁肉刀"
+msgstr "屠夫的剁肉刀"
 
 #: Source/translation_dummy.cpp:370
-#, fuzzy
-#| msgid "Lightsabre"
 msgid "Lightforge"
-msgstr "光​之​军刀"
+msgstr "光铸"
 
 #: Source/translation_dummy.cpp:371
 msgid "The Rift Bow"
-msgstr "裂隙​之​弓"
+msgstr "裂隙之弓"
 
 #: Source/translation_dummy.cpp:372
 msgid "The Needler"
-msgstr "穿​针​引线"
+msgstr "穿针引线"
 
 #: Source/translation_dummy.cpp:373
 msgid "The Celestial Bow"
@@ -6889,35 +6924,35 @@ msgstr "天堂弓"
 
 #: Source/translation_dummy.cpp:374
 msgid "Deadly Hunter"
-msgstr "致命​猎手"
+msgstr "致命猎手"
 
 #: Source/translation_dummy.cpp:375
 msgid "Bow of the Dead"
-msgstr "死者​之​弓"
+msgstr "死者之弓"
 
 #: Source/translation_dummy.cpp:376
 msgid "The Blackoak Bow"
-msgstr "黑色​橡木弓"
+msgstr "黑色橡树弓"
 
 #: Source/translation_dummy.cpp:377
 msgid "Flamedart"
-msgstr "火焰​镖"
+msgstr "火焰镖"
 
 #: Source/translation_dummy.cpp:378
 msgid "Fleshstinger"
-msgstr "肉​刺"
+msgstr "肉刺"
 
 #: Source/translation_dummy.cpp:379
 msgid "Windforce"
-msgstr "风​之​力"
+msgstr "风之力"
 
 #: Source/translation_dummy.cpp:380
 msgid "Eaglehorn"
-msgstr "鹰​之​号​角"
+msgstr "鹰之号角"
 
 #: Source/translation_dummy.cpp:381
 msgid "Gonnagal's Dirk"
-msgstr "贡纳加尔​的​匕首"
+msgstr "贡纳加尔的匕首"
 
 #: Source/translation_dummy.cpp:382
 msgid "The Defender"
@@ -6925,11 +6960,11 @@ msgstr "防守者"
 
 #: Source/translation_dummy.cpp:383
 msgid "Gryphon's Claw"
-msgstr "狮​鹫​之​爪"
+msgstr "狮鹫之爪"
 
 #: Source/translation_dummy.cpp:384
 msgid "Black Razor"
-msgstr "黑色​剃刀"
+msgstr "黑色剃刀"
 
 #: Source/translation_dummy.cpp:385
 msgid "Gibbous Moon"
@@ -6937,11 +6972,11 @@ msgstr "凸月"
 
 #: Source/translation_dummy.cpp:386
 msgid "Ice Shank"
-msgstr "寒冰​削​骨刀"
+msgstr "寒冰削骨刀"
 
 #: Source/translation_dummy.cpp:387
 msgid "The Executioner's Blade"
-msgstr "刽子手​的​利刃"
+msgstr "刽子手的利刃"
 
 #: Source/translation_dummy.cpp:388
 msgid "The Bonesaw"
@@ -6953,23 +6988,23 @@ msgstr "影隼"
 
 #: Source/translation_dummy.cpp:390
 msgid "Wizardspike"
-msgstr "巫师​之​刺"
+msgstr "巫师之刺"
 
 #: Source/translation_dummy.cpp:391
 msgid "Lightsabre"
-msgstr "光​之​军刀"
+msgstr "光之军刀"
 
 #: Source/translation_dummy.cpp:392
 msgid "The Falcon's Talon"
-msgstr "鹰隼​之​爪"
+msgstr "鹰隼之爪"
 
 #: Source/translation_dummy.cpp:393
 msgid "Inferno"
-msgstr "地​狱火"
+msgstr "地狱火"
 
 #: Source/translation_dummy.cpp:394
 msgid "Doombringer"
-msgstr "末​日​使者"
+msgstr "末日使者"
 
 #: Source/translation_dummy.cpp:395
 msgid "The Grizzly"
@@ -6989,7 +7024,7 @@ msgstr "锐喙"
 
 #: Source/translation_dummy.cpp:399
 msgid "BloodSlayer"
-msgstr "血腥​杀戮者"
+msgstr "血腥杀戮者"
 
 #: Source/translation_dummy.cpp:400
 msgid "The Celestial Axe"
@@ -7009,11 +7044,11 @@ msgstr "阿吉纳拉斧头"
 
 #: Source/translation_dummy.cpp:404
 msgid "Hellslayer"
-msgstr "地狱​屠​戮者"
+msgstr "地狱屠戮者"
 
 #: Source/translation_dummy.cpp:405
 msgid "Messerschmidt's Reaver"
-msgstr "梅​塞施密特​的​劫掠者"
+msgstr "梅塞施密特的劫掠者"
 
 #: Source/translation_dummy.cpp:406
 msgid "Crackrust"
@@ -7021,39 +7056,39 @@ msgstr "裂纹"
 
 #: Source/translation_dummy.cpp:407
 msgid "Hammer of Jholm"
-msgstr "霍尔姆​之​锤"
+msgstr "霍尔姆之锤"
 
 #: Source/translation_dummy.cpp:408
 msgid "Civerb's Cudgel"
-msgstr "希弗柏​的​短棍"
+msgstr "希弗伯的短棍"
 
 #: Source/translation_dummy.cpp:409
 msgid "The Celestial Star"
-msgstr "天堂​之​星"
+msgstr "天堂之星"
 
 #: Source/translation_dummy.cpp:410
 msgid "Baranar's Star"
-msgstr "巴拉纳​之​星"
+msgstr "巴拉纳之星"
 
 #: Source/translation_dummy.cpp:411
 msgid "Gnarled Root"
-msgstr "多​节根"
+msgstr "多节根"
 
 #: Source/translation_dummy.cpp:412
 msgid "The Cranium Basher"
-msgstr "碎​颅"
+msgstr "碎颅"
 
 #: Source/translation_dummy.cpp:413
 msgid "Schaefer's Hammer"
-msgstr "舍费尔​之​锤"
+msgstr "舍费尔之锤"
 
 #: Source/translation_dummy.cpp:414
 msgid "Dreamflange"
-msgstr "梦​境​边缘"
+msgstr "梦境边缘"
 
 #: Source/translation_dummy.cpp:415
 msgid "Staff of Shadows"
-msgstr "暗影​之​杖"
+msgstr "暗影之杖"
 
 #: Source/translation_dummy.cpp:416
 msgid "Immolator"
@@ -7061,15 +7096,15 @@ msgstr "焚化者"
 
 #: Source/translation_dummy.cpp:417
 msgid "Storm Spire"
-msgstr "风暴​尖刺"
+msgstr "风暴尖刺"
 
 #: Source/translation_dummy.cpp:418
 msgid "Gleamsong"
-msgstr "闪光​之​歌"
+msgstr "闪光之歌"
 
 #: Source/translation_dummy.cpp:419
 msgid "Thundercall"
-msgstr "风暴​召唤"
+msgstr "风暴召唤"
 
 #: Source/translation_dummy.cpp:420
 msgid "The Protector"
@@ -7077,7 +7112,7 @@ msgstr "保护者"
 
 #: Source/translation_dummy.cpp:421
 msgid "Naj's Puzzler"
-msgstr "诺吉​的​解密棒"
+msgstr "诺吉的解密棒"
 
 #: Source/translation_dummy.cpp:422
 msgid "Mindcry"
@@ -7085,11 +7120,11 @@ msgstr "心声"
 
 #: Source/translation_dummy.cpp:423
 msgid "Rod of Onan"
-msgstr "奥南​之​棒"
+msgstr "奥南之棒"
 
 #: Source/translation_dummy.cpp:424
 msgid "Helm of Spirits"
-msgstr "精魂​头盔"
+msgstr "精魂头盔"
 
 #: Source/translation_dummy.cpp:425
 msgid "Thinking Cap"
@@ -7101,7 +7136,7 @@ msgstr "霸主盔"
 
 #: Source/translation_dummy.cpp:427
 msgid "Fool's Crest"
-msgstr "愚人​奖章"
+msgstr "愚人奖章"
 
 #: Source/translation_dummy.cpp:428
 msgid "Gotterdamerung"
@@ -7109,35 +7144,35 @@ msgstr "暮光"
 
 #: Source/translation_dummy.cpp:429
 msgid "Royal Circlet"
-msgstr "贵族​头环"
+msgstr "贵族头环"
 
 #: Source/translation_dummy.cpp:430
 msgid "Torn Flesh of Souls"
-msgstr "魂​飞魄​散"
+msgstr "魂飞魄散"
 
 #: Source/translation_dummy.cpp:431
 msgid "The Gladiator's Bane"
-msgstr "角​斗士​之​祸"
+msgstr "角斗士的祸根"
 
 #: Source/translation_dummy.cpp:432
 msgid "The Rainbow Cloak"
-msgstr "彩虹​斗篷"
+msgstr "彩虹斗篷"
 
 #: Source/translation_dummy.cpp:433
 msgid "Leather of Aut"
-msgstr "奥特​之​皮"
+msgstr "奥特之皮"
 
 #: Source/translation_dummy.cpp:434
 msgid "Wisdom's Wrap"
-msgstr "智慧​束带"
+msgstr "智慧束带"
 
 #: Source/translation_dummy.cpp:435
 msgid "Sparking Mail"
-msgstr "电光锁​甲"
+msgstr "电光锁甲"
 
 #: Source/translation_dummy.cpp:436
 msgid "Scavenger Carapace"
-msgstr "清道夫​的​甲壳"
+msgstr "清道夫的甲壳"
 
 #: Source/translation_dummy.cpp:437
 msgid "Nightscape"
@@ -7145,11 +7180,11 @@ msgstr "夜色"
 
 #: Source/translation_dummy.cpp:438
 msgid "Naj's Light Plate"
-msgstr "诺吉​的​轻铠​甲"
+msgstr "诺吉的轻铠甲"
 
 #: Source/translation_dummy.cpp:439
 msgid "Demonspike Coat"
-msgstr "恶​魔长​角​外​套"
+msgstr "恶魔长角外套"
 
 #: Source/translation_dummy.cpp:440
 msgid "The Deflector"
@@ -7157,23 +7192,23 @@ msgstr "偏转者"
 
 #: Source/translation_dummy.cpp:441
 msgid "Split Skull Shield"
-msgstr "裂颅​盾"
+msgstr "裂颅盾"
 
 #: Source/translation_dummy.cpp:442
 msgid "Dragon's Breach"
-msgstr "巨​龙​之息"
+msgstr "巨龙之息"
 
 #: Source/translation_dummy.cpp:443
 msgid "Blackoak Shield"
-msgstr "黑​橡木盾"
+msgstr "黑橡树盾"
 
 #: Source/translation_dummy.cpp:444
 msgid "Holy Defender"
-msgstr "神圣​卫士"
+msgstr "神圣卫士"
 
 #: Source/translation_dummy.cpp:445
 msgid "Stormshield"
-msgstr "暴风​之​盾"
+msgstr "暴风之盾"
 
 #: Source/translation_dummy.cpp:446
 msgid "Bramble"
@@ -7181,19 +7216,19 @@ msgstr "刺棘"
 
 #: Source/translation_dummy.cpp:447
 msgid "Ring of Regha"
-msgstr "雷加之​戒"
+msgstr "雷加之戒"
 
 #: Source/translation_dummy.cpp:448
 msgid "The Bleeder"
-msgstr "放​血者"
+msgstr "放血者"
 
 #: Source/translation_dummy.cpp:449
 msgid "Constricting Ring"
-msgstr "紧缩​之​戒"
+msgstr "紧缩之戒"
 
 #: Source/translation_dummy.cpp:450
 msgid "Ring of Engagement"
-msgstr "订​婚​戒指"
+msgstr "订婚戒指"
 
 #: Source/translation_dummy.cpp:451
 msgid "Tin"
@@ -7201,7 +7236,7 @@ msgstr "锡"
 
 #: Source/translation_dummy.cpp:452
 msgid "Brass"
-msgstr "黄​铜"
+msgstr "黄铜"
 
 #: Source/translation_dummy.cpp:453
 msgid "Bronze"
@@ -7221,7 +7256,7 @@ msgstr "白银"
 
 #: Source/translation_dummy.cpp:457
 msgid "Platinum"
-msgstr "铂​金"
+msgstr "铂金"
 
 #: Source/translation_dummy.cpp:458
 msgid "Mithril"
@@ -7229,15 +7264,15 @@ msgstr "秘银"
 
 #: Source/translation_dummy.cpp:459
 msgid "Meteoric"
-msgstr "陨​铁"
+msgstr "陨铁"
 
 #: Source/translation_dummy.cpp:461
 msgid "Strange"
-msgstr "奇​异"
+msgstr "奇异"
 
 #: Source/translation_dummy.cpp:462
 msgid "Useless"
-msgstr "无​用"
+msgstr "无用"
 
 #: Source/translation_dummy.cpp:463
 msgid "Bent"
@@ -7269,11 +7304,11 @@ msgstr "残忍"
 
 #: Source/translation_dummy.cpp:470
 msgid "Massive"
-msgstr "蛮​横"
+msgstr "蛮横"
 
 #: Source/translation_dummy.cpp:471
 msgid "Savage"
-msgstr "野​蛮"
+msgstr "野蛮"
 
 #: Source/translation_dummy.cpp:472
 msgid "Ruthless"
@@ -7301,31 +7336,31 @@ msgstr "优良"
 
 #: Source/translation_dummy.cpp:478
 msgid "Warrior's"
-msgstr "战士​的"
+msgstr "战士的"
 
 #: Source/translation_dummy.cpp:479
 msgid "Soldier's"
-msgstr "士兵​的"
+msgstr "士兵的"
 
 #: Source/translation_dummy.cpp:480
 msgid "Lord's"
-msgstr "勋爵​的"
+msgstr "勋爵的"
 
 #: Source/translation_dummy.cpp:481
 msgid "Knight's"
-msgstr "骑士​的"
+msgstr "骑士的"
 
 #: Source/translation_dummy.cpp:482
 msgid "Master's"
-msgstr "大师​的"
+msgstr "大师的"
 
 #: Source/translation_dummy.cpp:483
 msgid "Champion's"
-msgstr "勇士​的"
+msgstr "勇士的"
 
 #: Source/translation_dummy.cpp:484
 msgid "King's"
-msgstr "国王​的"
+msgstr "国王的"
 
 #: Source/translation_dummy.cpp:485
 msgid "Vulnerable"
@@ -7337,7 +7372,7 @@ msgstr "生锈"
 
 #: Source/translation_dummy.cpp:487
 msgid "Strong"
-msgstr "强​壮"
+msgstr "强壮"
 
 #: Source/translation_dummy.cpp:488
 msgid "Grand"
@@ -7373,15 +7408,15 @@ msgstr "丹红"
 
 #: Source/translation_dummy.cpp:497
 msgid "Crimson"
-msgstr "猩​红"
+msgstr "猩红"
 
 #: Source/translation_dummy.cpp:498
 msgid "Garnet"
-msgstr "石榴"
+msgstr "石榴石"
 
 #: Source/translation_dummy.cpp:499
 msgid "Ruby"
-msgstr "红​宝石"
+msgstr "红宝石"
 
 #: Source/translation_dummy.cpp:500
 msgid "Blue"
@@ -7393,11 +7428,11 @@ msgstr "碧空"
 
 #: Source/translation_dummy.cpp:502
 msgid "Lapis"
-msgstr "青​金石"
+msgstr "青金石"
 
 #: Source/translation_dummy.cpp:503
 msgid "Cobalt"
-msgstr "钴​制"
+msgstr "钴制"
 
 #: Source/translation_dummy.cpp:504
 msgid "Sapphire"
@@ -7429,67 +7464,67 @@ msgstr "黄宝石"
 
 #: Source/translation_dummy.cpp:511
 msgid "Amber"
-msgstr "琥​珀"
+msgstr "琥珀"
 
 #: Source/translation_dummy.cpp:512
 msgid "Jade"
-msgstr "碧玉"
+msgstr "玉石"
 
 #: Source/translation_dummy.cpp:513
 msgid "Obsidian"
-msgstr "黑​曜石"
+msgstr "黑曜石"
 
 #: Source/translation_dummy.cpp:514
 msgid "Emerald"
-msgstr "绿​宝石"
+msgstr "翡翠"
 
 #: Source/translation_dummy.cpp:515
 msgid "Hyena's"
-msgstr "鬣​狗​的"
+msgstr "鬣狗的"
 
 #: Source/translation_dummy.cpp:516
 msgid "Frog's"
-msgstr "青蛙​的"
+msgstr "青蛙的"
 
 #: Source/translation_dummy.cpp:517
 msgid "Spider's"
-msgstr "蜘蛛​的"
+msgstr "蜘蛛的"
 
 #: Source/translation_dummy.cpp:518
 msgid "Raven's"
-msgstr "乌鸦​的"
+msgstr "乌鸦的"
 
 #: Source/translation_dummy.cpp:519
 msgid "Snake's"
-msgstr "毒​蛇​的"
+msgstr "毒蛇的"
 
 #: Source/translation_dummy.cpp:520
 msgid "Serpent's"
-msgstr "巨蛇​的"
+msgstr "巨蛇的"
 
 #: Source/translation_dummy.cpp:521
 msgid "Drake's"
-msgstr "幼龙​的"
+msgstr "幼龙的"
 
 #: Source/translation_dummy.cpp:522
 msgid "Dragon's"
-msgstr "翼龙​的"
+msgstr "翼龙的"
 
 #: Source/translation_dummy.cpp:523
 msgid "Wyrm's"
-msgstr "游龙​的"
+msgstr "游龙的"
 
 #: Source/translation_dummy.cpp:524
 msgid "Hydra's"
-msgstr "九头蛇​的"
+msgstr "九头蛇的"
 
 #: Source/translation_dummy.cpp:525
 msgid "Angel's"
-msgstr "天使​的"
+msgstr "天使的"
 
 #: Source/translation_dummy.cpp:526
 msgid "Arch-Angel's"
-msgstr "大​天使​的"
+msgstr "大天使的"
 
 #: Source/translation_dummy.cpp:527
 msgid "Plentiful"
@@ -7501,11 +7536,11 @@ msgstr "慷慨"
 
 #: Source/translation_dummy.cpp:529
 msgid "Flaming"
-msgstr "烈​焰"
+msgstr "烈焰"
 
 #: Source/translation_dummy.cpp:530
 msgid "Lightning"
-msgstr "闪​电"
+msgstr "闪电"
 
 #: Source/translation_dummy.cpp:531
 msgid "quality"
@@ -7517,7 +7552,7 @@ msgstr "残废"
 
 #: Source/translation_dummy.cpp:533
 msgid "slaying"
-msgstr "杀​戮"
+msgstr "杀戮"
 
 #: Source/translation_dummy.cpp:534
 msgid "gore"
@@ -7621,7 +7656,7 @@ msgstr "傻瓜"
 
 #: Source/translation_dummy.cpp:559
 msgid "dyslexia"
-msgstr "文​盲"
+msgstr "文盲"
 
 #: Source/translation_dummy.cpp:560
 msgid "magic"
@@ -7677,7 +7712,7 @@ msgstr "麻烦"
 
 #: Source/translation_dummy.cpp:573
 msgid "the pit"
-msgstr "坑​洞"
+msgstr "坑洞"
 
 #: Source/translation_dummy.cpp:574
 msgid "the sky"
@@ -7701,11 +7736,11 @@ msgstr "星象"
 
 #: Source/translation_dummy.cpp:579
 msgid "the vulture"
-msgstr "秃​鹫"
+msgstr "秃鹫"
 
 #: Source/translation_dummy.cpp:580
 msgid "the jackal"
-msgstr "豺​狼"
+msgstr "豺狼"
 
 #: Source/translation_dummy.cpp:581
 msgid "the fox"
@@ -7721,7 +7756,7 @@ msgstr "老鹰"
 
 #: Source/translation_dummy.cpp:584
 msgid "the wolf"
-msgstr "野​狼"
+msgstr "野狼"
 
 #: Source/translation_dummy.cpp:585
 msgid "the tiger"
@@ -7737,11 +7772,11 @@ msgstr "猛犸"
 
 #: Source/translation_dummy.cpp:588
 msgid "the whale"
-msgstr "鲸​鱼"
+msgstr "鲸鱼"
 
 #: Source/translation_dummy.cpp:589
 msgid "fragility"
-msgstr "易​损"
+msgstr "易损"
 
 #: Source/translation_dummy.cpp:590
 msgid "brittleness"
@@ -7797,11 +7832,11 @@ msgstr "闪光"
 
 #: Source/translation_dummy.cpp:603
 msgid "lightning"
-msgstr "闪​电"
+msgstr "闪电"
 
 #: Source/translation_dummy.cpp:604
 msgid "thunder"
-msgstr "雷​电"
+msgstr "雷电"
 
 #: Source/translation_dummy.cpp:605
 msgid "many"
@@ -7821,19 +7856,19 @@ msgstr "腐败"
 
 #: Source/translation_dummy.cpp:609
 msgid "thieves"
-msgstr "窃​贼"
+msgstr "窃贼"
 
 #: Source/translation_dummy.cpp:610
 msgid "the bear"
-msgstr "野​熊"
+msgstr "野熊"
 
 #: Source/translation_dummy.cpp:611
 msgid "the bat"
-msgstr "蝙​蝠"
+msgstr "蝙蝠"
 
 #: Source/translation_dummy.cpp:612
 msgid "vampires"
-msgstr "吸血​鬼"
+msgstr "吸血鬼"
 
 #: Source/translation_dummy.cpp:613
 msgid "the leech"
@@ -7845,7 +7880,7 @@ msgstr "鲜血"
 
 #: Source/translation_dummy.cpp:615
 msgid "piercing"
-msgstr "穿​刺"
+msgstr "穿刺"
 
 #: Source/translation_dummy.cpp:616
 msgid "puncturing"
@@ -7885,7 +7920,7 @@ msgstr "和谐"
 
 #: Source/translation_dummy.cpp:625
 msgid "blocking"
-msgstr "格​挡"
+msgstr "格挡"
 
 #: Source/translation_dummy.cpp:626
 msgid "The Magic Rock"
@@ -7893,15 +7928,15 @@ msgstr "魔石"
 
 #: Source/translation_dummy.cpp:627
 msgid "Gharbad The Weak"
-msgstr "虚弱​的​贾巴德"
+msgstr "虚弱的贾巴德"
 
 #: Source/translation_dummy.cpp:628
 msgid "Zhar the Mad"
-msgstr "疯狂​的​扎尔"
+msgstr "疯狂的扎尔"
 
 #: Source/translation_dummy.cpp:629
 msgid "Lachdanan"
-msgstr "拉齐达​南"
+msgstr "拉齐达南"
 
 #: Source/translation_dummy.cpp:631
 msgid "The Butcher"
@@ -7909,11 +7944,11 @@ msgstr "屠夫"
 
 #: Source/translation_dummy.cpp:632
 msgid "Ogden's Sign"
-msgstr "奥格登​之​征"
+msgstr "奥格登之征"
 
 #: Source/translation_dummy.cpp:633
 msgid "Halls of the Blind"
-msgstr "目盲​之厅"
+msgstr "目盲之厅"
 
 #: Source/translation_dummy.cpp:634
 msgid "Valor"
@@ -7921,31 +7956,31 @@ msgstr "荣耀"
 
 #: Source/translation_dummy.cpp:635
 msgid "Warlord of Blood"
-msgstr "鲜血​战神"
+msgstr "鲜血战神"
 
 #: Source/translation_dummy.cpp:636
 msgid "The Curse of King Leoric"
-msgstr "国王​李奥瑞克​的​诅咒"
+msgstr "国王李奥瑞克的诅咒"
 
 #: Source/translation_dummy.cpp:639
 msgid "Archbishop Lazarus"
-msgstr "大​主教​拉扎鲁斯"
+msgstr "大主教拉扎鲁斯"
 
 #: Source/translation_dummy.cpp:640
 msgid "Grave Matters"
-msgstr "大​墓​地​大​问题"
+msgstr "大墓地大问题"
 
 #: Source/translation_dummy.cpp:641
 msgid "Farmer's Orchard"
-msgstr "农夫​的​果园"
+msgstr "农夫的果园"
 
 #: Source/translation_dummy.cpp:642
 msgid "Little Girl"
-msgstr "小​女孩"
+msgstr "小女孩"
 
 #: Source/translation_dummy.cpp:643
 msgid "Wandering Trader"
-msgstr "旅行​商人"
+msgstr "旅行商人"
 
 #: Source/translation_dummy.cpp:644
 msgid "The Defiler"
@@ -7957,7 +7992,7 @@ msgstr "纳·库尔"
 
 #: Source/translation_dummy.cpp:647
 msgid "The Jersey's Jersey"
-msgstr "小丑​的​愚弄"
+msgstr "小丑的愚弄"
 
 #: Source/translation_dummy.cpp:648
 msgctxt "spell"
@@ -7967,12 +8002,12 @@ msgstr "火焰弹"
 #: Source/translation_dummy.cpp:649
 msgctxt "spell"
 msgid "Healing"
-msgstr "治疗​术"
+msgstr "治疗术"
 
 #: Source/translation_dummy.cpp:650
 msgctxt "spell"
 msgid "Lightning"
-msgstr "闪​电术"
+msgstr "闪电术"
 
 #: Source/translation_dummy.cpp:651
 msgctxt "spell"
@@ -7987,82 +8022,82 @@ msgstr "鉴定"
 #: Source/translation_dummy.cpp:653
 msgctxt "spell"
 msgid "Fire Wall"
-msgstr "火焰​墙"
+msgstr "火焰墙"
 
 #: Source/translation_dummy.cpp:654
 msgctxt "spell"
 msgid "Town Portal"
-msgstr "城镇​传送门"
+msgstr "城镇传送门"
 
 #: Source/translation_dummy.cpp:655
 msgctxt "spell"
 msgid "Stone Curse"
-msgstr "石化​诅咒"
+msgstr "石化诅咒"
 
 #: Source/translation_dummy.cpp:656
 msgctxt "spell"
 msgid "Infravision"
-msgstr "夜​视术"
+msgstr "夜视术"
 
 #: Source/translation_dummy.cpp:657
 msgctxt "spell"
 msgid "Phasing"
-msgstr "相​位术"
+msgstr "相位术"
 
 #: Source/translation_dummy.cpp:658
 msgctxt "spell"
 msgid "Mana Shield"
-msgstr "法力​护盾"
+msgstr "法力护盾"
 
 #: Source/translation_dummy.cpp:659
 msgctxt "spell"
 msgid "Fireball"
-msgstr "火​球术"
+msgstr "火球术"
 
 #: Source/translation_dummy.cpp:660
 msgctxt "spell"
 msgid "Guardian"
-msgstr "召唤​守护者"
+msgstr "召唤守护者"
 
 #: Source/translation_dummy.cpp:661
 msgctxt "spell"
 msgid "Chain Lightning"
-msgstr "连锁​闪​电"
+msgstr "连锁闪电"
 
 #: Source/translation_dummy.cpp:662
 msgctxt "spell"
 msgid "Flame Wave"
-msgstr "烈​焰​波"
+msgstr "烈焰波"
 
 #: Source/translation_dummy.cpp:663
 msgctxt "spell"
 msgid "Doom Serpents"
-msgstr "多​头​蛇"
+msgstr "多头蛇"
 
 #: Source/translation_dummy.cpp:664
 msgctxt "spell"
 msgid "Blood Ritual"
-msgstr "鲜血​仪式"
+msgstr "鲜血仪式"
 
 #: Source/translation_dummy.cpp:665
 msgctxt "spell"
 msgid "Nova"
-msgstr "闪电​新​星"
+msgstr "闪电新星"
 
 #: Source/translation_dummy.cpp:666
 msgctxt "spell"
 msgid "Invisibility"
-msgstr "隐形​术"
+msgstr "隐形术"
 
 #: Source/translation_dummy.cpp:667
 msgctxt "spell"
 msgid "Inferno"
-msgstr "地​狱火"
+msgstr "地狱火"
 
 #: Source/translation_dummy.cpp:668
 msgctxt "spell"
 msgid "Golem"
-msgstr "召唤​魔像"
+msgstr "召唤魔像"
 
 #: Source/translation_dummy.cpp:669
 msgctxt "spell"
@@ -8072,12 +8107,12 @@ msgstr "狂暴"
 #: Source/translation_dummy.cpp:670
 msgctxt "spell"
 msgid "Teleport"
-msgstr "传​送术"
+msgstr "传送术"
 
 #: Source/translation_dummy.cpp:671
 msgctxt "spell"
 msgid "Apocalypse"
-msgstr "天​启"
+msgstr "天启"
 
 #: Source/translation_dummy.cpp:672
 msgctxt "spell"
@@ -8087,27 +8122,27 @@ msgstr "灵化术"
 #: Source/translation_dummy.cpp:673
 msgctxt "spell"
 msgid "Item Repair"
-msgstr "物品​修理"
+msgstr "物品修理"
 
 #: Source/translation_dummy.cpp:674
 msgctxt "spell"
 msgid "Staff Recharge"
-msgstr "魔杖​充能"
+msgstr "魔杖充能"
 
 #: Source/translation_dummy.cpp:675
 msgctxt "spell"
 msgid "Trap Disarm"
-msgstr "解除​陷阱"
+msgstr "解除陷阱"
 
 #: Source/translation_dummy.cpp:676
 msgctxt "spell"
 msgid "Elemental"
-msgstr "召唤​元素"
+msgstr "召唤元素"
 
 #: Source/translation_dummy.cpp:677
 msgctxt "spell"
 msgid "Charged Bolt"
-msgstr "电​荷弹"
+msgstr "电荷弹"
 
 #: Source/translation_dummy.cpp:678
 msgctxt "spell"
@@ -8122,17 +8157,17 @@ msgstr "复活术"
 #: Source/translation_dummy.cpp:680
 msgctxt "spell"
 msgid "Telekinesis"
-msgstr "心灵​传动"
+msgstr "心灵传动"
 
 #: Source/translation_dummy.cpp:681
 msgctxt "spell"
 msgid "Heal Other"
-msgstr "治疗​他​人"
+msgstr "治疗他人"
 
 #: Source/translation_dummy.cpp:682
 msgctxt "spell"
 msgid "Blood Star"
-msgstr "血​星"
+msgstr "血星"
 
 #: Source/translation_dummy.cpp:683
 msgctxt "spell"
@@ -8148,10 +8183,10 @@ msgid ""
 "men. Only the vilest powers of Hell could so utterly destroy a man from "
 "within..."
 msgstr ""
-"啊，关于​我们​国王​的​故事，是​吧？李奥瑞克​国王​的​堕落​对于​这​王国​来​说​是​一​场​悲剧。人"
-"民​一直​热爱​着​国王，但是​从此​人们​反而​生活​在​对​他​的​恐惧​之中。我​一直​反思，他​原来​是​"
-"如此​虔诚，如何​堕落​到​离​光明​如此​遥远。只有，来自​地狱​最​邪恶​的​力量​才​能​如此​彻底​的​"
-"从​内心​摧毁​他。"
+"啊，是关于我们国王的故事吧？李奥瑞克国王的堕落，是这片土地遭受的沉重打击。人"
+"民曾深爱着国王，如今却活在对他的恐惧之中。我一直在问自己：他曾经是那样虔诚的"
+"一个人，怎么会堕落到如此远离圣光的地步？只有地狱最邪恶的力量，才能如此彻底地"
+"从内部摧毁一个人……"
 
 #: Source/translation_dummy.cpp:685
 msgid ""
@@ -8173,16 +8208,20 @@ msgid ""
 "levels beneath the Cathedral. Please, good master, put his soul at ease by "
 "destroying his now cursed form..."
 msgstr ""
-"村子​需要​你​的​帮助，好心​人！几​个​月​前，李奥瑞克​的​儿子，艾伯莱希特​王子​被​绑架​了。"
-"国王​勃然大怒，在​村子​中​到处​寻找​他​失踪​的​孩子。日子​一​天天​过去，李奥瑞克​开始​逐渐​"
-"陷入​疯狂。他​把​儿子​的​失踪，归咎于​无辜​的​村民，残忍​的​处决​了​他们。只​有​不到​一半​的​"
-"人​从​他​的​疯狂​举动​中​幸存​…​…​\n"
-"宫​里​的​骑士​和​祭司​试图​安慰​他，国王​反​到​认为​他们​是​想​谋反。在​国王​即将​咽气​的​时候，"
-"对​他​的​追随者们​降下​了​可怕​的​诅咒。他​发誓​要​让​他们​在​黑暗中​永远​的​效忠​自己。\n"
-"​但是​实时​上​发生​的​事情​比​我​想​象​中​的​还​要​黑暗​和​扭曲！现在，我们​的​前任​国王​已经​从​长"
-"眠​中​复活​了，并​在​地下​回廊​中​指挥​着​一​只​不​死​军团。他​的​身体​已经​被​火化，埋葬​在​大​教"
-"堂​的​地下​墓室​的​第三​层。求​你​了，好心人，摧毁​它​那​现在​被​诅咒​的​身体，让​他​的​灵魂​得"
-"到​解放。"
+"村子需要你的帮助，好心的旅人！几个月前，李奥瑞克国王的儿子——艾伯莱希特王子被"
+"人绑架了。国王勃然大怒，在村子里四处搜寻他失踪的孩子。日子一天天过去，\n"
+"李奥瑞克越来越深地陷入了疯狂。他将王子的失踪归咎于无辜的村民，残忍地处决了他"
+"们。在他的疯狂之下，只有不到一半的人幸存了下来……\n"
+"\n"
+"\n"
+"王宫的骑士和祭司试图安抚国王，但他反而将矛头指向了他们。可悲的是，他们被迫将"
+"国王杀死。临终之际，国王对他昔日的追随者们降下了可怕的诅咒，\n"
+"发誓要让他们在黑暗中永远服侍自己……\n"
+"\n"
+"然而事情的发展比我想象的还要黑暗！如今，我们的前任国王已从永眠中苏醒，在迷宫"
+"深处统帅着一支亡灵军团。\n"
+"他的遗体被埋葬在大教堂地下第三层的墓室中。求你了，好心的旅人，请摧毁他那被诅"
+"咒的躯体，让他的灵魂得以安息……"
 
 #: Source/translation_dummy.cpp:686
 msgid ""
@@ -8190,8 +8229,8 @@ msgid ""
 "down there, waiting in the putrid darkness for his chance to destroy this "
 "land..."
 msgstr ""
-"正​如​之前​我​告诉​你​的，好心人，国王​被​埋葬​在​地下​墓穴​第三​层。他​就​在​那​下面，在​那​腐"
-"朽​的​黑暗​中​等待​着​摧毁​这​片​土地​的​机会。"
+"正如我之前说过的，好心的旅人，国王被埋葬在地下第三层。他就在下面，在那腐朽的"
+"黑暗中，等待着毁灭这片土地的机会。"
 
 #: Source/translation_dummy.cpp:687
 msgid ""
@@ -8200,9 +8239,9 @@ msgid ""
 "consumes our land, for your victory is a good omen. May Light guide you on "
 "your way, good master."
 msgstr ""
-"我们​国王​的​诅咒​已经​解除，但​我​担心​那​只是​巨大​邪恶​的​冰山​一​角。然而，正​因为​你​的​胜"
-"利，我们​还​有​在​被​邪恶​席卷​这​片​土地​前​被​救赎​的​机会。希望​光明​指引​你​的​旅途，好心"
-"人。"
+"国王的诅咒已经解除，但我担心这只是更深邪恶的冰山一角。不过，你的胜利是一个好"
+"兆头，我们或许还有机会从吞噬这片土地的黑暗中获救。愿圣光指引你的前路，好心的"
+"旅人。"
 
 #: Source/translation_dummy.cpp:688
 msgid ""
@@ -8211,9 +8250,9 @@ msgid ""
 "this kingdom from that day forward, but perhaps if you were to free his "
 "spirit from his earthly prison, the curse would be lifted..."
 msgstr ""
-"失去​儿子，对于​李奥瑞克​国王​来​说​是​个​沉痛​的​打击。我​尽​我​所能​的​减轻​他​的​疯狂，但是​"
-"终究​邪恶​还是​占据​了​他。从​那​天​起，黑色​的​诅咒​笼罩​着​王国，要是​你​也许​能​让​他​的​灵魂​"
-"从​人间​解脱，诅咒​便​会​就此​解除。"
+"失去儿子对李奥瑞克国王而言是太过沉重的打击。我尽了最大努力来缓解他的疯狂，但"
+"最终黑暗还是吞没了他。自那天起，黑色的诅咒便笼罩着这个王国。但如果你能将他的"
+"灵魂从凡世的牢笼中解放出来，也许诅咒就会随之消散……"
 
 #: Source/translation_dummy.cpp:689
 msgid ""
@@ -8221,8 +8260,8 @@ msgid ""
 "the kind and just ruler that he was. His death was so sad and seemed very "
 "wrong, somehow."
 msgstr ""
-"我​不​想​去​回忆​国王​的​驾崩。我​印象中​他​是​一​位​仁慈​且​公正​的​统治者。不止​为​何，他​的​死​"
-"是​如此​的​悲痛，就​像是​一​场​悲剧。"
+"我不愿去想国王离世的事。我更愿意记住他原本的样子——一位仁慈而公正的君主。他的"
+"死是如此令人悲伤，总让人觉得有些不对劲。"
 
 #: Source/translation_dummy.cpp:690
 msgid ""
@@ -8231,17 +8270,17 @@ msgid ""
 "mithril for him, as well as a field crown to match. I still cannot believe "
 "how he died, but it must have been some sinister force that drove him insane!"
 msgstr ""
-"我​打造​的​武器​和​盔甲​大部分​被​李奥瑞克​国王​武装​他​的​骑士。我​还​为​他​本人​锻造​了​一​把​趁"
-"手​的​秘银​双​手​大剑​和​一​顶​与​之​相配​的​王冠。我​始终​无法​接受​他​的​驾崩，一定​是​某​种​强大​"
-"的​邪恶​把​他​逼疯​了！"
+"李奥瑞克国王麾下骑士的武器和铠甲，大部分都出自我手。我还特意为他锻造了一把上"
+"等秘银打造的双手巨剑，还有一顶与之相配的战冠。我至今无法相信他就这么走了，一"
+"定是有某种邪恶的力量把他逼疯的！"
 
 #: Source/translation_dummy.cpp:691
 msgid ""
 "I don't care about that. Listen, no skeleton is gonna be MY king. Leoric is "
 "King. King, so you hear me? HAIL TO THE KING!"
 msgstr ""
-"我​才​不​在乎​呢。听​着，我​的​国王​才​不​会​是​一​具​骨​架子。李奥瑞克​才​是​国王。什么​是​国"
-"王，懂​吗？向​国王​致敬！"
+"我才不管那些。听着，一具骷髅才不配当我的国王。李奥瑞克才是国王。国王，你听到"
+"了吗？国王万岁！"
 
 #: Source/translation_dummy.cpp:692
 msgid ""
@@ -8250,8 +8289,8 @@ msgid ""
 "you do not stop his reign, he will surely march across this land and slay "
 "all who still live here."
 msgstr ""
-"在​人间​活跃​的​亡灵​跟​随​着​被​诅咒​的​国王。他​它​拥有​着​复生无​尽亡者​大军​的​力量。如果​你​"
-"不​能​阻止​他​的​统治，他​一定​会​率领​大军​杀​穿​这​片​土地，屠杀​所有​生者。"
+"徘徊于生者之间的亡灵追随着那位受诅咒的国王。他拥有不断复活亡者、壮大不死军团"
+"的力量。若你不能阻止他的统治，他必将率领大军横扫这片土地，屠尽所有生灵。"
 
 #: Source/translation_dummy.cpp:693
 msgid ""
@@ -8260,14 +8299,14 @@ msgid ""
 "need something to use against this King of the undead, then I can help you "
 "out..."
 msgstr ""
-"瞧，我​就​是​来​做​生意​的。我​不​卖​情报，也​不​关心​那死​的​比​我​活​的​还​长​的​国王。如果​你​需"
-"要​些​东西​对付​这​死不​了​的​国王，那​我​倒​是​可以​帮​帮​你。"
+"听好，我是来做生意的。不卖消息，也不关心什么死得比我这辈子还长的国王。不过如"
+"果你需要对付那个不死国王的东西，我倒可以帮上忙……"
 
 #: Source/translation_dummy.cpp:694
 msgid ""
 "The warmth of life has entered my tomb. Prepare yourself, mortal, to serve "
 "my Master for eternity!"
-msgstr "温暖​是​生命​气息​来到​了​我​的​墓穴。那​就​来​吧，凡​人，为​我​主效命​终生​吧！"
+msgstr "生命的温暖踏入了我的墓穴。准备受死吧，凡人，来永远侍奉我的主人！"
 
 #: Source/translation_dummy.cpp:695
 msgid ""
@@ -8277,9 +8316,9 @@ msgid ""
 "led them to believe that it too holds some arcane powers. Hmm, perhaps they "
 "are not all as smart as we had feared..."
 msgstr ""
-"我​知道​这​种​奇怪​的​行为​也​让​你​困惑。我​猜想，既然​许多​恶魔​害怕​太阳光并且相信​它​拥有​"
-"巨大​的​力量，那么可能​是​你​所​说​的​招牌上​描绘​的​旭日​让​他们​相信​它​也​拥有​一些​神秘​的​力"
-"量。嗯，也许​他们​并不​像​我们​担心​的​那么​聪明……"
+"看来这种奇怪的行为也让你感到困惑。我推测，既然许多恶魔畏惧阳光并相信它蕴藏着"
+"巨大的力量，那么你所说的那块招牌上描绘的旭日，很可能让他们误以为它也拥有某种"
+"神秘的力量。嗯，也许这些恶魔并不像我们担心的那么聪明……"
 
 #: Source/translation_dummy.cpp:696
 msgid ""
@@ -8292,11 +8331,11 @@ msgid ""
 "the sign to my inn. I don't know why the demons would steal my sign but "
 "leave my family in peace... 'tis strange, no?"
 msgstr ""
-"大人，我​有​一​个​奇怪​的​经历。我​知道​你​对​迷宫​里​的​怪物​很​了解，这​是​我​一​生​都​无法​理解​"
-"的……我​在​晚上​被​酒店​外面​的​刮擦声​吵醒​了。当​我​从​卧室​往外​看​的​时候，我​看到​客栈院子​"
-"里​有​一些​像​魔鬼​一样​的​小​动物。过​了​一会儿，他们​跑掉​了，但​还​没​来​得​及​把​招牌​偷​到​我​"
-"的​客栈。我​不​知道​为什么​恶魔会​偷走​我​的​标志，却​让​我​的​家人​安然​无恙​…​…​”​很​奇怪，不​是​"
-"吗？"
+"大人，我遇到了一件怪事。我知道你对迷宫里的怪物了如指掌，可这事我真是想破头也"
+"想不明白……那天夜里，我被酒馆外面一阵刮擦声惊醒。我从卧室往外一看，只见客栈院"
+"子里有几个小恶魔似的黑影。没多久它们就跑掉了，但在逃跑之前，它们把我酒馆的招"
+"牌给偷走了。我不明白这些恶魔为什么要偷我的招牌，却放过了我的家人……你说奇怪不"
+"奇怪？"
 
 #: Source/translation_dummy.cpp:697
 msgid ""
@@ -8306,9 +8345,9 @@ msgid ""
 "cap was left in one of the rooms by a magician who stayed here some time "
 "ago. Perhaps it may be of some value to you."
 msgstr ""
-"哦，你​不​必​把​我​的​招牌​拿​回来，但​我​想​它​确实​可以​帮​我​省下​再​做​一​个​牌子​的​费用。好​"
-"吧，让​我​想想，我​能​给​你​什么​作为​找到​它​的​费用？嗯，我们​这里​有​什么……啊，是​的！这​"
-"顶​帽子​是​一​个​魔法师​不久​前​留​下来​的，他​把​它​放​在​一​个​房间​里。也许它​对​你​有​些价值。"
+"哦，你其实不必专程把招牌送回来——不过倒也省了我重做一块的开销。好吧，让我想"
+"想，该拿什么来酬谢你呢？嗯，我看看……啊，有了！这顶帽子是很久以前一位住店的魔"
+"法师落在房间里的，兴许对你有些用处。"
 
 #: Source/translation_dummy.cpp:698
 msgid ""
@@ -8316,8 +8355,8 @@ msgid ""
 "- is nothing sacred? I hope that Ogden and Garda are all right. I suppose "
 "that they would come to see me if they were hurt..."
 msgstr ""
-"我​的​天哪，恶魔们​晚上​在​村子​里​到处​乱​跑，掠夺​我们​的​家园​——​难道​没有​什么​神圣​的​东西​"
-"吗？我​希望​奥格登​和​加尔达​没​事。我​想​如果​他们​受伤​了​他们​会​来​看​我​的……"
+"我的天哪，恶魔们晚上在村子里到处乱跑，掠夺我们的家园——难道没有什么神圣的东西"
+"吗？我希望奥格登和加尔达没事。我想如果他们受伤了他们会来看我的……"
 
 #: Source/translation_dummy.cpp:699
 msgid ""
@@ -8325,7 +8364,8 @@ msgid ""
 "right through the whole thing. Thank the Light that those monsters didn't "
 "attack the inn."
 msgstr ""
-"天​哪！招牌就​在​那里​吗？我​祖母​和​我​一定​一直​都​在​睡觉。感谢​那些​怪物​没有​攻击​客栈。"
+"天哪！招牌原来跑那儿去了？我和祖母一定是从头到尾睡死了过去。感谢圣光，那些怪"
+"物没有袭击客栈。"
 
 #: Source/translation_dummy.cpp:700
 msgid ""
@@ -8334,9 +8374,9 @@ msgid ""
 " \n"
 "Demons are concerned with ripping out your heart, not your signpost."
 msgstr ""
-"你​说​恶魔​偷​了​奥格登​的​招牌？这​听​起来​不​像​我​听​说​过​或​见​过​的​暴行。\n"
+"你说恶魔偷了奥格登的招牌？这可不像我所听说——或亲眼见识过的那些暴行。\n"
 " \n"
-"​恶魔​关心​的​是​撕碎​你​的​心，而​不​是​你​的​路标。"
+"恶魔关心的是把你的心掏出来，而不是偷你的路标。"
 
 #: Source/translation_dummy.cpp:701
 msgid ""
@@ -8345,9 +8385,9 @@ msgid ""
 "new sign with some pretty drawing on it. Maybe a nice mug of ale or a piece "
 "of cheese..."
 msgstr ""
-"你​知道​我​怎么​想​吗？有​人​拿​了​那个​牌子，他们​会​想要​很多​钱​的。如果​我​是​奥格登……我​不​"
-"是，但​如果​我​是……我​想​买​一​个​新​牌子，上面​画​些​漂亮​的​图案。也许​是​一​杯​啤酒​或者​一​块​"
-"奶酪……"
+"你知道我怎么想吗？有人偷了那块招牌，他们肯定会狮子大开口。如果我是奥格登……我"
+"不是，但如果我是……我倒想直接买块新招牌，画上好看的图案。画一大杯麦芽酒，或者"
+"一块奶酪……"
 
 #: Source/translation_dummy.cpp:702
 msgid ""
@@ -8355,9 +8395,9 @@ msgid ""
 " \n"
 "Never let their erratic actions confuse you, as that too may be their plan."
 msgstr ""
-"没有​人​能​真正​理解​恶魔​的​思想。\n"
+"凡人永远无法真正理解恶魔的思维。\n"
 " \n"
-"​永远​不​要​让​他们​不​稳定​的​行为​迷惑​你，因为​那​也​可能​是​他们​的​计划。"
+"不要被它们反复无常的行径迷惑，这或许正是它们的诡计所在。"
 
 #: Source/translation_dummy.cpp:703
 msgid ""
@@ -8367,9 +8407,9 @@ msgid ""
 "Look, I got over simple sign stealing months ago. You can't turn a profit on "
 "a piece of wood."
 msgstr ""
-"他​是​说​我​拿​了​那个？我​想​格里斯沃尔德​也​站​在​他​这​边。\n"
+"什么——他在说我偷的吗？照这说法，我看格里斯沃尔德也是跟他一伙的。\n"
 " \n"
-"​听​着，我​几​个​月​前​就​忘​了​偷牌子​了。你​不​能​靠​一​块​木头​赚​钱。"
+"听着，偷招牌这种小把戏我几个月前就看不上了。一块破木牌赚不了钱。"
 
 #: Source/translation_dummy.cpp:704
 msgid ""
@@ -8377,16 +8417,16 @@ msgid ""
 "no leave with life! You kill big uglies and give back Magic. Go past corner "
 "and door, find uglies. You give, you go!"
 msgstr ""
-"嘿​-​你​就​是​那个​杀人​狂！你​给​我​拿​魔旗​否则​我们​就​进攻！你​不​能​离开​生命！你​杀​了​大丑八"
-"怪​还​了​魔法。穿过​街角​和​门，找到​丑陋​的​东西。你​给，你​走！"
+"嘿——你！杀光我们的人！你拿魔旗回来，不然我们打你！你别想活着离开！你杀掉大丑"
+"怪，把魔旗还回来。转过墙角和大门，找到大丑怪。你交出来，就让你走！"
 
 #: Source/translation_dummy.cpp:705
 msgid "You kill uglies, get banner. You bring to me, or else..."
-msgstr "你​杀​了​丑八怪，得到​横幅。你​给​我​带来，否则……"
+msgstr "你杀大丑怪，拿旗帜。你给我，不然……"
 
 #: Source/translation_dummy.cpp:706
 msgid "You give! Yes, good! Go now, we strong. We kill all with big Magic!"
-msgstr "你​给​我！是​的，很​好！走​吧，我们​坚强。我们​用​大​魔法​杀人！"
+msgstr "你交了！好，很好！走人吧，我们现在强了。我们用大魔法杀光所有人！"
 
 #: Source/translation_dummy.cpp:707
 msgid ""
@@ -8414,29 +8454,28 @@ msgid ""
 "You must hurry and save the prince from the sacrificial blade of this "
 "demented fiend!"
 msgstr ""
-"这​不​是​好​兆头，因为​它​证实​了​我​最​黑暗​的​恐惧。虽然​我​不​允许​自己​相信​古老​的​传说，但​"
-"我​现在​不​能​否认​它们。也许​是​时候​揭露​我​是​谁​了。\n"
+"这不是个好兆头，因为它证实了我最深的恐惧。虽然我此前不愿相信那些古老的传说，"
+"但如今我再也无法否认它们。也许是时候揭示我的真实身份了。\n"
 " \n"
-"​我​的​真名​是​迪卡德·凯恩，我​是​一​个​古老​兄弟会​的​最后​一​个​后代，这​个​兄弟​会​致力于​保护​"
-"一​个​永恒​邪恶​的​秘密。一​个​很​明显​已经​被​释放​的​恶魔。\n"
+"我的真名是凯恩长老，我是古老兄弟会的最后一名传人，那个兄弟会毕生致力于守护一"
+"种永恒之恶的秘密。而那股邪恶，显然已经降临于世。\n"
 " \n"
-"拉扎鲁斯大​主教​曾经​是​李奥瑞克​国王​最​信任​的​顾问，他​带领​一​队​普通​的​市民​进入​迷宫，"
-"寻找​国王​失踪​的​儿子​艾伯莱希特。过​了​很​长​一​段​时间​他们​才​回来，只有​少数​人​带​着​生命​"
-"逃走​了。\n"
+"大主教拉扎鲁斯曾是李奥瑞克国王最信任的谋臣，他曾带领一群朴实的镇民进入迷宫，"
+"去寻找国王失踪的儿子艾伯莱希特。过了许久他们才返回，只有寥寥数人得以逃生。\n"
 " \n"
-"诅咒​我​是​个​傻瓜！我​当时​应该​怀疑​他​暗中​的​背叛。一定​是​拉扎鲁斯​自己​绑架​了​艾伯莱希"
-"特，然后​把​他​藏​在​迷宫​里。我​不​明白​大主教​为什么​转向​黑暗，或者​他​对​这​个​孩子​有​什么​"
-"兴趣，除非​他​打算​把​他​献给​他​的​黑暗​主人！\n"
+"真该诅咒我这蠢货！我当时就该怀疑他居心叵测。绑架艾伯莱希特的必然就是拉扎鲁斯"
+"本人，他此后将王子藏匿于迷宫深处。我实在不明白大主教为何投身黑暗，又为何对这"
+"个孩子如此执着——除非，他打算将王子献祭给他的黑暗主人！\n"
 " \n"
-"​那​一定​是​他​的​计划！他​的​“​救援队​”​的​幸存者​说，拉扎鲁斯​最后​一​次​被​看到​跑进​迷宫​最​深​"
-"处。你​必须​赶快​把​王子​从​这​个​疯狂​恶魔​的​祭剑​中​救​出来！"
+"那一定就是他的图谋！他那支“救援队伍”的幸存者说，有人最后看到拉扎鲁斯逃入了迷"
+"宫最深的腹地。你必须抓紧时间，将王子从那个丧心病狂的恶魔的祭刀下拯救出来！"
 
 #: Source/translation_dummy.cpp:708
 msgid ""
 "You must hurry and rescue Albrecht from the hands of Lazarus. The prince and "
 "the people of this kingdom are counting on you!"
 msgstr ""
-"你​必须​赶快​把​艾伯莱希特​从​拉扎鲁斯​手​中​救​出来。王子​和​这个​王国​的​人民​都​指望​着​你！"
+"你必须尽快从拉扎鲁斯手中救出艾伯莱希特。王子与这个王国的人民，全都指望你了！"
 
 #: Source/translation_dummy.cpp:709
 msgid ""
@@ -8451,13 +8490,13 @@ msgid ""
 "again sow chaos in the realm of mankind. You must venture through the portal "
 "and destroy Diablo before it is too late!"
 msgstr ""
-"你​的​故事​很​残酷，我​的​朋友。拉扎鲁斯​一定​会​因为​他​那​可怕​的​行为​在​地狱里​被​烧死。你​"
-"描述​的​那​个​男孩​不​是​我们​的​王子，但​我​相信​艾伯莱希特​可能​还​处在​危险​之中。你​所​说​的​"
-"权力​的​象征​一定​是​迷宫​中心​的​一​个​入口。\n"
+"你的故事令人不寒而栗，我的朋友。拉扎鲁斯必会为他的暴行在地狱中焚烧。你说的那"
+"个男孩并非我们的王子，但我相信艾伯莱希特仍身处险境。你提到的那个力量象征，必"
+"定是迷宫深处的一道传送门。\n"
 " \n"
-"​你​要​知道，我​的​朋友，你​所​反对​的​邪恶​是​恐怖​的​黑魔王。他​被​世人​称为​迪亚波罗。几​个​"
-"世纪​前，正​是​他​被​囚禁​在​迷宫​里，我​担心​他​又​一​次​企图​在​人类​的​王国​里​制造​混乱。你​必"
-"须​冒险​穿过​传送门，在​一切​都太迟之前​​摧毁迪亚波罗！"
+"听好了，我的朋友——你正在对抗的邪恶，正是黑暗的恐惧之王。凡人称他为迪亚波罗。"
+"数个世纪前，他被囚禁在迷宫之中，我担心他正试图再次在人类世界散播混乱。你必须"
+"穿过那道传送门，在一切太迟之前摧毁迪亚波罗！"
 
 #: Source/translation_dummy.cpp:710
 msgid ""
@@ -8466,9 +8505,9 @@ msgid ""
 "suppose he was killed along with most of the others. If you would do me a "
 "favor, good master - please do not talk to Farnham about that day."
 msgstr ""
-"拉扎鲁斯​是​大主教，他​带领​许多​市民​进入​迷宫。那天​我​失去​了​很多​好​朋友，拉扎鲁斯​再​"
-"也​没有​回来。我​想​他​是​和​其他​大多数​人​一起​被​杀​的。如果​你​能​帮​我​一​个​忙，好​心人​-​请​不​"
-"要​和​法恩汉​谈论​那​一​天。"
+"拉扎鲁斯就是那位带领许多镇民进入迷宫的大主教。那天我失去了许多挚友，而拉扎鲁"
+"斯再也没有回来。我想他大概和大多数人一样死在了里面。如果你能帮我一个忙，好心"
+"的旅人——请别和法恩汉提起那一天的事。"
 
 #: Source/translation_dummy.cpp:711
 msgid ""
@@ -8477,9 +8516,9 @@ msgid ""
 "that. He was an Archbishop, and always seemed to care so much for the "
 "townsfolk of Tristram. So many were injured, I could not save them all..."
 msgstr ""
-"当​我​听说​镇​上​的​人​那天​晚上​打算​干​什么​时，我​很​震惊。我​想​在​所有​人​中，拉扎鲁斯​应该​"
-"更​有​理智。他​是​一​位​大主教，似乎​总是​那么​关心​崔斯特姆​的​市民。这么​多​人​受伤，我​救​"
-"不​了​他们……"
+"听到镇民们那天晚上的计划时，我非常震惊。我以为在所有人当中，拉扎鲁斯应该是最"
+"有理智的。他可是大主教啊，平时那么关心崔斯特姆的百姓。那么多人受伤，我却无法"
+"将他们全部救回……"
 
 #: Source/translation_dummy.cpp:712
 msgid ""
@@ -8487,8 +8526,9 @@ msgid ""
 "mother's funeral, and was supportive of my grandmother and myself in a very "
 "troubled time. I pray every night that somehow, he is still alive and safe."
 msgstr ""
-"我​记得​拉扎鲁斯​是​一​个​非常​和​善​和​乐于​奉献​的​人。他​在​我​母亲​的​葬礼​上​发表​了​讲话，在​"
-"非常​困难​的​时候​支持​我​和​我​的​祖母。我​每​晚​都​祈祷，不​知​何故，他​还​活​着，安然​无恙。"
+"我记得拉扎鲁斯是个非常和蔼、乐于助人的人。他在我母亲的葬礼上致了悼词，在我和"
+"祖母最困难的时候给了我们支持。我每晚都祈祷，希望不管怎样，他还活着，平安无"
+"事。"
 
 #: Source/translation_dummy.cpp:713
 msgid ""
@@ -8497,9 +8537,9 @@ msgid ""
 "much as lift his mace against them. He just ran deeper into the dim, endless "
 "chambers that were filled with the servants of darkness!"
 msgstr ""
-"拉扎鲁斯领​我们​进迷宫​的​时候，我​在​那里。他​谈到​了​神圣​的​报应，但​当​我们​开始​与​那些​"
-"地狱​之​子​战斗​时，他​甚至​没有​举起​他​的​狼牙棒​来​对付​他们。他​只不过​是​往​黑暗​的​仆人们​"
-"所​住​的​昏暗​无​边​的​房间​里​跑​得​更​深！"
+"拉扎鲁斯领我们进迷宫的时候，我就在现场。他口口声声说着神圣的惩戒，可当我们开"
+"始和那些地狱崽子们交手时，他连手中的钉头锤都没有举起一下。他只是头也不回地，"
+"朝着那些遍布黑暗仆从的幽暗密室深处逃去！"
 
 #: Source/translation_dummy.cpp:714
 msgid ""
@@ -8507,8 +8547,8 @@ msgid ""
 "dead! Dead! Do you hear me? They just keep falling and falling... their "
 "blood spilling out all over the floor... all his fault..."
 msgstr ""
-"它们​刺，然后​咬，然后​它们​就​在​你​周围。说谎者！说​谎者！他们​都​死​了！死去​的​你​听见​"
-"了​吗？他们​只​是​不断​地​跌倒……他们​的​血洒​得​满​地​都​是……全​是​他​的​错……"
+"它们刺过来，然后咬过来，然后到处都是……骗子！骗子！他们全死了！死光了！你听到"
+"了吗？！他们一个接一个地倒下……血淌了一地……都是他的错……"
 
 #: Source/translation_dummy.cpp:715
 msgid ""
@@ -8516,8 +8556,8 @@ msgid ""
 "conflict within his being. He poses a great danger, and will stop at nothing "
 "to serve the powers of darkness which have claimed him as theirs."
 msgstr ""
-"我​不​认识​你们​所​说​的​拉扎鲁斯，但​我​确实​感觉​到​他​内心​有​很​大​的​矛盾。他​带来​了​巨大​的​"
-"危险，他​将​不​择​手段​地​为​黑暗​势力​服务，而黑暗​势力​也将​他​视为自己人。"
+"我不认识你所说的这位拉扎鲁斯，但我能感觉到他内心的剧烈冲突。他是个极度危险的"
+"人物，会不惜一切代价为黑暗势力效劳——而黑暗势力也早已将他视为自己的仆从。"
 
 #: Source/translation_dummy.cpp:716
 msgid ""
@@ -8525,16 +8565,16 @@ msgid ""
 "down there. Didn't help save my leg, did it? Look, I'll give you a free "
 "piece of advice. Ask Farnham, he was there."
 msgstr ""
-"是​的，正义​的​拉扎鲁斯，他​对​那里​的​怪物​非常​有效。没​救​我​的​腿，是​吗？听​着，我​给​你​"
-"一​个​免费​的​建议。问问​法恩汉，他​在​那儿。"
+"是啊，正义的拉扎鲁斯，他对付下面那些怪物可真\"厉害\"啊。反正没帮我保住腿，对"
+"吧？听着，免费送你个建议——去问法恩汉，当时他也在场。"
 
 #: Source/translation_dummy.cpp:717
 msgid ""
 "Abandon your foolish quest. All that awaits you is the wrath of my Master! "
 "You are too late to save the child. Now you will join him in Hell!"
 msgstr ""
-"放弃​你​愚蠢​的​追求。等待​你​的​只​有​我​主人​的​愤怒！你​来​不​及​救​孩子​了。现在​你​要​和​他​一"
-"起​下​地狱​了！"
+"放弃你那愚蠢的使命吧！等待你的只有我主人的怒火！你来得太晚了，那孩子已经没救"
+"了。现在，和他一起下地狱去吧！"
 
 #: Source/translation_dummy.cpp:718
 msgid ""
@@ -8544,9 +8584,9 @@ msgid ""
 "the same. Unfortunately, I do not know what would cause our water supply to "
 "be tainted."
 msgstr ""
-"嗯，我​不​知道​我​能​告诉​你​些​什么​对​你​有​帮助。充满​我们​水井​的​水​来自​地下泉水。我​听说​"
-"过​一​条​通往​大​湖​的​隧道​——​也许​它们​是​同​一​条。不幸​的​是，我​不​知道​什么​会​导致​我们​的​供"
-"水​受到​污染。"
+"嗯，关于这件事，我恐怕帮不了你太多。我们井里的水来自一处地下泉眼。我曾听说有"
+"一条隧道通向一个大湖——也许就是同一处水源。可惜，我也不知道是什么东西污染了我"
+"们的供水。"
 
 #: Source/translation_dummy.cpp:719
 msgid ""
@@ -8556,10 +8596,10 @@ msgid ""
 " \n"
 "Please, do what you can or I don't know what we will do."
 msgstr ""
-"我​一直​试图​在​我们​的​储藏室​里​储存​大量​的​食品​和​饮料，但​由于​全​镇​没有​淡水​供应，即使​"
-"是​我们​的​商店​也​很​快​就​会​干涸。\n"
+"我一直尽力在我们的储藏窖里备足食物和饮品，但如今全镇都断了洁净的水源，连我们"
+"的存货也很快会耗尽。\n"
 " \n"
-"​拜托，做​你​能​做​的，否则​我​不​知道​我们​会​做​什么。"
+"求你了，能帮的尽管帮吧，否则我真不知道我们该怎么办。"
 
 #: Source/translation_dummy.cpp:720
 msgid ""
@@ -8569,9 +8609,9 @@ msgid ""
 "passage that leads to the springs that serve our town. Please find what has "
 "caused this calamity, or we all will surely perish."
 msgstr ""
-"很​高兴​我​及时​赶上​了​你！我们​的​水井​变​得​微咸、死气​沉沉，一些​城里人​喝​得​不​好。我们​"
-"储备​的​淡水​很​快​就​干涸​了。我​相信​有​一​条​通道​通​向​为​我们​城镇​服务​的​泉水。请​找出​造成​"
-"这​场​灾难​的​原因，否则​我们​都​将​灭亡。"
+"幸好我及时找到了你！我们的井水变得又咸又臭，一些镇民喝了之后病倒了。我们储备"
+"的淡水眼看就要耗尽。我相信有一条通道通往为这座城镇供水的泉眼。请找出造成这场"
+"灾祸的原因，否则我们所有人都将难以活命。"
 
 #: Source/translation_dummy.cpp:721
 msgid ""
@@ -8580,9 +8620,9 @@ msgid ""
 " \n"
 "We cannot survive for long without your help."
 msgstr ""
-"拜托，你​必须​快点。每​过​一​个​小时，我们​就​更​接近​没有​水​喝​了。\n"
+"求你了，你一定要快。每过一小时，我们就离无水可饮更近一步。\n"
 " \n"
-"​没有​你​的​帮助，我们​活​不​了​多久。"
+"没有你的帮助，我们撑不了多久。"
 
 #: Source/translation_dummy.cpp:722
 msgid ""
@@ -8591,15 +8631,15 @@ msgid ""
 "perseverance and courage gives us hope. Please take this ring - perhaps it "
 "will aid you in the destruction of such vile creatures."
 msgstr ""
-"你​说​什么？仅仅​是​恶魔​的​存在​就​导致​了​水​被​污染​了？哦，我们​镇下​确实​隐藏​着​一​个​巨大​"
-"的​恶魔，但​你​的​毅力​和​勇气​给​了​我们​希望。请​收​下​这​枚​戒指​——​也许​它​能​帮助​你​消灭​这些​"
-"邪恶​的​生物。"
+"你说什么——仅仅因为恶魔的存在，水就被污染了？哦，我们镇子底下果然潜伏着巨大的"
+"邪恶。但你的坚毅与勇气给了我们希望。请收下这枚戒指——也许它能助你消灭那些邪恶"
+"的生物。"
 
 #: Source/translation_dummy.cpp:723
 msgid ""
 "My grandmother is very weak, and Garda says that we cannot drink the water "
 "from the wells. Please, can you do something to help us?"
-msgstr "我​祖母​很​虚​弱，嘉达​说​我们​不​能​喝​井​水。拜托，你​能​帮帮我们么？"
+msgstr "我祖母身体很虚弱，嘉达说井水不能喝了。求求你，能帮帮我们吗？"
 
 #: Source/translation_dummy.cpp:724
 msgid ""
@@ -8607,12 +8647,12 @@ msgid ""
 "have tried to clear one of the smaller wells, but it reeks of stagnant "
 "filth. It must be getting clogged at the source."
 msgstr ""
-"佩金​告诉​了​你​真相。我们​很​快​就​会​急​需​淡水。我​试​过​清理​其中​一​口​小​井，但​它​散发​着​死"
-"水​的​臭味。一定​是​源头​堵塞​了。"
+"佩金说得没错。我们很快就要面临严重的缺水。我试过清理一口小井，但里面散发着死"
+"水的恶臭。一定是源头那边出了什么问题。"
 
 #: Source/translation_dummy.cpp:725
 msgid "You drink water?"
-msgstr "你​想​喝​水​吗？"
+msgstr "你们凡人喝的是水吗？"
 
 #: Source/translation_dummy.cpp:726
 msgid ""
@@ -8622,17 +8662,17 @@ msgid ""
 "Know this - demons are at the heart of this matter, but they remain ignorant "
 "of what they have spawned."
 msgstr ""
-"如果​你​不​能​恢复​井​中​的​淡水，崔斯特姆人​就​会​死。\n"
+"如果你无法让崔斯特姆的水井重新涌出清水，镇民们都将死去。\n"
 " \n"
-"​知道​这​一点​-​恶魔​是​这​件​事​的​核心，但​他们​仍然​不​知道​他们​产生​了​什么。"
+"你要明白——恶魔才是这件事的根源，但它们对自己所孕育的恶果仍一无所知。"
 
 #: Source/translation_dummy.cpp:727
 msgid ""
 "For once, I'm with you. My business runs dry - so to speak - if I have no "
 "market to sell to. You better find out what is going on, and soon!"
 msgstr ""
-"这​一​次，我​和​你​在一起。可以​说，如果​我​没有​销路​的话，我​的​生意​就​完​了。你​最好​尽快​"
-"弄清楚​发生​了​什么​事！"
+"这回我站你这边。说白了，要是我连顾客都没了，生意还怎么做。你最好尽快查清楚到"
+"底怎么回事！"
 
 #: Source/translation_dummy.cpp:728
 msgid ""
@@ -8643,28 +8683,28 @@ msgid ""
 "the attempt to steal that treasure would be forever bound to defend it. A "
 "twisted, but strangely fitting, end?"
 msgstr ""
-"一​本​书​提到​了​一​间​满​是​人类​骸骨​的​密室？嗯，在​我​曾经​研究​学习​的​东方​图书馆，馆藏​的​"
-"一些​古籍​中​提到​了​白骨密室。这些​书籍​推断，当下界​领主​想要​保护​大量​宝藏​时，他们​会​"
-"创建​一些​结界。在​结界​中，那些​试图​偷窃​宝藏​时​死亡​的​人，将​永远​被​束缚。一​个​扭曲​"
-"的，既​在​情理​之​中，又​在​意料​之外​的​结局？"
+"一本提到满是人类骸骨的密室的书？嗯，我在东方图书馆研习的一些古籍中确实提及了"
+"\"白骨密室\"。那些典籍记载道：当地下世界的领主想要守护重宝时，便会创造一片领"
+"域，让所有试图盗取宝藏而死在其中的人，被永远束缚在那里为其守宝。一个扭曲至"
+"极、却又莫名恰如其分的结局，不是吗？"
 
 #: Source/translation_dummy.cpp:729
 msgid ""
 "I am afraid that I don't know anything about that, good master. Cain has "
 "many books that may be of some help."
-msgstr "我​恐怕​对​此​一无所知，好心​人。凯恩​读​过​很多​书，他​也许​能​提供​帮助。"
+msgstr "我恐怕对此一无所知，好心的旅人。凯恩读过很多书，他也许能提供帮助。"
 
 #: Source/translation_dummy.cpp:730
 msgid ""
 "This sounds like a very dangerous place. If you venture there, please take "
 "great care."
-msgstr "这​听​起来​是​个​非常​危险​的​地方。如果​你​在​那里​冒险，请​小心。"
+msgstr "这地方听起来非常危险。如果你要去那里冒险，请务必多加小心。"
 
 #: Source/translation_dummy.cpp:731
 msgid ""
 "I am afraid that I haven't heard anything about that. Perhaps Cain the "
 "Storyteller could be of some help."
-msgstr "恐怕​我​什么​也​没​听​说​过。说​书人凯恩​也许​能​帮​上​忙。"
+msgstr "恐怕我什么也没听说过。说书人凯恩也许能帮上忙。"
 
 #: Source/translation_dummy.cpp:732
 msgid ""
@@ -8672,7 +8712,7 @@ msgid ""
 "many things, and it would not surprise me if he had some answers to your "
 "question."
 msgstr ""
-"我​对​这​地方​一无所知，不过​你​可以​问问​凯恩。他​知道​很多​事情，知道​你​问题​的​答案​也​不​"
+"我对这地方一无所知，不过你可以问问凯恩。他知道很多事情，知道你问题的答案也不"
 "奇怪。"
 
 #: Source/translation_dummy.cpp:733
@@ -8681,8 +8721,8 @@ msgid ""
 "her - tells the tree... cause you gotta wait. Then I says, that might work "
 "against him, but if you think I'm gonna PAY for this... you... uh... yeah."
 msgstr ""
-"看，有​这样​一​个​木屋。你​知道​他​的​妻子，她​告诉​那​棵​树​…​…​因为​你​必须​等​着。然后​我​说，"
-"这​可能​对​他​不利，但​如果​你​认为​我​会​为​此​付出​代价​…​…​你​…​…​呃​…​…​对。"
+"看，有这样一个木屋。你知道他的妻子，她告诉那棵树……因为你必须等着。然后我说，"
+"这可能对他不利，但如果你认为我会为此付出代价……你……呃……对。"
 
 #: Source/translation_dummy.cpp:734
 msgid ""
@@ -8691,9 +8731,9 @@ msgid ""
 " \n"
 "Enter the Chamber of Bone at your own peril."
 msgstr ""
-"倘​若​你​死​在​这个​被​诅咒​的​结界​里，你​将​成为​黑暗​领主​永恒​的​仆人。\n"
-"\n"
-"​进入​白骨密室​的​风险​由​你​自行​承担。"
+"一旦你在这片被诅咒的领域内殒命，便将成为黑暗领主永恒的奴仆。\n"
+" \n"
+"进入白骨密室，后果自负。"
 
 #: Source/translation_dummy.cpp:735
 msgid ""
@@ -8701,8 +8741,8 @@ msgid ""
 "picking up a few things from you... or better yet, don't you need some rare "
 "and expensive supplies to get you through this ordeal?"
 msgstr ""
-"你​是​说​一​个​巨大​且​神秘​的​宝藏？或许​我​有​兴趣​从​你​那里​拿走​些​东西​…​…​或者​更​好​的。你​难"
-"道​不​需要​些​稀有​且​昂贵​的​物资​来​度过​这​场​折磨​吗？"
+"你是说一个巨大且神秘的宝藏？或许我有兴趣从你那里拿走些东西……或者更好的。你难"
+"道不需要些稀有且昂贵的物资来度过这场折磨吗？"
 
 #: Source/translation_dummy.cpp:736
 msgid ""
@@ -8712,17 +8752,17 @@ msgid ""
 "for what lay within the cold earth... Lazarus abandoned them down there - "
 "left in the clutches of unspeakable horrors - to die."
 msgstr ""
-"大​主教​拉扎鲁斯​似乎​怂恿​过​很多​镇民​冒险​进入​迷宫，去​寻找​国王​失踪​的​儿子。他​以​镇民​"
-"的​恐惧​为乐，鞭打​他们​使​其​成为​疯狂​的​暴徒。没有​人​对​倒​在​冰冷​地面​有所​准备​…​…​拉扎鲁"
-"斯​抛弃​了​他们，使​留​在​难以​言喻​的​恐怖​中，等死。"
+"看来是大主教拉扎鲁斯煽动了许多镇民进入迷宫，去寻找国王失踪的儿子。他利用他们"
+"的恐惧，将他们煽动成一群狂乱的暴民。没有人对冰冷地底等待着他们的一切有所准"
+"备……拉扎鲁斯把他们抛弃在下面，任他们被困在难以言表的恐怖之中，慢慢等死。"
 
 #: Source/translation_dummy.cpp:737
 msgid ""
 "Yes, Farnham has mumbled something about a hulking brute who wielded a "
 "fierce weapon. I believe he called him a butcher."
 msgstr ""
-"是​的，法恩汉​含糊​的​地​说到​一些​关于​一​个​笨重​的​畜生​挥舞​着​恐怖​武器​的​事。我​确定​他​称​"
-"他​为​屠夫。"
+"是的，法恩汉曾经含糊地提到过一个身形庞大的畜生，挥舞着可怕的武器。我敢肯定他"
+"管那东西叫\"屠夫\"。"
 
 #: Source/translation_dummy.cpp:738
 msgid ""
@@ -8733,17 +8773,18 @@ msgid ""
 "festering with disease and even I found them almost impossible to treat. "
 "Beware if you plan to battle this fiend..."
 msgstr ""
-"圣光​在​上，我​知道​这​恶魔​一些​事情。当拉扎鲁斯​带领​少数​幸存者​从​大​教堂​中​逃​出来​时，"
-"很多​人​身​上​都​有​着​恐怖​的​伤口。我​清楚，他​用​什么​玩意儿​在​受害者​身​上​割出​这样​的​伤口​"
-"的，但​绝对​不​是​来自​这​个​世界。它​留下​的​伤口​全​是​溃烂​与​恶疾，即便​是​我​也​毫​无​办法​去​"
-"治疗。如果​你​打算​跟​这​个​恶魔​战斗，当心​…​…"
+"圣光在上，我知道这个邪恶的恶魔。拉扎鲁斯带领的那支队伍中只有寥寥几个幸存者从"
+"大教堂爬回来时，许多人身上都留着它暴行的伤疤。我不知道它是用什么切开受害者"
+"的，但那东西绝非凡间之物。它留下的伤口迅速溃烂、染上恶疾，连我都几乎无从下"
+"手。若你打算与这恶魔交手，千万小心……"
 
 #: Source/translation_dummy.cpp:739
 msgid ""
 "When Farnham said something about a butcher killing people, I immediately "
 "discounted it. But since you brought it up, maybe it is true."
 msgstr ""
-"当​法恩汉​说起​屠夫​杀人​的​事​时，我​根本​不​信​他。然而​你​的​再次​提到，那​也许​是​真的。"
+"法恩汉说起什么屠夫杀人的时候，我一开始压根没信。但既然你也提到了，说不定是真"
+"的。"
 
 #: Source/translation_dummy.cpp:740
 msgid ""
@@ -8754,10 +8795,10 @@ msgid ""
 "I never saw that hideous beast again, but his blood-stained visage haunts me "
 "to this day."
 msgstr ""
-"我​亲眼​看到​法恩汉​所​说​的​“​屠夫​”，我​那些​被​他​杀死​朋友，尸体​铺成​了​路。他​手​中​挥舞​的​"
-"切肉刀​大​的​就​像​一​把​斧子，胆​敢​面对​他​的​勇士​都​被​剁成​了​尸块。在​打斗​中​我​被​另​一​群​尖"
-"啸​的​恶魔​拦​住，还好​我​碰巧​找到​了​逃离​的​楼梯。之后​我​再​也​没​见​过​那​可怕​的​怪物，但​他​"
-"那​血迹​斑斑​的​面容​让​我​至今​心有余悸。"
+"我亲眼看见了法恩汉所说的那个\"屠夫\"，它挥舞着武器穿过我朋友们的尸体。他挥动"
+"着一把大如战斧的屠刀，劈断肢体、砍倒一切挡路的勇士。我在混战中被一群尖啸的小"
+"恶魔冲散，侥幸找到了逃出去的楼梯。从那以后我再也没见过那头可怕的畜生，但它那"
+"血迹斑斑的身影至今仍让我噩梦不断。"
 
 #: Source/translation_dummy.cpp:741
 msgid ""
@@ -8765,8 +8806,8 @@ msgid ""
 "couldn't save them. Trapped in a room with so many bodies... so many "
 "friends... NOOOOOOOOOO!"
 msgstr ""
-"大！大​砍​刀​杀​了​我​所有​的​伙伴。没​法​阻止​他，必须​逃跑，救​不​了​他们。被​关​在​一​间​全​是​"
-"尸体​的​房间​…​…​那么​多​的​朋友​…​…​不，不！"
+"好大！好大的砍刀！把我所有的伙伴都杀了！拦不住，只能逃，救不了他们……被关在那"
+"个房间里，到处都是尸体……那么多朋友……不不不不不！"
 
 #: Source/translation_dummy.cpp:742
 msgid ""
@@ -8774,8 +8815,8 @@ msgid ""
 "others. You have seen his handiwork in the drunkard Farnham. His destruction "
 "will do much to ensure the safety of this village."
 msgstr ""
-"“​屠夫​”​是​个​彻彻底​底​的​虐待​狂，以​别人​的​痛苦​和​折磨​为​乐。你​已经​看到​他​的​杰作，让​法"
-"恩汉​一蹶不振​就此​成​了​醉鬼。消灭​他​能​有效​的​确保​村子​安全。"
+"\"屠夫\"是个以他人痛苦折磨为乐的虐待狂。你已经在那个醉鬼法恩汉身上看到了他的"
+"手笔。除掉他，将能大大保障这个村子的安全。"
 
 #: Source/translation_dummy.cpp:743
 msgid ""
@@ -8786,10 +8827,10 @@ msgid ""
 "I'll put it bluntly - kill him before he kills you and adds your corpse to "
 "his collection."
 msgstr ""
-"关于​那​个​狰狞​的​恶魔，我​知道​的​远比​你​想象​的​多。他​的​小​伙伴​抓到​了​我，在​格里斯沃尔"
-"德​赶来​成功​帮​我​逃出​魔窟​前，成功​的​卸掉​了​我​的​腿。\n"
-"\n"
-"​我​就​直​话​直​说​了，在​他杀​了​你，让​你​的​尸体​成为​他​收藏品​前杀​了​他。"
+"关于那个血腥的恶魔，我知道的比你想象的要多。他的小跟班们抓住了我，在格里斯沃"
+"尔德把我从那洞里拖出来之前，他们已经咬掉了我一条腿。\n"
+" \n"
+"我就直说了吧——在他杀了你、把你的尸体添进他的收藏之前，先杀了他。"
 
 #: Source/translation_dummy.cpp:744
 msgid ""
@@ -8798,9 +8839,9 @@ msgid ""
 "killed by a demon he called the Butcher. Avenge us! Find this Butcher and "
 "slay him so that our souls may finally rest..."
 msgstr ""
-"请​听​我​说。大主教​拉扎鲁斯，是​他​带领​我们​来​这里​寻找​失踪​的​王子。结果​那​混蛋​把​我们​"
-"引入​了​陷阱！现在​所有​人​都​死​了​…​…​被​一​个​叫做​“​屠夫​”​的​恶魔​杀死。为​我们​报仇！找到​这​"
-"个​“​屠夫​”，杀​了​他，让​我们​的​灵魂​最终​得到​安息。"
+"请听我说……大主教拉扎鲁斯，是他领我们来这里找失踪的王子的。那个混蛋把我们骗进"
+"了陷阱！现在所有人都死了……被一个他叫做\"屠夫\"的恶魔杀的……为我们报仇！找到那"
+"个屠夫，杀了他，让我们的灵魂终于能够安息……"
 
 #: Source/translation_dummy.cpp:745
 msgid ""
@@ -8812,10 +8853,11 @@ msgid ""
 "sightless for all eternity. The prison for those so damned is named the "
 "Halls of the Blind..."
 msgstr ""
-"你​朗诵​了​一​首​有趣​的​诗句，它​的​风格​让​我​想起​了​另​一​个​作品。让​我​好好​想想。\n"
+"你念出了一段有趣的韵文，其风格让我想起其他一些作品。让我想想——那是什么来"
+"着？\n"
 " \n"
-"​…​黑暗​遮蔽​的​隐秘。那些​可怜​的​灵魂​双目​发光​但​却​无法​看见，只有​被​利爪急促​的​挂磨声​永"
-"远​的​折磨。一​座​为​被​诅咒​的​人​所​建立​的​监狱，盲目​之​厅​…​…"
+"……黑暗笼罩隐秘之物。双眼在无形的幽暗中熠熠发光，只有利爪刮擦的声响短暂响起，"
+"折磨着那些永世失明的可怜灵魂。那座囚禁受诅之人的牢狱，名为目盲之厅……"
 
 #: Source/translation_dummy.cpp:746
 msgid ""
@@ -8824,10 +8866,10 @@ msgid ""
 " \n"
 "What? Oh, yes... uh, well, I suppose you could see what someone else knows."
 msgstr ""
-"我​从来​就​不​喜欢​诗词。偶尔，旅店​生意​好​的​时候，我​会​雇上​吟游​诗人。但​那​似乎​是​很​久​"
-"以前​的​事情​了。\n"
+"我从来就不喜欢诗词。偶尔，旅店生意好的时候，我会雇上吟游诗人。但那似乎是很久"
+"以前的事情了。\n"
 "\n"
-"​什么？啊，好​吧​…​…​呃，我​认为​你​可以​问问​别人​知道​什么。"
+"什么？啊，好吧……呃，我认为你可以问问别人知道什么。"
 
 #: Source/translation_dummy.cpp:747
 msgid ""
@@ -8835,8 +8877,8 @@ msgid ""
 "much like that poem while researching the history of demonic afflictions. It "
 "spoke of a place of great evil that... wait - you're not going there are you?"
 msgstr ""
-"不​知​为何，这​听​起来​挺​熟悉​的。我​似乎​回想​起​以前​研究​恶魔​痛楚​历史​时​读到​类似​的​诗"
-"句，它​讲述​了​一​个​非常​邪恶​的​地方​…​…​等​下，你​是​不​会​去​那儿​的​对​吧？"
+"这确实有些眼熟。我似乎记得在研究恶魔病痛史的时候，读到过与这首诗极为相似的文"
+"字。它描述的是一处大凶之地……等等——你不是打算去那里吧？"
 
 #: Source/translation_dummy.cpp:748
 msgid ""
@@ -8844,8 +8886,8 @@ msgid ""
 "he gave my grandmother a potion that helped clear her vision, so maybe he "
 "can help you, too."
 msgstr ""
-"如果​你​对​失明​有​疑问，你​应该​和​佩金谈谈。我​只​知道​它​给​了​我​祖母​一​瓶​药水，使得​她​能​"
-"清晰​的​看到​东西，或许​他​也​能​帮助​你。"
+"如果你对致盲有什么疑问，最好找佩金谈谈。我就知道他给过我祖母一瓶药水，让她眼"
+"前清晰了不少。兴许他也能帮到你。"
 
 #: Source/translation_dummy.cpp:749
 msgid ""
@@ -8853,12 +8895,12 @@ msgid ""
 "vivid description, my friend. Perhaps Cain the Storyteller could be of some "
 "help."
 msgstr ""
-"我​恐怕​从来​没​听​过​和​见​过​一​个​地方​与​你​生动​的​描述​相符，朋友。也许​说​书人凯恩能​提供​"
-"些​帮助。"
+"我恐怕从未听说、也未曾见过一个地方与你的描述相符，我的朋友。也许说书人凯恩能"
+"帮得上忙。"
 
 #: Source/translation_dummy.cpp:750
 msgid "Look here... that's pretty funny, huh? Get it? Blind - look here?"
-msgstr "看​这里​…​…​好玩​吧？明白？瞎子，看​这？"
+msgstr "看这儿……挺好笑的对吧？明白了吗？瞎了——看这儿？"
 
 #: Source/translation_dummy.cpp:751
 msgid ""
@@ -8868,9 +8910,9 @@ msgid ""
 "Tread carefully or you may yourself be staying much longer than you had "
 "anticipated."
 msgstr ""
-"这​是​一​个​极度​折磨​和​恐惧​的​地方，为​它​的​主人​很​好​的​服务。\n"
-"\n"
-"​小心点，不然​你​将​被困​在​那儿，时间​超乎​你​的​想象。"
+"这是个充满极度痛苦与恐惧的地方，正合它主人的心意。\n"
+" \n"
+"小心前行，否则你停留的时间，或许会比预想的长得多。"
 
 #: Source/translation_dummy.cpp:752
 msgid ""
@@ -8878,8 +8920,8 @@ msgid ""
 "you about this? No. Are you now leaving and going to talk to the storyteller "
 "who lives for this kind of thing? Yes."
 msgstr ""
-"我​想想，我​卖给​你​东西​了？没有。你​给​钱​让​我​告诉​你​这​事情​了​吗？没有。你​该​离开​去​找​"
-"那​个​活​着​就​是​为了​跟​你​说话​的​说书人​了​吗？是​的。"
+"我想想：我有东西要卖你吗？没有。你给我钱让我讲这事了吗？没有。你是不是该走"
+"了，去找那位专门研究这种事情的说书人？是的。"
 
 #: Source/translation_dummy.cpp:753
 msgid ""
@@ -8892,18 +8934,20 @@ msgid ""
 "suppose that your story could be true. If I were in your place, my friend, I "
 "would find a way to release him from his torture."
 msgstr ""
-"你​声称​和​拉齐达​南​谈​过？他​一生​是​个​伟大​的​英雄。拉齐​达​南​是​一​个​光荣​而​公正​的​人，多​"
-"年​来​一直​忠实​地​为​国王​服务。当然，你​已经​知道​了。\n"
+"你说你和拉齐达南谈过话？他生前是一位伟大的英雄。拉齐达南是一个光荣而正直的"
+"人，多年来一直忠诚地侍奉国王。不过你早就知道这些了。\n"
 " \n"
-"​在​那些​被​国王​诅咒​的​人​中，拉齐​达南​最​不​可能​不​战​而​屈身​于​黑暗，所以​我​想​你​的​故事​可"
-"能​是​真的。如果​我​在​你​的​位置，我​的​朋友，我​会​想​办法​把​他​从​折磨​中​释放​出来。"
+"在那些被国王诅咒缠身的人中，拉齐达南是最不会不战而降、屈服于黑暗的一个。所以"
+"我觉得你说的很可能是真的。如果我是你，我的朋友，我一定会想办法让他从折磨中解"
+"脱出来。"
 
 #: Source/translation_dummy.cpp:754
 msgid ""
 "You speak of a brave warrior long dead! I'll have no such talk of speaking "
 "with departed souls in my inn yard, thank you very much."
 msgstr ""
-"你​说​的​是​一​个​死​了​很​久​的​勇士！我​不​想​在​客栈​院子​里​和​死去​的​灵魂​说话，非常​感谢。"
+"你说的是一个早已死去的勇士！我不想在我的客栈院子里谈论什么与亡灵交谈的事情，"
+"多谢你了。"
 
 #: Source/translation_dummy.cpp:755
 msgid ""
@@ -8912,15 +8956,15 @@ msgid ""
 "drink it. As your healer, I strongly advise that should you find such an "
 "elixir, do as Lachdanan asks and DO NOT try to use it."
 msgstr ""
-"你​是​说​一​种​金色​的​药剂。我​从​未​调制​过​那​种​颜色​的​药水，所以​我​没​办法​告诉​你​如果​你​喝​"
-"了​它​会​怎样。作为​一​个​治疗者，我​强烈​建议​你​去​寻找​那​种​药剂，照着​拉齐达南​要求​的​"
-"做，但​你​绝对​不​要​喝​了​它。"
+"金色的灵药，你是说。我从没调制过那种颜色的药水，所以没法告诉你喝下去会有什么"
+"效果。作为你的医者，我郑重告诫你：如果你真的找到了那样的灵药，就照拉齐达南说"
+"的去做，千万——千万不要自己喝掉。"
 
 #: Source/translation_dummy.cpp:756
 msgid ""
 "I've never heard of a Lachdanan before. I'm sorry, but I don't think that I "
 "can be of much help to you."
-msgstr "我​从来​没​听​说​过​拉齐达南，抱歉​我​帮​不​了​你。"
+msgstr "我从来没听说过拉齐达南，抱歉我帮不了你。"
 
 #: Source/translation_dummy.cpp:757
 msgid ""
@@ -8929,14 +8973,14 @@ msgid ""
 "and loyal in nature. The curse that fell upon the followers of King Leoric "
 "would fall especially hard upon him."
 msgstr ""
-"如果​你​真的​遇到​了​拉齐达南，我​希望​你​帮​帮​他。我​和​他​打​过​几​次​交道，发现​他​生性​诚实​"
-"且​富有​荣誉感。李奥瑞克​国王​的​追随者​遭受​的​诅咒，在​他​身​上​会​更加​糟糕。"
+"如果你真的遇到了拉齐达南，我建议你帮帮他。我和他打过几次交道，发现他生性诚实"
+"且忠诚。而李奥瑞克国王的诅咒，对他来说会是格外沉重。"
 
 #: Source/translation_dummy.cpp:758
 msgid ""
 " Lachdanan is dead. Everybody knows that, and you can't fool me into "
 "thinking any other way. You can't talk to the dead. I know!"
-msgstr "拉齐达南​已经​死​了。所有​人​都​知道，你​没​法骗​我。你​不​能​和​死人​说话。我​知道！"
+msgstr "拉齐达南已经死了。所有人都知道，你没法骗我。你不能和死人说话。我知道！"
 
 #: Source/translation_dummy.cpp:759
 msgid ""
@@ -8945,9 +8989,9 @@ msgid ""
 " \n"
 "I sense in him honor and great guilt. Aid him, and you aid all of Tristram."
 msgstr ""
-"你​也许​能​遇到​被困​在​迷宫​里​的​人，拉齐​达南​只​是​其中​之一。\n"
+"你也许能遇到被困在迷宫里的人，拉齐达南只是其中之一。\n"
 "\n"
-"​我​从​他​身​上​感受​到​荣誉​和​巨大​的​内疚。帮助​他​就​是​帮助​崔斯特姆。"
+"我从他身上感受到荣誉和巨大的内疚。帮助他就是帮助崔斯特姆。"
 
 #: Source/translation_dummy.cpp:760
 msgid ""
@@ -8956,9 +9000,9 @@ msgid ""
 "questions anymore. Oh, that isn't what happened? Then I guess you'll be "
 "buying something or you'll be on your way."
 msgstr ""
-"等等，让​我​猜猜。一​条​巨大​裂缝​出现​在​凯恩脚​下​将​他​吞噬，地狱烈​焰​把​他​烧​得​个​精光，"
-"以至于​没​法​回答​你​问题​了。哦，不​是​那样么？那​我​就​只​能​认为​你​是​想​买​点​东西​或是​该​上"
-"路​了。"
+"等等，让我猜猜。一条巨大裂缝出现在凯恩脚下将他吞噬，地狱烈焰把他烧得个精光，"
+"以至于没法回答你问题了。哦，不是那样么？那我就只能认为你是想买点东西或是该上"
+"路了。"
 
 #: Source/translation_dummy.cpp:761
 msgid ""
@@ -8974,20 +9018,20 @@ msgid ""
 "it the last of my humanity as well. Please aid me and find the Elixir. I "
 "will repay your efforts - I swear upon my honor."
 msgstr ""
-"手​下​留情，别​杀​我，请​听​我​把​话​说完。我​曾经​是​李奥瑞克​国王​的​骑士​队长，以​正义​和​荣"
-"誉​捍卫​着​这​王国​的​律法。后来​他​的​黑暗​诅咒​降临​在​我们​身​上，只​因​我们​在​他​的​悲剧​死亡​"
-"中​扮演​的​角色。当​我​的​其他​骑士​同伴​屈服​于​他们​扭曲​命运​的​时，我​逃出​了​国王​的​墓室，"
-"寻找​某​种​能​解除​我​身​上​诅咒​的​方法。我​…​…​失败​了​…​…​\n"
-"\n"
-"​我​听说​有​一​种​“​金色​药剂​”​可以​解除​诅咒，让​我​的​灵魂​安息，可惜​我​无法​找到​它。我​的​意"
-"志​逐渐​衰弱，我​也​会​因此​最终​失去​人性。请​帮​帮​我，找到​药剂。我​以​荣耀​发誓​一定​会​报"
-"答​你​的​帮助。"
+"请住手，别杀我，听我说完。我曾是李奥瑞克国王的骑士队长，以正义与荣耀捍卫这片"
+"土地的律法。后来，由于我们在国王悲惨之死中扮演的角色，他黑暗的诅咒降临到了我"
+"们身上。当我的骑士同伴们纷纷沦陷于他们扭曲的命运时，我从国王的墓室中逃了出"
+"来，寻找某种能让我摆脱诅咒的方法。但我失败了……\n"
+" \n"
+"我听说有一种金色灵药可以解除诅咒，让我的灵魂得以安息，但我一直未能找到。我的"
+"力量正在消退，随之消逝的还有我最后的人性。请帮帮我，找到灵药。我以我的荣誉起"
+"誓，一定会报答你的努力。"
 
 #: Source/translation_dummy.cpp:762
 msgid ""
 "You have not found the Golden Elixir. I fear that I am doomed for eternity. "
 "Please, keep trying..."
-msgstr "如果​你​还​没​找到​“​金色​药剂​”，我​就​将​承受​永恒​的​诅咒​了。求​你，继续​寻找​吧​…​…"
+msgstr "你还没有找到金色灵药吗？我恐怕要永世不得解脱了。求求你，继续寻找吧……"
 
 #: Source/translation_dummy.cpp:763
 msgid ""
@@ -8997,9 +9041,9 @@ msgid ""
 "have little use for it. May it protect you against the dark powers below. Go "
 "with the Light, my friend..."
 msgstr ""
-"你​把​我​的​灵魂​从​诅咒​中​拯救​出来，为​此​我​欠​你​一​个​人情。如果​有​办法​让​死后​的​我​报​答​"
-"你，我​一定​会​去​做，但​现在​能​做​的​——​拿走​我​的​头盔​吧。我​今后​的​旅途​里，用​不​到​它​了。"
-"愿​它​能​保护​你​免​受​地底​黑暗​力量​的​侵扰。圣光伴​你​同行，我​的​朋友​…​…"
+"你将我的灵魂从永世的诅咒中拯救了出来，为此我欠你一份恩情。若来世有办法报答"
+"你，我定会寻找机会。但现在，请收下我的头盔吧——我即将踏上的旅途，已经不再需要"
+"它了。愿它护你免受地下黑暗势力的侵害。愿圣光与你同在，我的朋友……"
 
 #: Source/translation_dummy.cpp:764
 msgid ""
@@ -9012,17 +9056,16 @@ msgid ""
 "unpredictable nature of Chaos makes it difficult to know what the outcome of "
 "this smithing will be..."
 msgstr ""
-"格里斯沃尔德​谈到​了​“​愤怒铁砧​”​——​一​件​传说​中​的​神器，人们​一直​在​寻找，但​一直​没有​找"
-"到。愤怒​铁砧​是​用​剃刀​坑​恶魔​的​金属​骨头​制作​而​成​的，熔铸​在​五​个​最​强大​的​冥界​法师​的​"
-"头骨​周围。刻有​力量​和​混乱​符文，任何​在​这个​铁砧​上​锻造​的​武器​或​护甲​都​将​被​浸入​混乱​"
-"的​领域，并​将​其​嵌​入​魔法​属性。据说，混沌​的​不​可​预测性​使​人们​很​难​知道​这​场​锻造​会​有​"
-"什么​结果……"
+"格里斯沃尔德提到了\"怒火铁砧\"——一件传说中的神器，无数人苦苦寻觅却从未得见。"
+"怒火铁砧以剃刀深渊恶魔的金属骸骨铸成，熔铸在五位最强大的冥界魔导士颅骨之上。"
+"其上刻满了力量与混沌的符文，在此铁砧上锻造的任何武器或防具，都将被浸入混沌领"
+"域，获得魔法属性。但据说，混沌的不可预测性使得锻造的结果难以预料……"
 
 #: Source/translation_dummy.cpp:765
 msgid ""
 "Don't you think that Griswold would be a better person to ask about this? "
 "He's quite handy, you know."
-msgstr "你​不​觉得​格里斯沃尔德会​是​一​个​更​好​的​人问​这​个​问题​吗？你​知道，他​很​能干。"
+msgstr "你不觉得这事儿问格里斯沃尔德更合适吗？他这方面可是个行家，你知道的。"
 
 #: Source/translation_dummy.cpp:766
 msgid ""
@@ -9031,8 +9074,8 @@ msgid ""
 "However, in this matter, you would be better served to speak to either "
 "Griswold or Cain."
 msgstr ""
-"如果​你​一直​在​寻找​治疗​杵​或​净化​银圣杯​的​信息，我​可以​帮助​你，我​的​朋友。不过，在​这​"
-"件​事​上，你​最好​和​格里斯沃尔德​或​凯恩​谈​谈。"
+"如果你问的是治愈之杵或净化银杯的消息，我倒能帮上忙，我的朋友。但在这件事上，"
+"你最好去找格里斯沃尔德或凯恩谈谈。"
 
 #: Source/translation_dummy.cpp:767
 msgid ""
@@ -9041,9 +9084,9 @@ msgid ""
 "was struck upon this anvil, the ground would shake with a great fury. "
 "Whenever the earth moves, I always remember that story."
 msgstr ""
-"格里斯沃尔德​的​父亲​曾经​告诉​我们​中​的​一些​人，当​我们​成长​的​时候，一​个​巨大​的​铁砧​是​"
-"用来​制造​强大​的​武器。他​说，当​一​把​锤子​敲​在​这个​铁砧​上​时，地面​会​剧烈​地震动。每​当​"
-"地球​移动​时，我​总是​记得​那​个​故事。"
+"格里斯沃尔德的父亲在我们小时候常给我们讲一个故事，说有一座巨大的铁砧，专门用"
+"来锻造威力无穷的兵器。他说每当铁锤敲在这座铁砧上，大地就会愤怒地震颤。每次地"
+"面震动的时候，我都会想起那个故事。"
 
 #: Source/translation_dummy.cpp:768
 msgid ""
@@ -9064,17 +9107,17 @@ msgid ""
 " \n"
 "Find the Anvil for me, and I'll get to work!"
 msgstr ""
-"你好！很​高兴​见到​我​最​好​的​客户​之一！我​知道​你​一直​在​冒险​深入​迷宫，有​一​个​故事​告诉​"
-"我，你​可能​觉得​值得​花​时间​听……\n"
+"你好啊！能见到我最尊贵的顾客之一，总是件愉快的事！我知道你一直在向迷宫更深处"
+"探索，而我曾听过一个故事，你或许愿意花点时间听听……\n"
 " \n"
-"​一​个​从​迷宫​里​回来​的​人​告诉​我​他​逃跑​时​遇到​的​一​个​神秘​的​铁砧。他​的​描述​让​我​想起​了​我​"
-"年轻​时​听到​的​关于​燃烧​的​地狱炉​的​传说，那里​有​强大​的​魔法​武器。传说​在​地狱​熔炉​的​深"
-"处​安放​着​“​愤怒铁砧​”！这个​铁砧​里面​包含​着​恶魔​世界​的​精髓……\n"
+"从迷宫归来的人中，有一位向我提起过他在逃命途中偶遇的一尊神秘铁砧。他的描述让"
+"我想起年轻时听过的传说——在那燃烧的地狱熔炉中，强大的魔法武器被锻造而出。传说"
+"里说，地狱熔炉的深处沉睡着怒火铁砧！这尊铁砧蕴含着恶魔地下世界的本源之力……\n"
 " \n"
-"​据说​任何​在​燃烧​的​铁砧​上​制作​的​武器​都​充满​了​巨大​的​力量。如果​这​铁砧​真的​就​是​“​愤怒铁"
-"砧​”，我​也许​能​让​你​成为​一​件​武器，甚至​可以​打败​最​黑暗​的​地狱​之​主！\n"
+"据传说，凡是在那燃烧的铁砧上锻造的武器，都会被赋予强大的力量。若这尊铁砧当真"
+"就是怒火铁砧，我或许能为你打造一件足以击败甚至连地狱最黑暗之主的武器！\n"
 " \n"
-"帮​我​找​铁砧，我​就​去​干活！"
+"替我把铁砧找来，我这就开工！"
 
 #: Source/translation_dummy.cpp:769
 msgid ""
@@ -9082,8 +9125,8 @@ msgid ""
 "be your best hope, and I am sure that I can make you one of legendary "
 "proportions."
 msgstr ""
-"还​没有，嗯？好​吧，继续​找。铁砧​上​锻造​的​武器​可能​是​你​最​大​的​希望，我​相信​我​能​让​你​"
-"成为​传奇​般​的​人物​之一。"
+"还没找到？嗯，继续找吧。在铁砧上锻造的武器也许是你最大的王牌，我一定能为你打"
+"造一把传说中的兵器。"
 
 #: Source/translation_dummy.cpp:770
 msgid ""
@@ -9091,15 +9134,15 @@ msgid ""
 "Now we'll show those bastards that there are no weapons in Hell more deadly "
 "than those made by men! Take this and may Light protect you."
 msgstr ""
-"我​简直​不​敢​相信！这​是​“​愤怒铁砧​”。干​得​好，我​的​朋友。现在​我们​要​告诉​那些​混蛋，地"
-"狱​里​没有​比​人类​制造​的​武器​更​致命​的​武器​了！拿​着​这个，愿光​护佑​你​。"
+"难以置信！这真的是怒火铁砧——干得漂亮，我的朋友！现在，让那群杂种见识一下，地"
+"狱里最致命的武器，是出自凡人之手！收下这个，愿圣光护佑你。"
 
 #: Source/translation_dummy.cpp:771
 msgid ""
 "Griswold can't sell his anvil. What will he do then? And I'd be angry too if "
 "someone took my anvil!"
 msgstr ""
-"格里斯沃尔德​卖​不​出​他​的​铁砧。那​他​会​怎么​做？如果​有​人​拿​了​我​的​铁砧​我​也​会​生气​的！"
+"格里斯沃尔德不能卖铁砧了吗？那他怎么办？要是谁偷了我的铁砧，我也非气炸不可！"
 
 #: Source/translation_dummy.cpp:772
 msgid ""
@@ -9108,16 +9151,16 @@ msgid ""
 "used by either the Light or the Darkness. Securing the Anvil from below "
 "could shift the course of the Sin War towards the Light."
 msgstr ""
-"迷宫​里​有​许多​神器，拥有​着​凡​人​无法​理解​的​力量。其中​一些​拥有​神奇​的​力量，可以​被​光"
-"明​或​黑暗​所​利用。从​下面​固定​铁砧​可以​将​原罪之战​的​进程​转向​光明。"
+"迷宫之中有许多神器蕴含着凡人难以理解的力量。其中一些蕴藏的威力既可为光明所"
+"用，亦可为黑暗驱使。将铁砧从地底取出，或许能使原罪之战的战局向光明倾斜。"
 
 #: Source/translation_dummy.cpp:773
 msgid ""
 "If you were to find this artifact for Griswold, it could put a serious "
 "damper on my business here. Awwww, you'll never find it."
 msgstr ""
-"如果​你​为​格里斯沃尔德​找到​这​件​艺术品，它​会​严重​影响​我​在​这里​的​生意。啊，你​永远​找​"
-"不​到​它。"
+"你要是帮格里斯沃尔德找到那玩意儿，我这里的生意可就要遭重了。切，反正你也找不"
+"着的。"
 
 #: Source/translation_dummy.cpp:774
 msgid ""
@@ -9139,18 +9182,17 @@ msgid ""
 "said that when this holy armor is again needed, a hero will arise to don "
 "Valor once more. Perhaps you are that hero..."
 msgstr ""
-"鲜血​之​门​与​火焰​大厅​都​是​神秘​起源​的​地标。在​你​读到​这​本​书​的​地方，一定​充盈​着​强大​力"
-"量。\n"
-"\n"
-"​传说​有​一​个​用​黑曜​石​雕刻​的​底座，装满​了​漂浮​着​骨屑​的​沸腾​鲜血。传说​还​提到​了​鲜血"
-"石，它​能​开起​一​道​守护​远古​财宝​的​大门​…​…​\n"
-"\n"
-"​这​件​宝物​的​本质​到底​是​什么​众说纷纭，疑团​重重，我​的​朋友。但​据说​古代​的​英雄​阿凯尼​"
-"把​它​的​圣甲​“​荣耀​”​放置​在​一​个​秘密​的​地方。他​是​第一​个​扭转​原罪之战​的​浪潮，将​黑暗​军"
-"团​赶回​烈​焰​地狱​的​凡​人。\n"
-"\n"
-"阿凯尼​临死​前，他​的​铠甲​就​被​秘密​地​藏进​了​一​处​密室​中。相传​等到​这​副圣甲​需要​再​一​次​"
-"现世​时，一​位​英雄​将​会​挺身而出，并且​再度​荣耀​加身。也许​你​就​是​那​个​英雄​…​…"
+"鲜血之门与烈焰之厅，是神秘起源的圣迹。无论你手中这本书来自何处，那必是一处蕴"
+"藏着强大力量的所在。\n"
+" \n"
+"传说中有座由黑曜石雕成的基座，其覆满白骨的表面的顶端，有一池沸腾的鲜血。亦有"
+"提及，血之石能开启一扇守卫着远古宝藏的门……\n"
+" \n"
+"我的朋友，这宝藏的本质众说纷纭，但传说中，远古英雄阿凯尼将圣甲\"荣耀\"藏在一"
+"间秘库之中。阿凯尼是第一个扭转原罪之战战局、将黑暗军团逐回烈焰地狱的凡人。\n"
+" \n"
+"据说，在阿凯尼临终之际，他的铠甲被藏进了一间秘密宝库。传说称，当这副圣甲再次"
+"被需要之时，将有一位英雄崛起，再度披上\"荣耀\"。也许，你就是那位英雄……"
 
 #: Source/translation_dummy.cpp:775
 msgid ""
@@ -9158,8 +9200,8 @@ msgid ""
 "known as Valor. If you could find its resting place, you would be well "
 "protected against the evil in the Labyrinth."
 msgstr ""
-"每​个​孩子​听​过​战士​阿凯尼​和​他​被​称作​“​荣耀​”​的​传奇​盔甲​的​故事。如果​你​能​找到​它​沉睡​的​"
-"地方，你​就​能​更​好​的​保护​自己​对抗​迷宫​里​的​邪恶。"
+"每个孩子都听过战士阿凯尼和他那件名为\"荣耀\"的传奇铠甲的故事。如果你能找到它"
+"的沉睡之地，就能更好地保护自己，对抗迷宫中的邪恶。"
 
 #: Source/translation_dummy.cpp:776
 msgid ""
@@ -9167,14 +9209,15 @@ msgid ""
 "learning new cures and creating better elixirs that I must have forgotten. "
 "Sorry..."
 msgstr ""
-"嗯​…​…​这​听​起来​根本​就​记​不​住，因为​我​一直​忙于​学习​新​的​治疗​方法​和​制作​更​好​的​药剂，我​"
-"必须​忘掉​这些​事，抱歉​…​…"
+"嗯……听起来我本该记得的，但我一直忙着学习新的治疗方法、调配更好的药剂，结果就"
+"忘了。抱歉……"
 
 #: Source/translation_dummy.cpp:777
 msgid ""
 "The story of the magic armor called Valor is something I often heard the "
 "boys talk about. You had better ask one of the men in the village."
-msgstr "我​经常​听到​男孩们​讨论​关于​魔法​铠甲​“​荣耀​”​的​故事。你​最好​问问​村​里​的​男人们。"
+msgstr ""
+"我经常听到男孩们讨论关于魔法铠甲\"荣耀\"的故事。你最好问问村里的男人们。"
 
 #: Source/translation_dummy.cpp:778
 msgid ""
@@ -9183,9 +9226,9 @@ msgid ""
 "well, my friend, and it will take more than a bit of luck to unlock the "
 "secrets that have kept it concealed oh, lo these many years."
 msgstr ""
-"被​称作​“​荣耀​”​的​盔甲，也许​将​让​天平​向​你​倾斜。我​想​说​的​是，包括​我​在内​的​许多​人​曾经​"
-"都​尝试​寻找​它。阿凯尼​把​它​藏得​很​好，我​的​朋友，得​需要​点​运气​去​揭开​隐藏​它​的​秘密，"
-"哎，尽管​这么​多​年​过去​了。"
+"那件名为\"荣耀\"的铠甲，或许能为你扭转乾坤。说实话，包括我在内的许多人都曾寻"
+"找过它。阿凯尼藏得太好了，我的朋友。要揭开这么多年来守护它的秘密，光靠运气可"
+"不够。"
 
 #: Source/translation_dummy.cpp:779
 msgid "Zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz..."
@@ -9198,9 +9241,9 @@ msgid ""
 "The way is fraught with danger and your only hope rests within your self "
 "trust."
 msgstr ""
-"一旦​你​发现​了​鲜血石，请​小心​谨慎​的​使用​它。\n"
+"一旦你找到了鲜血石，务必小心使用。\n"
 "\n"
-"​道路​充满​了​危险，你​唯一​的​希望​源自于​你​的​自信。"
+"前路凶险，你唯一的希望在于相信自己的判断。"
 
 #: Source/translation_dummy.cpp:781
 msgid ""
@@ -9209,10 +9252,10 @@ msgid ""
 "No one has ever figured out where Arkaine stashed the stuff, and if my "
 "contacts couldn't find it, I seriously doubt you ever will either."
 msgstr ""
-"你​想要​找到​那件​被​称作​“​荣耀​”​的​盔甲？\n"
-"\n"
-"​没​人​知道​阿凯尼​把​东​西藏​在​哪里，如果​我​联系​的​人​都​找​不​到，我​很​怀疑​你​怎么​可能​会​找"
-"到。"
+"你打算去找那副名为“荣耀”的铠甲？\n"
+" \n"
+"从没有人弄清阿凯尼把那东西藏到了哪里，连我的人脉都找不到，我实在很怀疑你能否"
+"找得到。"
 
 #: Source/translation_dummy.cpp:782
 msgid ""
@@ -9228,14 +9271,15 @@ msgid ""
 "Legion of Darkness during the Sin War, he lost his humanity to his "
 "insatiable hunger for blood."
 msgstr ""
-"据​我​所​知，只有​一​种​传说​提到​过​你​描述​的​那​个​战士。他​的​故事​记录​在​在​古老​的​《​原罪​之​"
-"战编年史​》​中​…​…​\n"
-"\n"
-"​持续​千​年​的​战争，鲜血​与​死亡，鲜血​战神​的​受害者​残肢​断臂​堆积如山。他​的​黑暗​之​刃​向​"
-"生者​尖啸，散发​黑色​的​诅咒​；​任何​挡​在​地狱​刽子​手​面前​的​人​都​将​受到​酷刑​的​邀请。\n"
+"我只知道一则传说，讲述的正是你所描述的那样一位战士。他的故事记载于原罪之战的"
+"古老编年史中……\n"
 " \n"
-"书​中​还​写到，尽管​他​只​是​一​个​在​原罪​之​战​中​与​黑暗​军团​并肩​作战​凡​人，但​嗜​血​的​欲望​使"
-"得​他​失去​了​人性。"
+"被千年战争、鲜血与死亡所浸染，鲜血督军傲立于由他破碎的受害者堆成的尸山之上。"
+"他黑暗的利刃向生者嘶吼着黑色的诅咒；那是一种折磨的邀约，献给所有敢于直面这位"
+"地狱行刑者的人。\n"
+" \n"
+"书中亦记载，尽管他曾是与黑暗军团并肩作战的凡人，却在原罪之战中因对鲜血的贪婪"
+"而丧失了人性。"
 
 #: Source/translation_dummy.cpp:783
 msgid ""
@@ -9243,28 +9287,28 @@ msgid ""
 "master. I hope that you do not have to fight him, for he sounds extremely "
 "dangerous."
 msgstr ""
-"如此​歹毒​的​战士​我​从​未​听说，好心​人。我​希望​你​不​用​跟​他​战斗，他​听​上去​是​极其​的​危"
+"如此歹毒的战士我从未听说，好心的旅人。我希望你不用跟他战斗，他听上去是极其危"
 "险。"
 
 #: Source/translation_dummy.cpp:784
 msgid ""
 "Cain would be able to tell you much more about something like this than I "
 "would ever wish to know."
-msgstr "凯恩​能​告诉​你​更​多​有关​的​事情，这些​事​真​是​我​从来​愿意​知道​的。"
+msgstr "这种事情凯恩能告诉你的，比我愿意知道的还要多得多。"
 
 #: Source/translation_dummy.cpp:785
 msgid ""
 "If you are to battle such a fierce opponent, may Light be your guide and "
 "your defender. I will keep you in my thoughts."
-msgstr "如果​你​要​与​如此​凶猛​的​对手​战斗，那​愿​圣光​指引​和​保佑​你。我​会​一直​惦记​着​你。"
+msgstr "如果你要与如此凶猛的对手战斗，那愿圣光指引和保佑你。我会一直惦记着你。"
 
 #: Source/translation_dummy.cpp:786
 msgid ""
 "Dark and wicked legends surrounds the one Warlord of Blood. Be well "
 "prepared, my friend, for he shows no mercy or quarter."
 msgstr ""
-"“​鲜血​战神​”​被​黑暗​邪恶​的​传说​笼罩。做好​准备​我​的​朋友，因为​他​既​不​仁慈，也​不​讲​情"
-"面。"
+"\"鲜血督军\"周身笼罩着黑暗与邪恶的传说。做好万全准备，我的朋友——他既不仁慈，"
+"也绝不手软。"
 
 #: Source/translation_dummy.cpp:787
 msgid ""
@@ -9272,8 +9316,8 @@ msgid ""
 "that pretty girl that brings the drinks. Listen here, friend - you're "
 "obsessive, you know that?"
 msgstr ""
-"你​总是​不​停​的​提到​血么？不如说​点​鲜花、阳光​和​送​饮料​的​漂亮​女孩。听​着，朋友，你​真​"
-"是​执迷不悟，你​知道么？"
+"你怎么老说血啊血的？就不能聊聊花啊、太阳啊、还有那个端酒的美女。听着，伙计，"
+"你这叫走火入魔，知道不？"
 
 #: Source/translation_dummy.cpp:788
 msgid ""
@@ -9281,22 +9325,22 @@ msgid ""
 "years knowing only warfare. I am sorry... I can not see if you will defeat "
 "him."
 msgstr ""
-"他​的​剑术​令​人​惊叹，千​年​的​岁月​对​他​而​言​只​有​战斗。我​很​抱歉​…​…​我​也​不​好​判断​你​能​不​否​"
-"打败​他。"
+"他的剑术令人胆寒，千年时光对他而言只剩下一件事——战斗。我很抱歉……我看不清你能"
+"否战胜他。"
 
 #: Source/translation_dummy.cpp:789
 msgid ""
 "I haven't ever dealt with this Warlord you speak of, but he sounds like he's "
 "going through a lot of swords. Wouldn't mind supplying his armies..."
 msgstr ""
-"我​从​没​跟​那​个​什么​战神​进行​过​买卖，但是​我​听说​他​用​坏​过​很多​剑。你​不​介意​我​卖点​武器​"
-"装备​给​他​吧​…​…"
+"我没跟那个什么督军打过交道，不过我听说他砍坏的剑可不少。我倒不介意给他的军队"
+"供点货……"
 
 #: Source/translation_dummy.cpp:790
 msgid ""
 "My blade sings for your blood, mortal, and by my dark masters it shall not "
 "be denied."
-msgstr "我​的​刀刃​正在​为​你​的​血​歌唱，凡​人。我​的​黑暗​主人​也​会​很​高兴​听到​这​歌声。"
+msgstr "我的剑刃正渴望你的鲜血，凡人。以我黑暗主人的名义，它必将如愿！"
 
 #: Source/translation_dummy.cpp:791
 msgid ""
@@ -9306,9 +9350,9 @@ msgid ""
 "man could possess. I do not know what secrets it holds, my friend, but "
 "finding this stone would certainly prove most valuable."
 msgstr ""
-"格里斯沃尔德​谈到​了​天石，它​是​注定​要​飞​地位​于​东部。它​被​带到​那里​作​进一步​研究。这​"
-"块​石头​闪耀​着​一​种​能量，它​以​某​种​方式​赋予​了​一​个​普通​人​无法​拥有​的​视觉。我​不​知道​它​"
-"有​什么​秘密，我​的​朋友，但​找到​这​块​石头​肯定​是​最​有​价值​的。"
+"格里斯沃尔德提到了天石——据说原本要送往东方的某处隐秘之地进行更深入的研究。那"
+"块石头散发着某种能量，能赋予人超越常人的视觉。我不知道它藏有什么秘密，我的朋"
+"友，但若能找到它，必定价值非凡。"
 
 #: Source/translation_dummy.cpp:792
 msgid ""
@@ -9317,8 +9361,8 @@ msgid ""
 "sweetbreads that Garda has just finished baking. Shame what happened to "
 "them..."
 msgstr ""
-"商队​在​这里​停​了​下来，为​他们​向东​旅行​带​去​一些​补给。我​卖给​他们​不少​新鲜​水果​和​一些​"
-"佳达​刚刚​烤好​的​上​等​甜​面包。可惜​他们​发生​了​什么……"
+"商队在这里停了下来，为他们向东旅行带去一些补给。我卖给他们不少新鲜水果和一些"
+"佳达刚刚烤好的上等甜面包。可惜他们发生了什么……"
 
 #: Source/translation_dummy.cpp:793
 msgid ""
@@ -9326,7 +9370,7 @@ msgid ""
 "I will say this. If rocks are falling from the sky, you had better be "
 "careful!"
 msgstr ""
-"我​不​知道​他们​以为​用​那​块​石头​能​看到​什么，但​我​要​说​的​是。如果​岩石​从天而降，你​最好​"
+"我不知道他们以为用那块石头能看到什么，但我要说的是。如果岩石从天而降，你最好"
 "小心！"
 
 #: Source/translation_dummy.cpp:794
@@ -9338,10 +9382,10 @@ msgid ""
 "I don't see how you could hope to find anything that they would have been "
 "carrying."
 msgstr ""
-"好​吧，一​队​重要​人物​停​在​这里，但​那​是​很​久​以前​的​事​了。我​记得，他们​的​口音​很​奇怪，"
-"正​开始​长途​旅行。\n"
+"好吧，一队重要人物停在这里，但那是很久以前的事了。我记得，他们的口音很奇怪，"
+"正开始长途旅行。\n"
 " \n"
-"​我​不​明白​你​怎么​能​指望​找到​他们​会​带​的​东西。"
+"我不明白你怎么能指望找到他们会带的东西。"
 
 #: Source/translation_dummy.cpp:795
 msgid ""
@@ -9353,16 +9397,16 @@ msgid ""
 "found. If you should find it, I believe that I can fashion something useful "
 "from it."
 msgstr ""
-"呆​一会儿​-​我​有​个​故事​你​可能​会​觉得​有趣。一​辆​开往​东方​王国​的​大篷​车​前​段​时间​经过​这"
-"里。据说​它​带​着​一​片​落​在​地上​的​天空！大篷车​就​在​这​北​边​的​公路​上​被​披着​斗篷​的​骑手​伏"
-"击​了。我​在​残骸​中​搜寻​这​块​岩石，但​找​不​到。如果​你​能​找到​它，我​相信​我​能​从中​找到​有"
-"用​的​东西。"
+"留步——我有个故事你或许会感兴趣。不久前，一支前往东方王国的商队途经此地。传说"
+"他们携带着一块坠入凡间的天石！商队就在北边的道路上遭到了一群蒙面骑手的伏击。"
+"我搜遍了残骸想找那块天石，却一无所获。你若能找到它，我相信我能用它打造出有用"
+"的东西。"
 
 #: Source/translation_dummy.cpp:796
 msgid ""
 "I am still waiting for you to bring me that stone from the heavens. I know "
 "that I can make something powerful out of it."
-msgstr "我​还​在​等​你​从天​上​把​那​块​石头​带给​我。我​知道​我​能​从中​制造​出​强大​的​东西。"
+msgstr "我还在等你从天上把那块石头带给我。我知道我能从中制造出强大的东西。"
 
 #: Source/translation_dummy.cpp:797
 msgid ""
@@ -9371,9 +9415,9 @@ msgid ""
 "Ah, Here you are. I arranged pieces of the stone within a silver ring that "
 "my father left me. I hope it serves you well."
 msgstr ""
-"让​我​看看​-​是​的……是​的，正​如​我​所​相信​的。给​我​一点​时间……\n"
+"让我瞧瞧——嗯……嗯，果然如我所料。稍等片刻……\n"
 " \n"
-"​啊，给​你。我​把​几​块​石头​放​在​父亲​留给​我​的​银戒指里。希望​对​你​有​好处。"
+"啊，好了。我把石头的碎片镶进了父亲留给我的银戒指里。但愿它能护你平安。"
 
 #: Source/translation_dummy.cpp:798
 msgid ""
@@ -9381,8 +9425,8 @@ msgid ""
 "green and red and silver. Don't remember what happened to it, though. I "
 "really miss that ring..."
 msgstr ""
-"我​曾经​有​一​个​漂亮​的​戒指​；​这​是​一​个​非常​昂贵​的，蓝色，绿色，红色​和​银色。不过，我​"
-"不​记得​发生​了​什么。我​真的​很​想​念​那​个​戒指……"
+"我以前有枚漂亮的戒指，那可是个值钱货——上面有蓝色、绿色、红色还有银色。不过我"
+"不记得后来把它怎么了。我真的很想念那枚戒指……"
 
 #: Source/translation_dummy.cpp:799
 msgid ""
@@ -9390,8 +9434,8 @@ msgid ""
 "find it, I would prevent it. He will harness its powers and its use will be "
 "for the good of us all."
 msgstr ""
-"天石​是​非常​强大​的，如果​是​任何​人，但​格里斯沃尔德​谁​叫​你​找到​它，我​会​阻止​它。他​将​"
-"利用​它​的​力量，它​的​使用​将​造福于​我们​所有​人。"
+"天石力量极其强大，若非是格里斯沃尔德让你去寻找它，我定会阻止你。他能够驾驭它"
+"的力量，并将其用于造福我们所有人。"
 
 #: Source/translation_dummy.cpp:800
 msgid ""
@@ -9399,8 +9443,8 @@ msgid ""
 "he is doing, and as much as I try to steal his customers, I respect the "
 "quality of his work."
 msgstr ""
-"如果​有​人​能​用​那​块​石头​做​点​什么，格里斯沃尔德​也​能。他​知道​自己​在​做​什么，尽管​我​试"
-"图​窃取​他​的​客户，但​我​尊重​他​的​工作​质量。"
+"如果有人能用那块石头折腾出什么名堂，格里斯沃尔德准行。他手艺精湛，我虽然老想"
+"挖他的客人，但对他做的活计那是真心服气。"
 
 #: Source/translation_dummy.cpp:801
 msgid ""
@@ -9408,8 +9452,8 @@ msgid ""
 "as I do about Red Herrings. Perhaps Pepin the Healer could tell you more, "
 "but this is something that cannot be found in any of my stories or books."
 msgstr ""
-"女​巫艾德莉亚​想要​一​个​黑​蘑菇？我​对​黑​蘑菇​的​了解​和​对​红鲱​鱼​的​了解​一样​多。也许​治疗"
-"者​佩金​可以​告诉​你​更​多，但​这​是​我​的​任何​故事​或​书籍​中​都​找​不​到​的。"
+"女巫艾德莉亚想要一朵黑蘑菇？我对黑蘑菇的了解，跟我听过的'红鲱鱼'一样——都是没"
+"影的事儿。也许医者佩金能告诉你更多，但这是我任何故事和古籍里都找不到的。"
 
 #: Source/translation_dummy.cpp:802
 msgid ""
@@ -9418,8 +9462,8 @@ msgid ""
 "then that is her business, but I can't help you find any. Black mushrooms... "
 "disgusting!"
 msgstr ""
-"我​就​这么​说​吧。我​和​嘉达​永远​不​会​给​我们​的​贵宾​提供​黑蘑菇。如果​艾德莉亚​想​在​炖菜​里​"
-"放些​蘑菇，那​是​她​的​事，但​我​帮​不​了​你。黑​蘑菇……恶心！"
+"我就这么说吧。我和嘉达永远不会给我们的贵宾提供黑蘑菇。如果艾德莉亚想在炖菜里"
+"放些蘑菇，那是她的事，但我帮不了你。黑蘑菇……恶心！"
 
 #: Source/translation_dummy.cpp:803
 msgid ""
@@ -9429,10 +9473,9 @@ msgid ""
 "that its alchemy holds. If you can remove the brain of a demon when you kill "
 "it, I would be grateful if you could bring it to me."
 msgstr ""
-"巫婆​告诉​我​你​在​寻找​一​个​恶魔​的​大脑​来​帮助​我​制造​长生​不​老药。如果​我​能​解开​我​怀疑​它​"
-"的​炼金术​所​掌握​的​秘密，它​对​许多​被​这些​邪恶​野兽​伤害​的​人​来说​应该​是​非常​有​价值​的。"
-"如果​你​能​在​杀死​一​个​恶魔​的​时候​把​它​的​大脑取​出来，如果​你​能​把​它​带给​我，我​将​不胜​感"
-"激。"
+"女巫告诉我，你正在寻找一颗恶魔的大脑来帮我炼制灵药。若我能解开其中蕴含的炼金"
+"奥秘，对于那些被恶魔所伤的人来说，这将是极为珍贵的药物。如果你在杀死恶魔时能"
+"取出它的脑子并带给我，我将不胜感激。"
 
 #: Source/translation_dummy.cpp:804
 msgid ""
@@ -9440,14 +9483,14 @@ msgid ""
 "without this, but it can't hurt to have this to study. Would you please "
 "carry this to the witch? I believe that she is expecting it."
 msgstr ""
-"太​好​了，这​正​是​我​想要​的。没有​这个​我​就​可以​完成​长生不​老药，但是​有​这个​来​学习​也​没​"
-"什么​坏处。请​你​把​这个​带给​女​巫好​吗？我​相信​她​在​等​着​呢。"
+"太好了，这正是我想要的。没有它我也能完成灵药的炼制，但有了它来研究更是锦上添"
+"花。能帮我把这个带给那位女巫吗？我相信她正等着呢。"
 
 #: Source/translation_dummy.cpp:805
 msgid ""
 "I think Ogden might have some mushrooms in the storage cellar. Why don't you "
 "ask him?"
-msgstr "我​想​奥格登​的​地窖​里​可能​有​蘑菇。你​为什么​不​问问​他？"
+msgstr "奥格登的地窖里说不定有些蘑菇。你何不去问问他呢？"
 
 #: Source/translation_dummy.cpp:806
 msgid ""
@@ -9455,16 +9498,17 @@ msgid ""
 "I can offer you no more help than that, but it sounds like... a huge, "
 "gargantuan, swollen, bloated mushroom! Well, good hunting, I suppose."
 msgstr ""
-"如果​艾德莉亚​没有​这些，你​可以​打​赌​这​确实​是​一​件​罕见​的​事情。我​不​能​给​你​更​多​的​帮"
-"助，但是​听​起来……一​个​巨大​的，巨大​的，肿胀​的，膨胀​的​蘑菇！嗯，我​想​打猎​不错​吧。"
+"如果连艾德莉亚手里都没有这东西，那不用说你也能猜到它有多稀罕了。我能帮你的就"
+"这么多。不过听你这么一说……好家伙，一个巨大的、庞然的、肿胀的、膨胀的蘑菇！"
+"嗯，那就祝你狩猎顺利吧。"
 
 #: Source/translation_dummy.cpp:807
 msgid ""
 "Ogden mixes a MEAN black mushroom, but I get sick if I drink that. Listen, "
 "listen... here's the secret - moderation is the key!"
 msgstr ""
-"奥格登​混合​了​一​种​难​吃​的​黑蘑菇，但​如果​我​喝​了​它​我​会​生病​的。听​着，听​着……秘诀​就​在​"
-"这里​——​适度​才​是​关键！"
+"奥格登调的黑蘑菇酒，那可真是一绝！不过我一喝就上头。听着，听着……秘诀就是——喝"
+"啥都别过量！"
 
 #: Source/translation_dummy.cpp:808
 msgid ""
@@ -9472,16 +9516,16 @@ msgid ""
 "your eyes open for a black mushroom. It should be fairly large and easy to "
 "identify. If you find it, bring it to me, won't you?"
 msgstr ""
-"我们​这里​有​什么？有趣​的​是，它​看​起来​像​一​本​试剂​书。睁大​眼睛​看黑​蘑菇。它​应该​相当​"
-"大，并且​易​于​识别。如果​你​找到​了，把​它​带给​我，好​吗?"
+"这是什么？有意思，看起来像是一本药剂配方书。留心找找黑蘑菇——应该挺大的，很好"
+"认。找到了就带来给我，行吗？"
 
 #: Source/translation_dummy.cpp:809
 msgid ""
 "It's a big, black mushroom that I need. Now run off and get it for me so "
 "that I can use it for a special concoction that I am working on."
 msgstr ""
-"我​需要​一​个​又​大​又​黑​的​蘑菇。现在​跑​去​给​我​拿，这样​我​就​可以​用​它​做​我​正在​做​的​一​种​特"
-"殊​的​调味品​了."
+"我需要一朵又大又黑的蘑菇。快去给我弄来，我手头正在配制一种特殊药剂，正好用得"
+"上它。"
 
 #: Source/translation_dummy.cpp:810
 msgid ""
@@ -9491,9 +9535,9 @@ msgid ""
 "intends to make an elixir from it. If you help him find what he needs, "
 "please see if you can get a sample of the elixir for me."
 msgstr ""
-"是​的，这​将​是​完美​的​酿造，我​正在​创建。顺便​说​一​句，治疗者​正​在​寻找​某​种​恶魔​的​大"
-"脑，这样​他​就​可以​治疗​那些​被​他们​的​毒液​折磨​的​人。我​相信​他​打算​用​它​做​长生​不​老药。"
-"如果​你​帮​他​找到​他​需要​的​东西，请​你​帮​我​拿​一​个​长生​不​老药​的​样品。"
+"很好，正合我意。顺便告诉你，那位医者正在寻找某种恶魔的大脑，好用来医治那些被"
+"恶魔毒液所伤的人。我相信他打算用它来炼制灵药。如果你帮他找到了他需要的东西，"
+"替我要一份灵药的样品来。"
 
 #: Source/translation_dummy.cpp:811
 msgid ""
@@ -9502,23 +9546,23 @@ msgid ""
 "that grotesque organ that you are holding, and then bring me the elixir. "
 "Simple when you think about it, isn't it?"
 msgstr ""
-"你​为什么​把​它​带到​这里​来？我​现在​不​需要​恶魔​的​大脑。我​确实​需要​一些​治疗者​正​在​研制​"
-"的​长生​不​老药。他​需要​你​拿​着​的​奇怪​的​器官，然后​给​我​拿​长生​不​老药。想​起来​很​简单，"
-"不​是​吗？"
+"你怎么把它带到我这儿来了？我眼下并不需要恶魔的大脑。我需要的是那位医者正在研"
+"制的灵药。他需要你手里那个怪异的器官——你去给他，然后把灵药带给我。仔细想想，"
+"很简单，对吧？"
 
 #: Source/translation_dummy.cpp:812
 msgid ""
 "What? Now you bring me that elixir from the healer? I was able to finish my "
 "brew without it. Why don't you just keep it..."
 msgstr ""
-"什么？现在​你​把​医治者​的​长生​不​老​药​带给​我？不用​它​我​也能​完成​我​的​酿造。你​为什么​不​"
-"留​着​它……"
+"什么？你现在才把医者的灵药拿给我？没有它我也已经完成了我的药方。你自己留着"
+"吧……"
 
 #: Source/translation_dummy.cpp:813
 msgid ""
 "I don't have any mushrooms of any size or color for sale. How about "
 "something a bit more useful?"
-msgstr "我​没有​任何​大小​和​颜色​的​蘑菇​出售。再​来​点​有用​的​怎么样？"
+msgstr "各色各样的蘑菇，不管大小，我一概不卖。要不要看看真正有用的东西？"
 
 #: Source/translation_dummy.cpp:814
 msgid ""
@@ -9542,26 +9586,26 @@ msgid ""
 "before the stars align, for we may never have a chance to rid the world of "
 "his evil again!"
 msgstr ""
-"所以，地图​上​的​传说​是​真实​的。连​我​都​不​相信！我​想​是​时候​告诉​你​我​是​谁​了，我​的​朋"
-"友。你​看，我​并不​像​我​看​起来​那样……\n"
+"这么说，地图的传说确有其事。连我也从未真正相信过！我想，是时候向你坦诚我的真"
+"实身份了，我的朋友。你看，我并不只是你看到的那样……\n"
 " \n"
-"​我​的​真名​是​老凯恩，我​是​一​个​古老​兄弟会​的​最后​一​个​后代，这​个​兄弟​会​致力于​保守​和​保"
-"护​一​个​永恒​邪恶​的​秘密。一​个​很​明显​已经​被​释放​的​恶魔……\n"
+"我的真名是凯恩长老，我是古老兄弟会的最后一名传人，那个兄弟会毕生致力于守护一"
+"种永恒之恶的秘密。而那股邪恶，显然已经降临于世……\n"
 " \n"
-"​你​要​对付​的​恶魔​是​恐怖​的​黑魔王​——​凡​人​都​知道​的​迪亚波罗。几​个​世纪​前​被​囚禁​在​迷宫​里​"
-"的​正​是​他。你​现在​持有​的​地图​是​很​久​以前​创造​的，用来​标记迪亚波罗​从​监禁​中​复活​的​时"
-"间。当​那​张​地图​上​的​两​颗​星星​对​齐​时，迪亚波罗​将​达到​他​的​能量​顶峰。他​将​所​向​无"
-"敌……\n"
+"你正在对抗的邪恶，正是黑暗的恐惧之王——凡人称他为迪亚波罗。数个世纪前，他被囚"
+"禁在迷宫之中。你手中的这张地图，是远古时代为标记迪亚波罗将再次崛起的时刻而创"
+"造的。当地图上的两颗星辰对齐之时，迪亚波罗将达到力量的巅峰，近乎无敌……\n"
 " \n"
-"​你​现在​在​和​时间​赛跑，我​的​朋友！找到​迪亚波罗，在​众​星云集​之前​消灭​他，因为​我们​可"
-"能​再​也​没有​机会​摆脱​他​的​邪恶​了！"
+"你正在和时间赛跑，我的朋友！在星辰对齐之前找到迪亚波罗、消灭他——否则我们可能"
+"再也没有机会将他的邪恶从这个世界铲除了！"
 
 #: Source/translation_dummy.cpp:815
 msgid ""
 "Our time is running short! I sense his dark power building and only you can "
 "stop him from attaining his full might."
 msgstr ""
-"我们​的​时间​不​多​了！我​感觉​到​了​他​的​黑暗​力量，只有​你​才​能​阻止​他​达到​他​的​全部​力量。"
+"时间所剩无几！我能感觉到他的黑暗力量正在膨胀。只有你才能阻止他重获全部的力"
+"量。"
 
 #: Source/translation_dummy.cpp:816
 msgid ""
@@ -9570,9 +9614,9 @@ msgid ""
 "and you will need all your courage and strength to defeat him. May the Light "
 "protect and guide you, my friend. I will help in any way that I am able."
 msgstr ""
-"我​相信​你​已经​尽力​了，但​我​担心​你​的​力量​和​意志​都​不​够。迪亚波罗​现在​正​处于​他​尘世​力"
-"量​的​顶峰，你​将​需要​你​所有​的​勇气​和​力量​来​打败​他。愿​光明​保护​和​指引​你，我​的​朋友。"
-"我​将​尽​我​所​能​提供​帮助。"
+"我相信你已经尽了最大的努力，但我担心单凭力量和意志可能还不够。迪亚波罗如今已"
+"达到了他在凡间力量的巅峰。你需要鼓起全部的勇气与力量，才能战胜他。愿圣光庇护"
+"你、指引你，我的朋友。我会尽我所能助你一臂之力。"
 
 #: Source/translation_dummy.cpp:817
 msgid ""
@@ -9580,8 +9624,8 @@ msgid ""
 "that I would know anything? It sounds like this is a very serious matter. "
 "You should hurry along and see the storyteller as Adria suggests."
 msgstr ""
-"如果​女​巫帮​不​了​你，建议​你​去见凯恩，你​凭​什么​认为​我​什么​都​知道？听​起来​这​是​一​件​非"
-"常​严重​的​事情。你​应该​像​艾德莉亚​建议​的​那样，赶快​去​见​讲​故事​的​人。"
+"如果连女巫都帮不了你，让你来问凯恩，那你觉得我能比她知道得更多吗？这事听起来"
+"非同小可。听艾德莉亚的，快去找说书人吧。"
 
 #: Source/translation_dummy.cpp:818
 msgid ""
@@ -9591,9 +9635,9 @@ msgid ""
 "I can see that it is a map of the stars in our sky, but any more than that "
 "is beyond my talents."
 msgstr ""
-"我​对​这​张​地图​上​的​文字​不​太​了解，但​也许​艾德莉亚​或​凯恩​能​帮​你​破译​这​是​指​什么。\n"
+"这张地图上的文字我不大看得懂，不过或许艾德莉亚或凯恩能帮你破解其中的含义。\n"
 " \n"
-"​我​可以​看到​这​是​一​张​我们​天空​中​星星​的​地图，但​比​这​更​是​超出​我​的​能力。"
+"我看得出这是一幅我们天空星辰的地图，但除此之外，就超出了我的本事了。"
 
 #: Source/translation_dummy.cpp:819
 msgid ""
@@ -9602,9 +9646,9 @@ msgid ""
 "Cain is very knowledgeable about ancient writings, and that is easily the "
 "oldest looking piece of paper that I have ever seen."
 msgstr ""
-"问​这​类​事情​的​最​佳​人选​是​我们​的​说书​人。\n"
+"问这类事情的最佳人选是我们的说书人。\n"
 " \n"
-"凯恩​对​古代​著作​非常​了解，这​是​我​见​过​的​最​古老​的​一​张​纸。"
+"凯恩对古代著作非常了解，这是我见过的最古老的一张纸。"
 
 #: Source/translation_dummy.cpp:820
 msgid ""
@@ -9612,16 +9656,16 @@ msgid ""
 "have no idea how to read this, Cain or Adria may be able to provide the "
 "answers that you seek."
 msgstr ""
-"我​以前​从​未​见​过​这样​的​地图。你​从​哪儿​弄来​的？虽然​我​不​知道​该​怎么​读​这​篇​文章，但​凯"
-"恩​或​艾德莉亚​也许​能​提供​你​所​寻求​的​答案。"
+"我从来没见过这样的地图。你是从哪儿弄来的？虽然我看不懂，但凯恩或艾德莉亚也许"
+"能解答你的疑问。"
 
 #: Source/translation_dummy.cpp:821
 msgid ""
 "Listen here, come close. I don't know if you know what I know, but you have "
 "really got somethin' here. That's a map."
 msgstr ""
-"听​着，靠近点。我​不​知道​你​是否​知道​我​所​知道​的，但​你​真的​有些​东西​在​这里。那​是​一​张​"
-"地图。"
+"过来，靠近点听我说。这事你知不知我不清楚，但你手上这玩意可真不简单。那是张地"
+"图。"
 
 #: Source/translation_dummy.cpp:822
 msgid ""
@@ -9629,8 +9673,8 @@ msgid ""
 "portends great disaster, but its secrets are not mine to tell. The time has "
 "come for you to have a very serious conversation with the Storyteller..."
 msgstr ""
-"哦，恐怕​这​一点​都​不​是​好​兆头。这​张​星图​预示​着​巨大​的​灾难，但​它​的​秘密不​是​我​说​的。"
-"是​时候​让​你​和​讲​故事​的​人​好好​谈​谈​了……"
+"哦，这恐怕是极为不祥的兆头。这张星图预示着巨大的灾难，但其中的秘密不该由我来"
+"揭示。是时候让你和说书人好好谈一次了……"
 
 #: Source/translation_dummy.cpp:823
 msgid ""
@@ -9638,13 +9682,13 @@ msgid ""
 "that to Adria - she can probably tell you what it is. I'll say one thing; it "
 "looks old, and old usually means valuable."
 msgstr ""
-"我​一直​在​找​地图，但​那​肯定​不是。你​应该​把​这个​给​艾德莉亚​看-​她​可能​会​告诉​你​是​什么。"
-"我​要​说​一​件​事​；​它​看​起来​很​老，而且​老​通常​意味​着​有​价值。"
+"我一直在找一张地图，但肯定不是这张。你应该拿去给艾德莉亚瞧瞧——她兴许能告诉你"
+"这是什么。我就说一句：看着就古老，而古老通常意味着值钱。"
 
 #: Source/translation_dummy.cpp:824
 msgid ""
 "Pleeeease, no hurt. No Kill. Keep alive and next time good bring to you."
-msgstr "请​放心，不​要​受伤。不​杀人。保持​活力，下​次​给​你​带来​好​东西。"
+msgstr "求求你，别伤害我，别杀我。饶我一命，下次带好东西给你。"
 
 #: Source/translation_dummy.cpp:825
 msgid ""
@@ -9653,9 +9697,9 @@ msgid ""
 " \n"
 "You take this as proof I keep word..."
 msgstr ""
-"我​正在​为​你​做​些​东西。再说​一​遍，别​杀​了​加尔巴德。活​得​好好​的。\n"
+"我正在为你打造点东西。再说一遍，别杀加尔巴德。活着，做个好人。\n"
 " \n"
-"​你​把​这​当作​我​遵守​诺言​的​证据……"
+"你收下这个，就当是我守信的证明……"
 
 #: Source/translation_dummy.cpp:826
 msgid ""
@@ -9665,31 +9709,31 @@ msgid ""
 " \n"
 "No pain and promise I keep!"
 msgstr ""
-"还​没有！差不​多​了。\n"
+"还没好！快完成了。\n"
 " \n"
-"​非常​强大，非常​强大。生存！生存！\n"
+"非常强大，非常有劲。活下去！活下去！\n"
 " \n"
-"​没有​痛苦，我​信守​诺言！"
+"不痛苦，我守信用！"
 
 #: Source/translation_dummy.cpp:827
 msgid "This too good for you. Very Powerful! You want - you take!"
-msgstr "这​对​你​来说​太​好​了。非常​强大！你​想要​-​你​拿！"
+msgstr "这个对你来说太厉害了。超强！想要就拿去吧！"
 
 #: Source/translation_dummy.cpp:828
 msgid ""
 "What?! Why are you here? All these interruptions are enough to make one "
 "insane. Here, take this and leave me to my work. Trouble me no more!"
 msgstr ""
-"什么？！你​为什么​在​这里？所有​这些​干扰​都​足以​让​人​发疯。来，拿​着​这个，让​我​继续​工"
-"作。别​再​烦​我​了！"
+"什么？！你怎么还在这里？这些打扰真能把人逼疯。给，拿着，让我继续干活。别再烦"
+"我了！"
 
 #: Source/translation_dummy.cpp:829
 msgid "Arrrrgh! Your curiosity will be the death of you!!!"
-msgstr "啊！你​的​好奇心​将给你​​带来​死亡！！！"
+msgstr "啊啊啊！你的好奇心会害死你的！！！"
 
 #: Source/translation_dummy.cpp:830
 msgid "Hello, my friend. Stay awhile and listen..."
-msgstr "你​好，我​的​朋友。呆​一会儿​听​我​说……"
+msgstr "你好，我的朋友。请留步，听我道来……"
 
 #: Source/translation_dummy.cpp:831
 msgid ""
@@ -9698,9 +9742,9 @@ msgid ""
 " \n"
 "Read them carefully for they can tell you things that even I cannot."
 msgstr ""
-"当​你​冒险​深入​迷宫​时，你​可能​会​发现​那里​藏​着​大量​的​知识。\n"
+"当你深入探索迷宫时，或许会发现深藏其中的珍贵典籍。\n"
 " \n"
-"​仔细​阅读​它们，因为​它们​能​告诉​你​即使​是​我​也​不​能​告诉​你​的​事情。"
+"仔细阅读它们，因为它们能告诉你即使是我也不能告诉你的事情。"
 
 #: Source/translation_dummy.cpp:832
 msgid ""
@@ -9709,8 +9753,8 @@ msgid ""
 "and questions to which you seek knowledge, seek me out and I will tell you "
 "what I can."
 msgstr ""
-"我​知道​许多​神话​和​传说，其中​可能​包含​对​你​在​迷宫​之​旅​中​可能​出现​的​问题​的​答案。如果​"
-"你​遇到​挑战​和​问题，你​寻求​知识，寻找​我​出来，我​会​告诉​你​我​能​做​什么。"
+"我知道许多神话和传说，也许能帮助你解答在迷宫旅途中遇到的困惑。如果你遭遇了难"
+"题，寻求答案，不妨来找我——我一定尽力为你解答。"
 
 #: Source/translation_dummy.cpp:833
 msgid ""
@@ -9720,9 +9764,9 @@ msgid ""
 "is a skilled craftsman, and if he claims to be able to help you in any way, "
 "you can count on his honesty and his skill."
 msgstr ""
-"格里斯沃尔德​——​一​个​行动力​和​勇气​都​很​强​的​人。我​打​赌​他​从​没​告诉​过​你​他​进迷宫​救怀特​"
-"的​事，是​吗？他​知道​在​那里​会​有​很多​危险，但​话​说​回来，你​也是。他​是​一​个​技艺​高超​的​"
-"工匠，如果​他​声称​能​以​任何​方式​帮助​你，你​可以​指望​他​的​诚实​和​他​的​技能。"
+"格里斯沃尔德——一位行动果敢、勇气非凡的人。我打赌他从没告诉过你他进迷宫救怀特"
+"的事，是吗？他知道在那里会有很多危险，但话说回来，你也是。他是一个技艺高超的"
+"工匠，如果他说能帮上你的忙，你可以指望他的诚实和他的技能。"
 
 #: Source/translation_dummy.cpp:834
 msgid ""
@@ -9732,9 +9776,9 @@ msgid ""
 "all they had in making a life for themselves here. He is a good man with a "
 "deep sense of responsibility."
 msgstr ""
-"奥格登​已经​拥有​和​经营​旭日​酒店​近​四​年​了。他​买​了​它​就​在​几​个​月​前，这里​的​一切​都​变成​"
-"了​地狱。他​和​他​的​妻子​加尔达​没有​钱​离开，因为​他们​把​所有​的​钱​都​投资​在​这里​为​自己​创"
-"造​生活。他​是​一​个​很​有​责任感​的​好​人。"
+"奥格登经营旭日酒馆快四年了。就在几个月前他刚盘下这家店，紧接着这里就乱成一"
+"团。他和妻子嘉达把全部积蓄都投了进去，想在这安安稳稳过日子，如今已没有钱离开"
+"了。他是个有担当的好人。"
 
 #: Source/translation_dummy.cpp:835
 msgid ""
@@ -9744,9 +9788,9 @@ msgid ""
 "He finds comfort only at the bottom of his tankard nowadays, but there are "
 "occasional bits of truth buried within his constant ramblings."
 msgstr ""
-"可怜​的​法恩汉。他​令​人​不安​地​提醒​人们，在​那​黑暗​的​一​天，注定​要​与​拉扎鲁斯一起​进入​"
-"大​教堂​的​集会。他​带​着​生命​逃走​了，但​他​的​勇气​和​大部分​的​理智​都​留​在​了​某​个​黑暗​的​坑​"
-"里。如今，他​只​在​酒馆​的​最​底​层​找到​安慰，但​在​他​不断​的​闲谈​中，偶尔​也​隐藏​着​一些​真"
+"可怜的法恩汉。他是那场惨剧活生生的见证——在那个黑暗的日子，拉扎鲁斯带着一群镇"
+"民闯入了大教堂。他捡回了一条命，但他的勇气和神智却永远留在了某个黑暗的深渊"
+"中。如今，他只有在酒杯里才能找到些许慰藉，但他的醉话呓语中偶尔也藏着几分真"
 "相。"
 
 #: Source/translation_dummy.cpp:836
@@ -9757,9 +9801,9 @@ msgid ""
 "access to many strange and arcane artifacts and tomes of knowledge that even "
 "I have never seen before."
 msgstr ""
-"女​巫艾德莉亚​是​崔斯特姆​的​一​个​异类。她​是​在​大​教堂​被​亵渎​后​不久​到达​的，而​大多数​人​"
-"都​在​逃离。她​在​城镇​边缘​建​了​一​间​小​屋，似乎​是​一​夜​之间​建成​的，她​能​接触​到​许多​奇怪​"
-"而​神秘​的​文物​和​知识​的​大部头，连​我​都​从​未​见​过。"
+"女巫艾德莉亚在崔斯特姆是个异类。她是在大教堂被亵渎后不久到来的，而那时大多数"
+"人都在逃离这里。她在镇子边缘建了一座小屋——仿佛一夜之间凭空出现——还能接触到许"
+"多奇异的法器和玄奥的古籍，其中有些连我都前所未见。"
 
 #: Source/translation_dummy.cpp:837
 msgid ""
@@ -9770,10 +9814,10 @@ msgid ""
 "never returned. The Blacksmith found the boy, but only after the foul beasts "
 "had begun to torture him for their sadistic pleasures."
 msgstr ""
-"怀特​的​故事​是​一​个​可怕​而​悲惨​的​故事。他​从​他​母亲​的​怀抱​中​被​带到​迷宫​里，被​那些​挥舞​"
-"邪恶​长矛​的​邪恶​小​恶魔们​拖进​了​迷宫。那​天​还​有​许多​孩子​被​带走，包括​李奥瑞克​国王​的​"
-"儿子。宫殿​的​骑士们​下楼​去​了，但​再​也​没有​回来。铁匠​找到​了​那个​男孩，但​那​是​在​那些​"
-"邪恶​的​野兽​开始​折磨​他​以​获取​他们​的​虐待​狂般​的​快乐​之后。"
+"怀特的故事令人胆寒、令人心痛。那一天，他从母亲怀中被夺走，那些手持邪恶长矛的"
+"矮小恶魔将他拖进了迷宫深处。那天还有很多孩子被掳走，包括李奥瑞克国王的儿子。"
+"王宫的骑士们深入地下营救，却再也没有回来。铁匠最终找到了那孩子——但那时那群肮"
+"脏的畜生早已开始折磨他，以此取乐。"
 
 #: Source/translation_dummy.cpp:838
 msgid ""
@@ -9782,9 +9826,9 @@ msgid ""
 "existed. His knowledge and skills are equaled by few, and his door is always "
 "open."
 msgstr ""
-"啊，佩金。我​把​他​视为​真正​的​朋友​——​也许​是​我​在​这里​最​亲密​的​朋友。他​有时​有点​烦躁不"
-"安，但​从来​没有​一​个​更​关心​和​体贴​的​灵魂​存在​过。他​的​知识​和​技能​为数​不​多，他​的​大门​"
-"总是​敞开​的。"
+"啊，佩金。我视他为真正的朋友——也许是我在这里最亲近的人。他偶尔有些迷糊，但这"
+"世上再没有比他更善良、更体贴的人了。他的医术与学识鲜有人能望其项背，而他家的"
+"大门也永远向需要帮助的人敞开。"
 
 #: Source/translation_dummy.cpp:839
 msgid ""
@@ -9794,13 +9838,13 @@ msgid ""
 "for her safety, but I know that any man in the village would rather die than "
 "see her harmed."
 msgstr ""
-"吉莉安​是​个​好​女人。她​因兴​高采烈​和​爽朗​的​笑声​而​备受​崇拜，在​我​心​中​占有​特殊​的​地"
-"位。她​留​在​酒馆​里​养活​年迈​的​祖母，因为​她​病得​不​能​旅行​了。我​有时​担心​她​的​安全，但​"
-"我​知道​村​里​的​任何​男人​都​宁愿​死​也​不​愿​看到​她​受到​伤害。"
+"吉莉安是个好姑娘。她兴高采烈、笑声爽朗，深受大家喜爱，也在我心中占了特殊的位"
+"置。她留在酒馆是为了照顾年迈的祖母，老人家病得太重无法远行。我有时会担心她的"
+"安危，但我知道村里的任何男人宁愿死也不愿看到她受到伤害。"
 
 #: Source/translation_dummy.cpp:840
 msgid "Greetings, good master. Welcome to the Tavern of the Rising Sun!"
-msgstr "你​好，​大人。欢迎​来到​朝阳​酒馆！"
+msgstr "幸会，好心的旅人。欢迎光临旭日酒馆！"
 
 #: Source/translation_dummy.cpp:841
 msgid ""
@@ -9809,24 +9853,24 @@ msgid ""
 "any of them agree on was this old axiom. Perhaps it will help you. You can "
 "cut the flesh, but you must crush the bone."
 msgstr ""
-"我​的​酒馆​里​有​许多​冒险家，讲​的​故事​是​喝​啤酒​的​十​倍。我​唯一​听到​他们​一致​同意​的​就​是​"
-"这​条​古老​的​公理。也许​这​对​你​有​帮助。你​可以​割肉，但​必须​压碎​骨头。"
+"我这酒馆招待过许多冒险者，他们喝掉的麦芽酒有多沉，讲过的故事就有多长。我听他"
+"们唯一一致认同的只有一句老话——也许对你有用：'血肉可斩，但骨头非砸不可。'"
 
 #: Source/translation_dummy.cpp:842
 msgid ""
 "Griswold the blacksmith is extremely knowledgeable about weapons and armor. "
 "If you ever need work done on your gear, he is definitely the man to see."
 msgstr ""
-"铁匠​格里斯沃尔德​对​武器​和​护甲​非常​了解。如果​你​需要​修理​你​的​装备，他​绝对​是​你​要​找​"
-"的​人。"
+"铁匠格里斯沃尔德对武器和护甲非常了解。如果你需要修理装备，他绝对是你要找的"
+"人。"
 
 #: Source/translation_dummy.cpp:843
 msgid ""
 "Farnham spends far too much time here, drowning his sorrows in cheap ale. I "
 "would make him leave, but he did suffer so during his time in the Labyrinth."
 msgstr ""
-"法恩汉​在​这里​待​的​时间​太​长​了，他​用​廉价​的​啤酒​来​消愁。我​想​让​他​离开，但​他​在​迷宫​里​"
-"的​时候​确实​很​痛苦。"
+"法恩汉在这里待的时间太长了，他用廉价的麦酒消愁。我想让他离开，但他在迷宫里的"
+"时候确实很痛苦。"
 
 #: Source/translation_dummy.cpp:844
 msgid ""
@@ -9836,15 +9880,15 @@ msgid ""
 "Well, no matter. If you ever have need to trade in items of sorcery, she "
 "maintains a strangely well-stocked hut just across the river."
 msgstr ""
-"艾德莉亚​的​智慧​超过​了​她​的​年龄，但​我​必须​承认​——​她​有点​吓​到​我​了。\n"
+"艾德莉亚的智慧远超她的年龄，但我必须承认——她让我有些害怕。\n"
 " \n"
-"​好​吧，没​关系。如果​你​需要​交易​巫术​物品，她​在​河​对岸​有​一​个​奇怪​的​仓库。"
+"好吧，没关系。如果你需要交易巫术物品，她在河对岸有一间存货齐全的小屋。"
 
 #: Source/translation_dummy.cpp:845
 msgid ""
 "If you want to know more about the history of our village, the storyteller "
 "Cain knows quite a bit about the past."
-msgstr "如果​你​想​更​多​地​了解​我们​村子​的​历史，讲​故事​的​凯恩​对​过去​的​事​相当​了解。"
+msgstr "如果你想更多地了解我们村子的历史，讲故事的凯恩对过去的事相当了解。"
 
 #: Source/translation_dummy.cpp:846
 msgid ""
@@ -9854,9 +9898,10 @@ msgid ""
 "He probably went fooling about someplace that he shouldn't have been. I feel "
 "sorry for the boy, but I don't abide the company that he keeps."
 msgstr ""
-"怀特​是​个​说​唱​歌手​和​小​流氓。他​总是​惹​麻烦，发生​在​他​身​上​的​事​也​就​不足为奇​了。\n"
+"怀特是个小无赖，也是个小恶棍。他总是惹麻烦，落得如此下场并不意外。\n"
 " \n"
-"​他​可能​去​了​一​个​他​不​该​去​的​地方。我​为​那个​男孩​感到​难过，但​我​不​愿意​和​他​作伴。"
+"他大概是跑到什么不该去的地方胡闹去了。我替这孩子感到惋惜，但我可看不惯他结交"
+"的那帮人。"
 
 #: Source/translation_dummy.cpp:847
 msgid ""
@@ -9864,8 +9909,8 @@ msgid ""
 "always attending to the needs of others, but trouble of some sort or another "
 "does seem to follow him wherever he goes..."
 msgstr ""
-"佩金​是​个​好​人，当然​也​是​村​里​最​慷慨​的​人。他​总是​关心​别人​的​需要，但​无论​他​走到​哪"
-"里，总​有​一些​麻烦​跟着​他……"
+"佩金是个好人，当然也是村里最慷慨的人。他总是关心别人的需要，但无论他走到哪"
+"里，总有一些麻烦跟着他……"
 
 #: Source/translation_dummy.cpp:848
 msgid ""
@@ -9875,13 +9920,14 @@ msgid ""
 "Goodness knows I begged her to leave, telling her that I would watch after "
 "the old woman, but she is too sweet and caring to have done so."
 msgstr ""
-"吉莉安，我​的​酒吧​女​招待？如果​不​是​因为​她​对​大坝​的​责任感，她​早​就​从​这里​逃走​了。\n"
+"吉莉安，我的女招待？若不是出于对祖母的责任感，她早就逃离此地了。\n"
 " \n"
-"天​知道​我​求​她​离开，告诉​她​我​会​照顾​那​个​老​妇人，但​她​太​可爱​了，太​体贴​了。"
+"天知道我多番恳求她离开，告诉她我会照看那位老妇人，可她心地太善良、太体贴，实"
+"在做不到抛下不管。"
 
 #: Source/translation_dummy.cpp:849
 msgid "What ails you, my friend?"
-msgstr "你​怎么​了，我​的​朋友？"
+msgstr "哪里不舒服吗，我的朋友？"
 
 #: Source/translation_dummy.cpp:850
 msgid ""
@@ -9890,8 +9936,8 @@ msgid ""
 "hurt one of the monsters, make sure it is dead or it very well may "
 "regenerate itself."
 msgstr ""
-"我​有​一​个​非常​有趣​的​发现。与​我们​不同​的​是，迷宫​中​的​生物​不​用药​水​或​魔法​就​能​自愈。"
-"如果​你​伤害​了​其中​一​个​怪物，确保​它​已经​死​了，否则​它​很​可能​会​自己​再生。"
+"我有一个非常有趣的发现。与我们不同的是，迷宫中的生物不用药水或魔法就能自愈。"
+"若你伤到了怪物，务必确认它已经死了，否则它很可能会自行愈合。"
 
 #: Source/translation_dummy.cpp:851
 msgid ""
@@ -9900,9 +9946,8 @@ msgid ""
 "any, you should read them all, for some may hold secrets to the workings of "
 "the Labyrinth."
 msgstr ""
-"在​它​被​下面​隐藏​的​东西​接管​之前，大​教堂​是​一​个​非常​有​学问​的​地方。那里​有​许多书​可以​"
-"找到。如果​你​发现​了​什么，你​应该​把​它们​全部​读​一​遍，因为​有些​可能​掌握​着​迷宫​运作​的​"
-"秘密。"
+"在大教堂被潜伏地底的东西占据之前，那里曾是一座知识的殿堂。教堂里能找到许多书"
+"籍。如果你发现的话，应当仔细研读——因为其中可能隐藏着迷宫运作的秘密。"
 
 #: Source/translation_dummy.cpp:852
 msgid ""
@@ -9910,8 +9955,8 @@ msgid ""
 "healing. He is a shrewd merchant, but his work is second to none. Oh, I "
 "suppose that may be because he is the only blacksmith left here."
 msgstr ""
-"格里斯沃尔德​对​战争​艺术​的​了解​和​我​对​治疗​艺术​的​了解​一样​多。他​是​个​精明​的​商人，但​"
-"他​的​工作​是​首屈一指​的。哦，我​想​那​可能​是​因为​他​是​这里​唯一​的​铁匠。"
+"格里斯沃尔德对锻造的造诣，就如同我对医术的精通。他是个精明的商人，但他的工作"
+"是首屈一指的。哦，我想那可能是因为他是这里仅存的铁匠。"
 
 #: Source/translation_dummy.cpp:853
 msgid ""
@@ -9919,16 +9964,16 @@ msgid ""
 "an innate ability to discern the true nature of many things. If you ever "
 "have any questions, he is the person to go to."
 msgstr ""
-"凯恩​是​一​个​真正​的​朋友​和​智慧​的​圣人。他​拥有​一​个​庞大​的​图书馆，有​一​种​与生俱来​的​能"
-"力​来​辨别​许多​事物​的​本质。如果​你​有​任何​问题，他​就​是​你​要​找​的​人。"
+"凯恩是我真正的朋友，也是一位睿智的贤者。他拥有庞大的藏书，天生能洞察许多事物"
+"的本质。若有疑问，找他就对了。"
 
 #: Source/translation_dummy.cpp:854
 msgid ""
 "Even my skills have been unable to fully heal Farnham. Oh, I have been able "
 "to mend his body, but his mind and spirit are beyond anything I can do."
 msgstr ""
-"就​连​我​的​技能​也​无法​完全​治​愈法恩汉。哦，我​已经​能​修好​他​的​身体​了，但是​他​的​精神​和​"
-"精神​我​无​能​为力。"
+"就连我的医术也无法彻底治愈法恩汉。哦，我确实能治好他的身体——但他的心灵和精"
+"神，却已超出了我力所能及的范围。"
 
 #: Source/translation_dummy.cpp:855
 msgid ""
@@ -9938,9 +9983,9 @@ msgid ""
 "be much more than the hovel it appears to be, but I can never seem to get "
 "inside the place."
 msgstr ""
-"当​我​使用​一些​有限​的​魔法​来​创造​我​储​存​在​这里​的​药剂​和​长生​不​老药​时，艾德莉亚​是​一​个​"
-"真正​的​女巫。她​似乎​从​不​睡觉，她​总是​能​接触​到​许多​神秘​的​大部头​和​文物。我​相信​她​的​"
-"小屋​可能​比​看​上去​的​小屋​要​大​得​多，但​我​似乎​永远​也​进​不​了​这个​地方。"
+"我只是用一些粗浅的魔法来炼制我店里的药水和灵药，而艾德莉亚却是一位真正的女术"
+"士。她似乎从不睡觉，总能弄到各种神秘的古籍和法器。我相信她的小屋远不像看上去"
+"那么简陋，但我似乎永远也进不去那个地方。"
 
 #: Source/translation_dummy.cpp:856
 msgid ""
@@ -9949,8 +9994,8 @@ msgid ""
 "hideous. No one - and especially such a young child - should have to suffer "
 "the way he did."
 msgstr ""
-"可怜​的​怀特。我​为​那​孩子​做​了​一切​可能​的​事，但​我​知道​他​看​不​起​我​被迫​绑​在​他​腿上​的​木"
-"钉。他​的​伤口​很​难​看。没有​人​——​尤其是​这么​小​的​孩子​——​应该​像​他​那样​受​苦。"
+"可怜的怀特。我为那孩子做了一切可能的事，但我知道他看不起我被迫绑在他腿上的木"
+"钉。他的伤口很难看。没有人——尤其是这么小的孩子——应该像他那样受苦。"
 
 #: Source/translation_dummy.cpp:857
 msgid ""
@@ -9960,9 +10005,9 @@ msgid ""
 "many murders that happen in the surrounding countryside, or perhaps the "
 "wishes of his wife that keep him and his family where they are."
 msgstr ""
-"我​真​不​明白​奥格登​为什么​留​在​崔斯特姆。他​有点​紧张，但​他​是​一​个​聪明​而​勤奋​的​人，无"
-"论​他​去​哪里​都​会​做​得​很​好。我​想​可能​是​因为​害怕​周围​农村​发生​的​许多​谋杀案，也​可能​是​"
-"因为​他​妻子​的​愿望，他​和​他​的​家人​一直​呆​在​那里。"
+"我真不明白奥格登为什么还留在崔斯特姆。他有些神经质，但他是个聪明勤劳的人，无"
+"论去哪都能过得很好。我想也许是周遭乡野频发的命案让他害怕，又或许是他妻子的心"
+"愿——总之，他和家人就这样留了下来。"
 
 #: Source/translation_dummy.cpp:858
 msgid ""
@@ -9972,19 +10017,19 @@ msgid ""
 "She claims that they are visions, but I have no proof of that one way or the "
 "other."
 msgstr ""
-"奥格登​的​酒吧​女​招待​是​个​可爱​的​女孩。她​祖母​病​得​很​重，有​妄想症。\n"
+"奥格登的酒吧女招待是个可爱的女孩。她的祖母病得很重，饱受幻觉折磨。\n"
 " \n"
-"​她​声称​那​是​幻觉，但​我​没有​证据​证明​这​一​点。"
+"她祖母声称那是预知幻象，不过我也没法证实是真是假。"
 
 #: Source/translation_dummy.cpp:859
 msgid "Good day! How may I serve you?"
-msgstr "你​好！有​什么​我​能​为​您​效劳​吗？"
+msgstr "你好！能为您做些什么吗？"
 
 #: Source/translation_dummy.cpp:860
 msgid ""
 "My grandmother had a dream that you would come and talk to me. She has "
 "visions, you know and can see into the future."
-msgstr "我​祖母​梦​见​你​来​和​我​说话。她​有​远见​卓识，你​知道，而且​能​预见​未来。"
+msgstr "我祖母梦见你会来找我。她拥有预知能力，你知道的，她能看见未来。"
 
 #: Source/translation_dummy.cpp:861
 msgid ""
@@ -9994,10 +10039,10 @@ msgid ""
 "It would take someone quite brave, like you, to see what she is doing out "
 "there."
 msgstr ""
-"镇​边​的​那​个​女人​是​个​女巫！她​看​起来​很​好，她​的​名字​叫​艾德莉亚，很​讨人​喜欢，但​我​很​"
-"害怕​她。\n"
+"镇边的那个女人是个女巫！她看起来挺友善的，她的名字，艾德莉亚，也很好听，但我"
+"非常怕她。\n"
 " \n"
-"像​你​这样​勇敢​的​人才​能​看到​她​在​外面​干​什么。"
+"只有像你这样勇敢的人，才敢去一探究竟。"
 
 #: Source/translation_dummy.cpp:862
 msgid ""
@@ -10006,16 +10051,16 @@ msgid ""
 "received praises from our King Leoric himself - may his soul rest in peace. "
 "Griswold is also a great hero; just ask Cain."
 msgstr ""
-"我们​的​铁匠​是​崔斯特姆​人民​的​骄傲。他​不仅​是​一​个​手艺​大师，在​他​的​行会​中​赢得​了​许多​"
-"比赛，而且​他​还​得到​了​我们​国王​李奥瑞克​本人​的​赞扬​——​愿​他​的​灵魂​安息。格里斯沃尔德​"
-"也​是​一​位​伟大​的​英雄​；​问问​凯恩。"
+"我们的铁匠是崔斯特姆人民的骄傲。他不仅是一个手艺大师，在他的行会中赢得了许多"
+"比赛，而且他还得到了我们国王李奥瑞克本人的赞扬——愿他的灵魂安息。格里斯沃尔德"
+"也是一位伟大的英雄；问问凯恩。"
 
 #: Source/translation_dummy.cpp:863
 msgid ""
 "Cain has been the storyteller of Tristram for as long as I can remember. He "
 "knows so much, and can tell you just about anything about almost everything."
 msgstr ""
-"从​我​记事​起，凯恩​一直​是​崔斯特姆​的​说​书​人。他​知道​的​太​多​了，几乎​什么​都​能​告诉​你。"
+"从我记事起，凯恩一直是崔斯特姆的说书人。他知道的太多了，几乎什么都能告诉你。"
 
 #: Source/translation_dummy.cpp:864
 msgid ""
@@ -10026,9 +10071,10 @@ msgid ""
 "frustrated watching him slip farther and farther into a befuddled stupor "
 "every night."
 msgstr ""
-"法恩汉​是​个​酒鬼，他​的​肚子​里​装满​了​啤酒，其他​人​的​耳朵​里​全​是​废话。\n"
+"法恩汉是个醉鬼，肚子里灌满了麦酒，嘴里吐的全是胡话。\n"
 " \n"
-"​我​知道​佩金​和​奥格登​都​同情​他，但​每​天​晚上​看​着​他​越来越​昏迷​不​醒，我​感到​非常​沮丧。"
+"我知道佩金和奥格登都同情他，但眼看着他每晚醉得越来越深、越来越不省人事，我真"
+"是又气又急。"
 
 #: Source/translation_dummy.cpp:865
 msgid ""
@@ -10037,8 +10083,9 @@ msgid ""
 "sword and more mysterious than any spell you can name. If you ever are in "
 "need of healing, Pepin can help you."
 msgstr ""
-"佩金救​了​我​祖母​的​命，我​知道​我​永远​也​报答​不​了​他。他​治愈​任何​疾病​的​能力​比​最​强大​的​"
-"剑​更​强大，比​你​能​说出​的​任何​法术​都​更​神秘。如果​你​需要​治疗，佩金​可以​帮助​你。"
+"佩金救了我祖母的命，我知道这份恩情，我永远也还不清。他治愈任何疾病的能力，比"
+"最锋利的剑更有力量，比你能说出的任何法术更加玄妙。如果你需要医治，佩金一定能"
+"帮你。"
 
 #: Source/translation_dummy.cpp:866
 msgid ""
@@ -10049,10 +10096,10 @@ msgid ""
 "seen horrors that I cannot even imagine, but some of that darkness hangs "
 "over him still."
 msgstr ""
-"我​和​怀特​的​母亲，加那斯​一​起​长大。虽然​当​那些​可怕​的​生物​偷走​他​时，她​只​是​受到​了​轻"
-"微​的​伤害，但​她​始终​没有​康复。我​想​她​死​于​心碎。怀特​成​了​一​个​小气鬼，只​想​从​别人​的​"
-"汗水​中​获利。我​知道​他​受苦受难，经历​过​我​无法​想象​的​恐惧，但​他​身​上​仍然​笼罩​着​一些​"
-"黑暗。"
+"我是和怀特的母亲卡纳西一起长大的。那些狰狞的怪物掳走她的孩子时，她虽然只是受"
+"了点轻伤，却始终没能缓过来。我想她是伤心过度才去了。怀特变成了一个刻薄的年轻"
+"人，只想从别人的辛苦里捞上一笔。我知道他受过苦，见过我无法想象的恐怖，但那片"
+"阴影至今仍笼罩着他。"
 
 #: Source/translation_dummy.cpp:867
 msgid ""
@@ -10061,12 +10108,12 @@ msgid ""
 "them, and hope one day to leave this place and help them start a grand hotel "
 "in the east."
 msgstr ""
-"奥格登​和​他​的​妻子​把​我​和​我​的​祖母​带到​他们​家​里，甚至​让​我​在​旅馆​工作​挣​了​几​块​金币。"
-"我​欠​他们​太​多​了，希望​有​一​天​离开​这个​地方，帮助​他们​在​东方​开​一​家​大​酒店。"
+"奥格登和他的妻子把我和祖母接到了他们家里，甚至让我在店里帮忙赚几个金币。我欠"
+"他们的实在太多。希望有一天能离开这里，帮他们在东方开一家富丽堂皇的大旅馆。"
 
 #: Source/translation_dummy.cpp:868
 msgid "Well, what can I do for ya?"
-msgstr "你​好，我​能​为​你​做​些​什么？"
+msgstr "嘿，有什么能帮你的？"
 
 #: Source/translation_dummy.cpp:869
 msgid ""
@@ -10075,8 +10122,8 @@ msgid ""
 "undying horrors down there, and there's nothing better to shatter skinny "
 "little skeletons!"
 msgstr ""
-"如果​你​想​找​一​件​好​武器，让​我​给​你​看看。带上​你​最​基本​的​钝器，比如​狼牙棒。像​一​个​魅"
-"力​对抗​那些​不朽​的​恐惧​在​那里，没有​什么​比​粉碎​瘦小​的​骨架​更​好！"
+"想找件趁手的好兵器？看这个。就拿最普通的钝器来说——比如钉头锤。对付底下那些不"
+"死怪物简直是绝配，再也没有比它更适合敲碎那副瘦骨头的玩意儿了！"
 
 #: Source/translation_dummy.cpp:870
 msgid ""
@@ -10085,9 +10132,9 @@ msgid ""
 "mind, however, that it is slow to swing - but talk about dealing a heavy "
 "blow!"
 msgstr ""
-"斧头？是​的，这​是​一​个​很​好​的​武器，可以​对付​任何​敌人。看看​它​是​如何​劈​开​空气​的，然"
-"后​想象​一​个​漂亮​的​胖魔鬼​头​在​它​的​路径​上。但是，请​记住，摇摆​是​很​慢​的，但是​谈论​如"
-"何​处理​一​个​沉重​的​打击！"
+"斧头？嘿，那可是把好家伙，什么敌人都能招呼。你看这劈风的架势——再想想一颗肥嘟"
+"嘟的恶魔脑袋挡在它面前。不过记住，抡起来是慢了点，但说到重击嘛……那可真叫一个"
+"狠！"
 
 #: Source/translation_dummy.cpp:871
 msgid ""
@@ -10096,9 +10143,9 @@ msgid ""
 "or pierce on the undead, but against a living, breathing enemy, a sword will "
 "better slice their flesh!"
 msgstr ""
-"看看​那​个​边缘，那个​平衡。右​手​中​的​剑，和​对​的​敌人，是​一切​武器​的​主人。它​锐利​的​刀"
-"锋​在​不​死​生物​身上​几乎​找​不​到​可​砍​或​可​刺​的​东西，但​对于​一​个​活生生​的、会​呼吸​的​敌"
-"人，一​把​剑会​更​好​地​切开​他们​的​肉！"
+"看看这刃口，这平衡感。在合适的人手里，碰上合适的对手，剑就是万兵之王。它锋利"
+"的剑刃对付不死生物几乎砍不进去也刺不穿，但面对活生生的、有血有肉的敌人——一剑"
+"下去，皮开肉绽！"
 
 #: Source/translation_dummy.cpp:872
 msgid ""
@@ -10106,8 +10153,8 @@ msgid ""
 "Darkness. If you bring them to me, with a bit of work and a hot forge, I can "
 "restore them to top fighting form."
 msgstr ""
-"你​的​武器​和​护甲​将​显示​你​与​黑暗​斗争​的​迹象。如果​你​把​它们​带到​我​这里​来，稍加​改造​和​"
-"热锻，我​就​能​把​它们​恢复​到​最佳​战斗​状态。"
+"你的武器和护甲会逐渐显露出你与黑暗搏斗的痕迹。把它们拿来给我，在炽热的熔炉上"
+"敲打一番，我就能让它们焕然一新、重返战场。"
 
 #: Source/translation_dummy.cpp:873
 msgid ""
@@ -10116,17 +10163,17 @@ msgid ""
 "seems to get whatever she needs. If I knew even the smallest bit about how "
 "to harness magic as she did, I could make some truly incredible things."
 msgstr ""
-"当​我​不​得不​从​我们​该​死​的​小​镇​边缘​的​商队​里​偷运​我​所​需要​的​金属​和​工具​时，那​个​女​巫艾"
-"德莉亚​似乎​总​能​得到​她​所​需要​的​一切。如果​我​像​她​那样​懂得​如何​运用​魔法，我​就​能​做出​"
-"一些​真正​不可​思议​的​事情。"
+"我甚至得偷偷摸摸从经过这破镇子边缘的商队那儿搞来金属和工具——可那个女巫艾德莉"
+"亚，要什么就有什么，从来不用愁。我要是能像她那样掌握一丁点儿驾驭魔法的门道，"
+"准能造出些真正了不起的东西来。"
 
 #: Source/translation_dummy.cpp:874
 msgid ""
 "Gillian is a nice lass. Shame that her gammer is in such poor health or I "
 "would arrange to get both of them out of here on one of the trading caravans."
 msgstr ""
-"吉莉安​是​个​好​姑娘。可惜​她​的​男朋友​身体​这么​差，否则​我​会​安排​他们​两​个​都​乘商队​离开​"
-"这里。"
+"吉莉安是个好姑娘。可惜她祖母身体太差了，不然我早就安排她们俩搭商队离开这鬼地"
+"方了。"
 
 #: Source/translation_dummy.cpp:875
 msgid ""
@@ -10134,8 +10181,8 @@ msgid ""
 "in life. If I could bend steel as well as he can bend your ear, I could make "
 "a suit of court plate good enough for an Emperor!"
 msgstr ""
-"有时​我​觉得​凯恩​说​得​太​多​了，但​我​想​这​是​他​一​生​的​使命。如果​我​能​像​他​能​弯曲​你​的​耳朵​"
-"一样​弯曲​钢铁，我​就​能​做​一​套​足够​好​的​皇帝​用​的​宫廷​盘子！"
+"有时候我觉得凯恩话太多了，不过也许这就是他活在世上的使命吧。要是我能像他能说"
+"会道那样锻造钢铁，我就能打出一副配得上皇帝的宫廷板甲！"
 
 #: Source/translation_dummy.cpp:876
 msgid ""
@@ -10144,9 +10191,10 @@ msgid ""
 "my side. I fear that the attack left his soul as crippled as, well, another "
 "did my leg. I cannot fight this battle for him now, but I would if I could."
 msgstr ""
-"那​天​晚上​我​和​法恩汉​在一起，拉扎鲁斯​把​我们​领进​了​迷宫。我​再​也​见不到​大主教​了，如"
-"果​法恩汉​不​在​我​身边，我​可能​就​活​不​下去​了。我​担心​这​次​袭击​使​他​的​灵魂​像​另​一​次​袭击​"
-"我​的​腿​一样​残废。我​现在​不​能​为​他​而​战，但​如果​可以​的​话​我​会​的。"
+"那天晚上拉扎鲁斯带我们进迷宫的时候，我跟法恩汉并肩作战。那之后我再也没见过大"
+"主教——要是没有法恩汉守在身边，我恐怕也活不出来。我担心那次遭遇给他的灵魂留下"
+"了创伤，就像……那次给我的腿留下的创伤一样。我没办法替他打这一仗，但如果做得"
+"到，我一定会的。"
 
 #: Source/translation_dummy.cpp:877
 msgid ""
@@ -10154,8 +10202,8 @@ msgid ""
 "left in Tristram - or anywhere else for that matter - who has a bad thing to "
 "say about the healer."
 msgstr ""
-"把​别人​的​需要​放​在​自己​的​需要​之上​的​好​人。你​不​会​发现​任何​人​留​在​崔斯特姆-​或​任何​其他​"
-"地方​的​问题​-​谁​有​一​个​坏​东西​说​的​治疗者。"
+"他是个把别人的需求放在自己之上的好人。在崔斯特姆——或者说无论去哪儿——你找不到"
+"任何人说那位医者一句坏话。"
 
 #: Source/translation_dummy.cpp:878
 msgid ""
@@ -10165,9 +10213,9 @@ msgid ""
 "origin. I cannot hold that against him after what happened to him, but I do "
 "wish he would at least be careful."
 msgstr ""
-"那​小子​会​惹​上​大​麻烦​的……或者​我​想​我​应该​再​说​一​遍。我​试​着​让​他​对​在​这里​工作​和​学习​诚"
-"实​的​贸易感​兴趣，但​他​更​喜欢​经营​来源​可疑​的​货物​的​高额​利润。我​不​能​在​他​出​事​后​再​对​"
-"他​说​这话，但​我​真​希望​他​至少​要​小心点。"
+"那小子迟早要惹上大麻烦……不，应该说是再惹一次。我试过劝他来这儿干活，学一门正"
+"经手艺，可他偏喜欢倒腾那些来路不明的货色赚快钱。不过看他遭了那些罪，我也不好"
+"怪他——只是真心希望他至少小心点。"
 
 #: Source/translation_dummy.cpp:879
 msgid ""
@@ -10179,19 +10227,18 @@ msgid ""
 "starved during that first year when the entire countryside was overrun by "
 "demons."
 msgstr ""
-"客栈​老板​没有​什么​生意，也​没有​真正​的​盈利​途径。他​设法​维持​生计，为​那些​偶尔​在​村子​"
-"里​漂泊​的​人​提供​食物​和​住宿，但​他们​很​可能​会​偷偷​溜进​夜空，就​像​他们​付​钱​给​他​一样。"
-"如果​不​是​因为​他​在​地窖里​储存​了​大量​的​谷物​和​干肉，为什么，我们​大多数​人​会​在​第一​年​"
-"饿死，那时​整​个​乡村​都​被​恶魔​蹂​躏。"
+"客栈老板没什么生意，也赚不到什么钱。他靠着给偶尔路过镇子的旅人提供食宿来勉强"
+"度日——可那些人付钱的概率跟趁着夜色溜走的概率差不多。要不是他地窖里囤的那些谷"
+"物和干肉，我们大多数人早在那年乡野被恶魔淹没的时候就饿死了。"
 
 #: Source/translation_dummy.cpp:880
 msgid "Can't a fella drink in peace?"
-msgstr "你​个​家伙​就​不​能​安静​地​喝​酒​吗？"
+msgstr "就不能让人安安静静喝口酒吗？"
 
 #: Source/translation_dummy.cpp:881
 msgid ""
 "The gal who brings the drinks? Oh, yeah, what a pretty lady. So nice, too."
-msgstr "送​饮料​的​那​个​女孩？哦，是​啊，多​漂亮​的​女人​啊。太​好​了。"
+msgstr "倒酒的那个姑娘？哦，是啊，多漂亮的小姐。人也真好。"
 
 #: Source/translation_dummy.cpp:882
 msgid ""
@@ -10199,8 +10246,8 @@ msgid ""
 "stuff, but you listen to me... she's unnatural. I ain't never seen her eat "
 "or drink - and you can't trust somebody who doesn't drink at least a little."
 msgstr ""
-"为什么​那个​老太​婆​不​改变​一下。当然，当然，她​有​东西，但​你​听​我​说……她​很​不​自然。我​"
-"从来​没​见​过​她​吃喝​——​你​也​不​能​相信​一​个​不​喝​酒​的​人。"
+"那个老太婆怎么就从来不出手帮忙呢。没错没错，她是有本事……但你听我说——她那人不"
+"正常。我从没见过她吃饭喝水——连酒都不沾一点的人，你可不能信。"
 
 #: Source/translation_dummy.cpp:883
 msgid ""
@@ -10208,15 +10255,15 @@ msgid ""
 "'em are real scary or funny... but I think he knows more than he knows he "
 "knows."
 msgstr ""
-"凯恩​不​是​他​说​的​那样。当然，当然，他​讲​了​一​个​好​故事……有些​真的​很​吓人​或者​很​有趣……"
-"但​我​想​他​知道​的​比​他​知道​的​还​多。"
+"凯恩可不光是他自己说的那样。对，对，他故事讲得可好了……有些还真吓人，有些又好"
+"笑……但我觉得他知道的东西，比他以为自己知道的还要多。"
 
 #: Source/translation_dummy.cpp:884
 msgid ""
 "Griswold? Good old Griswold. I love him like a brother! We fought together, "
 "you know, back when... we... Lazarus...  Lazarus... Lazarus!!!"
 msgstr ""
-"格里斯沃尔德？善良​的​老格里斯沃尔德。我​像​兄弟​一样​爱​他！我们​一起​战斗，你​知道，"
+"格里斯沃尔德？善良的老格里斯沃尔德。我像兄弟一样爱他！我们一起战斗，你知道，"
 "当……我们……拉扎鲁斯……拉扎鲁斯……拉扎鲁斯！！！"
 
 #: Source/translation_dummy.cpp:885
@@ -10226,8 +10273,9 @@ msgid ""
 "wantin' help. Hey, I guess that would be kinda like you, huh hero? I was a "
 "hero too..."
 msgstr ""
-"呵呵，我​喜欢​佩金。他​真的​很​努力，你​知道​的。听​着，你​应该​了解​他。像​这样​的​好​人​总"
-"是​有​人​想​帮忙。嘿，我​想​那​会​有点​像​你，英雄？我​也​是​个​英雄……"
+"嘿嘿嘿，我喜欢佩金。他是真心在帮人，你知道吧。听着，你得跟他认识认识。好家"
+"伙，老有人想找他帮忙。嘿，这么说来，跟你还挺像的哈，英雄？我以前也是个英雄"
+"呢……"
 
 #: Source/translation_dummy.cpp:886
 msgid ""
@@ -10235,8 +10283,9 @@ msgid ""
 "problems. Listen here - that kid is gotta sweet deal, but he's been there, "
 "you know? Lost a leg! Gotta walk around on a piece of wood. So sad, so sad..."
 msgstr ""
-"怀特​是​个​问题​比​我​还​多​的​孩子，我​知道​所有​的​问题。听​着​-​那​孩子​一定​是​个​好​人，但​他​去​"
-"过​那里，你​知道​吗？丢​了​一​条​腿！得​在​一​块​木头​上​走​来​走去。太​伤心​了，太​伤心​了……"
+"怀特那小子，问题比我还多——说到问题我可门儿清。听着——那小子确实有门好生意，但"
+"他可是亲身经历过来了，知道吗？丢了一条腿！整天拄着块木头走路。可怜啊，真可"
+"怜……"
 
 #: Source/translation_dummy.cpp:887
 msgid ""
@@ -10244,8 +10293,8 @@ msgid ""
 "long as she keeps tappin' kegs, I'll like her just fine. Seems like I been "
 "spendin' more time with Ogden than most, but he's so good to me..."
 msgstr ""
-"奥格登​是​镇​上​最​好​的​男人。我​觉得​他​妻子​不​太​喜欢​我，但​只要​她​不​停​地​敲桶，我​就​很​喜"
-"欢​她。似乎​我​和​奥格登​在一起​的​时间​比​大多数​人​都​多，但​他​对​我​很​好……"
+"奥格登是镇上最好的人。不过我觉着他老婆不太待见我——但只要她不停从酒桶里倒酒，"
+"我就一样喜欢她。我好像跟奥格登待在一起的时间比谁都多，可他对我真是太好了……"
 
 #: Source/translation_dummy.cpp:888
 msgid ""
@@ -10253,8 +10302,8 @@ msgid ""
 "specialty. This here is the best... theeeee best! That other ale ain't no "
 "good since those stupid dogs..."
 msgstr ""
-"我​想​告诉​你，因为​我​知道​这​一切。这​是​我​的​专长。这​是​最​好​的……最​好​的！其他​的​啤酒​不​"
-"好，因为​那些​蠢​狗……"
+"我给你说道说道，这事儿我可全懂，是我的专长。这个才是最好的……最——好的！自打那"
+"些该死的恶狗来了之后，别的麦芽酒就都不行喽……"
 
 #: Source/translation_dummy.cpp:889
 msgid ""
@@ -10262,8 +10311,8 @@ msgid ""
 "somewhere under the church is a whole pile o' gold. Gleamin' and shinin' and "
 "just waitin' for someone to get it."
 msgstr ""
-"从来​没有​人……听​我​说。在​某​个​地方​-​我​不​太​确定​-​但是​在​教堂​下面​的​某​个​地方​有​一​堆​金"
-"子。闪闪​发光，只是​等待​有​人​得到​它。"
+"从从来没人……听我说话。在某个地方——我也说不准——但在教堂底下某个地方，有老大一"
+"堆金子。闪闪发光，就等着人去拿呢。"
 
 #: Source/translation_dummy.cpp:890
 msgid ""
@@ -10272,8 +10321,9 @@ msgid ""
 "brutes! Oh, I don't care what Griswold says, they can't make anything like "
 "they used to in the old days..."
 msgstr ""
-"我​知道​你​有​自己​的​想法，我​知道​你​不​会​相信​的，但​你​的​武器，你​在​那里​-​它​只​是​不​好​对付​"
-"那些​大​畜生！哦，我​不管​格里斯沃尔德​怎么​说，他们​不​能​像​以前​那样​做​任何​东西……"
+"我知道你有自己的想法，我也知道你不会信，但你手上那把武器——对付那些大块头畜生"
+"根本就不顶用！哎，我才不管格里斯沃尔德怎么说，如今造的武器哪比得上从前那些老"
+"手艺……"
 
 #: Source/translation_dummy.cpp:891
 msgid ""
@@ -10281,12 +10331,12 @@ msgid ""
 "and get out of here. That boy out there... He's always got somethin' good, "
 "but you gotta give him some gold or he won't even show you what he's got."
 msgstr ""
-"如果​我​是​你……我​不​是……但​如果​我​是，我​会​卖掉​你​所有​的​东西​然后​离开​这里。外面​那​个​男"
-"孩……他​总是​有​好​东西，但​你​得​给​他​点金子，否则​他​连​他​的​东西​都​不​给​你​看。"
+"假如我是你……虽然我不是……但假如是的话，我就卖掉你身上所有东西，赶紧离开这儿。"
+"外面那小子……他总有些好东西，但你得给他金币，不然他连看都不让你看。"
 
 #: Source/translation_dummy.cpp:892
 msgid "I sense a soul in search of answers..."
-msgstr "我​感觉​到​一​个​灵魂​在​寻找​答案……"
+msgstr "我感受到一个寻求答案的灵魂……"
 
 #: Source/translation_dummy.cpp:893
 msgid ""
@@ -10294,8 +10344,8 @@ msgid ""
 "words. Should you already have knowledge of the arcane mysteries scribed "
 "within a book, remember - that level of mastery can always increase."
 msgstr ""
-"智慧​是​应​得​的，而​不​是​给予​的。如果​你​发现​了​一​本​知识​的​大部头，就​要​吞没​它​的​文字。"
-"如果​你​已经​掌握​了​书​中​描述​的​神秘​事物​的​知识，记住​-​掌握​的​水平​总是​可以​提高​的。"
+"智慧需要自己去获取，而非他人给予。若你发现了一本典籍，便要细细品味其中的每个"
+"字。若你已掌握了书中所记载的奥术奥秘，记住——那境界永远有提升的空间。"
 
 #: Source/translation_dummy.cpp:894
 msgid ""
@@ -10306,9 +10356,9 @@ msgid ""
 "be kept at the ready in your mind. Know also that these scrolls can be read "
 "but once, so use them with care."
 msgstr ""
-"最​强大​的​力量​往往​是​最​短命​的。你​可以​在​羊​皮纸​的​卷轴​上​找到​古老​的​权力​话语。这些​卷"
-"轴​的​力量​在于​学徒​或​熟练​的​施展​能力。他们​的​弱点​是，他们​必须​首先​大声​朗读，永远​不​"
-"能​随时​准备​在​你​的​脑海​中。还​要​知道​这些​卷轴​只​能​读​一​次，所以​要​小心​使用。"
+"最强大的力量往往转瞬即逝。你可以在羊皮卷轴上发现古老的咒语。这些卷轴的力量在"
+"于——无论学徒还是大师，都能释放出同等的威力。但其弱点也摆在面前：你必须高声诵"
+"读才能施展，无法常驻心间。更要紧的是，每张卷轴只能诵读一次，请务必谨慎使用。"
 
 #: Source/translation_dummy.cpp:895
 msgid ""
@@ -10318,9 +10368,9 @@ msgid ""
 "magical energies many times over. I have the ability to restore their power "
 "- but know that nothing is done without a price."
 msgstr ""
-"尽管​太阳​的​热量​无法​估量，但​光是​蜡烛​的​火焰​就​更​危险。没有​适当​的​聚焦，任何​能量，"
-"无论​多​大，都​不​能​被​使用。对于​许多​法术​来说，被​赋予​灵能​的​杖​可以​被​多​次​充满​魔法​能"
-"量。我​有​能力​恢复​他们​的​力量，但​我​知道​没有​代价​是​做​不​到​的。"
+"太阳之灼热虽不可估量，但蜡烛的一簇火苗反而更加危险。任何能量——无论多么宏大——"
+"若没有恰当的引导，都无法为人所用。许多法术可以通过附魔法杖来反复充能。我有能"
+"力恢复它们的能量——但记住，凡事皆有代价。"
 
 #: Source/translation_dummy.cpp:896
 msgid ""
@@ -10328,8 +10378,8 @@ msgid ""
 "or scroll that you cannot decipher, do not hesitate to bring it to me. If I "
 "can make sense of it I will share what I find."
 msgstr ""
-"我们​知识​的​总和​就​是​它​的​人民​的​总和。如果​你​发现​一​本​书​或​卷轴，你​不​能​破译，不​要​犹"
-"豫，把​它​给​我。如果​我​能​理解​的话，我​会​分享​我​的​发现。"
+"我们知识的总和，便是这里每个人所知的总和。若你发现无法解读的书或卷轴，尽管拿"
+"来找我。若我能解读其中的奥秘，定会与你分享。"
 
 #: Source/translation_dummy.cpp:897
 msgid ""
@@ -10337,8 +10387,8 @@ msgid ""
 "blacksmith Griswold is more of a sorcerer than he knows. His ability to meld "
 "fire and metal is unequaled in this land."
 msgstr ""
-"对​一​个​只​懂​钢铁​的​人​来​说，没有​什么​比​钢铁​更​神奇​了。铁匠​格里斯沃尔德比​他​所​知道​的​"
-"更​像​个​巫师。他​融火​与​金属​的​能力​在​这​片​土地​上​是​无与伦比​的。"
+"对一个只懂钢铁的人来说，没有什么比钢铁更神奇了。铁匠格里斯沃尔德比他所知道的"
+"更像个法师。他融火与金属的能力在这片土地上是无与伦比的。"
 
 #: Source/translation_dummy.cpp:898
 msgid ""
@@ -10347,8 +10397,8 @@ msgid ""
 "matriarch over her own. She fears me, but it is only because she does not "
 "understand me."
 msgstr ""
-"腐败​有​欺骗​的​力量，而​清白​有​纯洁​的​力量。年轻​的​吉莉安​有​一​颗​纯洁​的​心，把​女​家长​的​"
-"需要​凌驾于​自己​的​需要​之上。她​害怕​我，但​那​只​是​因为​她​不​了解​我。"
+"腐朽的力量在于欺骗，而纯真的力量在于赤诚。年轻的吉莉安心地纯洁，将尊长的需要"
+"置于自身之上。她畏惧我，但那不过是因为她不了解我。"
 
 #: Source/translation_dummy.cpp:899
 msgid ""
@@ -10357,8 +10407,8 @@ msgid ""
 "not look. His knowledge of what lies beneath the cathedral is far greater "
 "than even he allows himself to realize."
 msgstr ""
-"在​黑暗中​打开​的​箱子​所​装​的​财宝，并不​比​在​光明​中​打开​的​箱子​更​大。讲​故事​的​凯恩​是​一​"
-"个​谜，但​只有​那些​谁​不​看。他​对​大​教堂​下面​的​东西​的​了解​远远​超过​了​他​自己​的​想象。"
+"黑暗中开启的宝箱，并不比在光明中开启的更为珍贵。说书人凯恩如同一个谜——但只对"
+"那些不愿细察的人而言。他对大教堂之下的了解，远超他敢于承认的程度。"
 
 #: Source/translation_dummy.cpp:900
 msgid ""
@@ -10367,9 +10417,9 @@ msgid ""
 "fellow townspeople betrayed by the Archbishop Lazarus. He has knowledge to "
 "be gleaned, but you must separate fact from fantasy."
 msgstr ""
-"你​对​一​个​人​的​信心​越​高，他​就​越​会​堕落。法恩汉​已经​失去​了​他​的​灵魂，但​不​是​任何​恶"
-"魔。当​他​看到​他​的​同乡们​被​拉扎鲁斯大​主教​出​卖​时，他​失去​了​理智。他​有​知识​可以​收"
-"集，但​你​必须​把​事实​和​幻想​分开。"
+"你对一个人寄予的信任越高，摔落时便越惨。法恩汉失去了他的灵魂——但并非任何恶魔"
+"所为，而是在他亲眼看见自己的乡民被大主教拉扎鲁斯背叛之时。他的醉话中藏着有用"
+"的线索，但需你仔细分辨哪些是事实，哪些是幻觉。"
 
 #: Source/translation_dummy.cpp:901
 msgid ""
@@ -10379,9 +10429,8 @@ msgid ""
 "understanding of the creation of elixirs and potions. He is as great an ally "
 "as you have in Tristram."
 msgstr ""
-"手、心​和心​在​完美​的​和谐​中​就​能​创造​奇迹。治疗者​佩金​以​一​种​连​我​都​看​不​到​的​方式​观察​"
-"身体。他​对​长生​不​老药​和​药水​的​理解​使​他​恢复​病人​和​伤者​的​能力​得到​了​放大。他​和​你​在​"
-"崔斯特姆​一样​是​个​伟大​的​盟友。"
+"手、心、神三者合一，方能创造奇迹。医者佩金看待身体的方式连我都难以企及。他炼"
+"制灵药与药水的造诣，使他的治愈之术更为强大。他是你在崔斯特姆最得力的盟友。"
 
 #: Source/translation_dummy.cpp:902
 msgid ""
@@ -10393,10 +10442,10 @@ msgid ""
 "reproachful, Wirt can provide assistance for your battle against the "
 "encroaching Darkness."
 msgstr ""
-"未来​有​很多​我们​看​不​到​的，但​当​它​来​临​时，将​是​孩子们​掌握​着​它。这个​男孩​的​灵魂​是​黑"
-"暗​的，但​他​对​这个​城镇​和​它​的​人民​没有​威胁。他​与​附近​城镇​的​顽童​和​不​为​人知​的​行会​的​"
-"秘密​交易​使​他​能够​接触​到​许多​在​崔斯特姆​很​难​找到​的​设备。虽然​他​的​方法​可能​会​受到​指"
-"责，但​怀特​可以​为​你​对抗​日益​逼近​的​黑暗​提供​帮助。"
+"未来有许多我们无法预见的事，但终有一日，掌握未来的将是孩子们。男孩怀特的灵魂"
+"之上笼罩着一片黑暗，但他对这个镇子和镇民并不构成威胁。他通过附近城镇的小混混"
+"和地下帮会秘密交易，能弄到许多在崔斯特姆难以寻觅的奇货。他的手段固然不值称"
+"道，但怀特确实能为你对抗那入侵的黑暗助上一臂之力。"
 
 #: Source/translation_dummy.cpp:903
 msgid ""
@@ -10408,15 +10457,15 @@ msgid ""
 "found there, provide a glimpse of a life that the people here remember. It "
 "is that memory that continues to feed their hopes for your success."
 msgstr ""
-"土墙​和​茅草​屋顶​不​是​一​个​家。旅馆​老板​奥格登​在​这个​镇​上​的​作用​比​许多​人​所​理解​的​要​大​"
-"得​多。他​为​吉莉安​和​她​的​女族​长​提供​庇护所，维持​法恩汉​留给​他​的​生活，并​为​留​在​镇​上​"
-"的​所有人​提供​一​个​锚，让​他们​回到​崔斯特姆​曾经​的​样子。他​的​小酒馆，以及​在​那里​仍然​"
-"可以​找到​的​简单​的​乐趣，让​我们​看到​了​这里​的​人们​所​记得​的​生活。正​是​这​段​记忆，让​他"
-"们​对​你​的​成功​充满​了​希望。"
+"土墙茅顶，不足以称之为家。酒馆老板奥格登对这座镇子的贡献远比多数人所理解的要"
+"大得多。他为吉莉安和她那病弱的祖母提供了遮风挡雨的住所，让法恩汉仅存的那口气"
+"还能撑下去，更为镇上仅存的所有人系上一只锚——拽着他们不要忘记崔斯特姆曾经的模"
+"样。他的酒馆，以及那里仍然留存的一点人间乐趣，给了这里的人们一瞥他们所怀念的"
+"生活。正是那份回忆，一直在滋养着他们对你的期盼与希望。"
 
 #: Source/translation_dummy.cpp:904
 msgid "Pssst... over here..."
-msgstr "嘿​…​…​过来​这儿​…​…"
+msgstr "嘘……这边来……"
 
 #: Source/translation_dummy.cpp:905
 msgid ""
@@ -10425,16 +10474,16 @@ msgid ""
 " \n"
 "Sometimes, only you will be able to find a purpose for some things."
 msgstr ""
-"并​不​是​所有​在​崔斯特姆​的​人​都​有​一​个​用途​-​或​市场​-​你​会​发现​在​迷宫​中​的​一切。连​我​都​不​"
-"相信。\n"
+"并不说你在崔斯特姆找到的所有东西，都有用武之地——或者说有人肯收。连我也不例"
+"外，虽然听着难以置信。\n"
 " \n"
-"​有时候，只有​你​才​能​为​某些​事情​找到​目标。"
+"有些时候，只有你自己才能为某些东西找到用场。"
 
 #: Source/translation_dummy.cpp:906
 msgid ""
 "Don't trust everything the drunk says. Too many ales have fogged his vision "
 "and his good sense."
-msgstr "别​相信​醉汉​说​的​每​一​句​话。太​多​的​啤酒​模糊​了​他​的​视力​和​判断力。"
+msgstr "别信那醉鬼的每一句话。喝太多麦酒把他的眼光和判断力都弄混了。"
 
 #: Source/translation_dummy.cpp:907
 msgid ""
@@ -10443,9 +10492,9 @@ msgid ""
 "Griswold, Pepin or that witch, Adria. I'm sure that they will snap up "
 "whatever you can bring them..."
 msgstr ""
-"如果​你​没​注意​到，我​不​会​从​崔斯特姆​买​任何​东西。我​是​一​个​进口​优质​商品​的​进口商。如"
-"果​你​想​兜售​垃圾，你​得​去​看看​格里斯沃尔德，佩金​或​那​个​女巫，艾德莉亚。我​相信​他们​"
-"会​抢购​你​能​带给​他们​的​任何​东西……"
+"你可能还没注意到——我不收崔斯特姆本地的货。我是做精品进口生意的。想卖破烂的"
+"话，去找格里斯沃尔德、佩金，或者那个女巫艾德莉亚。我敢肯定，不管你拿什么给他"
+"们，他们都会抢着要……"
 
 #: Source/translation_dummy.cpp:908
 msgid ""
@@ -10454,9 +10503,9 @@ msgid ""
 "I'll never get enough money to... well, let's just say that I have definite "
 "plans that require a large amount of gold."
 msgstr ""
-"我​想​我​欠铁匠​一​条​命​——​这​是​怎么回​事。当然，格里斯沃尔德​让​我​在​铁匠​铺当​学徒，他​是​"
-"个​很​好​的​人，但​我​永远​拿​不​到​足够​的​钱……好​吧，就​说​我​有​明确​的​计划，需要​大量​的​黄"
-"金。"
+"我这条命——也不管剩下多少吧——算是铁匠给的。没错，格里斯沃尔德邀我去铁匠铺当学"
+"徒，他人也挺好。可我永远也凑不够钱去……算了，这么说吧，我有一个很明确的计划，"
+"需要好大一笔金子。"
 
 #: Source/translation_dummy.cpp:909
 msgid ""
@@ -10465,9 +10514,9 @@ msgid ""
 "Gillian is a beautiful girl who should get out of Tristram as soon as it is "
 "safe. Hmmm... maybe I'll take her with me when I go..."
 msgstr ""
-"如果​我​再​大​几​岁，我​会​尽​我​所​能​给​她​带来​财富，让​我​向​你​保证，我​可以​得到​一些​非常​好​"
-"的​东西。吉莉安​是​一​个​美丽​的​女孩，她​应该​尽快​离开​崔斯特姆，只要​它​是​安全​的。嗯……"
-"也许​我​去​的​时候​会​带​她​一起​去……"
+"要是再大几岁，我肯定倾尽所有钱财去追求她——别不信，我真能弄到不少好东西的。吉"
+"莉安是个美丽的好姑娘，她该趁现在还安全赶紧离开崔斯特姆。嗯……也许我走的时候可"
+"以带她一起……"
 
 #: Source/translation_dummy.cpp:910
 msgid ""
@@ -10475,8 +10524,8 @@ msgid ""
 "woman across the river. He keeps telling me about how lucky I am to be "
 "alive, and how my story is foretold in legend. I think he's off his crock."
 msgstr ""
-"凯恩​知道​的​太​多​了。他​把​我​吓死​了，甚至​比河​对岸​的​那​个​女人​还​可怕。他​不​停​地​告诉​"
-"我，我​活​着​是​多么​幸运，我​的​故事​是​如何​在​传说​中​被​预言​的。我​想​他​是​疯​了。"
+"凯恩知道的太多了。他把我吓死了，甚至比河对岸的那个女人还可怕。他不停地告诉"
+"我，我活着是多么幸运，我的故事是如何在传说中被预言的。我想他是疯了。"
 
 #: Source/translation_dummy.cpp:911
 msgid ""
@@ -10486,9 +10535,9 @@ msgid ""
 "down there, so don't even start telling me about your plans to destroy the "
 "evil that dwells in that Labyrinth. Just watch your legs..."
 msgstr ""
-"法恩汉-​现在​有​一​个​男人​有​严重​的​问题，我​知道​所有​的​严重​问题​可以。他​过于​相信​一​个​人​"
-"的​正直，拉扎鲁斯​就​把​他​带进​了​死亡​的​深渊。哦，我​知道​下面​是​什么样​的，所以​别​告诉​"
-"我​你​打算​消灭​迷宫​里​的​恶魔。小心​你​的​腿……"
+"法恩汉——那才是个真有大麻烦的人。'大麻烦'有多严重，我可太清楚了。他太相信一个"
+"人的正直，结果拉扎鲁斯带他走进了鬼门关。哼，我比谁都清楚那底下是什么滋味——所"
+"以你别跟我吹嘘你的屠魔计划。记住：小心你的腿……"
 
 #: Source/translation_dummy.cpp:912
 msgid ""
@@ -10497,9 +10546,9 @@ msgid ""
 " \n"
 "If I'd have had some of those potions he brews, I might still have my leg..."
 msgstr ""
-"只要​你​不​需要​任何​东西​复位，老佩金​是​一样​好，他们​来​了。\n"
+"只要不是断肢再接那种活儿，老佩金的本事没得挑。\n"
 " \n"
-"​如果​我​有​一些​他​酿造​的​药水，我​可能​还​有​腿……"
+"要是当年我有他酿的那些药水，兴许这条腿还在……"
 
 #: Source/translation_dummy.cpp:913
 msgid ""
@@ -10508,9 +10557,9 @@ msgid ""
 "get whatever she needs, too. Adria gets her hands on more merchandise than "
 "I've seen pass through the gates of the King's Bazaar during High Festival."
 msgstr ""
-"艾德莉亚真​让​我​烦恼。当然，凯恩​对​你​说​的​关于​过去​的​事​是​令​人​毛骨悚然​的，但​那​个​女​"
-"巫能​看​透​你​的​过去。她​也​总​有​办法​得到​她​需要​的​东西。艾德莉亚​拿到​的​商品​比​我​在​节日​"
-"期间​穿过​国王​集市​的​大门​看到​的​还​要​多。"
+"艾德莉亚真的让我心里发毛。没错，凯恩讲的往事已经够瘆人的了——可那个女巫能看穿"
+"你的内心！她也总有办法弄到自己想要的东西。艾德莉亚搞到的货色，比我在盛大节日"
+"时穿过国王市集见到的东西都多。"
 
 #: Source/translation_dummy.cpp:914
 msgid ""
@@ -10519,9 +10568,9 @@ msgid ""
 "stupid tavern. I guess at the least he gives Gillian a place to work, and "
 "his wife Garda does make a superb Shepherd's pie..."
 msgstr ""
-"奥格登呆​在​这里​真​是​个​傻瓜。我​可以​以​一​个​非常​合理​的​价格​把​他​弄​到​城外​去，但​他​坚持​"
-"要​和​那家​愚蠢​的​酒馆​混​过去。我​想​至少​他​给​了​吉莉安​一​个​工作​的​地方，他​的​妻子​嘉达​做​"
-"了​一​个​很​棒​的​牧羊派……"
+"奥格登留在这儿真是蠢到家了。我能用很合理的价钱把他弄出镇子，可他偏要守着那家"
+"破酒馆过日子。不过至少他给了吉莉安一个工作的地方，而且他老婆嘉达做的牧羊人派"
+"确实没得说……"
 
 #: Source/translation_dummy.cpp:915
 msgid ""
@@ -10529,14 +10578,14 @@ msgid ""
 "who would seek to steal the treasures secured within this room. So speaks "
 "the Lord of Terror, and so it is written."
 msgstr ""
-"在​英雄​走廊​的​另​一​端​藏匿​着​白骨密室。任何​胆​敢​盗取​此​地​财宝​的​人，都​将​遭受​永恒​的​死"
-"亡。恐惧​之​王​如是​说，本​书​也​如实​写。"
+"在英雄走廊的另一端藏匿着白骨密室。任何胆敢盗取此地财宝的人，都将遭受永恒的死"
+"亡。恐惧之王如是说，本书也如实写。"
 
 #: Source/translation_dummy.cpp:916
 msgid ""
 "...and so, locked beyond the Gateway of Blood and past the Hall of Fire, "
 "Valor awaits for the Hero of Light to awaken..."
-msgstr "…​…​于是，打开​鲜血​之​门，穿过​火焰​大厅，荣耀​等待​着​光明​的​英雄​去​唤醒​…​…"
+msgstr "……于是，打开鲜血之门，穿过火焰大厅，荣耀等待着光明的英雄去唤醒……"
 
 #: Source/translation_dummy.cpp:917
 msgid ""
@@ -10565,8 +10614,8 @@ msgid ""
 "fulfill his endless sacrifices to the Dark ones who scream for one thing - "
 "blood."
 msgstr ""
-"地狱​的​军械库​如同​鲜血​战神​的​私宅。其​所​到​之​处，无​不​留下​成千上万​的​残肢断臂。无论​"
-"是​天使​还是​人类​都​将​遭到​残杀，只​为了​能够​呈上​邪魔们​最​渴望​的​东西​——​鲜血。"
+"地狱的军械库如同鲜血督军的私宅。其所到之处，无不留下成千上万的残肢断臂。无论"
+"是天使还是人类都将遭到残杀，只为了能够呈上邪魔们最渴望的东西——鲜血。"
 
 #: Source/translation_dummy.cpp:919
 msgid ""
@@ -10578,10 +10627,10 @@ msgid ""
 "sky. Neither side ever gains sway for long as the forces of Light and "
 "Darkness constantly vie for control over all creation."
 msgstr ""
-"注意​并​见证​这里​的​真理，因为​它们​是​赫拉迪姆​最后​的​遗产。甚至​在​现在，在​我们​所​知​的​"
-"领域​之外，在​天堂​的​乌托邦​王国​和​燃烧​地狱​的​混乱​深渊​之间，仍​有​一​场​战争​在​肆虐。这​"
-"场​战争​被​称为​大​冲突，它​的​肆虐​和​燃烧​时间​比​天空​中​任何​一​颗​星星​都​要​长。只要​光明​和​"
-"黑暗​的​力量​不断​争夺​对​所有​造物​的​控制权，任何​一​方​都​不​会​获得​支配权。"
+"留心铭记，见证此书中的真理——这是赫拉迪姆最后的遗产。高阶天堂的乌托邦诸国与烈"
+"焰地狱的混沌深渊之间，至今仍有一场战争在持续激荡。这场战争被称为\"永恒之战"
+"\"，它燃烧的时间比天空中的任何星辰都要久远。光明与黑暗的力量永无休止地争夺着"
+"一切造物的控制权，任何一方都无法长久占据上风。"
 
 #: Source/translation_dummy.cpp:920
 msgid ""
@@ -10593,10 +10642,10 @@ msgid ""
 "have even allied themselves with either side, and helped to dictate the "
 "course of the Sin War."
 msgstr ""
-"注意​并​见证​这里​的​真理，因为​它们​是​赫拉迪姆​最后​的​遗产。当天堂​和​地狱​之间​永恒​的​冲"
-"突​落​在​凡人​的​土地​上，这​就​是​原罪之战。天使​和​恶魔​伪​装​着​行走​在​人类​之中，秘密​地​战"
-"斗，远离​凡人​窥探​的​眼睛。一些​勇敢、强大​的​凡人​甚至​与​任何​一​方​结盟，并​帮助​指挥​罪"
-"恶​战争​的​进程。"
+"注意并见证这里的真理，因为它们是赫拉迪姆最后的遗产。当高阶天堂和地狱之间永恒"
+"的冲突落在凡人的土地上，这就是原罪之战。天使和恶魔伪装着行走在人类之中，秘密"
+"地战斗，远离凡人窥探的眼睛。一些勇敢、强大的凡人甚至与任何一方结盟，并帮助指"
+"挥罪恶战争的进程。"
 
 #: Source/translation_dummy.cpp:921
 msgid ""
@@ -10619,18 +10668,18 @@ msgid ""
 "faith. If Diablo were to be released, he would seek a body that is easily "
 "controlled as he would be very weak - perhaps that of an old man or a child."
 msgstr ""
-"注意​并​见证​这里​的​真理，因为​它们​是​赫拉迪姆​最后​的​遗产。近​三百​年​前，人们​知道​燃烧​"
-"地狱​的​三​大​恶魔​神秘​地​来到​了​我们​的​世界。兄弟​三​人​蹂躏​东方​的​土地​数十​年，而​人类​却​"
-"在​他们​身​后​战栗。我们​的​骑士团​——​赫拉迪姆​——​是​由​一​群​神秘​的​法师​建立​的，目的​是​一​劳"
-"永逸​地​追捕​和​俘虏​这​三​个​恶魔。\n"
+"留心铭记，见证此书中的真理——这是赫拉迪姆最后的遗产。大约三百年前，人们得知烈"
+"焰地狱的三位首恶已神秘地降临到我们的世界。这三兄弟在东方诸国肆虐了数十年，人"
+"类在他们的铁蹄下瑟瑟发抖。我们教团——赫拉迪姆——由一群秘密的法师创立，旨在追捕"
+"并永久封印三恶魔。\n"
 " \n"
-"​最初​的​赫拉迪姆​在​被​称为​“​灵魂​石​”​的​强大​文物​中​捕获​了​其中​两​个，并​将​它们​深​埋​在​荒凉​"
-"的​东部​沙漠​之下。第三​个​恶魔​逃脱​了​追捕，逃到​了​西部，许多​赫拉迪姆人​都​在​追捕。第"
-"三​个​恶魔-​被​称为​迪亚波罗，恐惧​之​王​-​最终​被​俘虏，他​的​灵魂石​和​埋​在​这​个​迷宫​的​本"
-"质。\n"
+"最早的赫拉迪姆将三恶魔中的两个封印在了名为灵魂石的强大神器之中，深埋在东方荒"
+"凉的黄沙之下。第三个恶魔逃脱了追捕，向西逃窜，众多赫拉迪姆一路追击。第三个恶"
+"魔——被称为恐惧之王的迪亚波罗——最终被捕获，其灵魂被锁入灵魂石，埋葬在这迷宫深"
+"处。\n"
 " \n"
-"​要​被​警告，灵魂​之石​必须​防止​被​那些​不​信​的​人​发现。如果​迪亚波罗​被​释放，他​会​寻找​一​"
-"个​身体​很​容易​控制，因为​他​会​非常​虚弱-​也许​是​一​个​老人​或​儿童。"
+"谨记：灵魂石绝不能被非信仰者发现。若迪亚波罗被释放，他将寻找一个易于控制的躯"
+"体——因为他会非常虚弱——或许是老人，或许是孩童。"
 
 #: Source/translation_dummy.cpp:922
 msgid ""
@@ -10642,10 +10691,10 @@ msgid ""
 "the factions of Belial and Azmodan while the forces of the High Heavens "
 "continually battered upon the very Gates of Hell."
 msgstr ""
-"因此，在​燃烧​的​地狱​里​发生​了​一​场​被​称为​黑暗​放逐​的​伟大​革命。较​小​的​邪恶​推翻​了​三​个​"
-"主要​的​邪恶，并​将​他们​的​精神​形式​放逐​到​凡人​的​领域。恶魔彼​列尔​（​谎言之王​）​和​阿兹"
-"莫丹​（​罪恶​之​王​）​在​兄弟​三​人​不​在​的​时候​争夺​地狱​的​统治权。所有​的​地狱​恶魔​都​在​彼列"
-"尔​和​阿兹莫丹​两​个​派系​之间​分化，而​天堂​的​力量​不断​地​冲击​着​地狱​的​大门。"
+"就这样，烈焰地狱中发生了一场被称为\"黑暗流放\"的伟大革命。次等恶魔们推翻了三"
+"大首恶，将他们的灵魂形态放逐到了凡间。恶魔彼列尔（谎言之王）与阿兹莫丹（罪恶"
+"之王）趁三兄弟不在之际争夺地狱的统治权。整个地狱在彼列尔与阿兹莫丹两派之间分"
+"崩离析，而天堂的大军则持续猛攻着地狱之门。"
 
 #: Source/translation_dummy.cpp:923
 msgid ""
@@ -10655,9 +10704,9 @@ msgid ""
 "secretive Order of mortal magi named the Horadrim, who quickly became adept "
 "at hunting demons. They also made many dark enemies in the underworlds."
 msgstr ""
-"许多​恶魔​为了​寻找​三​兄弟​来到​了​凡间。这些​恶魔​被​天使们​带到​了​凡​间，他们​在​东方​的​广"
-"大​城市​里​猎杀​他们。天使们​与​一​个​隐秘​的​名​为​赫拉迪姆​法师​教团​结盟，他​很​快​就​变得​善"
-"于​猎杀​恶魔。他们​也​在​阴间​制造​了​许多​黑暗​的​敌人。"
+"许多恶魔为了寻找三兄弟来到了凡间。天使们追踪这些恶魔来到凡世，在东方的广阔城"
+"市中猎杀它们。天使们与一个名为赫拉迪姆的隐秘凡人法师教团结盟，这个教团很快便"
+"精于猎杀恶魔之道。同时他们也在阴间树敌无数。"
 
 #: Source/translation_dummy.cpp:924
 msgid ""
@@ -10675,15 +10724,14 @@ msgid ""
 "He will then arise to free his Brothers and once more fan the flames of the "
 "Sin War..."
 msgstr ""
-"因此，这​三​个​主要​的​恶魔​以​灵魂​的​形式​被​放逐​到​凡人​的​领域，在​东方​缝​了​几十​年​的​混乱​"
-"之后，他们​被​凡人​赫拉迪姆​的​诅咒​的​秩序​所​追捕。赫拉迪姆​使用​了​被​称为​“​灵魂​石​”​的​人"
-"工​制品​来​容纳​仇恨​之​主​墨菲斯托​和​他​的​兄弟​毁灭​之​主巴力​的​精髓。最​小​的​弟弟​——​恐惧​之​"
-"王迪亚波罗​——​逃到​了​西方。\n"
+"三大首恶以灵魂形态被放逐到凡间。在东方散播了数十年混乱之后，他们被凡人的赫拉"
+"迪姆教团一路追捕。赫拉迪姆使用了名为灵魂石的神器来封印仇恨之王墨菲斯托及其兄"
+"弟毁灭之王巴尔的精魂。最小的兄弟——恐惧之王迪亚波罗——逃往了西方。\n"
 " \n"
-"​最终，赫拉迪姆​也​在​一​块​灵魂石中​俘​获​了​迪亚波罗，并​将​他​埋葬​在​一​座​被​遗忘​的​古老大​"
-"教堂​下。在​那里，恐怖​之​主​沉睡​着，等待​着​他​的​重生。你们​要​知道，他​要​寻求​一​个​充满​"
-"青春​和​力量​的​身体​来​占有，一​个​清白​和​容易​控制​的​身体。然后​他​会​起来​解救​他​的​兄弟"
-"们，再​一​次​煽起​原罪之战​的​火焰……"
+"最终，赫拉迪姆也将迪亚波罗捕获，封印入灵魂石，埋在一座古老、被遗忘的大教堂之"
+"下。在那里，恐惧之王沉睡着，等待着重生的时机。切记：他将寻找一个年轻而强大的"
+"躯体来占据——一个无辜且易于控制的躯体。他将苏醒，释放他的兄弟，再次点燃原罪之"
+"战的烈焰……"
 
 #: Source/translation_dummy.cpp:925
 msgid ""
@@ -10694,10 +10742,10 @@ msgid ""
 "that have brought this discord to the realms of man. My lord has named the "
 "battle for this world and all who exist here the Sin War."
 msgstr ""
-"所有​赞扬迪亚波罗-恐惧​之​王​和​黑暗​流放​的​幸存者。当​他​从​沉睡​中醒​来​时，我​的​主人​和​主"
-"人​对​我​说​了​一些​很​少​有​人​知道​的​秘密。他​告诉​我，天上​的​王国​和​燃烧​的​地狱​的​深坑​正在​"
-"进行​一​场​永恒​的​战争。他​揭示​了​将​这​种​不​和谐​带到​人类​领域​的​力量。我​主​已​将​这​场​为​世"
-"界​而​战​的​战争​和​所有​在​这里​生存​的​人​命名​为​原罪之战。"
+"一切颂赞归于迪亚波罗——恐惧之王，黑暗流放的幸存者。当他从漫长的沉睡中苏醒时，"
+"吾主对我讲述了凡人所不知的秘密。他告诉我，高阶天堂的诸国与烈焰地狱的深渊之"
+"间，正在进行一场永恒的战争。他揭示了将这场纷争带入凡人世界的力量。吾主已将这"
+"场为世界和一切生灵而战的战争，命名为原罪之战。"
 
 #: Source/translation_dummy.cpp:926
 msgid ""
@@ -10708,10 +10756,10 @@ msgid ""
 "beneath the sands of the east. Once my Lord releases his Brothers, the Sin "
 "War will once again know the fury of the Three."
 msgstr ""
-"荣耀​和​赞许​给​迪亚波罗-恐惧​之​王​和​三​人​之​首。我​主​对​我​谈到​他​的​两​个​兄弟，墨菲斯托​和​"
-"巴尔，他们​很​久​以前​被​放逐​到​这个​世界​上。我​的​主​希望​等待​时机，利用​他​令​人​敬畏​的​能"
-"力，以便​将​他​被​俘​的​兄弟们​从​东方​沙漠下​的​坟墓​中​解救​出来。一旦​我​主​释放​了​他​的​兄"
-"弟，原罪​之​战​将​再次​知道​三​人​的​愤怒。"
+"荣耀与赞颂归于迪亚波罗——恐惧之王，三兄弟之首。吾主对我讲起了他的两位兄弟——墨"
+"菲斯托与巴尔——他们在很久以前被放逐到了这个世界。吾主意在韬光养晦，积蓄他那令"
+"人敬畏的力量，以便将他被囚的兄弟从东方沙漠之下的坟墓中解救出来。一旦吾主释放"
+"了他的兄弟，原罪之战将再次感受到三兄弟的怒火。"
 
 #: Source/translation_dummy.cpp:927
 msgid ""
@@ -10725,12 +10773,12 @@ msgid ""
 "Diablo's call and pray that I will be rewarded when he at last emerges as "
 "the Lord of this world."
 msgstr ""
-"向​迪亚波​罗致敬​和​献祭​-​恐惧​之​王​和​灵魂​的​毁灭者。当​我​从​睡梦​中​唤醒​我​的​主人​时，他​试"
-"图​拥有​一​个​凡人​的​形体。迪亚波罗​试图​夺走​李奥瑞克​国王​的​尸体，但​我​的​主人​被​囚禁​后​"
-"太​虚​弱​了。我​的​主人​需要​一​个​简单​和​无辜​的​锚​到​这个​世界​上，所以​发现​男孩​艾伯莱希特"
-"特​是​完美​的​任务。当善良​的​国王​李奥瑞克​被​迪亚波罗的​失败​激怒​时，我​绑架​了​他​的​儿子​"
-"艾伯莱希特，把​他​带到​我​的​主人​面​前。我​现在​等待​着​迪亚波罗的​召唤，祈祷​当​他​最终​成"
-"为​这​个​世界​的​主​时，我​会​得到​回报。"
+"致敬与献祭归于迪亚波罗——恐惧之王，灵魂的毁灭者。当我将主人从沉睡中唤醒时，他"
+"试图占据一具凡人的躯体。迪亚波罗本欲夺取李奥瑞克国王的身体，但主人因长期囚禁"
+"而过于虚弱。我的主人需要一个简单而纯真的锚点来连接这个世界，于是便选中了男孩"
+"艾伯莱希特——这个完美的容器。善良的李奥瑞克国王在迪亚波罗失败的附体尝试中陷入"
+"了疯狂，而我则趁机绑架了他的儿子艾伯莱希特，将他带到了主人面前。如今我正等待"
+"着迪亚波罗的召唤，祈祷在他最终成为这个世界之主时，能得到应有的奖赏。"
 
 #: Source/translation_dummy.cpp:928
 msgid ""
@@ -10745,14 +10793,14 @@ msgid ""
 " \n"
 "Perhaps I can tell you more if we speak again. Good luck."
 msgstr ""
-"谢天谢地，你​终于​回来​了！\n"
-"​我​的​朋友，你​居住​过​的​这里​发生​了​巨大​的​变化。一切​都​很​平静，直​到​黑暗​骑士​到来，摧"
-"毁​了​我们​的​村子。很多​没有​抵抗​的​人​直接​被​砍杀，而​那些​拿起​武器​反抗​的​人​也​被​屠杀​或"
-"是​被​抓​走​成为​奴隶，甚至​更​糟。城镇​边​的​教堂​已经​被​亵渎，用​作​黑暗​仪式。回荡​在​叫声​"
-"夜晚​不​是​人​可以​忍受​的，也许​一些​镇民​还​活​着。这​条​我​的​旅店​和​这​铁​匠铺​之间​的​路​通​向​"
-"教堂，去​拯救​那些​人​吧。\n"
-"\n"
-"​如果​你​想要​知道​更​多​事，就​再​和​我​谈谈，我​也许​能​告诉​你。祝​你​好运。"
+"谢天谢地，你回来了！\n"
+"自从你离开这里，一切都变了，我的朋友。在黑暗骑士到来、毁掉我们的村庄之前，这"
+"里曾一片安宁。许多人当场倒下，而那些拿起武器反抗的人，不是被杀，就是被拖走沦"
+"为奴隶——甚至更惨。镇子边缘的教堂已被亵渎，正被用于黑暗的仪式。夜里回荡的尖叫"
+"不似人声，但我们的一些镇民或许还活着。沿着我的酒馆和铁匠铺之间的小路走，就能"
+"找到教堂——去拯救你能拯救的人吧。\n"
+" \n"
+"如果我们再谈谈，我或许能告诉你更多。祝你好运。"
 
 #: Source/translation_dummy.cpp:929
 msgid ""
@@ -10760,8 +10808,8 @@ msgid ""
 "a treasure that is hidden less so.  I will leave you with this.  Do not let "
 "the sands of time confuse your search."
 msgstr ""
-"继续​你​的​任务。找到​丢失​的​宝藏​并不​容易。找到​一​个​藏得​不​那么​深​的​宝藏。我​把​这个​留"
-"给​你。不​要​让​时间​的​沙子​迷惑​了​你​的​寻找。"
+"继续你的使命吧。寻找失落的宝藏本非易事，而寻找被刻意隐藏的宝物则更加艰难。我"
+"送你一句话：别让时光的沙尘模糊了你的搜寻之路。"
 
 #: Source/translation_dummy.cpp:930
 msgid ""
@@ -10770,14 +10818,15 @@ msgid ""
 "don't match our town at all.  I'd keep my mind on what lies below the "
 "cathedral and not what lies below our topsoil."
 msgstr ""
-"什么？！这​是​愚蠢​的。崔斯特姆​这里​没有​宝藏。让​我​看看！！啊，看​这些​画​不​准确。他"
-"们​根本​不​符合​我们​的​城市。我​会​把​心思放​在​大​教堂​下面，而​不​是​我们​的​表土​下面。"
+"什么？！这太荒唐了。崔斯特姆哪来什么埋藏的宝藏。让我看看！！啊，你看这些图根"
+"本不准，和我们镇子的布局完全对不上。我劝你多关心大教堂下面有什么，而不是关心"
+"我们地底下埋着什么。"
 
 #: Source/translation_dummy.cpp:931
 msgid ""
 "I really don't have time to discuss some map you are looking for.  I have "
 "many sick people that require my help and yours as well."
-msgstr "我​真的​没有​时间​讨论​你​要​找​的​地图。我​有​许多​病人​需要​我​和​你​的​帮助。"
+msgstr "我真没空讨论你在找的什么地图。我有很多病人需要照顾，你也一样忙得很。"
 
 #: Source/translation_dummy.cpp:932
 msgid ""
@@ -10785,8 +10834,8 @@ msgid ""
 "His honor stripped and his visage altered.  He is trapped in immortal "
 "torment.  Charged to conceal the very thing that could free him."
 msgstr ""
-"曾经​引​以为​傲​的​Iswall​深陷​在​这个​世界​的​表面​之下。他​的​荣誉​被​剥夺​了，面容​也​变​了。"
-"他​被困​在​不朽​的​折磨​之中。被​指控​隐瞒​能​让​他​自由​的​事情。"
+"曾经骄傲的伊斯瓦尔被困在了这个世界的地表之下。他的荣耀被剥夺，容貌被扭曲，在"
+"永无止境的折磨中受困。他被诅咒去隐藏那唯一能解救他的东西。"
 
 #: Source/translation_dummy.cpp:933
 msgid ""
@@ -10794,8 +10843,8 @@ msgid ""
 "at you later when you were running around the town with your nose in the "
 "dirt.  I'd ignore it."
 msgstr ""
-"我​敢​打赌，怀特​看见​你​来​了，就​装​出​一​副样子，这样​他​就​可以​在​你​鼻子​埋​在​泥土​里​在​城"
-"里​跑​的​时候​嘲笑​你​了。我​会​忽略​它。"
+"我敢打赌，怀特看见你过来，故意演戏耍你——好等你鼻尖贴着地面满镇子乱跑的时候，"
+"他躲在后面偷笑。换我就当没这回事。"
 
 #: Source/translation_dummy.cpp:934
 msgid ""
@@ -10804,16 +10853,17 @@ msgid ""
 "treasure are common fantasies of any child.  Wirt seldom indulges in "
 "youthful games.  So it may just be his imagination."
 msgstr ""
-"曾经​有​一​段​时间，这​个​城镇​是​远道而​来​的​旅行者​的​常去之​地。从​那​以后​发生​了​很​大​的​变"
-"化。但​隐藏​的​洞穴​和​埋藏​的​宝藏​是​任何​孩子​的​共同​幻想。怀特​很少​沉迷​于​年轻​人​的​游"
-"戏。所以​这​可​能​只​是​他​的​想象。"
+"曾几何时，这座小镇是四方旅人们常来歇脚的地方。可后来一切都变了。不过，什么隐"
+"藏洞穴、埋藏宝藏之类的，都是小孩子才信的东西。怀特很少沉溺于这种幼稚的游戏，"
+"所以这可能只是他的幻想罢了。"
 
 #: Source/translation_dummy.cpp:935
 msgid ""
 "Listen here.  Come close.  I don't know if you know what I know, but you've "
 "have really got something here.  That's a map."
 msgstr ""
-"听​着。靠近点。我​不​知道​你​是否​知道​我​所​知道​的，但​你​真的​有所​收获。那​是​一​张​地图。"
+"听着。靠近点。我不知道你是不是知道我所知道的，但你这回可真的发现好东西了。这"
+"是一张地图。"
 
 #: Source/translation_dummy.cpp:936
 msgid ""
@@ -10824,10 +10874,10 @@ msgid ""
 "offering would be altered in some strange way.  I don't know if this is just "
 "the talk of an old sick woman, but anything seems possible these days."
 msgstr ""
-"我​祖母​经常​给​我​讲​一些​关于​居住​在​教堂​外​墓地​的​奇怪​势力​的​故事。你​可能​会​对​其中​一​个​"
-"很​感​兴趣。她​说，如果​你​把​合适​的​祭品​留​在​墓地，进入​大​教堂​为​死者​祈祷，然后​再​回"
-"来，祭品​会​以​某​种​奇怪​的​方式​改变。我​不​知道​这​是​不​是​一​个​老​病妇​的​谈话，但​最近​似乎​"
-"什么​都​有​可能。"
+"我祖母常给我讲关于教堂外墓地中徘徊的奇异力量的故事。也许其中有一个你会感兴"
+"趣。她说，如果你在墓园中留下合适的祭品，然后进入大教堂为死者祈祷，再回到墓园"
+"时，祭品就会以某种奇异的方式发生变化。我不知道这是不是一个病弱老妇人的胡话，"
+"但近来这些日子，似乎什么都有可能。"
 
 #: Source/translation_dummy.cpp:937
 msgid ""
@@ -10835,8 +10885,8 @@ msgid ""
 "interested in picking up a few things from you.  Or better yet, don't you "
 "need some rare and expensive supplies to get you through this ordeal?"
 msgstr ""
-"嗯。你​说​的​是​一​个​巨大​而​神秘​的​宝藏。嗯。也许​我​有​兴趣​从​你​那里​得到​一些​东西。或者​"
-"更​好​的​是，你​不​需要​一些​稀有​而​昂贵​的​物资​来​度过​这​场​磨难​吗？"
+"嗯……一个巨大而神秘的宝藏，你是说。嗯……也许我会对你手里的一些东西感兴趣。或者"
+"换个角度想——你难道不需要一些稀有且昂贵的物资，来挺过这场磨难吗？"
 
 #: Source/translation_dummy.cpp:938
 msgid ""
@@ -10848,18 +10898,18 @@ msgid ""
 "you could destroy it, I would be forever grateful. I'd do it myself, but "
 "someone has to stay here with the cows..."
 msgstr ""
-"所以，你​是​每​个​人​都​在​谈论​的​英雄。也许​你​能​帮助​一​个​贫穷​的​农民​摆脱​困境？在​我​的​果"
-"园​的​边缘，就​在​这里​的​南边，有​一​个​可怕​的​东西​从​地​里​冒​出来！我​不​能​得到​我​的​庄稼​或​"
-"我​的​捆干草，我​可怜​的​奶牛会​饿死。巫婆​把​这个​给​了​我，说​它​会​把​那​东西​从​我​的​地​里​炸​"
-"出来。如果​你​能​毁掉​它，我​将​永远​感激。我​自己​会​做​的，但​总​得​有​人​留​下来​陪奶牛……"
+"啊，你就是大家都在说的那位英雄吧。也许你能帮一个可怜的、老实巴交的农民摆脱困"
+"境？就在我的果园边上，往南走不远，有个可怕的东西正从地里冒出来！我根本没法靠"
+"近我的庄稼和干草堆，我可怜的奶牛都快饿死了。那个巫婆给了我这个，说这东西能把"
+"那玩意儿从我的地里轰出来。如果你能帮我炸掉它，我将感激不尽。我本来想自己去"
+"的，但总得有人留在这儿看着奶牛……"
 
 #: Source/translation_dummy.cpp:939
 msgid ""
 "I knew that it couldn't be as simple as that witch made it sound. It's a sad "
 "world when you can't even trust your neighbors."
 msgstr ""
-"我​知道​事情​不​会​像​巫婆​说​的​那么​简单。当​你​连​邻居​都​不​能​信任​的​时候，这​是​一​个​悲哀​的​"
-"世界。"
+"我就知道事情不会像那个巫婆说的那么简单。连邻居都不能信任，这世道真是可悲。"
 
 #: Source/translation_dummy.cpp:940
 msgid ""
@@ -10867,8 +10917,9 @@ msgid ""
 "it? You what? Oh, don't tell me you lost it! Those things don't come cheap, "
 "you know. You've got to find it, and then blast that horror out of our town."
 msgstr ""
-"它​不见​了​吗？你​把​它​送回​了​孕育​它​的​阴间​吗？你​什么？哦，别​告诉​我​你​丢​了！你​知道，"
-"那些​东西​不便宜。你​一定​要​找到​它，然后​把​那​恐惧​的​东西​轰​出去。"
+"它消失了吗？你把它送回孕育它的黑暗深渊了？你说什么？哦，别告诉我你把那东西弄"
+"丢了！你知道，那玩意儿可不便宜。你非得找到它不可，然后把那个恐怖的东西轰出我"
+"们的镇子。"
 
 #: Source/translation_dummy.cpp:941
 msgid ""
@@ -10877,8 +10928,8 @@ msgid ""
 "church, and so forth, these are trying times. I am but a poor farmer, but "
 "here -- take this with my great thanks."
 msgstr ""
-"我​听到​爆炸声​了！多谢​你，善良​的​陌生人。随着​所有​这些​东西​从​地下​冒​出来，怪物​占领​"
-"了​教堂，等等，这些​都​是​艰难​的​时刻。我​只​是​一​个​贫穷​的​农民，但​在​这里​——​请​接受​我​的​"
+"我在这儿都听见爆炸声了！万分感谢你，好心的陌生人。瞧瞧这世道——东西从地里冒出"
+"来，怪物占领了教堂，真是多事之秋。我只是个穷农民，但请收下这个——聊表我深深的"
 "谢意。"
 
 #: Source/translation_dummy.cpp:942
@@ -10888,12 +10939,12 @@ msgid ""
 "those creatures you could come back... and spare a little time to help a "
 "poor farmer?"
 msgstr ""
-"哦，我​有​这么​大​的​麻烦​…​也许​…​不，我​不​能​强加​给​你，还​有​其他​的​麻烦。也许​在​你​清除​了​"
-"教堂​里​的​一些​生物​之后​你​可以​回来……抽出​一点​时间​去​帮助​一​个​贫穷​的​农民？"
+"唉，我这麻烦可真不小啊……也许……不，你还有那么多麻烦事，我哪能再给你添乱。也许"
+"等你把教堂里那些妖怪清理一些之后，再回来……抽点时间帮帮一个穷农民？"
 
 #: Source/translation_dummy.cpp:943
 msgid "Waaaah! (sniff) Waaaah! (sniff)"
-msgstr "哇​啊​(​嗅​）​哇​啊​(嗅嗅​）"
+msgstr "呜哇哇！（抽鼻子）呜哇哇！（抽鼻子）"
 
 #: Source/translation_dummy.cpp:944
 msgid ""
@@ -10902,17 +10953,16 @@ msgid ""
 "but we snuck over there, and then suddenly this BUG came out!  We ran away "
 "but Theo fell down and the bug GRABBED him and took him away!"
 msgstr ""
-"我​失去​了​西奥！我​失去​了​我​最​好​的​朋友！我们​在​河​边​玩，西奥​说​他​想​去​看看​绿色​的​东"
-"西。我​说​我们​不​应该，但​我们​偷偷​溜​过去，然后​突然​这个​虫子​出来​了！我们​逃跑​了，但​"
-"西奥​摔倒​了，虫子​抓住​他，把​他​带走​了！"
+"西奥不见了！我最好的朋友不见了！我们在河边玩，西奥说他想去看看那个大大的绿色"
+"东西。我说我们不该去，但我们还是偷偷溜了过去，然后突然就冒出来一只大虫子！我"
+"们拼命逃跑，可西奥摔倒了，那只虫子抓住了他，把他拖走了！"
 
 #: Source/translation_dummy.cpp:945
 msgid ""
 "Didja find him?  You gotta find Theodore, please!  He's just little.  He "
 "can't take care of himself!  Please!"
 msgstr ""
-"你​找到​他​了​吗？你​得​找到​西奥多，求​你​了！他​只​是​个​小​孩子。他​不​能​照顾​自己！求​你​"
-"了！"
+"你找到他了吗？求你一定要找到西奥多！他还那么小，他照顾不了自己的！求求你了！"
 
 #: Source/translation_dummy.cpp:946
 msgid ""
@@ -10920,22 +10970,24 @@ msgid ""
 "scare you?  Hey!  Ugh!  There's something stuck to your fur!  Ick!  Come on, "
 "Theo, let's go home!  Thanks again, hero person!"
 msgstr ""
-"你​找到​他​了！你​找到​他​了！非常​感谢。哦，西奥，那些​讨厌​的​虫子吓到​你​了​吗？嘿​啊！"
-"有​东西粘​在​你​的​毛上​了！哎呀！来​吧，西奥，我们​回家​吧！再次​感谢你，英雄​！"
+"你找到他了！你找到他了！谢谢你！哦，西奥，那些讨厌的虫子有没有吓着你？嘿！"
+"呃！你毛上黏了什么东西！好恶心！来吧，西奥，我们回家！再次谢谢你，英雄！"
 
 #: Source/translation_dummy.cpp:947
 msgid ""
 "We have long lain dormant, and the time to awaken has come.  After our long "
 "sleep, we are filled with great hunger.  Soon, now, we shall feed..."
 msgstr ""
-"我们​早​已​沉睡，觉醒​的​时刻​已经​到来。长眠​之后，我们​感到​非常​饥饿。很​快，现在，我"
-"们​将​喂养……"
+"我们已沉睡了漫长的岁月，如今苏醒的时刻到了。经历了长久的沉睡，我们饥渴难耐。"
+"很快，我们就将饱餐一顿……"
 
 #: Source/translation_dummy.cpp:948
 msgid ""
 "Have you been enjoying yourself, little mammal?  How pathetic. Your little "
 "world will be no challenge at all."
-msgstr "你​玩​得​开心​吗，小​哺​乳​动物？真​可怜。你​的​小​世界​不​会​是​什么​挑战。"
+msgstr ""
+"一直玩得很开心吧，小哺乳动物？真是可悲。你那小小的世界，对我们来说根本不值一"
+"提。"
 
 #: Source/translation_dummy.cpp:949
 msgid ""
@@ -10943,14 +10995,15 @@ msgid ""
 "men call home.  Our tendrils shall envelop this world, and we will feast on "
 "the flesh of its denizens.  Man shall become our chattel and sustenance."
 msgstr ""
-"这些​地必​被​玷污，我们​的​后裔​必漫​过​人们​称为​家​的​田地。我们​的​卷须​要​包裹​这​世界，我"
-"们​要​以​其​居民​的​肉为食。人类​将​成为​我们​的​动产​和​食物。"
+"这片土地必将遭到玷污，我们的子嗣将蔓延过人类称为家园的田野。我们的触须将包裹"
+"这个世界，我们将以其上居民的血肉为食。人类，将成为我们的牲畜与食粮。"
 
 #: Source/translation_dummy.cpp:950
 msgid ""
 "Ah, I can smell you...you are close! Close! Ssss...the scent of blood and "
 "fear...how enticing..."
-msgstr "啊，我​能​闻到​你​…​你​就​在​附近！接近！血​和​恐惧​的​味道​…​多么​诱​人……"
+msgstr ""
+"啊，我能闻到你了……你就在附近！再近一点！嘶嘶……鲜血与恐惧的芬芳……多么诱人啊……"
 
 #: Source/translation_dummy.cpp:951
 msgid ""
@@ -10968,15 +11021,15 @@ msgid ""
 "within all things and beyond all things. Light and unity are the products of "
 "this holy foundation, a unity of purpose and a unity of possession."
 msgstr ""
-"在​金光​之​年，一​座​大​教堂​被​立​了​起来。这个​圣地​的​基石​是​用半​透明​的​安提拉​石​雕刻​而​成​"
-"的，安提拉石​是​以​与​赫拉迪姆​分享​力量​的​天使​命名​的。\n"
+"在黄金之光之年，一道谕令颁下，要兴建一座宏伟的大教堂。这座圣所的基石，将由名"
+"为安泰瑞尔的半透明宝石雕成——此石以那位将力量分予赫拉迪姆的天使命名。\n"
 " \n"
-"​在​画影子​的​那​一​年，大​地​震动，大​教堂​粉碎​倒塌。随着​地下​墓穴​和​城堡​的​建造​开始，人"
-"们​开始​抵抗​原罪之战​的​蹂躏，废墟​被​清理​出来​寻找​石头。就​这样，基石​从​人们​的​眼​中​消"
-"失​了。\n"
+"在阴影降临之年，大地震颤，大教堂崩裂倾颓。当墓穴与城堡开始兴建、人类奋起抵抗"
+"罪恶之战的蹂躏时，废墟中的石块被尽数取走。于是，那块基石便从世人眼中消失"
+"了。\n"
 " \n"
-"​石头​属于​这个​世界，也​属于​所有​的​世界，就​像​光​既​存在​于​万物​之​中，也​存在​于​万物​之"
-"外。光明​与​统一​是​这​个​神圣​基础​的​产物，是​目的​的​统一​和​占有​的​统一。"
+"此石既属于这个世界——也属于一切世界——正如光既存于万物之内，又超脱于万物之外。"
+"光与统一，正是这神圣根基的产物，是目标的一致，也是归属的一致。"
 
 #: Source/translation_dummy.cpp:952
 msgid "Moo."
@@ -10984,11 +11037,11 @@ msgstr "哞。"
 
 #: Source/translation_dummy.cpp:953
 msgid "I said, Moo."
-msgstr "我​说​了，哞。"
+msgstr "我说了，哞。"
 
 #: Source/translation_dummy.cpp:954
 msgid "Look I'm just a cow, OK?"
-msgstr "听​着，我​只​是​一​头​牛，好​吗？"
+msgstr "听着，我就是一头牛，行了吧？"
 
 #: Source/translation_dummy.cpp:955
 msgid ""
@@ -11003,24 +11056,25 @@ msgid ""
 "my house, it's just south of the fork in the river... you know... the one "
 "with the overgrown vegetable garden."
 msgstr ""
-"好​吧，好​吧。我​不​是​一​头​牛。我​一般​不​会​这样​到处​走​；​但是，当时​我​正​坐​在​家​里​处理​自"
-"己​的​事情，突然​这些​虫​子、藤蔓、球茎​之类​的​东西​开始​从​地板​上​冒​出来……太​可怕​了！如"
-"果​我​有​正常​的​衣服​穿，就​不​会​那么​糟糕​了。嘿​你​能回​我​家​帮​我​拿​衣服​吗？棕色​的，不​是​"
-"灰色​的，那​是​晚装​的。我​会​自己​做​的，但​我​不​想​让​任何​人​看到​我​这样。给，拿​着​这个，"
-"你​可能​需要​它……杀死​那些​长满​一切​的​东西。你​不​会​错过​我​家​的，就​在​河​的​岔口​南​边……你​"
-"知道​的……有​杂草​丛生​的​菜园​的​那​个。"
+"好吧好吧，我不是真的牛。我平时不会这副打扮到处走的。但那天我正坐在家里忙自己"
+"的事，突然这些虫子啊、藤蔓啊、球茎啊什么的就从地板里冒了出来……太可怕了！但凡"
+"有件正常的衣服穿，也不至于这么糟糕。嘿！你能回我家帮我拿套衣服来吗？棕色的那"
+"套，不是灰色的——灰色那套是晚礼服。我自己也想回去拿，可我不想让人看见我这副样"
+"子。给，拿着这个，你可能会用到……用来杀死那些到处疯长的东西。我家很好认，就在"
+"河岔口往南……你知道的……菜园子全被杂草吞没的那家。"
 
 #: Source/translation_dummy.cpp:956
 msgid ""
 "What are you wasting time for?  Go get my suit!  And hurry!  That Holstein "
 "over there keeps winking at me!"
-msgstr "你​在​浪费​时间​干​什么？去​拿​我​的​衣服！快点！那边​那​个​荷斯坦人​一直​对​我​眨眼！"
+msgstr ""
+"你还在磨蹭什么？快去拿我的衣服！快点儿！那边那头荷斯坦奶牛一直在冲我抛媚眼！"
 
 #: Source/translation_dummy.cpp:957
 msgid ""
 "Hey, have you got my suit there?  Quick, pass it over!  These ears itch like "
 "you wouldn't believe!"
-msgstr "嘿，你​有​我​的​西装​吗？快，传​过来！这些​耳朵​痒​得​你​都​不​敢​相信！"
+msgstr "嘿，衣服拿来了吗？快递过来！这耳朵痒得你根本想象不到！"
 
 #: Source/translation_dummy.cpp:958
 msgid ""
@@ -11028,8 +11082,8 @@ msgid ""
 "occasions!  I can't wear THIS.  What are you, some kind of weirdo?  I need "
 "the BROWN suit."
 msgstr ""
-"不​不​不！这​是​我​的​灰色​西装！这​是​晚装！正式​场合！我​不​能​穿​这个。你​是​什么​怪人？我​"
-"需要​那​套​棕色​的​西装。"
+"不不不不！这是我的灰色西装！那是晚礼服！正式场合穿的！我怎么能穿这个。你是哪"
+"来的怪人？我要的是棕色那套。"
 
 #: Source/translation_dummy.cpp:959
 msgid ""
@@ -11039,46 +11093,47 @@ msgid ""
 "you could use a new... yknowwhatImean?  The whole adventurer motif is just "
 "so... retro.  Just a word of advice, eh?  Ciao."
 msgstr ""
-"啊，好多​了。呼！终于​有​尊严​了！我​的​鹿角​是​直​的​吗？很​好。听​着，非常​感谢​你​帮​我。"
-"来，把​这个​当作​礼物​；​而且，你​知道……一点​时尚​提示……你​可以​用​一点……你​可以​用​一​个​新​"
-"的……你​知道​什么​时候？整个​冒险家​的​主题​就​是……复古​的。只​是​一​句​忠告，嗯？再见。"
+"啊——这下好多了。呼！总算有点体面了！我的鹿角没歪吧？很好。听着，非常感谢你帮"
+"了我。这个送给你当谢礼。还有啊……一点时尚小建议……你可以稍微……你可以考虑换个……"
+"懂我意思吧？这一身冒险者的打扮实在是太……复古了。就一句忠告，嗯？再见咯。"
 
 #: Source/translation_dummy.cpp:960
 msgid ""
 "Look.  I'm a cow.  And you, you're monster bait. Get some experience under "
 "your belt!  We'll talk..."
 msgstr ""
-"你​看。我​是​一​头​牛。而​你，你​是​怪物诱饵。在​你​的​腰带​下​获得​一些​经验！我们​谈​谈……"
+"听着，我是头牛。而你嘛，你是怪物诱饵。先去攒点经验再来！到时候我们再谈……"
 
 #: Source/translation_dummy.cpp:961
 msgid ""
 "It must truly be a fearsome task I've set before you. If there was just some "
 "way that I could... would a flagon of some nice, fresh milk help?"
 msgstr ""
-"这​一定​是​我​摆​在​你​面前​的​一​项​可怕​的​任务。如果​有​什么​办法​我​可以……喝​一​大杯​新鲜​的​牛"
-"奶​好​吗？"
+"我让你干的活一定吓坏你了吧。要是我有什么办法……来一大杯新鲜的牛奶，会不会好"
+"点？"
 
 #: Source/translation_dummy.cpp:962
 msgid ""
 "Oh, I could use your help, but perhaps after you've saved the catacombs from "
 "the desecration of those beasts."
-msgstr "哦，我​需要​你​的​帮助，但​也许​在​你​从​那些​野兽​的​亵渎​中​拯救​了​地下​墓穴​之后。"
+msgstr ""
+"哦，我确实需要你帮忙，不过也许等你从那些野兽的亵渎中救出地下墓穴之后再说吧。"
 
 #: Source/translation_dummy.cpp:963
 msgid ""
 "I need something done, but I couldn't impose on a perfect stranger. Perhaps "
 "after you've been here a while I might feel more comfortable asking a favor."
 msgstr ""
-"我​需要​做​点​什么，但​我​不​能​强加​给​一​个​完全​陌生​的​人。也许​在​你​来​了​一​段​时间​之后，我​"
-"会​更​乐意​请​你​帮​个​忙。"
+"我有件事想请你帮忙，但我总不能强求一个素不相识的人。也许等你在这儿待久一些，"
+"我就好开口了。"
 
 #: Source/translation_dummy.cpp:964
 msgid ""
 "I see in you the potential for greatness.  Perhaps sometime while you are "
 "fulfilling your destiny, you could stop by and do a little favor for me?"
 msgstr ""
-"我​从​你​身​上​看到​了​伟大​的​潜力。也许​某​个​时候​你​正在​完成​你​的​命运，你​可以​停​下来​帮​我​"
-"一​个​小​忙？"
+"我在你身上看到了成就伟大的潜质。也许有朝一日——在你完成命运使命的间隙——你可以"
+"顺道过来，帮我一个小小的忙？"
 
 #: Source/translation_dummy.cpp:965
 msgid ""
@@ -11086,21 +11141,21 @@ msgid ""
 "more powerful. I wouldn't want to injure the village's only chance to "
 "destroy the menace in the church!"
 msgstr ""
-"我​想​你​也许​可以​帮​我，但​也许​在​你​变得​更​有​力量​之后。我​可​不​想​破坏​村子​里​摧毁​教堂​威"
-"胁​的​唯一​机会！"
+"我觉得你大概能帮上我，不过也许等你再强大一些再说。我可不想害得村子失去摧毁教"
+"堂威胁的唯一希望！"
 
 #: Source/translation_dummy.cpp:966
 msgid ""
 "Me, I'm a self-made cow.  Make something of yourself, and... then we'll talk."
-msgstr "我，我​是​一​头​白手​起家​的​母牛。做点​自己，然后……那​我们​谈​谈。"
+msgstr "我嘛，是头白手起家的牛。你先干出点名堂来，然后……我们再谈。"
 
 #: Source/translation_dummy.cpp:967
 msgid ""
 "I don't have to explain myself to every tourist that walks by!  Don't you "
 "have some monsters to kill?  Maybe we'll talk later.  If you live..."
 msgstr ""
-"我​不​必​向​每​一​个​路​过​的​游客​解释​我​自己！你​不​是​有​怪物​要​杀​吗？也许​我们​以后​再​谈。如"
-"果​你​活​着……"
+"我才没义务跟每个路过的游客解释！你不是还有怪物要杀吗？等以后再说吧——要是你能"
+"活着回来的话……"
 
 #: Source/translation_dummy.cpp:968
 msgid ""
@@ -11108,8 +11163,8 @@ msgid ""
 "it.  I can't trust you, you're going to get eaten by monsters any day now... "
 "I need someone who's an experienced hero."
 msgstr ""
-"别烦​我​了。我​在​找​一​个​真正​的​英雄。但​你​不是。我​不​能​相信​你，你​随时​都​会​被​怪物​吃掉​"
-"的……我​需要​一​个​有​经验​的​英雄。"
+"别来烦我了。我在等一个真正的英雄，而你——不是。我不能信任一个随时会被怪物吃掉"
+"的人……我需要一个有经验的英雄。"
 
 #: Source/translation_dummy.cpp:969
 msgid ""
@@ -11125,12 +11180,12 @@ msgid ""
 "it's just south of the fork in the river... you know... the one with the "
 "overgrown vegetable garden."
 msgstr ""
-"好​吧，我​来​切​公牛。我​不​是​故意​误导​你​的。我​坐​在​家​里，心情​很​不​好，这时​情况​变得​很​"
-"不​稳定​；​一​大​群​怪物​从​地板​上​跑​了​出来！我​只​是​吓​了​一​跳。我​跑出​家门​的​时候​正好​穿​着​"
-"这​件​球衣，现在​我​看​起来​很​可笑。如果​我​有​正常​的​衣服​穿，就​不​会​那么​糟糕​了。嘿​你​能"
-"回​我​家​帮​我​拿​衣服​吗？棕色​的，不​是​灰色​的，那​是​晚装​的。我​会​自己​做​的，但​我​不​想​让​"
-"任何​人​看到​我​这样。给，拿​着​这个，你​可能​需要​它……杀死​那些​长满​一切​的​东西。你​不​会​"
-"错过​我​家​的，就​在​河​的​岔口​南​边……你​知道​的……有​杂草​丛生​的​菜园​的​那​个。"
+"好吧，我不演了。刚才不是故意耍你的。那天我正坐在家里，心情忧郁，突然之间天旋"
+"地转——一大群怪物从地板里冲了出来！我当场吓瘫了。冲出家门的时候恰好就穿着这件"
+"牛皮衣，现在看起来真是蠢透了。但凡有件正常的衣服穿，也不至于这么糟糕。嘿！你"
+"能回我家帮我拿套衣服来吗？棕色的那套，不是灰色的——那是晚礼服。我自己也想回去"
+"拿，可我不想让人看见我这副样子。给，拿着这个，你可能会用到……用来杀死那些到处"
+"疯长的东西。我家很好认，就在河岔口往南……你知道的……菜园子全被杂草吞没的那家。"
 
 #: Source/translation_dummy.cpp:970
 msgid ""
@@ -11138,8 +11193,8 @@ msgid ""
 "creature -- to no avail.  My methods of enslaving lesser demons seem to have "
 "no effect on this fearsome beast."
 msgstr ""
-"我​试​过​法术，威胁，放弃​和​这个​肮脏​的​生物​讨价​还价​——​都​没有用。我​奴役​小​恶魔​的​方法​"
-"似乎​对​这​个​可怕​的​野兽​没有​效果。"
+"我试过了法术、威吓、驱逐和与这肮脏生物的谈判——全都无济于事。我用来奴役低阶恶"
+"魔的法术，似乎对这个可怕的怪物毫无效果。"
 
 #: Source/translation_dummy.cpp:971
 msgid ""
@@ -11148,8 +11203,9 @@ msgid ""
 "of my vision.  The faint scrabble of claws dances at the edges of my "
 "hearing. They are searching, I think, for this journal."
 msgstr ""
-"我​的​家正​慢慢​被​这个​不​受​欢迎​的​囚犯​的​卑鄙​行径​所​腐蚀。地窖​里​到处​都​是​影子，它们​就​"
-"在​我​视线​的​角落​之外。我​耳边​隐约​传来​爪子​的​拼字声。我​想，他们​在​找​这​本​杂志。"
+"我的住所正被这个不受欢迎的囚犯的恶毒所慢慢腐蚀。地窖中阴影重重——它们就在我视"
+"野的边缘蠕动。细微的利爪刮擦声在我耳边萦绕不去。我想，它们在找的，就是这本日"
+"记。"
 
 #: Source/translation_dummy.cpp:972
 msgid ""
@@ -11158,9 +11214,9 @@ msgid ""
 "destroyed my library.  Na-Krul... The name fills me with a cold dread.  I "
 "prefer to think of it only as The Creature rather than ponder its true name."
 msgstr ""
-"在​咆哮​中，这​个​生物​漏​了​自己​的​名字​——​纳克鲁尔。我​曾​试图​研究​这个​名字，但​小​恶魔​不​"
-"知​何​故毁​了​我​的​图书馆。纳克鲁尔……我​对​这个​名字​充满​了​恐惧。我​宁愿​把​它​当作​一​种​生"
-"物，而​不​愿​考虑​它​的​真名。"
+"在咆哮中，这个生物泄露了它的名字——纳-克鲁尔。我试图研究这个名字，但那些小恶魔"
+"不知怎么毁掉了我的藏书室。纳-克鲁尔……这名字让我浑身发冷，充满恐惧。我宁愿只称"
+"它为\"那个生物\"，也不愿去细想它的真名。"
 
 #: Source/translation_dummy.cpp:973
 msgid ""
@@ -11169,9 +11225,8 @@ msgid ""
 "curses upon me for trapping it here.  Its words fill my heart with terror, "
 "and yet I cannot block out its voice."
 msgstr ""
-"那​被​困住​的​生物​狂怒​的​嚎叫​使​我​无法​获得​急​需​的​睡眠。它​向​那​把​它​送到​虚空​的​人​发怒，"
-"因​我​把​它​困​在​这里，就​咒诅​我。它​的​话语​使​我​的​心​充满​恐惧，然而​我​无法​阻挡​它​的​声"
-"音。"
+"那被困的生物愤怒的嚎叫让我彻夜难眠。它诅咒那个将它送入虚空的人，也因我将它困"
+"在此地而对我恶语相向。它的话语令我心生恐怖，可我却无法屏蔽它的声音。"
 
 #: Source/translation_dummy.cpp:974
 msgid ""
@@ -11180,8 +11235,9 @@ msgid ""
 "knowledge to free their lord.  I hope that whoever finds this journal will "
 "seek the knowledge."
 msgstr ""
-"我​的​时间​快​用完​了。我​必须​记录​下​削弱​恶魔​的​方法，然后​隐藏​这​段​文字，以免​他​的​爪牙"
-"们​想​办法​利用​我​的​知识​来​解放​他们​的​主。我​希望​找到​这​本​日记​的​人​都​能​找到​知识。"
+"我的时间快用完了。我必须记录下削弱这恶魔的方法，然后将这些文字藏起来，以免它"
+"的爪牙设法利用我的知识来解救他们的主人。希望找到这本日记的人，能去追寻这份知"
+"识。"
 
 #: Source/translation_dummy.cpp:975
 msgid ""
@@ -11198,14 +11254,14 @@ msgid ""
 "only these spells to gain entry or his power may be too great for you to "
 "defeat."
 msgstr ""
-"无论​谁​找到​这​卷​卷轴，都​将​负责​阻止​这些​墙内​的​恶魔​生物。我​的​时间​到​了。即使​是​现"
-"在，它​的​地狱​般​的​爪子​在​脆弱​的​门，我​躲​在​后面​爪。\n"
+"无论谁寻得这卷书，都肩负着阻止藏于这些墙内那恶魔造物的使命。我的时日已尽。即"
+"便此刻，它那地狱般的爪牙仍在抓挠着我藏身的那扇脆弱之门。\n"
 " \n"
-"​我​已经​用​神秘​的​魔法​把​恶魔​束​缚​住，把​它​包裹​在​长城​里，但​我​担心​这​还​不​够。\n"
+"我已用奥术魔法让这恶魔步履蹒跚，并将其封于高墙之内，但我担心这远远不够。\n"
 " \n"
-"​在​我​的​三​个​幽灵​身​上​找到​的​法术​将​为​你​提供​进入​他​的​领地​的​保护，但​前提​是​必须​按​正确​"
-"的​顺序​施放。入口​的​杠杆​会​移除​障碍物，释放​恶魔​；​别碰​他们！只​使用​这些​法术​进入，"
-"否则​他​的​力量​可能​太​大，你​无法​击败。"
+"我三本魔法书中记载的法术，将为你开启通往它领域的庇护之门——但唯有按正确顺序施"
+"放方可。入口处的杠杆会解除屏障、释放恶魔；切勿触碰！只可用这些法术进入，否则"
+"它的力量或许强得让你无法取胜。"
 
 #: Source/translation_dummy.cpp:976
 msgid "In Spiritu Sanctum."
@@ -11222,82 +11278,82 @@ msgstr "Efficio Obitus Ut Inimicus."
 #: Source/translation_dummy.cpp:979
 msgctxt "monster"
 msgid "Hellboar"
-msgstr "地狱猪"
+msgstr "地狱蛮猪"
 
 #: Source/translation_dummy.cpp:980
 msgctxt "monster"
 msgid "Stinger"
-msgstr "钉​刺者"
+msgstr "钉刺者"
 
 #: Source/translation_dummy.cpp:981
 msgctxt "monster"
 msgid "Psychorb"
-msgstr "癫​狂​球体"
+msgstr "癫狂球体"
 
 #: Source/translation_dummy.cpp:982
 msgctxt "monster"
 msgid "Arachnon"
-msgstr "蛛​网​魔"
+msgstr "蛛网魔"
 
 #: Source/translation_dummy.cpp:983
 msgctxt "monster"
 msgid "Felltwin"
-msgstr "孪​生者"
+msgstr "孪生魔"
 
 #: Source/translation_dummy.cpp:984
 msgctxt "monster"
 msgid "Hork Spawn"
-msgstr "腐尸​诞生者"
+msgstr "霍克衍体"
 
 #: Source/translation_dummy.cpp:985
 msgctxt "monster"
 msgid "Venomtail"
-msgstr "毒尾"
+msgstr "毒尾蝎"
 
 #: Source/translation_dummy.cpp:986
 msgctxt "monster"
 msgid "Necromorb"
-msgstr "死​尸"
+msgstr "死灵球"
 
 #: Source/translation_dummy.cpp:987
 msgctxt "monster"
 msgid "Spider Lord"
-msgstr "蜘蛛​领主"
+msgstr "蜘蛛领主"
 
 #: Source/translation_dummy.cpp:988
 msgctxt "monster"
 msgid "Lashworm"
-msgstr "鞭状蠕​虫"
+msgstr "鞭蠕虫"
 
 #: Source/translation_dummy.cpp:989
 msgctxt "monster"
 msgid "Torchant"
-msgstr "火​蚂蚁"
+msgstr "火焰蚁"
 
 #: Source/translation_dummy.cpp:990
 msgctxt "monster"
 msgid "Hell Bug"
-msgstr "地​狱恶​虫"
+msgstr "地狱恶虫"
 
 #: Source/translation_dummy.cpp:991
 msgctxt "monster"
 msgid "Gravedigger"
-msgstr "掘​墓者"
+msgstr "掘墓者"
 
 #: Source/translation_dummy.cpp:992
 msgctxt "monster"
 msgid "Tomb Rat"
-msgstr "墓穴​蝙蝠"
+msgstr "墓穴鼠"
 
 #: Source/translation_dummy.cpp:993
 msgctxt "monster"
 msgid "Firebat"
-msgstr "火焰​蝙"
+msgstr "火焰蝠"
 
 #: Source/translation_dummy.cpp:994
 msgctxt "monster"
 msgid "Skullwing"
-msgstr "头骨​之翼"
+msgstr "颅翼魔"
 
 #: Source/translation_dummy.cpp:995
 msgctxt "monster"
@@ -11307,32 +11363,32 @@ msgstr "巫妖"
 #: Source/translation_dummy.cpp:996
 msgctxt "monster"
 msgid "Crypt Demon"
-msgstr "地​穴恶魔"
+msgstr "地穴恶魔"
 
 #: Source/translation_dummy.cpp:997
 msgctxt "monster"
 msgid "Hellbat"
-msgstr "地狱蝙​蝠"
+msgstr "地狱蝠"
 
 #: Source/translation_dummy.cpp:998
 msgctxt "monster"
 msgid "Bone Demon"
-msgstr "白​骨恶魔"
+msgstr "白骨恶魔"
 
 #: Source/translation_dummy.cpp:999
 msgctxt "monster"
 msgid "Arch Lich"
-msgstr "高​阶​巫妖"
+msgstr "高阶巫妖"
 
 #: Source/translation_dummy.cpp:1000
 msgctxt "monster"
 msgid "Biclops"
-msgstr "双​钩"
+msgstr "双角巨魔"
 
 #: Source/translation_dummy.cpp:1001
 msgctxt "monster"
 msgid "Flesh Thing"
-msgstr "血​肉​造物"
+msgstr "血肉造物"
 
 #: Source/translation_dummy.cpp:1002
 msgctxt "monster"
@@ -11341,95 +11397,95 @@ msgstr "收割者"
 
 #: Source/translation_dummy.cpp:1003
 msgid "Giant's Knuckle"
-msgstr "巨人​的​指节"
+msgstr "巨人之拳"
 
 #: Source/translation_dummy.cpp:1004
 msgid "Mercurial Ring"
-msgstr "水​银戒指"
+msgstr "水银之戒"
 
 #: Source/translation_dummy.cpp:1005
 msgid "Xorine's Ring"
-msgstr "索​克林​之​戒"
+msgstr "佐琳之戒"
 
 #: Source/translation_dummy.cpp:1006
 msgid "Karik's Ring"
-msgstr "卡里克​之戒"
+msgstr "卡里克之戒"
 
 #: Source/translation_dummy.cpp:1007
 msgid "Ring of Magma"
-msgstr "熔岩​指环"
+msgstr "熔岩之戒"
 
 #: Source/translation_dummy.cpp:1008
 msgid "Ring of the Mystics"
-msgstr "神秘​指环"
+msgstr "秘法之戒"
 
 #: Source/translation_dummy.cpp:1009
 msgid "Ring of Thunder"
-msgstr "雷电​指环"
+msgstr "雷霆之戒"
 
 #: Source/translation_dummy.cpp:1010
 msgid "Amulet of Warding"
-msgstr "闪避​护符"
+msgstr "庇护护符"
 
 #: Source/translation_dummy.cpp:1011
 msgid "Gnat Sting"
-msgstr "虫​咬"
+msgstr "蚊刺"
 
 #: Source/translation_dummy.cpp:1012
 msgid "Flambeau"
-msgstr "烛​台"
+msgstr "焰炬"
 
 #: Source/translation_dummy.cpp:1013
 msgid "Armor of Gloom"
-msgstr "阴​沉护​甲"
+msgstr "阴郁之甲"
 
 #: Source/translation_dummy.cpp:1014
 msgid "Blitzen"
-msgstr "闪​电​迅捷"
+msgstr "闪电疾驰"
 
 #: Source/translation_dummy.cpp:1015
 msgid "Thunderclap"
-msgstr "霹​雳"
+msgstr "雷击"
 
 #: Source/translation_dummy.cpp:1016
 msgid "Shirotachi"
-msgstr "白池"
+msgstr "白太刀"
 
 #: Source/translation_dummy.cpp:1017
 msgid "Eater of Souls"
-msgstr "灵魂​吞噬者"
+msgstr "噬魂者"
 
 #: Source/translation_dummy.cpp:1018
 msgid "Diamondedge"
-msgstr "钻石利刃"
+msgstr "钻石锋刃"
 
 #: Source/translation_dummy.cpp:1019
 msgid "Bone Chain Armor"
-msgstr "骨链​甲"
+msgstr "骨链甲"
 
 #: Source/translation_dummy.cpp:1020
 msgid "Demon Plate Armor"
-msgstr "恶​魔板​甲"
+msgstr "恶魔板甲"
 
 #: Source/translation_dummy.cpp:1021
 msgid "Acolyte's Amulet"
-msgstr "侍​从​护符"
+msgstr "侍僧护符"
 
 #: Source/translation_dummy.cpp:1022
 msgid "Gladiator's Ring"
-msgstr "角​斗士​戒指"
+msgstr "角斗士之戒"
 
 #: Source/translation_dummy.cpp:1023
 msgid "Jester's"
-msgstr "愚弄​法术​的"
+msgstr "愚者的"
 
 #: Source/translation_dummy.cpp:1024
 msgid "Crystalline"
-msgstr "晶状"
+msgstr "水晶的"
 
 #: Source/translation_dummy.cpp:1025
 msgid "Doppelganger's"
-msgstr "双​生​的"
+msgstr "镜像的"
 
 #: Source/translation_dummy.cpp:1026
 msgid "devastation"
@@ -11437,11 +11493,11 @@ msgstr "毁灭"
 
 #: Source/translation_dummy.cpp:1027
 msgid "decay"
-msgstr "衰退"
+msgstr "衰朽"
 
 #: Source/translation_dummy.cpp:1028
 msgid "peril"
-msgstr "危险"
+msgstr "灾厄"
 
 #: Source/translation_dummy.cpp:1029
 msgctxt "spell"
@@ -11451,182 +11507,141 @@ msgstr "法力"
 #: Source/translation_dummy.cpp:1030
 msgctxt "spell"
 msgid "the Magi"
-msgstr "大​法师​之​力"
+msgstr "魔导之力"
 
 #: Source/translation_dummy.cpp:1031
 msgctxt "spell"
 msgid "the Jester"
-msgstr "小丑​的​愚弄"
+msgstr "愚者之戏"
 
 #: Source/translation_dummy.cpp:1032
 msgctxt "spell"
 msgid "Lightning Wall"
-msgstr "闪电墙"
+msgstr "闪电之墙"
 
 #: Source/translation_dummy.cpp:1033
 msgctxt "spell"
 msgid "Immolation"
-msgstr "献祭"
+msgstr "献祭之火"
 
 #: Source/translation_dummy.cpp:1034
 msgctxt "spell"
 msgid "Warp"
-msgstr "逃脱术"
+msgstr "跃迁术"
 
 #: Source/translation_dummy.cpp:1035
 msgctxt "spell"
 msgid "Reflect"
-msgstr "反射"
+msgstr "反射术"
 
 #: Source/translation_dummy.cpp:1036
 msgctxt "spell"
 msgid "Berserk"
-msgstr "狂​战士"
+msgstr "狂暴术"
 
 #: Source/translation_dummy.cpp:1037
 msgctxt "spell"
 msgid "Ring of Fire"
-msgstr "火焰​环"
+msgstr "烈焰之环"
 
 #: Source/translation_dummy.cpp:1038
 msgctxt "spell"
 msgid "Search"
-msgstr "搜索"
+msgstr "搜索术"
 
 #: Source/translation_dummy.cpp:1039
 msgctxt "spell"
 msgid "Rune of Fire"
-msgstr "火焰​符文"
+msgstr "火焰符文"
 
 #: Source/translation_dummy.cpp:1040
 msgctxt "spell"
 msgid "Rune of Light"
-msgstr "闪电符文"
+msgstr "圣光符文"
 
 #: Source/translation_dummy.cpp:1041
 msgctxt "spell"
 msgid "Rune of Nova"
-msgstr "新​星符文"
+msgstr "新星符文"
 
 #: Source/translation_dummy.cpp:1042
 msgctxt "spell"
 msgid "Rune of Immolation"
-msgstr "献祭​符文"
+msgstr "献祭符文"
 
 #: Source/translation_dummy.cpp:1043
 msgctxt "spell"
 msgid "Rune of Stone"
-msgstr "符文石"
+msgstr "岩石符文"
 
 #. TRANSLATORS: Thousands separator
 #: Source/utils/format_int.cpp:28 Source/utils/format_int.cpp:64
 msgid ","
 msgstr ","
 
-#~ msgid "Decrease Gamma"
-#~ msgstr "减少​伽马"
+#~ msgid "Diablo Shareware"
+#~ msgstr "《暗黑破坏神》共享版"
 
-#~ msgid "Increase Gamma"
-#~ msgstr "增加​伽马"
+#~ msgid "Hellfire Shareware"
+#~ msgstr "《地狱火》共享版"
 
-#~ msgid "Restart In Town"
-#~ msgstr "在​城里​重新​开始"
+#, c++-format
+#~ msgid "The host is running a different game mode ({:s}) than you."
+#~ msgstr "主机运行的({:s})模式与你当前的模式不同。"
 
-#~ msgid "Trying to drop a floor item?"
-#~ msgstr "尝试​扔​掉​一些​物品​?"
+#~ msgid "Adria Refills Mana"
+#~ msgstr "艾德莉亚补充法力值"
 
-#~ msgid ""
-#~ "Forces waiting for Vertical Sync. Prevents tearing effect when drawing a "
-#~ "frame. Disabling it can help with mouse lag on some systems."
-#~ msgstr ""
-#~ "强制​等待​垂直​同步。防止​因​绘制帧​时​导致​的​撕裂​效果。关闭​该​项​有助于​在​某些​系统​上​"
-#~ "减少​鼠标​延迟。"
+#~ msgid "Failed to open archive for writing."
+#~ msgstr "无法打开储藏档案进行写入。"
 
-#~ msgid "FPS Limiter"
-#~ msgstr "FPS​限制"
+#~ msgid "Adria will refill your mana when you visit her shop."
+#~ msgstr "艾德莉亚将会在你光顾他的商店时为你完全回复你的法力值。"
 
-#~ msgid "FPS is limited to avoid high CPU load. Limit considers refresh rate."
-#~ msgstr "限制​帧数​以​防止​CPU​的​过​多​占用。推荐​使用​屏幕刷新率。"
+#~ msgid "Enable floating numbers"
+#~ msgstr "允许浮动数字"
 
-#~ msgid "To hit"
-#~ msgstr "命​中"
+#~ msgid "Enables floating numbers on gaining XP / dealing damage etc."
+#~ msgstr "在获得 XP/造成伤害等时启用浮动数字。"
 
-#~ msgid "Heart"
-#~ msgstr "心脏"
+#~ msgid "Off"
+#~ msgstr "关"
 
-#~ msgid "Options:"
-#~ msgstr "选​项:"
+#~ msgid "Random Angles"
+#~ msgstr "随机角度"
 
-#~ msgid "version {:s}"
-#~ msgstr "版本​{:s}"
+#~ msgid "Vertical Only"
+#~ msgstr "仅垂直"
 
-#~ msgid "No automap available in town"
-#~ msgstr "城镇​中​没有​自动​地图"
+#~ msgid "Griswold the Blacksmith"
+#~ msgstr "铁匠格里斯沃尔德"
 
-#~ msgid "recover life"
-#~ msgstr "恢复​生命​值"
+#~ msgid "Pepin the Healer"
+#~ msgstr "医治者佩金"
 
-#~ msgid "deadly heal"
-#~ msgstr "治疗​致命​伤"
+#~ msgid "Wounded Townsman"
+#~ msgstr "受伤的镇民"
 
-#~ msgid "decrease strength"
-#~ msgstr "降低​力量"
+#~ msgid "Ogden the Tavern owner"
+#~ msgstr "酒馆老板奥格登"
 
-#~ msgid "decrease dexterity"
-#~ msgstr "降低​敏捷"
+#~ msgid "Cain the Elder"
+#~ msgstr "长者凯恩"
 
-#~ msgid "decrease vitality"
-#~ msgstr "降低​活力"
+#~ msgid "Adria the Witch"
+#~ msgstr "女巫艾德莉亚"
 
-#~ msgid "you can't heal"
-#~ msgstr "你​无法治​愈"
+#~ msgid "Gillian the Barmaid"
+#~ msgstr "酒吧女招待吉莉安"
 
-#~ msgid "hit monster doesn't heal"
-#~ msgstr "命​中​怪物​无法​自愈"
+#~ msgid "Cow"
+#~ msgstr "奶牛"
 
-#~ msgid "Faster attack swing"
-#~ msgstr "更​快​的​挥动"
+#~ msgid "Lester the farmer"
+#~ msgstr "农夫莱斯特"
 
-#~ msgid "see with infravision"
-#~ msgstr "夜视​能力"
+#~ msgid "Celia"
+#~ msgstr "西莉亚"
 
-#~ msgid "Failed to open player archive for writing."
-#~ msgstr "无法​加载​玩​家​数据​进行​写入。"
-
-#~ msgid "Unable to read to save file archive"
-#~ msgstr "因​无法​读取，无法​保存​存档"
-
-#~ msgid "Unable to write to save file archive"
-#~ msgstr "因​无法​写入，无法​保存​存档"
-
-#~ msgid "Indestructible,  "
-#~ msgstr "坚​不​可摧​,  "
-
-#~ msgid "No required attributes"
-#~ msgstr "无​需​属性"
-
-#~ msgid ""
-#~ "Beyond the Hall of Heroes lies the Chamber of Bone.  Eternal death awaits "
-#~ "any who would seek to steal the treasures secured within this room.  So "
-#~ "speaks the Lord of Terror, and so it is written."
-#~ msgstr ""
-#~ "在​英雄​走廊​的​另​一​端​藏匿​着​白骨密室。任何​胆​敢​盗取​此​地​财宝​的​人，都​将​遭受​永恒​的​"
-#~ "死亡。恐惧​之​王​如是​说，本​书​也​如实​写。"
-
-#~ msgid ""
-#~ "The armories of Hell are home to the Warlord of Blood.  In his wake lay "
-#~ "the mutilated bodies of thousands.  Angels and man alike have been cut "
-#~ "down to fulfill his endless sacrifices to the Dark ones who scream for "
-#~ "one thing - blood."
-#~ msgstr ""
-#~ "地狱​的​军械库​如同​鲜血​战神​的​私宅。其​所​到​之​处，无​不​留下​成千上万​的​残肢断臂。无"
-#~ "论​是​天使​还是​人类​都​将​遭到​残杀，只​为了​能够​呈上​邪魔们​最​渴望​的​东西​——​鲜血。"
-
-#~ msgid ""
-#~ "Cloudy and cooler today.  Casting the nets of necromancy across the void "
-#~ "landed two new subspecies of flying horror; a good day's work.  Must "
-#~ "remember to order some more bat guano and black candles from Adria; I'm "
-#~ "running a bit low."
-#~ msgstr ""
-#~ "今天​多云​凉爽。将​亡灵​之​网​撒向​虚空，降落​了​两​个​新​的​飞行​恐惧​亚种​；​一​天​的​好​工"
-#~ "作。一定​要​记得​从​艾德莉亚​订购​更​多​的​蝙蝠​粪​和​黑​蜡烛​；​我​的​血压​有点​低。"
+#~ msgid "Complete Nut"
+#~ msgstr "完整的纳特"


### PR DESCRIPTION
The current PO language file was generated from the codebase of the previous commit. The translation work uses the official texts from Diablo III as the terminology baseline, with DeepSeek V4 employed for both translation and proofreading. Preliminary testing shows that the translation quality has improved significantly, and the machine‑translated artifacts left over from the earlier Ubisoft‑localized version have been thoroughly eliminated.

However, a few issues remain, which are presumed to be caused by the game engine itself. For instance, entries such as "book of xxx" have been translated, but the changes do not take effect in‑game.