### PR TITLE
handle positional spells in casting logic

### DIFF
--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -2897,6 +2897,8 @@ bool TryIconCurs()
 		if (IsWallSpell(spellID)) {
 			const Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
 			NetSendCmdLocParam4(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellFrom);
+		} else if (IsPositionalSpell(spellID)) {
+			NetSendCmdLocParam3(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);
 		} else if (pcursmonst != -1 && leveltype != DTYPE_TOWN) {
 			NetSendCmdParam4(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);
 		} else if (PlayerUnderCursor != nullptr && !PlayerUnderCursor->hasNoLife() && !myPlayer.friendlyMode) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -3207,6 +3207,9 @@ void CheckPlrSpell(bool isShiftHeld, SpellID spellID, SpellType spellType)
 		LastPlayerAction = PlayerActionType::Spell;
 		const Direction sd = GetDirection(myPlayer.position.tile, cursPosition);
 		NetSendCmdLocParam4(true, CMD_SPELLXYD, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), static_cast<uint16_t>(sd), spellFrom);
+	} else if (IsPositionalSpell(spellID)) {
+		LastPlayerAction = PlayerActionType::Spell;
+		NetSendCmdLocParam3(true, CMD_SPELLXY, cursPosition, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);
 	} else if (pcursmonst != -1 && !isShiftHeld) {
 		LastPlayerAction = PlayerActionType::SpellMonsterTarget;
 		NetSendCmdParam4(true, CMD_SPELLID, pcursmonst, static_cast<int8_t>(spellID), static_cast<uint8_t>(spellType), spellFrom);

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -90,6 +90,20 @@ bool IsWallSpell(SpellID spl)
 	return spl == SpellID::FireWall || spl == SpellID::LightningWall;
 }
 
+bool IsPositionalSpell(SpellID spl)
+{
+	return spl == SpellID::Teleport
+	    || spl == SpellID::Phasing
+	    || spl == SpellID::Warp
+	    || spl == SpellID::Guardian
+	    || spl == SpellID::Golem
+	    || spl == SpellID::RuneOfFire
+	    || spl == SpellID::RuneOfLight
+	    || spl == SpellID::RuneOfNova
+	    || spl == SpellID::RuneOfImmolation
+	    || spl == SpellID::RuneOfStone;
+}
+
 bool TargetsMonster(SpellID id)
 {
 	return id == SpellID::Fireball

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -22,6 +22,7 @@ enum class SpellCheckResult : uint8_t {
 bool IsValidSpell(SpellID spl);
 bool IsValidSpellFrom(int spellFrom);
 bool IsWallSpell(SpellID spl);
+bool IsPositionalSpell(SpellID spl);
 bool TargetsMonster(SpellID id);
 int GetManaAmount(const Player &player, SpellID sn);
 void ConsumeSpell(Player &player, SpellID sn);


### PR DESCRIPTION
Add `IsPositionalSpell()` check for spells that target a position rather than a monster or wall. 
Fixes casting behavior for Teleport, Guardian, Golem, 
and rune spells by sending `CMD_SPELLXY` instead
of falling through to monster or player targeting logic.

closes https://github.com/diasurgical/DevilutionX/issues/8357