### PR TITLE
add bounds check for light index

### DIFF
--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -387,7 +387,7 @@ void AddUnLight(int i)
 	if (DisableLighting)
 		return;
 #endif
-	if (i == NO_LIGHT)
+	if (i < 0 || i >= MAXLIGHTS)
 		return;
 
 	Lights[i].isInvalid = true;
@@ -401,7 +401,7 @@ void ChangeLightRadius(int i, uint8_t radius)
 	if (DisableLighting)
 		return;
 #endif
-	if (i == NO_LIGHT)
+	if (i < 0 || i >= MAXLIGHTS)
 		return;
 
 	Light &light = Lights[i];
@@ -419,7 +419,7 @@ void ChangeLightXY(int i, Point position)
 	if (DisableLighting)
 		return;
 #endif
-	if (i == NO_LIGHT)
+	if (i < 0 || i >= MAXLIGHTS)
 		return;
 
 	Light &light = Lights[i];
@@ -437,7 +437,7 @@ void ChangeLightOffset(int i, DisplacementOf<int8_t> offset)
 	if (DisableLighting)
 		return;
 #endif
-	if (i == NO_LIGHT)
+	if (i < 0 || i >= MAXLIGHTS)
 		return;
 
 	Light &light = Lights[i];
@@ -458,7 +458,7 @@ void ChangeLight(int i, Point position, uint8_t radius)
 	if (DisableLighting)
 		return;
 #endif
-	if (i == NO_LIGHT)
+	if (i < 0 || i >= MAXLIGHTS)
 		return;
 
 	Light &light = Lights[i];


### PR DESCRIPTION
Prevent out-of-bounds access to the `Lights` array when the index is
outside `[0, MAXLIGHTS)`, avoiding crashes from invalid or corrupted
light indices.

The five light-manipulation functions (`AddUnLight`, `ChangeLightRadius`,
`ChangeLightXY`, `ChangeLightOffset`, `ChangeLight`) only guarded against
`NO_LIGHT` (-1), admitting any index ≥ `MAXLIGHTS` (32) as well as
negative indices ≤ −2. A crafted save file with `player.lightId = 100`
triggers an OOB write to `Lights[100]` via `LoadGame` → `ChangeLightXY(myPlayer.lightId, …)` (`loadsave.cpp:2646`); 
a `monster.lightId = −2` writes before the array into adjacent BSS globals (`VisionList`, `VisionActive`).


Save file only. No network packet struct carries a light ID.
Verified against all `TCmd*`, `TSyncMonster`, `DMonsterStr`, and `PlayerNetPack`
definitions. The two network-adjacent call sites (`sync.cpp:199`,
`msg.cpp:871`) read the locally-allocated `monster.lightId`, never a
packet field. Remote players always have `lightId = NO_LIGHT`
(`player.cpp:3282`).


closes https://github.com/diasurgical/DevilutionX/issues/8546