### PR TITLE
implement inventory sorting by item type

### DIFF
--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -27,27 +27,23 @@
 #include "engine/render/clx_render.hpp"
 #include "engine/render/text_render.hpp"
 #include "engine/size.hpp"
-#include "hwcursor.hpp"
-#include "inv_iterators.hpp"
 #include "levels/tile_properties.hpp"
 #include "levels/town.h"
 #include "minitext.h"
 #include "options.h"
 #include "panels/ui_panels.hpp"
 #include "player.h"
-#include "plrmsg.h"
 #include "qol/stash.h"
 #include "qol/visual_store.h"
 #include "stores.h"
-#include "towners.h"
 #include "utils/display.h"
 #include "utils/format.hpp"
 #include "utils/format_int.hpp"
 #include "utils/is_of.hpp"
 #include "utils/language.h"
+#include "utils/sdl_compat.h"
 #include "utils/sdl_geometry.h"
 #include "utils/str_cat.hpp"
-#include "utils/utf8.hpp"
 
 namespace devilution {
 
@@ -1414,32 +1410,62 @@ bool AutoPlaceItemInInventory(Player &player, const Item &item, bool sendNetwork
 	return false;
 }
 
+namespace {
+
+// Returns a grouping key so that visually similar items sort next to each
+// other. The actual placement order within a group is still driven by item
+// size (handled by the comparator below).
+int InventoryItemGroupKey(const Item &item)
+{
+	switch (item._itype) {
+	case ItemType::Gold:
+		return 0;
+	case ItemType::Misc:
+		// Scrolls of different spells should not be merged, so include the
+		// spell id in the key. All other misc items (potions, elixirs, ...)
+		// share the same _iMiscId per kind, which is exactly what we want.
+		if (item.isScroll())
+			return 1000 + static_cast<int>(item._iSpell);
+		return 2000 + static_cast<int>(item._iMiscId);
+	default:
+		return 10000 + static_cast<int>(item._itype);
+	}
+}
+
+bool CompareInventoryItems(const Player &player, int lhsIdx, int rhsIdx)
+{
+	const Item &lhs = player.InvList[lhsIdx];
+	const Item &rhs = player.InvList[rhsIdx];
+
+	const int lhsKey = InventoryItemGroupKey(lhs);
+	const int rhsKey = InventoryItemGroupKey(rhs);
+	if (lhsKey != rhsKey)
+		return lhsKey < rhsKey;
+
+	const Size lhsSize = GetInventorySize(lhs);
+	const Size rhsSize = GetInventorySize(rhs);
+	if (lhsSize.height != rhsSize.height)
+		return lhsSize.height > rhsSize.height;
+	return lhsSize.width > rhsSize.width;
+}
+
 std::vector<int> SortItemsBySize(Player &player)
 {
-	std::vector<std::pair<Size, int>> itemSizes; // Pair of item size and its index in InvList
-	itemSizes.reserve(player._pNumInv);          // Reserves space for the number of items in the player's inventory
+	std::vector<int> sortedIndices;
+	sortedIndices.reserve(player._pNumInv);
 
 	for (int i = 0; i < player._pNumInv; i++) {
-		const Size size = GetInventorySize(player.InvList[i]);
-		itemSizes.emplace_back(size, i);
+		sortedIndices.push_back(i);
 	}
 
-	// Sort items by height first, then by width
-	std::sort(itemSizes.begin(), itemSizes.end(), [](const auto &a, const auto &b) {
-		if (a.first.height == b.first.height) return a.first.width > b.first.width;
-		return a.first.height > b.first.height;
+	std::ranges::sort(sortedIndices, [&player](int lhs, int rhs) {
+		return CompareInventoryItems(player, lhs, rhs);
 	});
-
-	// Extract sorted indices
-	std::vector<int> sortedIndices;
-	sortedIndices.reserve(itemSizes.size()); // Pre-allocate the necessary capacity
-
-	for (const auto &itemSize : itemSizes) {
-		sortedIndices.push_back(itemSize.second);
-	}
 
 	return sortedIndices;
 }
+
+} // namespace
 
 void ReorganizeInventory(Player &player)
 {
@@ -1448,16 +1474,16 @@ void ReorganizeInventory(Player &player)
 
 	// Temporary storage for items and a copy of InvGrid
 	std::vector<Item> tempStorage(player._pNumInv);
-	std::array<int8_t, 40> originalInvGrid;                                                       // Declare an array for InvGrid copy
-	std::copy(std::begin(player.InvGrid), std::end(player.InvGrid), std::begin(originalInvGrid)); // Copy InvGrid to originalInvGrid
+	std::array<int8_t, 40> originalInvGrid;                                                               // Declare an array for InvGrid copy
+	std::ranges::copy(std::begin(player.InvGrid), std::end(player.InvGrid), std::begin(originalInvGrid)); // Copy InvGrid to originalInvGrid
 
 	// Move items to temporary storage and clear inventory slots
 	for (int i = 0; i < player._pNumInv; ++i) {
 		tempStorage[i] = player.InvList[i];
 		player.InvList[i] = {};
 	}
-	player._pNumInv = 0;                                                // Reset inventory count
-	std::fill(std::begin(player.InvGrid), std::end(player.InvGrid), 0); // Clear InvGrid
+	player._pNumInv = 0;                  // Reset inventory count
+	std::ranges::fill(player.InvGrid, 0); // Clear InvGrid
 
 	// Attempt to place items back, now from the temp storage
 	bool reorganizationFailed = false;
@@ -1476,7 +1502,7 @@ void ReorganizeInventory(Player &player)
 				player.InvList[player._pNumInv++] = item;
 			}
 		}
-		std::copy(std::begin(originalInvGrid), std::end(originalInvGrid), std::begin(player.InvGrid)); // Restore InvGrid
+		std::ranges::copy(originalInvGrid, std::begin(player.InvGrid)); // Restore InvGrid
 	}
 }
 


