### PR TITLE
Fix video/UI aspect ratio distortion on SDL3 builds

### DIFF
--- a/Source/storm/storm_svid.cpp
+++ b/Source/storm/storm_svid.cpp
@@ -417,7 +417,7 @@ bool SVidPlayBegin(const char *filename, int flags)
 		if (
 #ifdef USE_SDL3
 		    !SDL_SetRenderLogicalPresentation(renderer, renderWidth, renderHeight,
-		        *GetOptions().Graphics.integerScaling ? SDL_LOGICAL_PRESENTATION_INTEGER_SCALE : SDL_LOGICAL_PRESENTATION_STRETCH)
+		        *GetOptions().Graphics.integerScaling ? SDL_LOGICAL_PRESENTATION_INTEGER_SCALE : SDL_LOGICAL_PRESENTATION_LETTERBOX)
 #else
 		    SDL_RenderSetLogicalSize(renderer, renderWidth, renderHeight) <= -1
 #endif
@@ -552,7 +552,7 @@ void SVidPlayEnd()
 		if (
 #ifdef USE_SDL3
 		    !SDL_SetRenderLogicalPresentation(renderer, gnScreenWidth, gnScreenHeight,
-		        *GetOptions().Graphics.integerScaling ? SDL_LOGICAL_PRESENTATION_INTEGER_SCALE : SDL_LOGICAL_PRESENTATION_STRETCH)
+		        *GetOptions().Graphics.integerScaling ? SDL_LOGICAL_PRESENTATION_INTEGER_SCALE : SDL_LOGICAL_PRESENTATION_LETTERBOX)
 #else
 		    SDL_RenderSetLogicalSize(renderer, gnScreenWidth, gnScreenHeight) <= -1
 #endif


### PR DESCRIPTION
## Bug Fixed
This issue occurs when building with USE_SDL3=ON.
Resizing the window causes the image to stretch and distorts the aspect ratio.
Changing the resolution settings restores it to normal.

<img width="1022" height="275" alt="wrong" src="https://github.com/user-attachments/assets/5f8404db-89a7-44ea-a22b-304c377be1fc" />
 

## Cause
SVidPlayBegin() in storm_svid.cpp sets the scale mode to SDL_LOGICAL_PRESENTATION_STRETCH instead of SDL_LOGICAL_PRESENTATION_LETTERBOX.
In contrast, ReinitializeIntegerScale() in display.cpp uses SDL_LOGICAL_PRESENTATION_LETTERBOX, which is why changing resolution settings fixes the issue.

## Fix
Updated SVidPlayBegin() in storm_svid.cpp to use SDL_LOGICAL_PRESENTATION_LETTERBOX instead.