### PR TITLE
CMake: Re-sign macOS app bundle after fixup_bundle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,6 +484,8 @@ if(APPLE)
       install(CODE "
         include(BundleUtilities)
         fixup_bundle(${CMAKE_BINARY_DIR}/${MACOSX_BUNDLE_BUNDLE_NAME}.app \"\" \"\")
+        # fixup_bundle invalidates any existing code signature, so re-sign.
+        execute_process(COMMAND codesign --force --deep --sign - ${CMAKE_BINARY_DIR}/${MACOSX_BUNDLE_BUNDLE_NAME}.app)
         "
         COMPONENT Runtime)
   endif()


### PR DESCRIPTION
fixup_bundle() rewrites install names via install_name_tool, which invalidates any existing code signature. On arm64 macOS, execution requires at least an ad-hoc signature, so this left CI-built app bundles unable to launch. Re-sign after fixup_bundle to fix it.