### PR TITLE
Fix/multi overflow check

### DIFF
--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -126,7 +126,7 @@ void BufferInit(TBuffer *pBuf)
 
 void CopyPacket(TBuffer *buf, const std::byte *packet, size_t size)
 {
-	if (buf->dwNextWriteOffset + size + 2 > 0x1000) {
+	if (size > 0x1000 - 2 || buf->dwNextWriteOffset > 0x1000 - (size + 2)) {
 		return;
 	}
 
@@ -154,8 +154,9 @@ std::byte *CopyBufferedPackets(std::byte *destination, TBuffer *source, size_t *
 			srcPtr += chunkSize;
 			*size -= chunkSize;
 		}
-		memmove(source->bData, srcPtr, (source->bData - srcPtr) + source->dwNextWriteOffset + 1);
-		source->dwNextWriteOffset += source->bData - srcPtr;
+		const auto consumed = static_cast<size_t>(srcPtr - source->bData);
+		memmove(source->bData, srcPtr, source->dwNextWriteOffset - consumed + 1);
+		source->dwNextWriteOffset -= consumed;
 		return destination;
 	}
 	return destination;


### PR DESCRIPTION
Corrects two arithmetic bugs in the multiplayer packet buffering code
(`TBuffer`) that could lead to heap buffer overflows.

 **Possible with crafted or malformed network traffic**

`CopyPacket` guarded the 4096-byte `bData` buffer with
`buf->dwNextWriteOffset + size + 2 > 0x1000`. Because both operands are
`size_t`, a large `size` wraps the sum to a small value that passes the
check, after which the `memcpy` writes past the end of `bData`. The
check is now expressed as `size > 0x1000 - 2 ||
buf->dwNextWriteOffset > 0x1000 - (size + 2)`, comparing against
constants so no intermediate can overflow.

`CopyBufferedPackets` computed its compaction length as
`(source->bData - srcPtr) + source->dwNextWriteOffset + 1`. Since
`srcPtr` only ever advances forward, `source->bData - srcPtr` is a
negative `ptrdiff_t` that converts to a very large `size_t`, making
`memmove` read and write far out of bounds. The length is now derived
from the number of consumed bytes (`dwNextWriteOffset - consumed + 1`),
and `dwNextWriteOffset` is decremented by the same amount. The loop's
existing `chunkSize > *size` guard already prevents destination
overflow, and the in-buffer `0` terminator written by `CopyPacket`
guarantees `consumed <= dwNextWriteOffset`, so the new subtraction
cannot underflow.
