### PR TITLE
Fix speedbook tooltip showing default key instead of bound key

### DIFF
--- a/Source/control/control_infobox.cpp
+++ b/Source/control/control_infobox.cpp
@@ -3,9 +3,11 @@
 
 #include <fmt/format.h>
 
+#include "controls/control_mode.hpp"
 #include "engine/render/primitive_render.hpp"
 #include "inv.h"
 #include "levels/trigs.h"
+#include "options.h"
 #include "panels/partypanel.hpp"
 #include "qol/stash.h"
 #include "qol/visual_store.h"
@@ -343,7 +345,12 @@ void CheckPanelInfo()
 		InfoString = _("Select current spell button");
 		InfoColor = UiFlags::ColorWhite;
 		MainPanelFlag = true;
-		AddInfoBoxString(_("Hotkey: 's'"));
+		std::string_view speedbookKeyName = ControlMode == ControlTypes::Gamepad
+		    ? GetOptions().Padmapper.InputNameForAction("DisplaySpells", true)
+		    : GetOptions().Keymapper.KeyNameForAction("DisplaySpells");
+		if (!speedbookKeyName.empty()) {
+			AddInfoBoxString(fmt::format(fmt::runtime(_("Hotkey: '{:s}'")), speedbookKeyName));
+		}
 		const Player &myPlayer = *MyPlayer;
 		const SpellID spellId = myPlayer._pRSpell;
 		if (IsValidSpell(spellId)) {


### PR DESCRIPTION
The 'Select current spell button' tooltip in the main panel always
displayed 'Hotkey: s'' regardless of how the speedbook action was
rebound in the keybinds menu.

Look up the actual current binding for the DisplaySpells action via
the keymapper (or padmapper in gamepad mode) so the tooltip matches
the user's configured key.

closes https://github.com/diasurgical/DevilutionX/issues/8399

<img width="994" height="259" alt="image" src="https://github.com/user-attachments/assets/08b5e003-6a83-4b8b-9f79-ed6f69c04216" />
