### PR TITLE
Fix app failing to launch on macOS when built with USE_SDL3

### DIFF
--- a/Source/utils/paths.cpp
+++ b/Source/utils/paths.cpp
@@ -152,7 +152,7 @@ const std::string &AssetsPath()
 		assetsPath.emplace("D:\\assets\\");
 #elif defined(__3DS__) || defined(__SWITCH__)
 		assetsPath.emplace("romfs:/");
-#elif defined(__APPLE__) && defined(USE_SDL1)
+#elif defined(__APPLE__) && (defined(USE_SDL1) || defined(USE_SDL3))
 		// In `Info.plist` we have
 		//
 		//    <key>SDL_FILESYSTEM_BASE_DIR_TYPE</key>


### PR DESCRIPTION
## Symptom
On macOS, building with `USE_SDL3` enabled:

```shell
cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DUSE_SDL3=ON
cmake --build build -j $(sysctl -n hw.physicalcpu)
```

and then running the app fails to launch, printing:

```shell
Couldn't open ui_art/diablo.pal: No such file or directory

The MPQ file(s) might be damaged. Please check the file integrity.
2026-09-13 15:20:17.281 devilutionx[66950:274228] ERROR: Error
Failed to open file:
ui_art\diablo.pal
```

## Cause
SDL3 reverts to SDL1 behavior and no longer auto-resolves the app bundle's `Contents/Resources/` directory, but the `#elif` branch in `Source/utils/paths.cpp` only checked for `USE_SDL1`. This left `USE_SDL3` falling through to the generic branch, which looks for a nonexistent `assets/` subdirectory, causing every asset load to fail.

## Changes
- Extended the condition in `AssetsPath()` to `defined(USE_SDL1) || defined(USE_SDL3)`, so SDL3 also resolves the bundled resources path via `Info.plist`'s `SDL_FILESYSTEM_BASE_DIR_TYPE`, matching the SDL1 behavior.