### PR TITLE
Adjust workarounds for Amiga compilation

### DIFF
--- a/.github/workflows/amiga-m68k.yml
+++ b/.github/workflows/amiga-m68k.yml
@@ -43,7 +43,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DM68K_COMMON="-s -fbbb=- -ffast-math" \
             -DM68K_CPU=68040 \
-            -DM68K_FPU=hard
+            -DM68K_FPU=hard \
+            -DDISABLE_LTO=ON
 
       - name: Build DevilutionX
         run: cmake --build build

--- a/CMake/platforms/amiga.cmake
+++ b/CMake/platforms/amiga.cmake
@@ -10,13 +10,6 @@ set(SDL1_VIDEO_MODE_BPP 8)
 set(DEVILUTIONX_SYSTEM_BZIP2 OFF)
 set(DEVILUTIONX_SYSTEM_ZLIB OFF)
 
-# Disable dead code elimination and sibling call optimization
-# because m68k-amigaos GCC miscompiles with these optimizations.
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fno-ext-dce -fno-optimize-sibling-calls")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fno-ext-dce -fno-optimize-sibling-calls")
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fno-ext-dce -fno-optimize-sibling-calls")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-ext-dce -fno-optimize-sibling-calls")
-
 # `fseeko` fails to link on Amiga.
 add_definitions(-Dfseeko=fseek)
 


### PR DESCRIPTION
* In https://github.com/AmigaPorts/m68k-amigaos-gcc/issues/42, `-foptimize-sibling-calls` was fixed.
* In https://github.com/AmigaPorts/m68k-amigaos-gcc/issues/34, the developer for m68k-amigaos-gcc confirmed with a reduced test case that the `-fext-dce` segfault simply doesn't occur at `-O2`. I guess we can turn it back on so long as it's not causing builds to fail.
* We'll need to disable LTO in CI until https://github.com/AmigaPorts/m68k-amigaos-gcc/issues/93 is addressed.