### PR TITLE
Unify store UI options

### DIFF
--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -851,7 +851,6 @@ GameplayOptions::GameplayOptions()
     , testBard("Test Bard", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::OnlyHellfire, N_("Test Bard"), N_("Force the Bard character type to appear in the hero selection menu."), false)
     , testBarbarian("Test Barbarian", OptionEntryFlags::CantChangeInGame | OptionEntryFlags::OnlyHellfire, N_("Test Barbarian"), N_("Force the Barbarian character type to appear in the hero selection menu."), false)
     , experienceBar("Experience Bar", OptionEntryFlags::None, N_("Experience Bar"), N_("Experience Bar is added to the UI at the bottom of the screen."), false)
-    , showItemGraphicsInStores("Show Item Graphics in Stores", OptionEntryFlags::None, N_("Show Item Graphics in Stores"), N_("Show item graphics to the left of item descriptions in store menus."), false)
     , showHealthValues("Show health values", OptionEntryFlags::None, N_("Show health values"), N_("Displays current / max health value on health globe."), false)
     , showManaValues("Show mana values", OptionEntryFlags::None, N_("Show mana values"), N_("Displays current / max mana value on mana globe."), false)
     , showMultiplayerPartyInfo("Show Multiplayer Party Information", OptionEntryFlags::CantChangeInMultiPlayer, N_("Show Party Information"), N_("Displays the health and mana of all connected multiplayer party members."), false)
