### PR TITLE
Validate spell IDs after deserializing item save data

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -301,6 +301,11 @@ struct LevelConversionData {
 	item._iFlags = static_cast<ItemSpecialEffect>(file.NextLE<uint32_t>());
 	item._iMiscId = static_cast<item_misc_id>(file.NextLE<int32_t>());
 	item._iSpell = static_cast<SpellID>(file.NextLE<int32_t>());
+
+	if (!IsValidSpell(item._iSpell)) {
+		item._iSpell = SpellID::Null;
+	}
+
 	item._iCharges = file.NextLE<int32_t>();
 	item._iMaxCharges = file.NextLE<int32_t>();
 	item._iDurability = file.NextLE<int32_t>();


### PR DESCRIPTION
## Summary

Validate `item._iSpell` immediately after deserializing it in `LoadItemData()`.

If the loaded spell ID is invalid, it is replaced with `SpellID::Null` before it can be used by the rest of the codebase.

## Motivation

Issue #8547 reports that an invalid spell ID loaded from save data can later be passed to `GenerateStaffNameMagical()`, resulting in an out-of-bounds access to the spell data table.

Validating the value at the deserialization boundary prevents invalid spell IDs from propagating further.

Closes #8547.