### PR TITLE
Share a precompiled header across the object libraries

### DIFF
--- a/CMake/Definitions.cmake
+++ b/CMake/Definitions.cmake
@@ -23,6 +23,17 @@ foreach(
   UNPACKED_SAVES
   DEVILUTIONX_WINDOWS_NO_WCHAR
   TERMUX
+
+  # Defined for every target rather than only for the ones that link SDL, even
+  # though only they can use it. The shared precompiled header is built with it
+  # (see Source/pch.hpp), and GCC refuses a precompiled header that was created
+  # with a macro the consumer does not have: as a usage requirement of
+  # DevilutionX::SDL it would cost the libraries that do not link SDL their
+  # precompiled header, which measures worse than not giving them one at all.
+  # DevilutionX::SDL keeps defining it as well, for the targets that are not
+  # built through add_devilutionx_library(), such as the tests.
+  USE_SDL1
+  USE_SDL3
 )
   if(${def_name})
     list(APPEND DEVILUTIONX_DEFINITIONS ${def_name})

--- a/CMake/functions/devilutionx_library.cmake
+++ b/CMake/functions/devilutionx_library.cmake
@@ -74,6 +74,31 @@ function(add_devilutionx_library NAME)
 endfunction()
 
 # Same as add_devilutionx_library(${NAME} OBJECT).
+#
+# Object libraries additionally share the precompiled header owned by
+# `libdevilutionx_pch` (see Source/pch.hpp). They all compile with the same
+# code generation model and with a superset of that target's defines, which is
+# what makes a single shared PCH valid for every one of them. Executables are
+# excluded: they build with a different PIC/PIE model, which GCC treats as
+# invalidating the PCH.
+#
+# `DEVILUTIONX_PCH_SHARED` is off for compilers that reject a PCH built with
+# anything other than the consumer's exact flags; there libdevilutionx gets its
+# own PCH instead of everyone sharing one.
 function(add_devilutionx_object_library NAME)
   add_devilutionx_library(${NAME} OBJECT ${ARGN})