### PR DESCRIPTION
Introduce a new sorting mechanism for the player inventory that groups
items by their type (e.g., gold, misc, weapons, armor) before sorting by
size. This improves visual organization by ensuring similar items are
placed together.

**Unsorted**
<img width="386" height="416" alt="image" src="https://github.com/user-attachments/assets/5e244731-f09e-43e6-9efc-c83b9419b085" />
**Current Sort**
<img width="380" height="417" alt="image" src="https://github.com/user-attachments/assets/ec79d611-811d-4ab0-95c5-b10ab96b93b4" />
**New Sort**
<img width="378" height="419" alt="image" src="https://github.com/user-attachments/assets/81957286-948b-41b4-9d78-8d7d39b18221" />


PS: 
Running clang-format -i introduced that change because the WebKit base style sets `SpaceBeforeCpp11BracedList: true`, which gives `return { };`

Used `std::ranges::*`

## PS2: I Will have a look at the failed stuff

The WebKit style guide is explicit:

> *"Any empty braces should contain a space."*
> — https://webkit.org/code-style-guidelines/#empty-braces-space

So `return { };` (with space) is the correct form, and `return {};` (no space) is the wrong one for the `WebKit` preset. `clang-format` 18 (currently pinned in CI) flips this and demands `{}`, which directly contradicts the guide.

This is a long-standing bug, tracked and fixed upstream:

- Original report: https://bugs.llvm.org/show_bug.cgi?id=40840
- Tracking issue: https://github.com/llvm/llvm-project/issues/93635
- Fix: [PR #153765](https://github.com/llvm/llvm-project/pull/153765) → commit [`6cfedea`](https://github.com/llvm/llvm-project/commit/6cfedea492c11cd46f03cfad76a638bf73de40f4), which adds a new `SpaceInEmptyBraces` option and sets it to `Always` for the `WebKit` preset, superseding the older `SpaceInEmptyBlock` flag (see https://clang.llvm.org/docs/ClangFormatStyleOptions.html#spaceinemptyblock).
- Marked `\version 22` in the clang-format docs  ->  the fix ships in **clang-format 22**.

### Verified behaviour across versions

I ran a minimal reproducer (`echo "int main() { return {}; }"`) through `clang-format -style=webkit` for every version that has a published Docker image:

| `clang-format` | Output for `return {};` | Matches WebKit guide? |
|---:|---|:---:|
| 18 | `return {};` | X |
| 19 | `return {};` | X |
| 20 | `return {};` | X |
| 21 | `return {};` | X |
| **22** | **`return { };`** | Y |

Reproduced with the official `ghcr.io/jidicula/clang-format:<v>` images (project default) and also locally against the v18 and v20 binaries installed on a CachyOS/Arch system

furthermore, we should be more consistent and clear about what we want to have as minimum requirement. 

CMakeLists.txt:336-337
```
set(CMAKE_CXX_STANDARD 23)

```
**Which means CLANG 17 (15 started having partial support) \ GCC 13 (11 partial support)**

.devcontainer/Dockerfile:1-2
```
ARG VARIANT=debian-12

```
Debian12 comes with `clang-format` 14 but supports up to `clang-format-19`
https://packages.debian.org/search?suite=bookworm&section=all&arch=any&searchon=names&keywords=clang-format

```
❯ docker run --rm devilutionx-devcontainer bash -c 'echo "gcc:      $(gcc --version | head -1)"; echo "g++:      $(g++ --version | head -1)"; echo "clang:    $(clang --version 2>/dev/null | head -1 || echo NOT INSTALLED)"; echo "clang++:  $(clang++ --version 2>/dev/null | head -1 || echo NOT INSTALLED)"; echo "clang-format: $(clang-format --version | head -1)"; echo "clang-tidy:   $(clang-tidy --version | head -1)"; echo "cmake:    $(cmake --version | head -1)"'
gcc:      gcc (Debian 12.2.0-14+deb12u1) 12.2.0
g++:      g++ (Debian 12.2.0-14+deb12u1) 12.2.0
clang:    
clang++:  
clang-format: Debian clang-format version 14.0.6
clang-tidy:   Debian LLVM version 14.0.6
cmake:    cmake version 3.25.1
```

**Another discrepancy is the Amiga container image tag says gcc10 but CMake reports GNU 13.2.0.**
