### PR TITLE
Fix OOB read from unterminated player names in save/network data

### DIFF
--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -367,7 +367,7 @@ void UnPackPlayer(const PlayerPack &packed, Player &player)
 	ClrPlrPath(player);
 	player.destAction = ACTION_NONE;
 
-	CopyUtf8(player._pName, packed.pName, sizeof(player._pName));
+	CopyUtf8(player._pName, std::string_view(packed.pName, PlayerNameLength), sizeof(player._pName));
 
 	InitPlayer(player, true);
 
@@ -465,7 +465,7 @@ bool UnPackNetItem(const Player &player, const ItemNetPack &packedItem, Item &it
 
 bool UnPackNetPlayer(const PlayerNetPack &packed, Player &player)
 {
-	CopyUtf8(player._pName, packed.pName, sizeof(player._pName));
+	CopyUtf8(player._pName, std::string_view(packed.pName, PlayerNameLength), sizeof(player._pName));
 
 	ValidateField(packed.pClass, packed.pClass < GetNumPlayerClasses());
 	player._pClass = static_cast<HeroClass>(packed.pClass);

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -703,7 +703,7 @@ bool pfile_ui_set_hero_infos(bool (*uiAddHeroInfo)(_uiheroinfo *))
 			if (ReadHero(*archive, &pkplr)) {
 				_uiheroinfo uihero;
 				uihero.saveNumber = i;
-				strcpy(hero_names[i], pkplr.pName);
+				CopyUtf8(hero_names[i], std::string_view(pkplr.pName, PlayerNameLength), sizeof(hero_names[i]));
 				const bool hasSaveGame = ArchiveContainsGame(*archive);
 				if (hasSaveGame)
 					pkplr.bIsHellfire = gbIsHellfireSaveGame ? 1 : 0;


### PR DESCRIPTION
Replaces unbounded string operations with explicitly bounded `std::string_view` construction, following the security audit finding in `SECURITY_AUDIT.md` (section D).

### Possible with a crafted save file or malicious network packet

`PlayerPack::pName` and `PlayerNetPack::pName` are `char[32]` fields populated via `memcpy` from raw save archives or network data. If a crafted save file (or malicious peer in multiplayer) fills all 32 bytes with non-null characters, the name has no null terminator within the buffer.

`pfile.cpp:706` used `strcpy(hero_names[i], pkplr.pName)`, which scans indefinitely for a null byte, causing an out-of-bounds read on the source and a potential out-of-bounds write past the 32-byte destination.

`pack.cpp:370` and `pack.cpp:468` (`UnPackPlayer`, `UnPackNetPlayer`) passed `packed.pName` to `CopyUtf8`, which accepts a `std::string_view`. The implicit `char[32]` → `std::string_view` conversion calls `strlen()` internally, triggering the same unbounded scan before `CopyUtf8` ever executes.