+  if(DEVILUTIONX_PCH)
+    # pch.hpp is C++, and so is the precompiled header built from it. Some
+    # platforms add sources in other languages (C on Amiga, Objective-C on
+    # iOS); without this CMake looks for a C precompiled header that no target
+    # ever builds and fails to generate.
+    foreach(_src ${ARGN})
+      if(NOT _src MATCHES "\\.(cpp|cxx|cc)$")
+        set_source_files_properties(${_src} PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+      endif()
+    endforeach()
+  endif()
+  if(DEVILUTIONX_PCH_SHARED AND NOT NAME STREQUAL "libdevilutionx_pch")
+    target_precompile_headers(${NAME} REUSE_FROM libdevilutionx_pch)
+  endif()
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,20 @@ set_property(CACHE DEVILUTIONX_DEFAULT_RESAMPLER PROPERTY STRINGS ${_resamplers}
 # Optimization / link options
 option(DISABLE_LTO "Disable link-time optimization (by default enabled in release mode)" OFF)
 option(PIE "Generate position-independent code" OFF)
+option(DEVILUTIONX_PCH "Use a shared precompiled header for the devilutionX object libraries" ON)
+
+# Whether one precompiled header can be shared between all the object libraries.
+#
+# They do not all compile with the same defines: linking asio, sol2 or mpqfs
+# adds one, so the set varies per library. GCC and Clang accept a precompiled
+# header whose macro state is a subset of the consumer's, which lets a single
+# minimal PCH serve all of them. MSVC instead requires the options to match and
+# reports a mismatch as an error rather than falling back to parsing the header,
+# so there we give libdevilutionx its own PCH: it is a single target with one
+# flag set, and it is where most of the win is anyway.
+if(DEVILUTIONX_PCH AND NOT MSVC)
+  set(DEVILUTIONX_PCH_SHARED ON)
+endif()
 cmake_dependent_option(DEVILUTIONX_DISABLE_RTTI "Disable RTTI" ON "NONET" OFF)
 cmake_dependent_option(DEVILUTIONX_DISABLE_EXCEPTIONS "Disable exceptions" ON "DISABLE_ZERO_TIER" OFF)
 RELEASE_OPTION(DEVILUTIONX_STATIC_CXX_STDLIB "Link C++ standard library statically (if available)")
@@ -251,6 +265,23 @@ find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
   set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
   set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+
+  if(DEVILUTIONX_PCH)
+    # ccache treats the .gch as an opaque blob, so it cannot tell whether a
+    # difference in `-D` flags or in __TIME__/__DATE__ actually changed the
+    # precompiled output. Left to itself it takes the safe route and misses on
+    # every PCH-using compile, which costs far more than the PCH gains.
+    # The sloppiness has to reach ccache at *build* time, so it goes on the
+    # launcher rather than into the configure-time environment.
+    set(CMAKE_CXX_COMPILER_LAUNCHER
+        "${CMAKE_COMMAND}" -E env CCACHE_SLOPPINESS=pch_defines,time_macros "${CCACHE_PROGRAM}")
+
+    # Emits the `#pragma GCC pch_preprocess` marker that lets ccache hash the
+    # PCH's preprocessed text instead of bailing out. No-op without a PCH.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fpch-preprocess>)
+    endif()
+  endif()
 endif()
 
 if(DEVILUTIONX_DISABLE_RTTI)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -174,9 +174,59 @@ set(_optimize_in_debug_srcs
   utils/cl2_to_clx.cpp
   utils/pcx_to_clx.cpp)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set_source_files_properties(${_optimize_in_debug_srcs} PROPERTIES COMPILE_OPTIONS "-O2;--param=max-vartrack-size=900000000")
+  set(_optimize_in_debug_flags "-O2;--param=max-vartrack-size=900000000")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  set_source_files_properties(${_optimize_in_debug_srcs} PROPERTIES COMPILE_OPTIONS "-O2")
+  set(_optimize_in_debug_flags "-O2")
+endif()
+if(_optimize_in_debug_flags)
+  # These sources also opt out of the precompiled header: it is built with the
+  # optimization flags of the build type, and neither GCC nor Clang accepts a
+  # precompiled header created at a different optimization level. GCC ignores
+  # it with a `-Winvalid-pch` warning, Clang fails the build outright with
+  # "__OPTIMIZE__ predefined macro was disabled in AST file".
+  set_source_files_properties(${_optimize_in_debug_srcs} PROPERTIES
+    COMPILE_OPTIONS "${_optimize_in_debug_flags}"
+    SKIP_PRECOMPILE_HEADERS ON)
+endif()
+
+# Owns the precompiled header that every other object library reuses.
+#
+# It must be defined before them, both because `REUSE_FROM` requires the target
+# to already exist and because of the `target_link_dependencies` ordering rule
+# below.
+#
+# This target intentionally links only what `pch.hpp` itself needs. Anything
+# else would add defines to it, and GCC rejects a precompiled header that was
+# built with a macro the consumer does not have (a subset is fine, which is why
+# a minimal target works for all of them). See Source/pch.hpp.
+#
+# Not built where the PCH cannot be shared (MSVC); libdevilutionx gets its own
+# below instead. See DEVILUTIONX_PCH_SHARED in the top-level CMakeLists.txt.
+if(DEVILUTIONX_PCH_SHARED)
+  add_devilutionx_object_library(libdevilutionx_pch pch.cpp)
+  target_link_libraries(libdevilutionx_pch PUBLIC
+    DevilutionX::SDL
+    magic_enum::magic_enum
+    unordered_dense::unordered_dense
+  )
+  # Everything the PCH precompiles has to resolve to the same file a consumer
+  # would have opened. GCC does not check include paths when validating a
+  # precompiled header, so a difference here is silent: the PCH bakes in one
+  # resolution and the consumer can no longer reach the other.
+  #
+  # 3DS and Switch shadow system headers with shims on asio's include path
+  # (Source/platform/*/asio/include/errno.h adds ESHUTDOWN, which their newlib
+  # only defines under __LINUX_ERRNO_EXTENSIONS__). pch.hpp reaches <errno.h>
+  # via <ostream>, so without these directories the PCH records the unshadowed
+  # header and the shim is never read. Only the include directories: linking
+  # asio would add its compile definitions to the PCH, and consumers without
+  # them would then reject it.
+  if(TARGET asio)
+    target_include_directories(libdevilutionx_pch BEFORE PRIVATE
+      $<TARGET_PROPERTY:asio,INTERFACE_INCLUDE_DIRECTORIES>)
+  endif()
+
+  target_precompile_headers(libdevilutionx_pch PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/pch.hpp)
 endif()
 
 # We need to define all the object libraries first
@@ -1052,6 +1102,13 @@ endif()
 
 add_devilutionx_object_library(libdevilutionx ${libdevilutionx_SRCS})
 target_include_directories(libdevilutionx PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
+# Where the PCH cannot be shared, this target still gets one of its own. All of
+# its sources compile with the same flags, so there is no mismatch to worry
+# about, and at ~150 sources it accounts for most of what the PCH saves.
+if(DEVILUTIONX_PCH AND NOT DEVILUTIONX_PCH_SHARED)
+  target_precompile_headers(libdevilutionx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/pch.hpp)
+endif()
 target_link_dependencies(libdevilutionx PUBLIC
   DevilutionX::SDL
   libsmackerdec

--- a/Source/pch.cpp
+++ b/Source/pch.cpp
@@ -1,0 +1,3 @@
+// Translation unit that exists only so that `libdevilutionx_pch` has a source
+// file to attach the shared precompiled header to. See pch.hpp.
+#include "pch.hpp"

--- a/Source/pch.hpp
+++ b/Source/pch.hpp
@@ -1,0 +1,75 @@
+#pragma once
+/**
+ * @file pch.hpp
+ *
+ * @brief Precompiled header shared by every devilutionX object library.
+ *
+ * Header parsing dominates our build: roughly 78% of the time spent compiling
+ * `Source/` goes into headers rather than into our own code. Precompiling the
+ * external headers that nearly every translation unit pulls in cuts the
+ * affected targets roughly in half.
+ *
+ * It is built once by `libdevilutionx_pch` and reused everywhere else via
+ * `target_precompile_headers(... REUSE_FROM ...)`. That target is deliberately
+ * kept free of the optional third-party defines (asio/sol/mpqfs) that only some
+ * libraries get: GCC accepts a PCH whose macro state is a *subset* of the
+ * consumer's, but rejects one built with a macro the consumer lacks. Reusing
+ * libdevilutionx's own PCH instead fails for exactly that reason.
+ *
+ * This file deliberately contains **no devilutionX headers**. Anything listed
+ * here is baked into the PCH, so touching it forces all ~250 translation units
+ * to rebuild. Restricting the contents to third-party headers means the PCH is
+ * invalidated only when a dependency or the toolchain changes, never by
+ * ordinary work on the game. Measured against including our own hot headers as
+ * well, this gives up only a few percent of the total win.
+ *
+ * Do not include this file directly: it is injected by
+ * `target_precompile_headers`, and every source file must keep listing the
+ * headers it actually uses so the build still works with `DEVILUTIONX_PCH=OFF`.
+ *
+ * The third-party includes below are guarded with `__has_include`. The target
+ * that builds the PCH (`libdevilutionx_pch`) always has all of them available,
+ * so the precompiled image is complete. The guards only matter on the fallback
+ * path: if a compiler ever rejects the PCH, it re-parses this header in a
+ * target that may not have those include directories, and we want that to
+ * degrade to a slower build rather than a broken one. Every translation unit
+ * still includes what it uses, so nothing here changes what compiles.
+ */
+
+// NOLINTBEGIN(misc-include-cleaner)
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <format>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <span>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#ifdef USE_SDL3
+#if __has_include(<SDL3/SDL.h>)
+#include <SDL3/SDL.h>
+#endif
+#elif __has_include(<SDL.h>)
+#include <SDL.h>
+#endif
+
+#if __has_include(<ankerl/unordered_dense.h>)
+#include <ankerl/unordered_dense.h>
+#endif
+#if __has_include(<magic_enum/magic_enum.hpp>)
+#include <magic_enum/magic_enum.hpp>
+#endif
+// NOLINTEND(misc-include-cleaner)


### PR DESCRIPTION
Adds a shared precompiled header to use with all the translation units. This reduces compilation time by about 20% across the board, measured locally and evident from CI build times here.