### PR TITLE
Add configurable FPS cap to CPU Sleep frame rate control, and fix the broken deadline math in `LimitFrameRate`

### DIFF
--- a/Source/engine/dx.cpp
+++ b/Source/engine/dx.cpp
@@ -5,6 +5,7 @@
  */
 #include "engine/dx.h"
 
+#include <algorithm>
 #include <cstdint>
 
 #ifdef USE_SDL3
@@ -92,14 +93,14 @@ void LimitFrameRate()
 {
 	if (*GetOptions().Graphics.frameRateControl != FrameRateControl::CPUSleep)
 		return;
+	const uint32_t frameDelay = 1000000 / std::max(1U, static_cast<uint32_t>(*GetOptions().Graphics.fpsCap));
 	static uint32_t frameDeadline;
 	const uint32_t tc = SDL_GetTicks() * 1000;
-	uint32_t v = 0;
-	if (frameDeadline > tc) {
-		v = tc % refreshDelay;
-		SDL_Delay((v / 1000) + 1); // ceil
-	}
-	frameDeadline = tc + v + refreshDelay;
+	if (frameDeadline == 0 || frameDeadline < tc)
+		frameDeadline = tc + frameDelay;
+	if (frameDeadline > tc)
+		SDL_Delay(((frameDeadline - tc) / 1000) + 1);
+	frameDeadline += frameDelay;
 }
 
 } // namespace

--- a/Source/options.cpp
+++ b/Source/options.cpp
@@ -793,6 +793,12 @@ GraphicsOptions::GraphicsOptions()
 #endif
               { FrameRateControl::CPUSleep, N_("Limit FPS") },
           })
+    , fpsCap("FPS Cap",
+          OptionEntryFlags::CantChangeInGame,
+          N_("FPS Cap"),
+          N_("Target frame rate used when Frame Rate Control is set to Limit FPS."),
+          60,
+          { 30, 60, 75, 120, 144, 165, 240, 360 })
     , brightness("Brightness Correction", OptionEntryFlags::Invisible, "Brightness Correction", "Brightness correction level.", 0)
     , zoom("Zoom", OptionEntryFlags::None, N_("Zoom"), N_("Zoom on when enabled."), false)
     , perPixelLighting("Per-pixel Lighting", OptionEntryFlags::None, N_("Per-pixel Lighting"), N_("Subtile lighting for smoother light gradients."), DEFAULT_PER_PIXEL_LIGHTING)
@@ -823,6 +829,7 @@ std::vector<OptionEntryBase *> GraphicsOptions::GetEntries()
 		&integerScaling,
 #endif
 		&frameRateControl,
+		&fpsCap,
 		&brightness,
 		&zoom,
 		&showFPS,

--- a/Source/options.h
+++ b/Source/options.h
@@ -543,6 +543,8 @@ struct GraphicsOptions : OptionCategoryBase {
 #endif
 	/** @brief Limit frame rate either for vsync or CPU load. */
 	OptionEntryEnum<FrameRateControl> frameRateControl;
+	/** @brief Target frame rate when Frame Rate Control is set to CPU Sleep. */
+	OptionEntryInt<int> fpsCap;
 	/** @brief Brightness level. */
 	OptionEntryInt<int> brightness;
 	/** @brief Zoom on start. */


### PR DESCRIPTION
This PR adds a user-facing **FPS Cap** option under **Settings → Graphics** that lets players pick a target frame rate (`30 / 60 / 75 / 120 / 144 / 165 / 240 / 360`) when **Frame Rate Control** is set to **Limit FPS**.

While implementing, I noticed the existing `LimitFrameRate()` math was wrong, even with the option enabled, the cap oscillated between the target and the native framerate instead of holding steady. This PR rewrites the deadline logic with a simple, correct steady-interval scheduler.

## What's new (feature)

- New `GraphicsOptions::fpsCap` option (default: `60`), with allowed values `30, 60, 75, 120, 144, 165, 240, 360`.
- Slot inserted right below **Frame Rate Control** in the graphics menu so the relationship is obvious.
- Tooltip: *"Target frame rate used when Frame Rate Control is set to Limit FPS."*
- Flagged `CantChangeInGame` (matches the neighbouring **Frame Rate Control** row).

## What's fixed

`LimitFrameRate()` previously:

```cpp
v = tc % frameDelay;
SDL_Delay((v / 1000) + 1);          // waits the elapsed time, not the remaining time
frameDeadline = tc + v + frameDelay; // deadline drifts forward every iteration
```

**Two bugs:**

1. The delay was `v = tc % frameDelay`,  i.e. the time **already elapsed** in the current frame interval, instead of the time **remaining** until the next interval boundary. The scheduler ended up roughly doubling the intended wait.
2. `frameDeadline` was recomputed each frame as `tc + v + frameDelay`, causing a per-iteration drift of `v` microseconds. Net effect: the cap never settled and oscillated between fast and slow framerates, with reported FPS well above the target.

Replaced with a steady-interval scheduler that advances `frameDeadline` by `frameDelay` per frame and waits `frameDeadline - tc`

## Limitations / known gotchas

The FPS Cap only takes effect when **Frame Rate Control** is set to **Limit FPS** (CPU Sleep). With Vertical Sync on, the limiter returns early and the new option is a no-op, the cap is gated by design. 

<img width="857" height="681" alt="image" src="https://github.com/user-attachments/assets/ba0552a7-5deb-408e-abd6-5a221ecfdda2" />
<img width="771" height="504" alt="image" src="https://github.com/user-attachments/assets/e73c420e-b2fe-4720-88fd-1ce540a043e3" />
<img width="944" height="625" alt="image" src="https://github.com/user-attachments/assets/bc27b825-d5db-4062-8d65-ce0ddeb20b5c" />
<img width="1177" height="668" alt="image" src="https://github.com/user-attachments/assets/849dbc8d-7372-447f-82a2-cd451d01da93" />