@@ -878,7 +877,12 @@ GameplayOptions::GameplayOptions()
     , numFullManaPotionPickup("Full Mana Potion Pickup", OptionEntryFlags::None, N_("Full Mana Potion Pickup"), N_("Number of Full Mana potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
     , numRejuPotionPickup("Rejuvenation Potion Pickup", OptionEntryFlags::None, N_("Rejuvenation Potion Pickup"), N_("Number of Rejuvenation potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
     , numFullRejuPotionPickup("Full Rejuvenation Potion Pickup", OptionEntryFlags::None, N_("Full Rejuvenation Potion Pickup"), N_("Number of Full Rejuvenation potions to pick up automatically."), 0, { 0, 1, 2, 4, 8, 16 })
-    , visualStoreUI("Visual Store UI", OptionEntryFlags::None, N_("Visual Store UI"), N_("Use visual grid-based store interface instead of text-based menus. Both store and inventory panels open together."), false)
+    , storeUi("Store UI", OptionEntryFlags::None, N_("Store UI"), N_("User interface for stores"), StoreUi::Text,
+          {
+              { StoreUi::Text, N_("Text-only list") },
+              { StoreUi::ListWithItemGraphics, N_("List with item graphics") },
+              { StoreUi::VisualGrid, N_("Visual grid") },
+          })
     , skipLoadingScreenThresholdMs("Skip loading screen threshold, ms", OptionEntryFlags::Invisible, "", "", 0)
 {
 }
@@ -897,13 +901,12 @@ std::vector<OptionEntryBase *> GameplayOptions::GetEntries()
 		&testBard,
 		&testBarbarian,
 		&experienceBar,
-		&showItemGraphicsInStores,
-		&visualStoreUI,
+		&floatingInfoBox,
+		&storeUi,
 		&showHealthValues,
 		&showManaValues,
 		&showMultiplayerPartyInfo,
 		&enemyHealthBar,
-		&floatingInfoBox,
 		&showMonsterType,
 		&showItemLabels,
 		&autoRefillBelt,

--- a/Source/options.h
+++ b/Source/options.h
@@ -90,6 +90,15 @@ enum class Resampler : uint8_t {
 #endif
 };
 
+enum class StoreUi : uint8_t {
+	/** @brief Vanilla Diablo UI. */
+	Text = 0,
+	/** @brief Show item graphics to the left of item descriptions in store menus. */
+	ListWithItemGraphics = 1,
+	/** @brief Use visual grid-based store UI instead of text-based menus. */
+	VisualGrid = 2,
+};
+
 std::string_view ResamplerToString(Resampler resampler);
 std::optional<Resampler> ResamplerFromString(std::string_view resampler);
 
@@ -582,8 +591,6 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryBoolean testBarbarian;
 	/** @brief Show the current level progress. */
 	OptionEntryBoolean experienceBar;
-	/** @brief Show item graphics to the left of item descriptions in store menus. */
-	OptionEntryBoolean showItemGraphicsInStores;
 	/** @brief Display current/max health values on health globe. */
 	OptionEntryBoolean showHealthValues;
 	/** @brief Display current/max mana values on mana globe. */
@@ -636,8 +643,8 @@ struct GameplayOptions : OptionCategoryBase {
 	OptionEntryInt<int> numRejuPotionPickup;
 	/** @brief Number of Full Rejuvenating potions to pick up automatically */
 	OptionEntryInt<int> numFullRejuPotionPickup;
-	/** @brief Use visual grid-based store UI instead of text-based menus. */
-	OptionEntryBoolean visualStoreUI;
+	/** @brief Store user interface. */
+	OptionEntryEnum<StoreUi> storeUi;
 
 	/**
 	 * @brief If loading takes less than this value, skips displaying the loading screen.

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -437,7 +437,7 @@ void StartSmith()
 	AddSText(0, 3, _("Blacksmith's shop"), UiFlags::ColorWhitegold | UiFlags::AlignCenter, false);
 	AddSText(0, 7, _("Would you like to:"), UiFlags::ColorWhitegold | UiFlags::AlignCenter, false);
 	AddSText(0, 10, _("Talk to Griswold"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
-	if (*GetOptions().Gameplay.visualStoreUI) {
+	if (*GetOptions().Gameplay.storeUi == StoreUi::VisualGrid) {
 		AddSText(0, 12, _("Trade / Repair"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
 		AddSText(0, 14, _("Leave the shop"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
 	} else {
@@ -694,7 +694,7 @@ void StartWitch()
 	AddSText(0, 2, _("Witch's shack"), UiFlags::ColorWhitegold | UiFlags::AlignCenter, false);
 	AddSText(0, 9, _("Would you like to:"), UiFlags::ColorWhitegold | UiFlags::AlignCenter, false);
 	AddSText(0, 12, _("Talk to Adria"), UiFlags::ColorBlue | UiFlags::AlignCenter, true);
-	if (*GetOptions().Gameplay.visualStoreUI) {
+	if (*GetOptions().Gameplay.storeUi == StoreUi::VisualGrid) {
 		AddSText(0, 14, _("Buy / Sell"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
 		AddSText(0, 16, _("Recharge staves"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
 		AddSText(0, 18, _("Leave the shack"), UiFlags::ColorWhite | UiFlags::AlignCenter, true);
@@ -1284,7 +1284,7 @@ void StartDrunk()
 
 void SmithEnter()
 {
-	if (*GetOptions().Gameplay.visualStoreUI) {
+	if (*GetOptions().Gameplay.storeUi == StoreUi::VisualGrid) {
 		switch (CurrentTextLine) {
 		case 10:
 			TownerId = TOWN_SMITH;
@@ -1530,7 +1530,7 @@ void SmithRepairEnter()
 
 void WitchEnter()
 {
-	if (*GetOptions().Gameplay.visualStoreUI) {
+	if (*GetOptions().Gameplay.storeUi == StoreUi::VisualGrid) {
 		switch (CurrentTextLine) {
 		case 12:
 			OldTextLine = 12;
@@ -1672,7 +1672,7 @@ void WitchRechargeEnter()
 {
 	if (CurrentTextLine == BackButtonLine()) {
 		StartStore(TalkID::Witch);
-		CurrentTextLine = *GetOptions().Gameplay.visualStoreUI ? 16 : 18;
+		CurrentTextLine = *GetOptions().Gameplay.storeUi == StoreUi::VisualGrid ? 16 : 18;
 		return;
 	}
 
@@ -1701,7 +1701,7 @@ void BoyEnter()
 			StartStore(TalkID::NoMoney);
 		} else {
 			TakePlrsMoney(50);
-			if (*GetOptions().Gameplay.visualStoreUI) {
+			if (*GetOptions().Gameplay.storeUi == StoreUi::VisualGrid) {
 				ActiveStore = TalkID::None;
 				OpenVisualStore(VisualStoreVendor::Boy);
 			} else {
@@ -1883,7 +1883,7 @@ void HealerEnter()
 		StartStore(TalkID::Gossip);
 		break;
 	case 14:
-		if (*GetOptions().Gameplay.visualStoreUI) {
+		if (*GetOptions().Gameplay.storeUi == StoreUi::VisualGrid) {
 			ActiveStore = TalkID::None;
 			OpenVisualStore(VisualStoreVendor::Healer);
 		} else {
@@ -2182,7 +2182,7 @@ void SetupTownStores()
 
 void FreeStoreMem()
 {
-	if (*GetOptions().Gameplay.showItemGraphicsInStores) {
+	if (*GetOptions().Gameplay.storeUi == StoreUi::ListWithItemGraphics) {
 		FreeHalfSizeItemSprites();
 	}
 	ActiveStore = TalkID::None;
@@ -2214,7 +2214,7 @@ void PrintSString(const Surface &out, int margin, int line, std::string_view tex
 	constexpr int CursWidth = INV_SLOT_SIZE_PX * 2;
 	constexpr int HalfCursWidth = CursWidth / 2;
 
-	if (*GetOptions().Gameplay.showItemGraphicsInStores && cursId >= 0) {
+	if (*GetOptions().Gameplay.storeUi == StoreUi::ListWithItemGraphics && cursId >= 0) {
 		const Size size = GetInvItemSize(static_cast<int>(CURSOR_FIRSTITEM) + cursId);
 		const bool useHalfSize = size.width > INV_SLOT_SIZE_PX || size.height > INV_SLOT_SIZE_PX;
 		const bool useRed = HasAnyOf(flags, UiFlags::ColorRed);
@@ -2232,7 +2232,7 @@ void PrintSString(const Surface &out, int margin, int line, std::string_view tex
 		}
 	}
 
-	if (*GetOptions().Gameplay.showItemGraphicsInStores && cursIndent) {
+	if (*GetOptions().Gameplay.storeUi == StoreUi::ListWithItemGraphics && cursIndent) {
 		const Rectangle textRect { { rect.position.x + HalfCursWidth + 8, rect.position.y }, { rect.size.width - HalfCursWidth + 8, rect.size.height } };
 		DrawString(out, text, textRect, { .flags = flags });
 	} else {
@@ -2286,7 +2286,7 @@ void ClearSText(int s, int e)
 
 void StartStore(TalkID s)
 {
-	if (*GetOptions().Gameplay.showItemGraphicsInStores) {
+	if (*GetOptions().Gameplay.storeUi == StoreUi::ListWithItemGraphics) {
 		CreateHalfSizeItemSprites();
 	}
 	SpellbookFlag = false;
@@ -2529,7 +2529,7 @@ void StoreESC()
 		break;
 	case TalkID::WitchRecharge:
 		StartStore(TalkID::Witch);
-		CurrentTextLine = *GetOptions().Gameplay.visualStoreUI ? 16 : 18;
+		CurrentTextLine = *GetOptions().Gameplay.storeUi == StoreUi::VisualGrid ? 16 : 18;
 		break;
 	case TalkID::HealerBuy:
 		StartStore(TalkID::Healer);

--- a/test/store_transaction_test.cpp
+++ b/test/store_transaction_test.cpp
@@ -130,9 +130,9 @@ protected:
 		// Seed the RNG for deterministic item generation.
 		SetRndSeed(42);
 
-		// Make sure visualStoreUI is off (the base fixture does this too,
+		// Make sure visual store is off (the base fixture does this too,
 		// but be explicit).
-		GetOptions().Gameplay.visualStoreUI.SetValue(false);
+		GetOptions().Gameplay.storeUi.SetValue(StoreUi::Text);
 	}
 
 	/**

--- a/test/ui_test.hpp
+++ b/test/ui_test.hpp
@@ -47,7 +47,7 @@ constexpr const char UITestMissingMpqMsg[] = "MPQ assets (spawn.mpq or DIABDAT.M
  *  - A single-player game with one Warrior at character level 25 and 100 000 gold.
  *  - ControlMode pinned to KeyboardAndMouse (tests are deterministic regardless of host input).
  *  - All panels / stores / overlays closed before and after each test.
- *  - visualStoreUI option disabled so we always exercise the text-based store path.
+ *  - Always exercise the text-based store path.
  *  - A loopback network provider (needed by functions that send net commands).
  */
 class UITest : public ::testing::Test {
@@ -105,8 +105,7 @@ protected:
 		ControlMode = ControlTypes::KeyboardAndMouse;
 
 		// Always use the text-based store path so we can drive its state machine.
-		GetOptions().Gameplay.visualStoreUI.SetValue(false);
-		GetOptions().Gameplay.showItemGraphicsInStores.SetValue(false);
+		GetOptions().Gameplay.storeUi.SetValue(StoreUi::Text);
 
 		// Close everything that might be open.
 		CloseAllPanels();

--- a/test/visual_store_test.cpp
+++ b/test/visual_store_test.cpp
@@ -49,7 +49,7 @@ protected:
 		SetRndSeed(42);
 
 		// Enable the visual store UI for these tests.
-		GetOptions().Gameplay.visualStoreUI.SetValue(true);
+		GetOptions().Gameplay.storeUi.SetValue(StoreUi::VisualGrid);
 	}
 
 	void TearDown() override


### PR DESCRIPTION
Unifies "Show Item Graphics" and "Visual Store" boolean options into a single enum.

Also moves floating info box option next to the store UI option as they are somewhat related.