### PR TITLE
support localized help output

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1065,8 +1065,9 @@ void PrintFlagRequiresArgument(std::string_view flag)
 	PrintFlagMessage(flag, " requires an argument");
 }
 
-void DiabloParseFlags(int argc, char **argv)
+bool DiabloParseFlags(int argc, char **argv)
 {
+	bool printHelp = false;
 #ifdef _DEBUG
 	int argumentIndexOfLastCommandPart = -1;
 	std::string currentCommand;
@@ -1080,7 +1081,7 @@ void DiabloParseFlags(int argc, char **argv)
 	for (int i = 1; i < argc; i++) {
 		const std::string_view arg = argv[i];
 		if (arg == "-h" || arg == "--help") {
-			PrintHelpAndExit();
+			printHelp = true;
 		} else if (arg == "--version") {
 			printInConsole(PROJECT_NAME);
 			printInConsole(" v");
@@ -1190,7 +1191,7 @@ void DiabloParseFlags(int argc, char **argv)
 			printInConsole(argv[i]);
 			printInConsole("'");
 			printNewlineInConsole();
-			PrintHelpAndExit();
+			printHelp = true;
 		}
 	}
 
@@ -1205,6 +1206,8 @@ void DiabloParseFlags(int argc, char **argv)
 	if (recordNumber != -1)
 		demo::InitRecording(recordNumber, createDemoReference);
 #endif
+
+	return printHelp;
 }
 
 void DiabloInitScreen()
@@ -2760,7 +2763,7 @@ int DiabloMain(int argc, char **argv)
 	SDL_SetLogPriorities(SDL_LOG_PRIORITY_DEBUG);
 #endif
 
-	DiabloParseFlags(argc, argv);
+	const bool printHelp = DiabloParseFlags(argc, argv);
 	InitKeymapActions();
 	InitPadmapActions();
 
@@ -2774,6 +2777,12 @@ int DiabloMain(int argc, char **argv)
 
 	// Then look for a voice pack file based on the selected translation
 	LoadLanguageArchive();
+
+	if (printHelp) {
+		HeadlessMode = true;
+		LanguageInitialize();
+		PrintHelpAndExit();
+	}
 
 	ApplicationInit();
 	LuaInitialize();


### PR DESCRIPTION
Return help flag state from `DiabloParseFlags` instead of calling
`PrintHelpAndExit` directly, deferring help output until after
language initialization so text appears in the selected locale.

<img width="807" height="802" alt="Image" src="https://github.com/user-attachments/assets/94c32885-6e9b-461d-81e7-9bb2c86992a9" />

<img width="665" height="776" alt="Image" src="https://github.com/user-attachments/assets/61230c4a-f910-4a50-b5c9-da255804fdf4" />

closes https://github.com/diasurgical/DevilutionX/issues/3255