### PR TITLE
clamp loaded player class to valid range

### DIFF
--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -487,7 +487,7 @@ void LoadPlayer(LoadHelper &file, Player &player)
 
 	file.NextBytes(player._pName, PlayerNameLength);
 	TerminateUtf8(player._pName, PlayerNameLength);
-	player._pClass = static_cast<HeroClass>(file.NextLE<int8_t>());
+	player._pClass = static_cast<HeroClass>(std::clamp<uint8_t>(file.NextLE<uint8_t>(), 0, static_cast<uint8_t>(GetNumPlayerClasses() - 1)));
 	file.Skip(3); // Alignment
 	player._pStrength = file.NextLE<int32_t>();
 	player._pBaseStr = file.NextLE<int32_t>();


### PR DESCRIPTION
The fix at `Source/loadsave.cpp:490` now clamps the deserialized class value to `[0, GetNumPlayerClasses() - 1]`, matching the existing validation in `pack.cpp:365`.
Invalid save data will default to the last valid class instead of causing an OOB read in `GetClassAttributes()`.

closes https://github.com/diasurgical/DevilutionX/issues/8545
[spawn_0_class200_malicious.zip](https://github.com/user-attachments/files/30470855/spawn_0_class200_malicious.zip)
file is safe, it just crashes without the patch